### PR TITLE
Fixed error for importing old subscriptions, which added channels multiple times to profiles

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -149,7 +149,6 @@ export default Vue.extend({
             ]
 
             const profileObject = {}
-
             Object.keys(profileData).forEach((key) => {
               if (!requiredKeys.includes(key)) {
                 const message = this.$t('Settings.Data Settings.Unknown data key')
@@ -772,6 +771,7 @@ export default Vue.extend({
     async convertOldFreeTubeFormatToNew(oldData) {
       const convertedData = []
       for (const channel of oldData) {
+        const listOfProfilesAlreadyAdded = []
         for (const profile of channel.profile) {
           let index = convertedData.findIndex(p => p.name === profile.value)
           if (index === -1) { // profile doesn't exist yet
@@ -785,7 +785,10 @@ export default Vue.extend({
               _id: channel._id
             })
             index = convertedData.length - 1
+          } else if (listOfProfilesAlreadyAdded.indexOf(index) !== -1) {
+            continue
           }
+          listOfProfilesAlreadyAdded.push(index)
           convertedData[index].subscriptions.push({
             id: channel.channelId,
             name: channel.channelName,


### PR DESCRIPTION
---
Fixed error for importing old subscriptions, which added channels multiple times to profiles
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Is closing issue #562 

**Description**
When importing .db files from old FreeTube, a check is performed, to which profiles the channel was added already. If it was added already, then the duplicate addition is skipped

**Testing (for code that is not small enough to be easily understandable)**
Tested with the file PrestoN provided for me

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.8

