### PR TITLE
[Fix] Inconsistent order in history

### DIFF
--- a/src/js/history.js
+++ b/src/js/history.js
@@ -62,12 +62,10 @@ function showHistory(){
   historyDb.find({}).sort({
     timeWatched: -1
   }).exec((err, docs) => {
-    let position = 0;
-    docs.forEach((video) => {
+    docs.forEach((video, index) => {
         invidiousAPI('videos', video.videoId, {}, (data) => {
-            data.position = position;
+            data.position = index;
             displayVideo(data, 'history');
-            position++;
         });
     });
 


### PR DESCRIPTION
- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.

I found an issue with history having inconsistent order. 

Steps to recreate: 
1. Clear history
2. Watch 3 videos to add them to your history
3. Switch between Settings and History tabs multiple times and you will see that videos are in different order every time.

That happens because position counter is updated in callback line 70 in below code sample.

https://github.com/FreeTubeApp/FreeTube/blob/2bb080e833a8fa3a4c687dac744e5c0761d55ebf/src/js/history.js#L65-L72

To avoid that use built in index from [forEach](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Parameters) instead of external counter.
