### PR TITLE
Comment sorting and comment day time display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20706,9 +20706,9 @@
       }
     },
     "yt-comment-scraper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.2.0.tgz",
-      "integrity": "sha512-XVQijojldm4ztqT8GnS4YJAJYxJelEE4zTdYHiup0BRYnNMbo8p4/W3lHLcbx/6FamKBdCyCSieM4RM98li4Pw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.2.tgz",
+      "integrity": "sha512-i2e+7ZNm5Dvdwsk3W8UyKtxR2xjtcMfUVGUjxVAR31HlEb8wE66XslDr5eIxSCpbhCLV7ItbmvL8NGL3D1TSxw==",
       "requires": {
         "axios": "^0.19.2",
         "html2json": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "youtube-chat": "^1.1.0",
     "youtube-suggest": "^1.1.0",
     "yt-channel-info": "^1.1.2",
-    "yt-comment-scraper": "^1.2.0",
+    "yt-comment-scraper": "^1.3.2",
     "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.3",
     "yt-xml2vtt": "^1.1.2",

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -5,7 +5,7 @@ import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timestamp-catcher.vue'
 
-import CommentScraper from 'D:\\Workspace\\JavaScript\\yt-comment-scraper\\index.js'//'yt-comment-scraper' //'D:\\Workspace\\JavaScript\\yt-comment-scraper\\index.js'
+import CommentScraper from 'yt-comment-scraper' //'D:\\Workspace\\JavaScript\\yt-comment-scraper\\index.js'
 
 export default Vue.extend({
   name: 'WatchVideoComments',

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -5,7 +5,7 @@ import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timestamp-catcher.vue'
 
-import CommentScraper from 'yt-comment-scraper'
+import CommentScraper from 'D:\\Workspace\\JavaScript\\yt-comment-scraper\\index.js'//'yt-comment-scraper' //'D:\\Workspace\\JavaScript\\yt-comment-scraper\\index.js'
 
 export default Vue.extend({
   name: 'WatchVideoComments',
@@ -27,7 +27,8 @@ export default Vue.extend({
       showComments: false,
       commentScraper: null,
       nextPageToken: null,
-      commentData: []
+      commentData: [],
+      sortNewest: false
     }
   },
   computed: {
@@ -55,6 +56,10 @@ export default Vue.extend({
         'top',
         'newest'
       ]
+    },
+
+    currentSortValue: function () {
+      return (this.sortNewest) ? 'newest' : 'top'
     }
   },
   methods: {
@@ -63,17 +68,15 @@ export default Vue.extend({
     },
 
     handleSortChange: function (sortType) {
-      console.log(sortType)
-      this.showToast({
-        message: 'Not currently implemented'
-      })
+      this.sortNewest = !this.sortNewest
+      this.getCommentData(true)
     },
 
-    getCommentData: function () {
+    getCommentData: function (sortChanged = false) {
       this.isLoading = true
       switch (this.backendPreference) {
         case 'local':
-          this.getCommentDataLocal()
+          this.getCommentDataLocal(sortChanged)
           break
         case 'invidious':
           this.getCommentDataInvidious(this.nextPageToken)
@@ -107,9 +110,10 @@ export default Vue.extend({
       }
     },
 
-    getCommentDataLocal: function () {
-      if (this.commentScraper === null) {
-        this.commentScraper = new CommentScraper(false)
+    getCommentDataLocal: function (sortChanged = false) {
+      if (this.commentScraper === null || sortChanged === true) {
+        this.commentScraper = new CommentScraper(false, this.sortNewest)
+        this.commentData = []
       }
       this.commentScraper.scrape_next_page_youtube_comments(this.id).then((response) => {
         console.log(response)

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -4,8 +4,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timestamp-catcher.vue'
-
-import CommentScraper from 'yt-comment-scraper' //'D:\\Workspace\\JavaScript\\yt-comment-scraper\\index.js'
+import CommentScraper from 'yt-comment-scraper'
 
 export default Vue.extend({
   name: 'WatchVideoComments',

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -21,7 +21,7 @@
       v-if="commentData.length > 0 && !isLoading && showComments"
       class="commentSort"
       :placeholder="$t('Comments.Sort by')"
-      :value="sortValues[0]"
+      :value="currentSortValue"
       :select-names="sortNames"
       :select-values="sortValues"
       @change="handleSortChange"


### PR DESCRIPTION
---
Comment sorting and comment day time display
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [x] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/projects/3#card-46699030

**Description**
Sorting was added to the module and now hooked up to Preston's sorting button. Also the bug with the time since comment publish not displaying correctly for days is fixed. The sorting button now also displays the currently selected sorting method.


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
On a few videos checked again YouTube's website

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.8