### PR TITLE
Changed title of Watch view to title of the video

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -413,6 +413,7 @@ export default Vue.extend({
           }
 
           this.isLoading = false
+          this.updateTitle()
         })
         .catch(err => {
           const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -578,6 +579,7 @@ export default Vue.extend({
           }
 
           this.isLoading = false
+          this.updateTitle()
         })
         .catch(err => {
           const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -618,7 +620,6 @@ export default Vue.extend({
         type: 'video'
       }
 
-      this.updateTitle()
       this.updateHistory(videoData)
     },
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -992,14 +992,6 @@ export default Vue.extend({
 
     updateTitle: function () {
       document.title = `${this.videoTitle} - FreeTube`
-
-      // simulates a reload to update the title after fetching it
-      this.$router.go({
-        path: this.$router.path,
-        query: {
-          t: +new Date()
-        }
-      })
     },
 
     ...mapActions([

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -618,6 +618,7 @@ export default Vue.extend({
         type: 'video'
       }
 
+      this.updateTitle()
       this.updateHistory(videoData)
     },
 
@@ -986,6 +987,18 @@ export default Vue.extend({
 
     getTimestamp: function () {
       return Math.floor(this.getWatchedProgress())
+    },
+
+    updateTitle: function () {
+      document.title = `${this.videoTitle} - FreeTube`
+
+      // simulates a reload to update the title after fetching it
+      this.$router.go({
+        path: this.$router.path,
+        query: {
+          t: +new Date()
+        }
+      })
     },
 
     ...mapActions([


### PR DESCRIPTION
---
Changed Title of Watch view 
---
**Pull Request Type**
- [ ] Bugfix
- [ ] Feature Implementation
- [x] Enhancement

**Related issue**
Fixes #702 

**Description**
I have changed the title of the Watch view from the generic "Watch - FreeTube" to now show the title of the video instead

**Screenshots (if appropriate)**
![pr](https://user-images.githubusercontent.com/59970326/97354404-b01a1a00-186b-11eb-9627-fa15242ec88c.JPG)

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: 1909
 - FreeTube version: 0.9

**Additional context**
I wasn't sure exactly where to call my updateTitle function. I decided to call it in addToHistory because 
that will get called once for every video. Let me know if you have a better spot for it or want me to change anything.