### PR TITLE
Saving favorite videos for later

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -170,8 +170,9 @@ export default Vue.extend({
   methods: {
     toggleSave: function () {
       console.log('TODO: ft-list-video method toggleSave')
+      this.writeFavoriteToIntermediateFile({ id: this.data.videoId, title: this.data.title, channel: this.data.author, channelId: this.data.authorId, viewCount: this.data.viewCount, duration: this.data.lengthSeconds, uploadedTime: this.data.publishedDate })
       this.showToast({
-        message: this.$t('Saving videos are currently not available.  Please wait for a future update')
+        message: this.$t('Currently only saving is supported.')
       })
     },
 
@@ -396,7 +397,8 @@ export default Vue.extend({
       'showToast',
       'toLocalePublicationString',
       'updateHistory',
-      'removeFromHistory'
+      'removeFromHistory',
+      'writeFavoriteToIntermediateFile'
     ])
   }
 })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -54,7 +54,6 @@ const state = {
     '#DD2C00'
   ]
 }
-
 const getters = {
   getIsSideNavOpen () {
     return state.isSideNavOpen
@@ -106,6 +105,7 @@ const getters = {
 }
 
 const actions = {
+
   updateShowProgressBar ({ commit }, value) {
     commit('setShowProgressBar', value)
   },
@@ -379,6 +379,15 @@ const actions = {
 
   showToast (_, payload) {
     FtToastEvents.$emit('toast-open', payload.message, payload.action, payload.time)
+  },
+
+  writeFavoriteToIntermediateFile(_, videoData) {
+    if (process.env.NODE_ENV === 'development') {
+      fs.appendFileSync('./favorites.json', JSON.stringify(videoData) + '\n')
+    } else {
+      const electron = require('electron')
+      fs.appendFileSync(`${electron.remote.app.getPath('userData')}/favorites.json`, JSON.stringify(videoData) + '\n')
+    }
   }
 }
 


### PR DESCRIPTION
---
Saving favorite videos for later
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Description**
At the moment no function to save favorite videos is available due to the absence of the major playlist feature. Because this feature will 100% come in the future, I added the possibility to use the favorite button already to save the videos in an intermediate JSON format, which then can be imported later when the playlists are available

**Testing (for code that is not small enough to be easily understandable)**
Writing to the file was tested in dev and non-dev mode. 

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: v10.0.0

**Additional context**
File lies in the user data folder as favorites.json
