### PR TITLE
Fixing wrong url parameter for YouTube video links with timestamp

### DIFF
--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -127,6 +127,9 @@ export default Vue.extend({
     },
 
     getFinalUrl(url) {
+      if (url.indexOf('?') === -1) {
+        return this.includeTimestamp ? `${url}?t=${this.getTimestamp()}` : url
+      }
       return this.includeTimestamp ? `${url}&t=${this.getTimestamp()}` : url
     },
 

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -69,6 +69,7 @@ export default Vue.extend({
 
       console.log('getting local trending')
       ytrend.scrape_trending_page(this.region).then((result) => {
+        console.log(result)
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
         })

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -69,7 +69,6 @@ export default Vue.extend({
 
       console.log('getting local trending')
       ytrend.scrape_trending_page(this.region).then((result) => {
-        console.log(result)
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
         })


### PR DESCRIPTION
---
Fixing wrong url parameter for YouTube video links with timestamp
---
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes issue #784 

**Description**
The code checks if a '?' is already in the URL, so another URL parameter is already available. If not, then the '&' which is usually used for timestamps is swapped with a '?' to make the URL valid.
