### PR TITLE
Fixed tooltip position

### DIFF
--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -14,7 +14,7 @@
       <ft-tooltip
         v-if="tooltip !== ''"
         class="selectTooltip"
-        position="right"
+        position="bottom"
         :tooltip="tooltip"
       />
     </label>

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -21,7 +21,7 @@
       <ft-tooltip
         v-if="tooltip !== ''"
         class="selectTooltip"
-        position = "bottom-left"
+        position="bottom-left"
         :tooltip="tooltip"
       />
     </label>

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -21,6 +21,7 @@
       <ft-tooltip
         v-if="tooltip !== ''"
         class="selectTooltip"
+        position = "bottom-left"
         :tooltip="tooltip"
       />
     </label>

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -57,6 +57,14 @@
   transform: translate(-50%, -1em);
 }
 
+.text.bottom-left {
+  margin-top: 1em;
+  top: 100%;
+  left: -50px;
+  -webkit-transform: translate(-50%, -1em);
+  transform: translate(-50%, -1em);
+}
+
 .text.left {
   margin-right:1em;
   right: 100%;

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -15,6 +15,8 @@
 
 .button:focus + .text.bottom,
 .button:hover + .text.bottom,
+.button:hover + .text.bottom-left,
+.button:hover + .text.bottom-left,
 .button:focus + .text.top,
 .button:hover + .text.top {
   -webkit-transform: translate(-50%, 0);
@@ -60,7 +62,7 @@
 .text.bottom-left {
   margin-top: 1em;
   top: 100%;
-  left: -50px;
+  left: -100px;
   -webkit-transform: translate(-50%, -1em);
   transform: translate(-50%, -1em);
 }

--- a/src/renderer/components/ft-tooltip/ft-tooltip.js
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.js
@@ -7,7 +7,7 @@ export default Vue.extend({
     position: {
       type: String,
       default: 'bottom',
-      validator: (value) => value === 'bottom' || value === 'left' || value === 'right' || value === 'top'
+      validator: (value) => value === 'bottom' || value === 'left' || value === 'right' || value === 'top' || value === 'bottom-left'
     },
     tooltip: {
       type: String,


### PR DESCRIPTION
---
Fixed the improper position of a few Tooltip components on the Settings page
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
#794 

**Description**
This fixes theimproper position of Tooptip on the Settings page with some added extra styles and positions.

**Screenshots (if appropriate)**
![Screenshot (285)](https://user-images.githubusercontent.com/43727167/101205558-cea5d900-3693-11eb-80c3-37094d8d9807.png)
![Screenshot (284)](https://user-images.githubusercontent.com/43727167/101205563-d1083300-3693-11eb-9422-a9833a2da1e1.png)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: latest

**Additional context**
Add any other context about the problem here.
