### PR TITLE
[issue-782] Added goToChannel function to redirect the comment author's channel

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -245,6 +245,7 @@ export default Vue.extend({
 
         const commentData = response.comments.map((comment) => {
           comment.showReplies = false
+          comment.authorLink = comment.authorLink[1]
           comment.authorThumb = comment.authorThumbnails[1].url.replace('https://yt3.ggpht.com', `${this.invidiousInstance}/ggpht/`)
           if (this.hideCommentLikes) {
             comment.likes = null
@@ -313,6 +314,7 @@ export default Vue.extend({
 
         const commentData = response.comments.map((comment) => {
           comment.showReplies = false
+          comment.authorLink = comment.authorLink[1]
           comment.authorThumb = comment.authorThumbnails[1].url.replace('https://yt3.ggpht.com', `${this.invidiousInstance}/ggpht/`)
           if (this.hideCommentLikes) {
             comment.likes = null
@@ -348,6 +350,9 @@ export default Vue.extend({
       })
     },
 
+    goToChannel: function (channelId) {
+      this.$router.push({ path: `${channelId}` })
+    },
     ...mapActions([
       'showToast',
       'toLocalePublicationString',

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -48,6 +48,7 @@
         <img
           :src="comment.authorThumb"
           class="commentThumbnail"
+          @click="goToChannel(comment.authorLink)"
         >
         <p class="commentAuthor">
           {{ comment.author }}


### PR DESCRIPTION
---
Title
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [X ] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to.
#782 

**Description**
Please write a clear and concise description of what the pull request does.

Added the function to redirect the comment author's channel when clicking the thumbnails in the video comment section.
Only two files are changed : 
src/renderer/components/watch-video-comments/watch-video-comments.js
src/renderer/components/watch-video-comments/watch-video-comments.vue

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

https://youtu.be/FHSUa8OfgTw

![image](https://user-images.githubusercontent.com/50673489/101588956-80574980-39b5-11eb-9f58-3d7734eedf39.png)
![image](https://user-images.githubusercontent.com/50673489/101588961-84836700-39b5-11eb-91ed-8d2fe9719e74.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Window
 - OS Version: [e.g. 22] 10
 - FreeTube version: [e.g. 0.8]

**Additional context**
Add any other context about the problem here.
