### PR TITLE
Fixed typo: "API di Indidious" to "API di Invidious"

### DIFF
--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -98,7 +98,7 @@ Settings:
     Preferred API Backend:
       Preferred API Backend: 'Back-end API Preferito'
       Local API: 'API Locali'
-      Invidious API: 'API di Indidious'
+      Invidious API: 'API di Invidious'
     Video View Type:
       Video View Type: 'Modalità di Visualizzazione Video'
       Grid: 'Griglia'


### PR DESCRIPTION
---
Changed "_API di Indidious_" to "_API di Invidious_"
---


**Pull Request Type**
Please select what type of pull request this is:
- Bugfix: Typo

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/559

**Description**
Just made a correction to "API di Invidious"

**Desktop (please complete the following information):**
 - OS: Win10
 - FreeTube version: 0.8.0

**Additional context**
I hope i didn't messed up anything XD
