### PR TITLE
Open youtube links in description in Freetube

### DIFF
--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -32,7 +32,6 @@ export default Vue.extend({
     if (this.description !== '') {
       this.shownDescription = autolinker.link(this.description)
       this.shownDescription = this.parseDescriptionHtml(this.shownDescription)
-      
     } else {
       this.shownDescription = autolinker.link(this.description)
     }

--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -29,8 +29,10 @@ export default Vue.extend({
     }
   },
   mounted: function () {
-    if (this.descriptionHtml !== '') {
-      this.shownDescription = this.parseDescriptionHtml(this.descriptionHtml)
+    if (this.description !== '') {
+      this.shownDescription = autolinker.link(this.description)
+      this.shownDescription = this.parseDescriptionHtml(this.shownDescription)
+      
     } else {
       this.shownDescription = autolinker.link(this.description)
     }
@@ -55,12 +57,10 @@ export default Vue.extend({
       descriptionText = descriptionText.replace(/&v.+?(?=")/g, '')
       descriptionText = descriptionText.replace(/&redirect-token.+?(?=")/g, '')
       descriptionText = descriptionText.replace(/&redir_token.+?(?=")/g, '')
-      descriptionText = descriptionText.replace(/href="http(s)?:\/\/youtube\.com/g, 'href="freetube://https://youtube.com')
+      descriptionText = descriptionText.replace(/href="http(s)?:\/\/(www\.)?youtube\.com/g, 'href="freetube://https://youtube.com')
       descriptionText = descriptionText.replace(/href="\/watch/g, 'href="freetube://https://youtube.com')
-      descriptionText = descriptionText.replace(/(.*?)/,'testing')
       descriptionText = descriptionText.replace(/href="\/results\?search_query=/g, 'href="freetube://')
       descriptionText = descriptionText.replace(/yt\.www\.watch\.player\.seekTo/g, 'changeDuration')
-
       return descriptionText
     }
   }

--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -57,6 +57,7 @@ export default Vue.extend({
       descriptionText = descriptionText.replace(/&redir_token.+?(?=")/g, '')
       descriptionText = descriptionText.replace(/href="http(s)?:\/\/youtube\.com/g, 'href="freetube://https://youtube.com')
       descriptionText = descriptionText.replace(/href="\/watch/g, 'href="freetube://https://youtube.com')
+      descriptionText = descriptionText.replace(/(.*?)/,'testing')
       descriptionText = descriptionText.replace(/href="\/results\?search_query=/g, 'href="freetube://')
       descriptionText = descriptionText.replace(/yt\.www\.watch\.player\.seekTo/g, 'changeDuration')
 


### PR DESCRIPTION
---
Open youtube links in description in Freetube
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Fixes #811 

**Description**
This pull request allows the user to click on a youtube link and have it open in Freetube

**Testing (for code that is not small enough to be easily understandable)**
Tested manually by clicking youtube links in the description.

**Desktop (please complete the following information):**
 - OS: Mac OS
 - OS Version: 10.15.7
 - FreeTube version:  v0.9.3

**Additional context**
Originally the description actually never got parsed because the if statements was checking if descriptionHtml was null or not, we don't want to check descriptionHtml, we actually want to check this.description afterwards there was a just a little regex issue that I fixed afterwards.
