### PR TITLE
Fix weird published text display on topic videos

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -253,7 +253,7 @@ export default Vue.extend({
       this.isLive = this.data.liveNow
       this.viewCount = this.data.viewCount
 
-      if (typeof (this.data.publishedText) !== 'undefined' && !this.isLive) {
+      if (typeof (this.data.publishedText) !== 'undefined' && this.data.publishedText !== null && !this.isLive) {
         // produces a string according to the template in the locales string
         this.toLocalePublicationString({
           publishText: this.data.publishedText,


### PR DESCRIPTION
---
'Fix weird published text display on topic videos"
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Related issue**
Closes issue #541 and #361 

**Description**
The publishedText in the toLocalePublicationString() function in utils.js is null. This leads to a wrongly used phrase. Now it does not display anything, because the time when uploaded is simply missing.

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/34301369/94921475-adb8e000-04b8-11eb-9415-d63f153ebe6f.png)

After:
![image](https://user-images.githubusercontent.com/34301369/94921427-97128900-04b8-11eb-8d10-a7fb0aef3b2a.png)


**Testing (for fixes that are not easily understandable)**
Tested on the 2pac topic channel

**Desktop (please complete the following information):**
 - OS: Windodws
 - OS 10
 - FreeTube version: Newest release
