### PR TITLE
Fixed comment loading issue upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18429,9 +18429,9 @@
       }
     },
     "yt-comment-scraper": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.9.tgz",
-      "integrity": "sha512-oMeHTLUjMhxhUdVxw7P7ea00YJnkWF3VPaoHk62WO4kHMLL16AvCx8x1Z6j6XW6CsTpDE/0PejqKeB2+83pLgA==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-1.3.10.tgz",
+      "integrity": "sha512-tKVVOaClFzOnx+eS7k2ClpovvPAeilLC2Y57mmBDDMIoHPNWy8DMDHa5f8CJNLiIhXQiDSd1ugdluer1qKttsQ==",
       "requires": {
         "axios": "^0.19.2",
         "html2json": "^1.0.2"
@@ -18510,25 +18510,17 @@
       }
     },
     "ytpl": {
-      "version": "2.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/ytpl/-/ytpl-2.0.0-alpha.1.tgz",
-      "integrity": "sha512-YKHfoYV7jkC/PjvcJe+GfBC4KPl9sXSIcHW0B0/ohYyv+BLlykeV6fM3olzQ0rT6LGhUK3qPgitqui8Py9bveA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ytpl/-/ytpl-1.0.1.tgz",
+      "integrity": "sha512-v2TGepCZSoVYZAAPoHIz1Hr+auGBJb11npBY4PLAofAdQFlJMopGodmv3JENkW1ghxBW94CASfyOJ9bgpb+nEg==",
       "requires": {
         "html-entities": "^1.3.1",
-        "miniget": "^4.1.0"
-      },
-      "dependencies": {
-        "miniget": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.1.0.tgz",
-          "integrity": "sha512-kzhrNv5L7LlomwGmPGQsLQ2PnT1LeJJWfB0wNFGyv426gEM1gsfziBQmfkr6XOBA8EusZg9nowlNT5CbuKTjZg=="
-        }
+        "miniget": "^2.0.1"
       }
     },
     "ytsr": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/ytsr/-/ytsr-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-NELl/ubEnBxxU/AofsXu8p6T2BArf/ROLOocblTgeSr7oNPPn6jPv57MCT4cIWJdzxWiHcdl6BqrypoIPejfmw==",
+      "version": "github:TimeForANinja/node-ytsr#9899ee9588401e881e86f59b8c7b31e770a485a5",
+      "from": "github:TimeForANinja/node-ytsr#wip-api-adjustments",
       "requires": {
         "html-entities": "^1.3.1",
         "miniget": "^4.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18510,17 +18510,24 @@
       }
     },
     "ytpl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ytpl/-/ytpl-1.0.1.tgz",
-      "integrity": "sha512-v2TGepCZSoVYZAAPoHIz1Hr+auGBJb11npBY4PLAofAdQFlJMopGodmv3JENkW1ghxBW94CASfyOJ9bgpb+nEg==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/ytpl/-/ytpl-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-dMA3YaIhR/xfA9WVBV17nI1PAHtwHoKqn5OlgC4vEfzLmV9VGo1BJM0p51FcQXDDgbC/EPZJbNCPmecXs5zO6w==",
       "requires": {
         "html-entities": "^1.3.1",
-        "miniget": "^2.0.1"
+        "miniget": "^4.1.0"
+      },
+      "dependencies": {
+        "miniget": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.1.0.tgz",
+          "integrity": "sha512-kzhrNv5L7LlomwGmPGQsLQ2PnT1LeJJWfB0wNFGyv426gEM1gsfziBQmfkr6XOBA8EusZg9nowlNT5CbuKTjZg=="
+        }
       }
     },
     "ytsr": {
-      "version": "github:TimeForANinja/node-ytsr#9899ee9588401e881e86f59b8c7b31e770a485a5",
-      "from": "github:TimeForANinja/node-ytsr#wip-api-adjustments",
+      "version": "2.0.0-alpha.3",
+      "resolved": "github:TimeForANinja/node-ytsr#9899ee9588401e881e86f59b8c7b31e770a485a5",
       "requires": {
         "html-entities": "^1.3.1",
         "miniget": "^4.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4291,6 +4291,15 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.5.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "chownr": {
@@ -7862,9 +7871,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.4",
     "yt-xml2vtt": "^1.1.3",
-    "ytdl-core": "^4.0.6",
-    "ytpl": "^1.0.1",
-    "ytsr": "github:TimeForANinja/node-ytsr#wip-api-adjustments"
+    "ytdl-core": "^4.1.1",
+    "ytpl": "^2.0.0-alpha.1",
+    "ytsr": "^2.0.0-alpha.3"
   },
   "description": "A private YouTube client",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
     "youtube-chat": "^1.1.0",
     "youtube-suggest": "^1.1.0",
     "yt-channel-info": "^1.1.4",
-    "yt-comment-scraper": "^1.3.9",
+    "yt-comment-scraper": "^1.3.10",
     "yt-dash-manifest-generator": "^1.1.0",
     "yt-trending-scraper": "^1.0.4",
     "yt-xml2vtt": "^1.1.3",
-    "ytdl-core": "^4.1.1",
-    "ytpl": "^2.0.0-alpha.1",
-    "ytsr": "^2.0.0-alpha.3"
+    "ytdl-core": "^4.0.6",
+    "ytpl": "^1.0.1",
+    "ytsr": "github:TimeForANinja/node-ytsr#wip-api-adjustments"
   },
   "description": "A private YouTube client",
   "devDependencies": {


### PR DESCRIPTION
---
Fixed comment loading issue upstream
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation


**Description**
The comments module only returned empty objects due to a problem with encoding in the XSRF token received from the comments page.


**Testing (for code that is not small enough to be easily understandable)**
Tested in the module itself and when running FreeTube in dev mode

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.9.2 nightly

**Additional context**
For anyone searching similar problems, here a short description to get it indexed by search engines: The HTML page of Youtube encoded the '=' sign in the XSRF token, which is required to access comments, in Unicode for some reason (so \u003d) which then is not converted back when sending the Ajax request for the comment data. This leads to a wrong token and therefore no data
