### PR TITLE
Implement videojs-abloop in the video player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "freetube",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19204,9 +19204,9 @@
       }
     },
     "videojs-abloop": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/videojs-abloop/-/videojs-abloop-1.1.2.tgz",
-      "integrity": "sha512-+S16Uw+t7zgCT6rwyQ1PT3/6q1CjeoVAM7c/6bRVAJo5tb0O22Mp4TIYTXIdMKlAuGH5xKc7zbjLS6bVMElINA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-abloop/-/videojs-abloop-1.2.0.tgz",
+      "integrity": "sha512-6/hvtB5gNQUr5FJ969UhXVg5H+3wxhOzh9AVftlezOXlhzzaWfNfiOJYqNKo01Gc/eSQOvfttrOX7jH+aHpwrw=="
     },
     "videojs-contrib-quality-levels": {
       "version": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "opml-to-json": "0.0.3",
     "rss-parser": "^3.9.0",
     "video.js": "7.6.6",
-    "videojs-abloop": "^1.1.2",
+    "videojs-abloop": "^1.2.0",
     "videojs-contrib-quality-levels": "^2.0.9",
     "videojs-http-source-selector": "^1.1.6",
     "videojs-replay": "^1.1.0",

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -7,6 +7,7 @@ import qualitySelector from '@silvermine/videojs-quality-selector'
 import 'videojs-vtt-thumbnails-freetube'
 import 'videojs-contrib-quality-levels'
 import 'videojs-http-source-selector'
+import 'videojs-abloop'
 
 export default Vue.extend({
   name: 'FtVideoPlayer',
@@ -65,7 +66,13 @@ export default Vue.extend({
       dataSetup: {
         aspectRatio: '16:9',
         nativeTextTracks: false,
-        plugins: {},
+        plugins: {
+          abLoopPlugin: {
+            start: 0,
+            end: false,
+            createButtons: true
+          }
+        },
         controlBar: {
           children: [
             'playToggle',
@@ -159,7 +166,7 @@ export default Vue.extend({
           await this.determineDefaultQualityLegacy()
         }
 
-        this.player = videojs(videoPlayer)
+        this.player = videojs(videoPlayer, this.dataSetup.plugins)
 
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)
@@ -188,6 +195,11 @@ export default Vue.extend({
             this.player.play()
           }, 200)
         }
+
+        // this.dataSetup.plugins.abLoopPlugin = {}
+        // this.player.ready(function() {
+        //   this.abLoopPlugin.playLoop()
+        // })
 
         $(document).on('keydown', this.keyboardShortcutHandler)
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -7,7 +7,9 @@ import qualitySelector from '@silvermine/videojs-quality-selector'
 import 'videojs-vtt-thumbnails-freetube'
 import 'videojs-contrib-quality-levels'
 import 'videojs-http-source-selector'
-import 'videojs-abloop'
+import abLoopPlugin from 'videojs-abloop'
+
+abLoopPlugin(window, videojs)
 
 export default Vue.extend({
   name: 'FtVideoPlayer',
@@ -195,11 +197,6 @@ export default Vue.extend({
             this.player.play()
           }, 200)
         }
-
-        // this.dataSetup.plugins.abLoopPlugin = {}
-        // this.player.ready(function() {
-        //   this.abLoopPlugin.playLoop()
-        // })
 
         $(document).on('keydown', this.keyboardShortcutHandler)
 


### PR DESCRIPTION
---
Implements a loop button in the Player
---

**Pull Request Type**
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#549

**Description**
It adds a loop button by installing the [videojs-abloop](https://github.com/phhu/videojs-abloop) plugin in the player.

**Screenshots**
![image](https://user-images.githubusercontent.com/12251731/95807252-10438480-0ce0-11eb-90ed-6af7bd44e691.png)

**Testing (for code that is not small enough to be easily understandable)**
Click in the numbers to configure the loop and click in loop on.

**Desktop (please complete the following information):**
 - OS: Linux
 - OS Version: Manjaro Gnome 20
 - FreeTube version: 0.9

**Additional context**
I'm not really sure if the videojs-abloop is the best plugin for this, probably most part of the users just want a simple loop button and abloop instead adds two more button, one to set the start of the loop and other to set the end of that, I read the documentation and couldn't find anything to hide just those two button, I can take another read if you guys prefer, just wanted to make sure that this is or is not the way that this is supposed to work before do any more work.

I had to add this line to make the plugin work
```js
abLoopPlugin(window, videojs)
```
I saw that in the others plugins there is no declaration like this one, if there is a better way to do it just tell me =]
