### PR TITLE
Add build support for armv7l

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -16,8 +16,12 @@ if (platform == 'darwin') {
 } else if (platform == 'linux') {
   let arch = Arch.x64
 
-  if (args[2] === 'arm') {
+  if (args[2] === 'arm64') {
     arch = Arch.arm64
+  }
+
+  if (args[3] === 'arm32') {
+    arch = Arch.armv7l
   }
 
   targets = Platform.LINUX.createTarget(['deb', 'zip', 'apk', 'rpm', 'AppImage', 'pacman'], arch)

--- a/package.json
+++ b/package.json
@@ -119,9 +119,11 @@
   },
   "scripts": {
     "build": "run-s rebuild:electron pack build-release",
-    "build:arm": "run-s rebuild:electron pack build-release:arm",
+    "build:arm64": "run-s rebuild:electron pack build-release:arm64",
+    "build:arm32": "run-s rebuild:electron pack build-release:arm32",
     "build-release": "node _scripts/build.js",
-    "build-release:arm": "node _scripts/build.js arm",
+    "build-release:arm64": "node _scripts/build.js arm64",
+    "build-release:arm32": "node _scripts/build.js arm32",
     "debug": "run-s rebuild:electron debug-runner",
     "debug-runner": "node _scripts/dev-runner.js --remote-debug",
     "dev": "run-s rebuild:electron dev-runner",


### PR DESCRIPTION
---
Title
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [ X] Feature Implementation

**Description**
armv7l build support

npm run build:arm32 for armv7l
npm run build:arm64 for aarch64


