### PR TITLE
Sort countries by name instead of ID

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -130,7 +130,7 @@ const actions = {
       fileData = fs.readFileSync(`${fileLocation}en-US/countries.json`)
     }
     const countries = JSON.parse(fileData).map((entry) => { return { id: entry.id, name: entry.name, code: entry.alpha2 } })
-    countries.sort((a, b) => { return a.id - b.id })
+    countries.sort((a, b) => { return a.name - b.name })
 
     const regionNames = countries.map((entry) => { return entry.name })
     const regionValues = countries.map((entry) => { return entry.code })


### PR DESCRIPTION
---
Sort countries by name instead of ID
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to.

**Description**
In the countries dropdown in settings, instead of sorting by id sort countries by their name to make it easier to search through the list visually. The order may be OK in English locale, but when you switch to a different language countries get out of order.

**Screenshots (if appropriate)**

Before:

![countries_before](https://user-images.githubusercontent.com/4525736/97671879-45f3b600-1ab3-11eb-870f-0fabab82b051.png)

After:

![countries_after](https://user-images.githubusercontent.com/4525736/97671890-49873d00-1ab3-11eb-8baa-e608437452fe.png)

**Testing (for code that is not small enough to be easily understandable)**
Yes, I tested it locally with Russian and English locales.
