### PR TITLE
Fix label text overlow in sidebar

### DIFF
--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -60,6 +60,7 @@
 
 .navLabel {
   margin-left: 5px;
+  margin-bottom: 0;
   display: inline-block;
 }
 
@@ -106,7 +107,7 @@
 
 .closed .navOption {
   width: 100%;
-  height: 40px;
+  min-height: 40px;
   padding: 0px;
   padding-top: 10px;
   padding-bottom: 10px;


### PR DESCRIPTION
---
Fix label text overlow in sidebar
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
-

**Description**

In Russian locale, the text in sidebar buttons becomes too long (`.navLabel`) and overflows the parent element (`.navOption`), which doesn't look nice.

**Screenshots (if appropriate)**

Before:

![before](https://user-images.githubusercontent.com/4525736/97671492-9585b200-1ab2-11eb-976b-ab56a41bb027.png)

After:

![after](https://user-images.githubusercontent.com/4525736/97671507-99b1cf80-1ab2-11eb-97b8-efb2aa1d79c1.png)


**Testing (for code that is not small enough to be easily understandable)**
-