### PR TITLE
Use shorter youtu.be links instead of youtube.com for YouTube share links

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -93,6 +93,10 @@ export default Vue.extend({
       return `https://www.youtube.com/watch?v=${this.id}`
     },
 
+    youtubeShareUrl: function () {
+      return `https://youtu.be/${this.id}`
+    },
+
     youtubeEmbedUrl: function () {
       return `https://www.youtube-nocookie.com/embed/${this.id}`
     },
@@ -168,7 +172,7 @@ export default Vue.extend({
           }
           break
         case 'copyYoutube':
-          navigator.clipboard.writeText(this.youtubeUrl)
+          navigator.clipboard.writeText(this.youtubeShareUrl)
           this.showToast({
             message: this.$t('Share.YouTube URL copied to clipboard')
           })

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -50,6 +50,10 @@ export default Vue.extend({
       return `https://www.youtube.com/watch?v=${this.id}`
     },
 
+    youtubeShareURL() {
+      return `https://youtu.be/${this.id}`
+    },
+
     youtubeEmbedURL() {
       return `https://www.youtube-nocookie.com/embed/${this.id}`
     }
@@ -88,7 +92,7 @@ export default Vue.extend({
       this.showToast({
         message: this.$t('Share.YouTube URL copied to clipboard')
       })
-      this.copy(this.getFinalUrl(this.youtubeURL))
+      this.copy(this.getFinalUrl(this.youtubeShareURL))
       this.$refs.iconButton.focusOut()
     },
 


### PR DESCRIPTION
---
Changes the share YouTube link option to use short YouTu.be links instead
---

**Pull Request Type**
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
[#639 ](https://github.com/FreeTubeApp/FreeTube/issues/639)

**Description**
Very simply makes a change so that when a video URL is copied it uses the shorter YouTube link instead. Eg. old link: https://www.youtube.com/watch?v=imaginaryURL is now new link: https://youtu.be/imaginaryURL

**Screenshots (if appropriate)**
No visible changes, URL is different now.

**Testing (for code that is not small enough to be easily understandable)**
Fairly straightforward. 

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.9

**Additional context**
The only note I have on this change is that perhaps people don't always want the shorter URL, but I couldn't think or find any reasons why this might be the case, whether it be privacy-related or usability-related. Feel free to correct if I'm missing something.
