### PR TITLE
Remove API Keys section from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,3 @@
-# API Keys
-
-When you are testing and working on FreeTube, PLEASE use your own API Key.  The keys included in the project are in use by the userbase and testing can cause these keys to max out.  Please do not risk degrading the experience for other users and use your own key if at all possible.  Thank you for your cooperation.
-
 # Code Contributions
 
 Please follow these guidlines before sending your pull request and making contributions.


### PR DESCRIPTION
- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.

Remove API Keys section from CONTRIBUTING.md as it is no longer relevant and might confuse new contributors.


