### PR TITLE
i18n: fix duplicated variable in translation files

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -32,7 +32,7 @@
 	"Search / Go to URL": "Suche / URL besuchen",
 	"Search Results": "Suchergebnisse",
 	"Subscriber": "Subscriber",
-	"Subscriber": "Subscribers",
+	"Subscribers": "Subscribers",
 	"Video": "Video",
 	"Videos": "Videos",
 	"View Full Playlist": "Vollständige Playlist anzeigen",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -32,7 +32,7 @@
 	"Search / Go to URL": "Search / Go to URL",
 	"Search Results": "Search Results",
 	"Subscriber": "Subscriber",
-	"Subscriber": "Subscribers",
+	"Subscribers": "Subscribers",
 	"Video": "Video",
 	"Videos": "Videos",
 	"View Full Playlist": "View Full Playlist",

--- a/locales/es.json
+++ b/locales/es.json
@@ -32,7 +32,7 @@
 	"Search / Go to URL": "Buscar / Ir a la URL",
 	"Search Results": "Resultados de búsqueda",
 	"Subscriber": "Suscriptor",
-	"Subscriber": "Suscriptores",
+	"Subscribers": "Suscriptores",
 	"Video": "Vídeo",
 	"Videos": "Vídeos",
 	"View Full Playlist": "Ver Lista de Reproducción completa",

--- a/locales/it.IT.json
+++ b/locales/it.IT.json
@@ -32,7 +32,7 @@
 	"Search / Go to URL": "Cerca / Vai all' URL",
 	"Search Results": "Cerca Risultati",
 	"Subscriber": "Iscritto",
-	"Subscriber": "Iscritti",
+	"Subscribers": "Iscritti",
 	"Video": "Video",
 	"Videos": "Video",
 	"View Full Playlist": "Vedi Intera Playlist",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -32,7 +32,7 @@
 	"Search / Go to URL": "Zoeken / Ga naar URL",
 	"Search Results": "Zoekresultaten",
 	"Subscriber": "Abonnee",
-	"Subscriber": "Abonnees",
+	"Subscribers": "Abonnees",
 	"Video": "Video",
 	"Videos": "Videos",
 	"View Full Playlist": "Volledige afspeellijst weergeven",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -32,7 +32,7 @@
 	"Search / Go to URL": "Поиск / перейти по URL",
 	"Search Results": "Результаты поиска",
 	"Subscriber": "Подписка",
-	"Subscriber": "Подписчиков",
+	"Subscribers": "Подписчиков",
 	"Video": "Видео",
 	"Videos": "Видео",
 	"View Full Playlist": "Список воспроизведения",


### PR DESCRIPTION
A variable in .json files has been written twice.

- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.

**Notes and Comments about your pull request**
Fixed an issue about a duplicated variable in translation files.
This pull request fixes #173 

