### PR TITLE
Fix for infinite comment repeat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20706,9 +20706,9 @@
       }
     },
     "yt-comment-scraper": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.2.tgz",
-      "integrity": "sha512-i2e+7ZNm5Dvdwsk3W8UyKtxR2xjtcMfUVGUjxVAR31HlEb8wE66XslDr5eIxSCpbhCLV7ItbmvL8NGL3D1TSxw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.3.tgz",
+      "integrity": "sha512-t0mIJOxsXriJTVIzQpRYz7BcAo2SbhhgY8YR2HJjxEq5zBYsu6mVujs8xzrCo1431hri1mDTanvLluS/WWCgjg==",
       "requires": {
         "axios": "^0.19.2",
         "html2json": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "youtube-chat": "^1.1.0",
     "youtube-suggest": "^1.1.0",
     "yt-channel-info": "^1.1.2",
-    "yt-comment-scraper": "^1.3.2",
+    "yt-comment-scraper": "^1.3.3",
     "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.3",
     "yt-xml2vtt": "^1.1.2",

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -4,6 +4,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timestamp-catcher.vue'
+
 import CommentScraper from 'yt-comment-scraper'
 
 export default Vue.extend({
@@ -115,6 +116,16 @@ export default Vue.extend({
         this.commentData = []
       }
       this.commentScraper.scrape_next_page_youtube_comments(this.id).then((response) => {
+        if (response === null) {
+          this.showToast({
+            message: this.$t('No more comments available'),
+            time: 7000,
+            action: () => {
+            }
+          })
+          this.isLoading = false
+          return
+        }
         console.log(response)
         const commentData = response.map((comment) => {
           comment.showReplies = false

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -493,7 +493,7 @@ Comments:
   Reply: Reply
   There are no comments available for this video: There are no comments available
     for this video
-  Load More Comments: Load More
+  Load More Comments: Load More Comments
   No more comments available: No more comments available
 Up Next: Up Next
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -493,7 +493,8 @@ Comments:
   Reply: Reply
   There are no comments available for this video: There are no comments available
     for this video
-  Load More Comments: Load More Comments
+  Load More Comments: Load More
+  No more comments available: No more comments available
 Up Next: Up Next
 
 # Toast Messages


### PR DESCRIPTION
---
Fix for infinite comment repeat
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes issue #586 

**Description**
The module upstream now returns null when no new comments are available. This is now checked before the comment processing and displays a toast message if it is the case.

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
With the provided video in the issue and a few more videos from the same channel

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.8

**Additional context**
Add any other context about the problem here.
