### PR TITLE
Add Copy / Open Channel URL to video dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "freetube",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -52,7 +52,9 @@ export default Vue.extend({
         'openInvidious',
         'copyInvidious',
         'openYoutubeChannel',
-        'copyYoutubeChannel'
+        'copyYoutubeChannel',
+        'openInvidiousChannel',
+        'copyInvidiousChannel'
       ]
     }
   },
@@ -91,6 +93,10 @@ export default Vue.extend({
       return `${this.invidiousInstance}/watch?v=${this.id}`
     },
 
+    invidiousChannelUrl: function () {
+      return `${this.invidiousInstance}/channel/${this.channelId}`
+    },
+
     youtubeUrl: function () {
       return `https://www.youtube.com/watch?v=${this.id}`
     },
@@ -120,7 +126,9 @@ export default Vue.extend({
         this.$t('Video.Open in Invidious'),
         this.$t('Video.Copy Invidious Link'),
         this.$t('Video.Open Channel in YouTube'),
-        this.$t('Video.Copy YouTube Channel Link')
+        this.$t('Video.Copy YouTube Channel Link'),
+        this.$t('Video.Open Channel in Invidious'),
+        this.$t('Video.Copy Invidious Channel Link')
       ]
 
       if (this.watched) {
@@ -226,6 +234,18 @@ export default Vue.extend({
           if (this.usingElectron) {
             const shell = require('electron').shell
             shell.openExternal(this.youtubeChannelUrl)
+          }
+          break
+        case 'copyInvidiousChannel':
+          navigator.clipboard.writeText(this.invidiousChannelUrl)
+          this.showToast({
+            message: this.$t('Share.Invidious Channel URL copied to clipboard')
+          })
+          break
+        case 'openInvidiousChannel':
+          if (this.usingElectron) {
+            const shell = require('electron').shell
+            shell.openExternal(this.invidiousChannelUrl)
           }
           break
       }

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -50,7 +50,9 @@ export default Vue.extend({
         'openYoutubeEmbed',
         'copyYoutubeEmbed',
         'openInvidious',
-        'copyInvidious'
+        'copyInvidious',
+        'openYoutubeChannel',
+        'copyYoutubeChannel'
       ]
     }
   },
@@ -97,6 +99,10 @@ export default Vue.extend({
       return `https://youtu.be/${this.id}`
     },
 
+    youtubeChannelUrl: function () {
+      return `https://youtube.com/channel/${this.channelId}`
+    },
+
     youtubeEmbedUrl: function () {
       return `https://www.youtube-nocookie.com/embed/${this.id}`
     },
@@ -112,7 +118,9 @@ export default Vue.extend({
         this.$t('Video.Open YouTube Embedded Player'),
         this.$t('Video.Copy YouTube Embedded Player Link'),
         this.$t('Video.Open in Invidious'),
-        this.$t('Video.Copy Invidious Link')
+        this.$t('Video.Copy Invidious Link'),
+        this.$t('Video.Open Channel in YouTube'),
+        this.$t('Video.Copy YouTube Channel Link')
       ]
 
       if (this.watched) {
@@ -206,6 +214,18 @@ export default Vue.extend({
             console.log('using electron')
             const shell = require('electron').shell
             shell.openExternal(this.invidiousUrl)
+          }
+          break
+        case 'copyYoutubeChannel':
+          navigator.clipboard.writeText(this.youtubeChannelUrl)
+          this.showToast({
+            message: this.$t('Share.YouTube Channel URL copied to clipboard')
+          })
+          break
+        case 'openYoutubeChannel':
+          if (this.usingElectron) {
+            const shell = require('electron').shell
+            shell.openExternal(this.youtubeChannelUrl)
           }
           break
       }

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -394,6 +394,8 @@ Video:
   Copy YouTube Embedded Player Link: Copy YouTube Embedded Player Link
   Open in Invidious: Open in Invidious
   Copy Invidious Link: Copy Invidious Link
+  Open Channel in YouTube: Open Channel in YouTube
+  Copy YouTube Channel Link: Copy YouTube Channel Link
   View: View
   Views: Views
   Loop Playlist: Loop Playlist
@@ -508,6 +510,8 @@ Share:
   Invidious Embed URL copied to clipboard: Invidious Embed URL copied to clipboard
   YouTube URL copied to clipboard: YouTube URL copied to clipboard
   YouTube Embed URL copied to clipboard: YouTube Embed URL copied to clipboard
+  YouTube Channel URL copied to clipboard: YouTube Channel URL copied to clipboard
+
 Mini Player: Mini Player
 Comments:
   Comments: Comments

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -396,6 +396,8 @@ Video:
   Copy Invidious Link: Copy Invidious Link
   Open Channel in YouTube: Open Channel in YouTube
   Copy YouTube Channel Link: Copy YouTube Channel Link
+  Open Channel in Invidious: Open Channel in Invidious
+  Copy Invidious Channel Link: Copy Invidious Channel Link
   View: View
   Views: Views
   Loop Playlist: Loop Playlist
@@ -508,6 +510,7 @@ Share:
   # On Click
   Invidious URL copied to clipboard: Invidious URL copied to clipboard
   Invidious Embed URL copied to clipboard: Invidious Embed URL copied to clipboard
+  Invidious Channel URL copied to clipboard: Invidious Channel URL copied to clipboard
   YouTube URL copied to clipboard: YouTube URL copied to clipboard
   YouTube Embed URL copied to clipboard: YouTube Embed URL copied to clipboard
   YouTube Channel URL copied to clipboard: YouTube Channel URL copied to clipboard


### PR DESCRIPTION
---
Add Open/Copy Channel URL to video dropdown
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#706 

**Description**
Added an option to copy/open the Channel URL from video dropdown


**Screenshots (if appropriate)**
![openChannel](https://user-images.githubusercontent.com/37299563/96983091-568ab600-1520-11eb-9ac6-e38b1f1d1ee3.png)

**Testing (for code that is not small enough to be easily understandable)**
basic testing for multiple channels. Tested some locales too, shows English text I've added.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.9.1

