### PR TITLE
Move background-color property in loading.css to *Theme.css

### DIFF
--- a/src/style/darkTheme.css
+++ b/src/style/darkTheme.css
@@ -43,6 +43,7 @@ input[type=text] {color: #EEEEEE;}
 .qualityTypes{color: #E0E0E0; background-color: #757575;}
 .speedTypes{color: #E0E0E0; background-color: #757575;}
 .unsaved{color: #E0E0E0;}
+.double-bounce1, .double-bounce2 {background-color: #f44336;}
 
 #main{color: #EEEEEE;}
 #main hr{border-bottom: 1px solid #212121;}

--- a/src/style/lightTheme.css
+++ b/src/style/lightTheme.css
@@ -39,6 +39,7 @@ body{background-color: #e0e0e0;}
 .qualityTypes{background-color: #eeeeee;}
 .speedTypes{background-color: #eeeeee;}
 .unsaved{color: #616161;}
+.double-bounce1, .double-bounce2 {background-color: #f44336;}
 
 #subscriptions img{border: 0px solid #000000;}
 #sideNav{background-color: white; -webkit-box-shadow: 4px -2px 51px -6px rgba(0,0,0,0.75);}

--- a/src/style/loading.css
+++ b/src/style/loading.css
@@ -15,7 +15,6 @@
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  background-color: #f44336;
   opacity: 0.6;
   position: absolute;
   top: 0;


### PR DESCRIPTION
This patch moves the background-color property for the .double-bounce1 and .double-bounce2 classes from loading.css into the css for both base themes. This will allow for the easier creation of themes by the community.