### PR TITLE
Implement frame by frame advance using keyboard shortcuts

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -671,12 +671,12 @@ export default Vue.extend({
             event.preventDefault()
             this.changeDurationByPercentage(0)
             break
-          case 90:
+          case 188:
             // Z Key
             // Return to previous frame
             this.framebyframe(-1)
             break
-          case 88:
+          case 190:
             // X Key
             // Advance to next frame
             this.framebyframe(1)

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -445,18 +445,13 @@ export default Vue.extend({
 
     framebyframe: function (step) {
       this.player.pause()
+      const qualityHeight = this.useDash ? this.player.qualityLevels()[this.player.qualityLevels().selectedIndex].height : 0
       let fps
       // Non-Dash formats are 30fps only
-      if (!this.useDash) {
-        fps = 30
-      } else if (this.player.qualityLevels()[this.player.qualityLevels().selectedIndex].height <= 480) {
-        fps = 30
+      if (qualityHeight >= 480 && this.maxFramerate === 60) {
+        fps = 60
       } else {
-        if (this.maxFramerate === 60) {
-          fps = 60
-        } else {
-          fps = 30
-        }
+        fps = 30
       }
       // The 3 lines below were taken from the videojs-framebyframe node module by Helena Rasche
       const frameTime = 1 / fps

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -672,12 +672,12 @@ export default Vue.extend({
             this.changeDurationByPercentage(0)
             break
           case 188:
-            // Z Key
+            // , Key
             // Return to previous frame
             this.framebyframe(-1)
             break
           case 190:
-            // X Key
+            // . Key
             // Advance to next frame
             this.framebyframe(1)
             break

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -254,14 +254,16 @@ export default Vue.extend({
     },
 
     determineMaxFramerate: function() {
-      fs.readFile(this.dashSrc[0].url, (err, data) => {
-        if (err) throw err
-        if (data.includes('frameRate="60"')) {
-          this.maxFramerate = 60
-        } else {
-          this.maxFramerate = 30
-        }
-      })
+      if (this.dashSrc[0] !== undefined) {
+        fs.readFile(this.dashSrc[0].url, (err, data) => {
+          if (err) throw err
+          if (data.includes('frameRate="60"')) {
+            this.maxFramerate = 60
+          } else {
+            this.maxFramerate = 30
+          }
+        })
+      }
     },
 
     determineDefaultQualityLegacy: function () {
@@ -448,7 +450,7 @@ export default Vue.extend({
       } else if (this.player.qualityLevels()[this.player.qualityLevels().selectedIndex].height <= 480) {
         fps = 30
       } else {
-        if (this.maxFramerate === 60) {
+        if (this.maxFramerate !== 30) {
           fps = 60
         } else {
           fps = 30

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -61,6 +61,7 @@ export default Vue.extend({
       useDash: false,
       useHls: false,
       selectedDefaultQuality: '',
+      maxFramerate: 0,
       activeSourceList: [],
       mouseTimeout: null,
       dataSetup: {
@@ -254,16 +255,17 @@ export default Vue.extend({
     },
 
     determineMaxFramerate: function() {
-      if (this.dashSrc[0] !== undefined) {
-        fs.readFile(this.dashSrc[0].url, (err, data) => {
-          if (err) throw err
-          if (data.includes('frameRate="60"')) {
-            this.maxFramerate = 60
-          } else {
-            this.maxFramerate = 30
-          }
-        })
-      }
+      fs.readFile(this.dashSrc[0].url, (err, data) => {
+        if (err) {
+          this.maxFramerate = 60
+          return
+        }
+        if (data.includes('frameRate="60"')) {
+          this.maxFramerate = 60
+        } else {
+          this.maxFramerate = 30
+        }
+      })
     },
 
     determineDefaultQualityLegacy: function () {
@@ -450,7 +452,7 @@ export default Vue.extend({
       } else if (this.player.qualityLevels()[this.player.qualityLevels().selectedIndex].height <= 480) {
         fps = 30
       } else {
-        if (this.maxFramerate !== 30) {
+        if (this.maxFramerate === 60) {
           fps = 60
         } else {
           fps = 30


### PR DESCRIPTION
---
Implement frame by frame advance using keyboard shortcuts
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#730 

**Description**
Enables advancing and returning to the next or previous frame by pressing Z or X, respectively.

**Testing (for code that is not small enough to be easily understandable)**
Open a video and press Z or X to move ahead or behind one frame.
Tested on both local and Invidious APIs, resolutions equal and above 720p and those below, dash and legacy file formats, on videos without a 60fps option for higher resolutions and those with it.

**Desktop**
 - OS: Artix
 - OS Version: N/A
 - FreeTube version: v0.9.2

**Additional context**
I settled on Z and X because those were the free keys that felt most natural to me.