### PR TITLE
Fix scheme in author thumbnail

### DIFF
--- a/src/js/videos.js
+++ b/src/js/videos.js
@@ -232,7 +232,7 @@ function displayChannel(channel) {
     let channelData = {};
 
     channelData.channelId = channel.authorId;
-    channelData.thumbnail = "https:" + channel.authorThumbnails[4].url;
+    channelData.thumbnail = channel.authorThumbnails[4].url;
     channelData.channelName = channel.author;
     channelData.description = channel.description;
     channelData.subscriberCount = channel.subCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");


### PR DESCRIPTION
- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.

Currently FreeTube adds an `https:` to `authorThumbnail` to correct an issue with the Invidious API that was fixed with omarroth/invidious@1fd7ff5. This produces `https:https://yt3.ggpht.com...` which doesn't resolve.