### PR TITLE
Changed the fixed string 'load more' in the subscription page

### DIFF
--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -23,7 +23,7 @@
       <ft-flex-box>
         <ft-button
           v-if="videoList.length > dataLimit"
-          label="Load More"
+          :label="$t('Subscriptions.Load More Videos')"
           background-color="var(--primary-color)"
           text-color="var(--text-with-main-color)"
           @click="increaseLimit"

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -76,6 +76,7 @@ Subscriptions:
   This profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting: Dieses
     Profil hat eine große Anzahl von Abonnementen.  RSS zur Vermeidung von Tarifbeschränkungen
     erzwingen
+  Load More Videos: Lade mehr Videos
 Trending: Trends
 Most Popular: Am beliebtesten
 Playlists: Wiedergabelisten

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -77,6 +77,7 @@ Subscriptions:
     Subscription list is currently empty. Start adding subscriptions to see them here.
   'Getting Subscriptions. Please wait.': Getting Subscriptions. Please wait.
   Refresh Subscriptions: Refresh Subscriptions
+  Load More Videos: Load More
 Trending: Trending
 Most Popular: Most Popular
 Playlists: Playlists

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -77,7 +77,7 @@ Subscriptions:
     Subscription list is currently empty. Start adding subscriptions to see them here.
   'Getting Subscriptions. Please wait.': Getting Subscriptions. Please wait.
   Refresh Subscriptions: Refresh Subscriptions
-  Load More Videos: Load More
+  Load More Videos: Load More Videos
 Trending: Trending
 Most Popular: Most Popular
 Playlists: Playlists


### PR DESCRIPTION
---
Changed the fixed string 'load more' in the subscription page
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
None

**Description**
The string in the button 'Load more' on the subscription page was hard coded and not pulled from the yaml files


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Tested with English and German.

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.8