### PR TITLE
Added ability to change volume with scroll wheel

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -193,7 +193,9 @@ export default Vue.extend({
 
         this.player.on('mousemove', this.hideMouseTimeout)
         this.player.on('mouseleave', this.removeMouseTimeout)
+
         this.player.on('volumechange', this.updateVolume)
+        this.player.controlBar.getChild('volumePanel').on('mousewheel', this.mouseScrollVolume)
 
         const v = this
 
@@ -214,6 +216,25 @@ export default Vue.extend({
     updateVolume: function (event) {
       const volume = this.player.volume()
       sessionStorage.setItem('volume', volume)
+    },
+
+    mouseScrollVolume: function (event) {
+      if (event.target) {
+        event.preventDefault()
+
+        if (this.player.muted() && event.wheelDelta > 0) {
+          this.player.muted(false)
+          this.player.volume(0)
+        }
+
+        if (!this.player.muted()) {
+          if (event.wheelDelta > 0) {
+            this.changeVolume(0.05)
+          } else if (event.wheelDelta < 0) {
+            this.changeVolume(-0.05)
+          }
+        }
+      }
     },
 
     determineFormatType: function () {


### PR DESCRIPTION
---
Added ability to change volume with scroll wheel
---

**Pull Request Type**
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Fixes #573 

**Description**
As the title suggests, I was finally able to figure out how to enable volume scroll on hover. Now, when the user hovers over the volume panel the user can change the volume with a wheel scroll. 

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: 1909
 - FreeTube version: 0.9

**Additional context**
Sorry for the re-post. 