### PR TITLE
Error handling update of comment scraper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18346,9 +18346,9 @@
       }
     },
     "yt-comment-scraper": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.8.tgz",
-      "integrity": "sha512-THyK1BfO36NuvcfKiDkdPtHpIdJ7sRsSVqJL6UblMxo5xEarAv3qZO8PB1FvpKto5SuxUmA8fZigNESV6mFTdA==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.9.tgz",
+      "integrity": "sha512-oMeHTLUjMhxhUdVxw7P7ea00YJnkWF3VPaoHk62WO4kHMLL16AvCx8x1Z6j6XW6CsTpDE/0PejqKeB2+83pLgA==",
       "requires": {
         "axios": "^0.19.2",
         "html2json": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "youtube-chat": "^1.1.0",
     "youtube-suggest": "^1.1.0",
     "yt-channel-info": "^1.1.4",
-    "yt-comment-scraper": "^1.3.8",
+    "yt-comment-scraper": "^1.3.9",
     "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.4",
     "yt-xml2vtt": "^1.1.3",


### PR DESCRIPTION
---
Error handling update of comment scraper
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Description**
A contributor added proper error handling to the comment extraction, which should prevent the extraction from erroring out after the HTML is converted to JSON.

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

**Testing (for code that is not small enough to be easily understandable)**
Yes on a few videos in only the module but also in the dev mode in FreeTube

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: 0.92
