### PR TITLE
Added config variable for portable settings store

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,6 +2,20 @@ import { app, BrowserWindow, Menu, ipcMain, screen } from 'electron'
 import { productName } from '../../package.json'
 import Datastore from 'nedb'
 
+const path = require('path')
+
+// Set app directory before loading user modules
+if (process.env.FREETUBE_APPDATA_DIR != null) {
+  app.setPath('appData', process.env.FREETUBE_APPDATA_DIR)
+  app.setPath('userData', path.join(app.getPath('appData')))
+} else if (process.env.PORTABLE_EXECUTABLE_DIR != null) {
+  app.setPath('appData', process.env.PORTABLE_EXECUTABLE_DIR, `${app.name}AppData`)
+  app.setPath('userData', path.join(app.getPath('appData'), `${app.name}AppData`))
+} else if (process.platform === 'win32') {
+  app.setPath('appData', process.env.APPDATA)
+  app.setPath('userData', path.join(app.getPath('appData'), app.name))
+}
+
 require('electron-context-menu')({
   showSearchWithGoogle: false,
   showSaveImageAs: true,
@@ -21,7 +35,6 @@ app.setName(productName)
 
 // disable electron warning
 process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true'
-const path = require('path')
 const isDev = process.env.NODE_ENV === 'development'
 const isDebug = process.argv.includes('--debug')
 let mainWindow


### PR DESCRIPTION
---
Added config variable for portable settings store
---

**Important note**
Backup your settings from `%AppData%\Roaming\FreeTube`

**Pull Request Type**

- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Fixes #130 Fixes #746

**Description**
This PR add a config variable `FREETUBE_APPDATA_DIR` for portable settings store in a custom folder.

**Testing (for code that is not small enough to be easily understandable)**

1. Backup your settings from `%AppData%\Roaming\FreeTube` and rename/remove the `FreeTube` folder
2. Windows users should use the zipped portable version, not the portable exe
3. In the folder where the `FreeTube.exe` lives:
   * create a shortcut and add `%comspec% /c set FREETUBE_APPDATA_DIR=%CD%\Data&& FreeTube.exe` to the `Target` field.
OR
   * create a batch file containing:
```bat
set FREETUBE_APPDATA_DIR=%CD%\Data
FreeTube.exe
```
4. Run the shortcut or the batch file. In both case the `cmd.exe` will be running (don't close it) and the `Data` folder will be created in the same folder as `FreeTube.exe`

**Any ramifications remaining**
1. The empty folder `%AppData%\Roaming\FreeTube\Dictionaries` is created
2. The registry key for the browser extension is added to `HKCU\Software\Classes\freetube`

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 7 (build 7601.0)
 - FreeTube version: 0.9.3 nightly

**Additional context**
1. The code is taken from https://github.com/getferdi/ferdi/blob/develop/src/index.js#L13:L23
2. The issues with the empty folder and the registry key can be solved with the portable launcher
