### PR TITLE
[Fix] Toggle saved video in videoListTemplate

### DIFF
--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -165,7 +165,7 @@ let subscriptionView = new Vue({
       goToChannel(channelId);
     },
     toggleSave: (videoId) => {
-      toggleSavedVideo(videoId);
+      addSavedVideo(videoId);
     },
     copy: (site, videoId) => {
       const url = 'https://' + site + '/watch?v=' + videoId;
@@ -255,7 +255,7 @@ let savedView = new Vue({
       goToChannel(channelId);
     },
     toggleSave: (videoId) => {
-      addSavedVideo(videoId);
+      toggleSavedVideo(videoId);
     },
     copy: (site, videoId) => {
       const url = 'https://' + site + '/watch?v=' + videoId;
@@ -528,7 +528,7 @@ let playerView = new Vue({
       showToast('URL has been copied to the clipboard');
     },
     save: (videoId) => {
-      toggleSavedVideo(videoId);
+      addSavedVideo(videoId);
     },
     play: (videoId, playlistId = '') => {
       loadingView.seen = true;


### PR DESCRIPTION
- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.

Updates toggleSave method on videos in videoListTemplate to actually remove videos from Favorites if it's already added.

It also solves an issue where there is no way to remove videos from Favorites without going to Video view page.

Update 02.18.2019: Only update this in savedView because it only really makes sense there.

