### PR TITLE
Added selection of resolution > 1080p for all devices.

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -159,7 +159,13 @@ export default Vue.extend({
           await this.determineDefaultQualityLegacy()
         }
 
-        this.player = videojs(videoPlayer)
+        this.player = videojs(videoPlayer, {
+          html5: {
+            vhs: {
+              limitRenditionByPlayerDimensions: false
+            }
+          }
+        })
 
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)


### PR DESCRIPTION
---
Added selection of resolution > 1080p for all devices.
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Description**
Resolutions higher than 1080p that have a mp4 file available can be selected even on monitors with less resolution. 

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.9.1 Nightly

**Additional context**
Sometimes the player stutters due to the immense amount of data. E.g. when playing 8k
