### PR TITLE
Creating ft-intersection-observer component

### DIFF
--- a/src/renderer/components/ft-intersection-observer/ft-intersection-observer.js
+++ b/src/renderer/components/ft-intersection-observer/ft-intersection-observer.js
@@ -40,11 +40,15 @@ export default Vue.extend({
   },
   methods: {
     handleIntersection(entries) {
-      if (this.runOnce || this.checkOnMount) {
-        this.$emit(entries[0].isIntersecting ? 'intersected' : 'unintersected')
-      } else {
+      if (!this.runOnce) {
         this.runOnce = true
+
+        if (!this.checkOnMount) {
+          return
+        }
       }
+
+      this.$emit(entries[0].isIntersecting ? 'intersected' : 'unintersected')
     }
   }
 })

--- a/src/renderer/components/ft-intersection-observer/ft-intersection-observer.js
+++ b/src/renderer/components/ft-intersection-observer/ft-intersection-observer.js
@@ -1,0 +1,50 @@
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'FtIntersectionObserver',
+  props: {
+    checkOnMount: {
+      type: Boolean,
+      default: false
+    },
+    margin: {
+      type: String,
+      default: '0px 0px 0px 0px'
+    },
+    observeParent: {
+      type: Boolean,
+      default: false
+    },
+    threshold: {
+      type: Number,
+      default: 1
+    }
+  },
+  data() {
+    const observer = new IntersectionObserver(this.handleIntersection, {
+      rootMargin: this.margin,
+      threshold: this.threshold
+    })
+    const runOnce = false
+
+    return {
+      observer,
+      runOnce
+    }
+  },
+  mounted() {
+    this.observer.observe(this.observeParent ? this.$refs.elem.parentElement : this.$refs.elem)
+  },
+  beforeDestroy() {
+    this.observer.disconnect()
+  },
+  methods: {
+    handleIntersection(entries) {
+      if (this.runOnce || this.checkOnMount) {
+        this.$emit(entries[0].isIntersecting ? 'intersected' : 'unintersected')
+      } else {
+        this.runOnce = true
+      }
+    }
+  }
+})

--- a/src/renderer/components/ft-intersection-observer/ft-intersection-observer.vue
+++ b/src/renderer/components/ft-intersection-observer/ft-intersection-observer.vue
@@ -1,0 +1,5 @@
+<template>
+  <div ref="elem" />
+</template>
+
+<script src="./ft-intersection-observer.js" />


### PR DESCRIPTION
---
Creating ft-intersection-observer component
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [X] Feature Implementation

**Related issue**
N/A

**Description**
I have created a standalone component to observe viewport intersection. It can observe either itself (most useful for detecting if the user has reached a certain part of the page), or its parent element, controlled by props. It also has props to control standard IntersectionObserver options, as well as an option (defaulting to false) to run its check during the first execution which happens automatically when IntersectionObserver.observe() is called. When an intersection is detected, it emits an 'intersected' event, and emits an 'unintersected' event when intersection ceases.

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

**Testing (for code that is not small enough to be easily understandable)**
I temporarily added console.log statements to component methods, then temporarily added the component to the Settings view, observing the console outputs as I scrolled.

**Desktop (please complete the following information):**
 - OS: Linux Xubuntu
 - OS Version: 20.04
 - FreeTube version: 0.8

**Additional context**
N/A
