### PR TITLE
Fix 0 (dis)likes displayed as NaN

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -264,8 +264,8 @@ export default Vue.extend({
             this.videoLikeCount = null
             this.videoDislikeCount = null
           } else {
-            this.videoLikeCount = result.videoDetails.likes
-            this.videoDislikeCount = result.videoDetails.dislikes
+            this.videoLikeCount = isNaN(result.videoDetails.likes) ? 0 : result.videoDetails.likes
+            this.videoDislikeCount = isNaN(result.videoDetails.dislikes) ? 0 : result.videoDetails.dislikes
           }
           this.isLive = result.player_response.videoDetails.isLive
           this.isLiveContent = result.player_response.videoDetails.isLiveContent


### PR DESCRIPTION
---
Fix 0 (dis)likes displayed as NaN
--

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes #897 

**Description**
It simply checks whether the value of likes and dislikes from ytdl-core is NaN, which means it is 0 on the webpage and if so replaces it with 0

**Testing (for code that is not small enough to be easily understandable)**
Tested on a few videos with 0 likes and dislikes

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: v10.0.0

