### PR TITLE
feat: added setting to always play videos in fullscreen

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -141,6 +141,10 @@ export default Vue.extend({
       return this.$store.getters.getDefaultVideoFormat
     },
 
+    defaultFullScreenMode: function () {
+      return this.$store.getters.getDefaultFullScreenMode
+    },
+
     autoplayVideos: function () {
       return this.$store.getters.getAutoplayVideos
     }
@@ -203,6 +207,11 @@ export default Vue.extend({
             }
           }
         })
+
+        if(this.defaultFullScreenMode){
+          this.player.requestFullscreen();
+        }
+       
 
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -208,10 +208,6 @@ export default Vue.extend({
           }
         })
 
-        if (this.defaultFullScreenMode) {
-          this.player.requestFullscreen()
-        }
-
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)
 
@@ -259,6 +255,7 @@ export default Vue.extend({
 
         this.player.on('ended', function () {
           v.$emit('ended')
+          v.player.exitFullscreen()
         })
 
         this.player.on('error', function (error, message) {
@@ -266,6 +263,9 @@ export default Vue.extend({
         })
 
         this.player.on('play', function () {
+          if (v.defaultFullScreenMode) {
+            v.player.requestFullscreen()
+          }
           if (this.usingElectron) {
             const { powerSaveBlocker } = require('electron')
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -208,10 +208,9 @@ export default Vue.extend({
           }
         })
 
-        if(this.defaultFullScreenMode){
-          this.player.requestFullscreen();
+        if (this.defaultFullScreenMode) {
+          this.player.requestFullscreen()
         }
-       
 
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -82,6 +82,10 @@ export default Vue.extend({
       return this.$store.getters.getDefaultTheatreMode
     },
 
+    defaultFullScreenMode: function () {
+      return this.$store.getters.getDefaultFullScreenMode
+    },
+
     hideRecommendedVideos: function () {
       return this.$store.getters.getHideRecommendedVideos
     },
@@ -119,6 +123,7 @@ export default Vue.extend({
       'updateForceLocalBackendForLegacy',
       'updateProxyVideos',
       'updateDefaultTheatreMode',
+      'updateDefaultFullScreenMode',
       'updateDefaultVolume',
       'updateDefaultPlayback',
       'updateDefaultVideoFormat',

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -41,6 +41,7 @@
           :label="$t('Settings.Player Settings.Enable FullScreen Mode by Default')"
           :compact="true"
           :default-value="defaultFullScreenMode"
+          :tooltip="$t('Tooltips.Player Settings.Enable FullScreen Mode by Default')"
           @change="updateDefaultFullScreenMode"
         />
       </div>

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -37,6 +37,12 @@
           :default-value="defaultTheatreMode"
           @change="updateDefaultTheatreMode"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Enable FullScreen Mode by Default')"
+          :compact="true"
+          :default-value="defaultFullScreenMode"
+          @change="updateDefaultFullScreenMode"
+        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -53,6 +53,7 @@ const state = {
   forceLocalBackendForLegacy: false,
   proxyVideos: false,
   defaultTheatreMode: false,
+  defaultFullScreenMode: false,
   defaultVolume: 1,
   defaultPlayback: 1,
   defaultVideoFormat: 'dash',
@@ -180,6 +181,10 @@ const getters = {
 
   getDefaultTheatreMode: () => {
     return state.defaultTheatreMode
+  },
+
+  getDefaultFullScreenMode: ()=> {
+    return state.defaultFullScreenMode
   },
 
   getDefaultVolume: () => {
@@ -348,6 +353,8 @@ const actions = {
             case 'defaultTheatreMode':
               commit('setDefaultTheatreMode', result.value)
               break
+            case 'defaultFullScreenMode':
+              commit('setDefaultFullScreenMode', result.value)
             case 'defaultVolume':
               commit('setDefaultVolume', result.value)
               sessionStorage.setItem('volume', result.value)
@@ -587,6 +594,14 @@ const actions = {
     })
   },
 
+  updateDefaultFullScreenMode ({ commit }, defaultFullScreenMode) {
+    settingsDb.update({ _id: 'defaultFullScreenMode' }, { _id: 'defaultFullScreenMode', value: defaultFullScreenMode}, { upsert: true }, (err, numReplaced) => {
+      if(!err) {
+        commit('setDefaultFullScreenMode', defaultFullScreenMode)
+      }
+    })
+  },
+
   updateDefaultVolume ({ commit }, defaultVolume) {
     settingsDb.update({ _id: 'defaultVolume' }, { _id: 'defaultVolume', value: defaultVolume }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
@@ -817,6 +832,9 @@ const mutations = {
   },
   setDefaultTheatreMode (state, defaultTheatreMode) {
     state.defaultTheatreMode = defaultTheatreMode
+  },
+  setDefaultFullScreenMode(state, defaultFullScreenMode) {
+    state.defaultFullScreenMode = defaultFullScreenMode
   },
   setUseProxy (state, useProxy) {
     state.useProxy = useProxy

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -183,7 +183,7 @@ const getters = {
     return state.defaultTheatreMode
   },
 
-  getDefaultFullScreenMode: ()=> {
+  getDefaultFullScreenMode: () => {
     return state.defaultFullScreenMode
   },
 
@@ -355,6 +355,7 @@ const actions = {
               break
             case 'defaultFullScreenMode':
               commit('setDefaultFullScreenMode', result.value)
+              break
             case 'defaultVolume':
               commit('setDefaultVolume', result.value)
               sessionStorage.setItem('volume', result.value)
@@ -595,8 +596,8 @@ const actions = {
   },
 
   updateDefaultFullScreenMode ({ commit }, defaultFullScreenMode) {
-    settingsDb.update({ _id: 'defaultFullScreenMode' }, { _id: 'defaultFullScreenMode', value: defaultFullScreenMode}, { upsert: true }, (err, numReplaced) => {
-      if(!err) {
+    settingsDb.update({ _id: 'defaultFullScreenMode' }, { _id: 'defaultFullScreenMode', value: defaultFullScreenMode }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
         commit('setDefaultFullScreenMode', defaultFullScreenMode)
       }
     })

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -165,6 +165,7 @@ Settings:
     Proxy Videos Through Invidious: Proxy Videos Through Invidious
     Autoplay Playlists: Autoplay Playlists
     Enable Theatre Mode by Default: Enable Theatre Mode by Default
+    Enable FullScreen Mode by Default: Enable FullScreen Mode by Default
     Default Volume: Default Volume
     Default Playback Rate: Default Playback Rate
     Default Video Format:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -559,6 +559,7 @@ Tooltips:
     Default Video Format: Set the formats used when a video plays. Dash formats can
       play higher qualities. Legacy formats are limited to a max of 720p but use less
       bandwidth. Audio formats are audio only streams
+    Enable FullScreen Mode by Default: Will make the video FullScreen when the it starts playing
   Subscription Settings:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of it's default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,


### PR DESCRIPTION
---
feat: added setting to always play videos in fullscreen
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#647 

**Description**
Now users can set the default mode to watch videos in fullscreen mode. This setting will be available on Player Settings. 

**Screenshots (if appropriate)**
![fullscreen](https://user-images.githubusercontent.com/43727167/104956058-5c921500-59f1-11eb-9863-2a7612b1f201.gif)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version:10
 - FreeTube version: Latest

**Additional context**
Add any other context about the problem here.
