### PR TITLE
Fix freetube:// protocol handling on macOS.

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -93,7 +93,7 @@ export default Vue.extend({
       console.log('User is using Electron')
       this.activateKeyboardShortcuts()
       this.openAllLinksExternally()
-      this.enableCliPing()
+      this.enableOpenUrl()
       this.setBoundsOnClose()
     }
 
@@ -262,12 +262,10 @@ export default Vue.extend({
       })
     },
 
-    enableCliPing: function () {
+    enableOpenUrl: function () {
       const v = this
-      electron.ipcRenderer.on('ping', function (event, message) {
-        let url = message[message.length - 1]
+      electron.ipcRenderer.on('openUrl', function (event, url) {
         if (url) {
-          url = url.replace('freetube://', '')
           v.$store.dispatch('getVideoIdFromUrl', url).then((result) => {
             if (result) {
               v.$router.push({


### PR DESCRIPTION
1. Handle open-url events.
2. Make protocol handling more robust on Win/Linux based on SO post.
3. Change 'ping' message to more descriptive 'openUrl' message.
4. Remove freetube:// protocol in main, and unify URL handling logic.

---
Title
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation

**Related issue**
Fixes #618.

**Description**
This fixes the freetube:// links that the Firefox redirect plugin uses on macOS, both when the app is closed and when it is already open.

**Testing (for code that is not small enough to be easily understandable)**
I've tested this in the above situations on the macOS version below. However the flow for the equivalent functionality in Windows/Linux has changed a bit, but I don't have a Windows/Linux machine to test that on. If someone could do a sanity check on that that would be great.

**Desktop (please complete the following information):**
 - OS: macOS
 - OS Version: 10.15.7
 - FreeTube version: 0.9
