### PR TITLE
Comment full text & comment link display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20577,9 +20577,9 @@
       }
     },
     "yt-comment-scraper": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.3.tgz",
-      "integrity": "sha512-t0mIJOxsXriJTVIzQpRYz7BcAo2SbhhgY8YR2HJjxEq5zBYsu6mVujs8xzrCo1431hri1mDTanvLluS/WWCgjg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.4.tgz",
+      "integrity": "sha512-/sf4hmjHBNtGItrZiHWetWwp3Q66G0Ur1HGKsP0Enfpxsq4/1otrie11dPCINl4oBmt5qQ0jVJt5j44zvom4Xg==",
       "requires": {
         "axios": "^0.19.2",
         "html2json": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "youtube-chat": "^1.1.0",
     "youtube-suggest": "^1.1.0",
     "yt-channel-info": "^1.1.3",
-    "yt-comment-scraper": "^1.3.3",
+    "yt-comment-scraper": "^1.3.4",
     "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.3",
     "yt-xml2vtt": "^1.1.2",

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -4,7 +4,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timestamp-catcher.vue'
-
+import autolinker from 'autolinker'
 import CommentScraper from 'yt-comment-scraper'
 
 export default Vue.extend({
@@ -121,7 +121,7 @@ export default Vue.extend({
       this.commentScraper.scrape_next_page_youtube_comments(this.id).then((response) => {
         if (response === null) {
           this.showToast({
-            message: this.$t('No more comments available'),
+            message: this.$t('Comments.No more comments available'),
             time: 7000,
             action: () => {
             }
@@ -150,6 +150,7 @@ export default Vue.extend({
           if (this.hideCommentLikes) {
             comment.likes = null
           }
+          comment.text = autolinker.link(comment.text)
           return comment
         })
         this.commentData = this.commentData.concat(commentData)

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -151,6 +151,9 @@ export default Vue.extend({
             comment.likes = null
           }
           comment.text = autolinker.link(comment.text)
+          comment.replies.forEach((reply) => {
+            reply.text = autolinker.link(reply.text)
+          })
           return comment
         })
         this.commentData = this.commentData.concat(commentData)

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -96,9 +96,11 @@
                 {{ reply.time }}
               </span>
             </p>
-            <p class="commentText">
-              {{ reply.text }}
-            </p>
+            <ft-timestamp-catcher
+              class="commentText"
+              :input-html="reply.text"
+              @timestamp-event="onTimestamp"
+            />
             <p class="commentLikeCount">
               <font-awesome-icon
                 icon="thumbs-up"


### PR DESCRIPTION
---
Comment full text & comment link display
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Issue #581 is closed with this PR.

**Description**
Previously comment containing links were only displayed up to the first link. This was due to an issue on the scraper module and the internal extraction of comments. I fixed that upstream. Additionally comments and replies now go through the auto linker module in order to display their links in blue and make clickable

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Tested on the video where the problem occurred and then on a few other videos

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.8
