### PR TITLE
Filter premium content from descriptions

### DIFF
--- a/src/js/subscriptions.js
+++ b/src/js/subscriptions.js
@@ -131,6 +131,10 @@ function loadSubscriptions() {
 }
 
 function addSubsToView(videoList) {
+    videoList = videoList.filter(a => {
+        return !a.premium;
+    });
+
     videoList.sort((a, b) => {
         return b.published - a.published;
     });


### PR DESCRIPTION
- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.

Accurate info on when premium content is published is currently not available from the Invidious API, so this fix filters it out. 

Of note is that some premium content is still watchable without having a subscription, and can be filtered using the `paid` attribute. A better fix might be to cache premium content in some way in order to provide a consistent `published` time.

Before:
![before](https://user-images.githubusercontent.com/14208607/51401424-5621e780-1b10-11e9-848b-c6835c17d48a.png)
After:
![after](https://user-images.githubusercontent.com/14208607/51401427-57ebab00-1b10-11e9-863f-5ef409e9a407.png)


Would close #198 and #208.