### PR TITLE
Added save icon to recommended video thumbnails

### DIFF
--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -947,6 +947,9 @@ let playerView = new Vue({
             playerView.legacySeen = false;
             playerView.playerSeen = true;
         },
+        toggleSave: (videoId) => {
+            addSavedVideo(videoId);
+        },
         copyYouTube: (videoId) => {
             const url = 'https://youtube.com/watch?v=' + videoId;
             clipboard.writeText(url);

--- a/src/style/player.css
+++ b/src/style/player.css
@@ -263,6 +263,19 @@ iframe {
     width: 100%;
 }
 
+.recommendThumbnail i {
+    color: white;
+    background-color: black;
+    padding: 6px;
+    opacity: 0.7;
+    position: relative;
+}
+
+.recommendVideoSave {
+    bottom: 145px;
+    left: 222px;
+}
+
 .recommendTitle {
     font-size: 16px;
     font-weight: bold;

--- a/src/templates/player.html
+++ b/src/templates/player.html
@@ -123,14 +123,15 @@
     <div v-if='!distractionFreeMode' id='recommendations'>
         <strong>Recommendations</strong>
         <div v-for='video in recommendedVideoList'>
-            <div class='recommendVideo' v-on:click='play(video.id)'>
+            <div class='recommendVideo'>
                 <div class='recommendThumbnail'>
-                    <img :src='video.thumbnail'></img>
+                    <img v-on:click='play(video.id)' :src='video.thumbnail'></img>
                     <p v-on:click='play(video.id)' class='videoDuration'>{{video.duration}}</p>
+                    <i class="fas fa-history recommendVideoSave" v-on:click='toggleSave(video.id)'></i>
                 </div>
-                <p class='recommendTitle'>{{video.title}}</p>
-                <p class='recommendChannel'>{{video.channelName}}</p>
-                <p class='recommendDate'>{{video.viewCount}}</p>
+                <p v-on:click='play(video.id)' class='recommendTitle'>{{video.title}}</p>
+                <p v-on:click='play(video.id)' class='recommendChannel'>{{video.channelName}}</p>
+                <p v-on:click='play(video.id)' class='recommendDate'>{{video.viewCount}}</p>
             </div>
             <hr />
         </div>


### PR DESCRIPTION
- [x] I have read and agree to the [Contribution Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/master/CONTRIBUTING.md)
- [x] I can maintain / support my code if issues arise.


**Notes and Comments about your pull request**

Refers to issue #489

Adds a save icon to give the option to favourite recommended videos suggested below the video player.
Icon is displayed in the top right hand corner following conventions in the rest of the project.

Moved the on click action from the main recommend video div to each element individually to prevent the video playing when the user only wants to favorite it. This is the approach utilised for the video template.

Screenshot showing design changes:

![Screenshot from 2020-06-11 23-14-17](https://user-images.githubusercontent.com/48567180/84444269-5062ff80-ac39-11ea-99dd-adadc8c9011d.png)



