### PR TITLE
Fix OPML import issue

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -8,7 +8,7 @@ import FtPrompt from '../ft-prompt/ft-prompt.vue'
 
 import { remote } from 'electron'
 import fs from 'fs'
-import { opmlToJSON } from "opml-to-json"
+import { opmlToJSON } from 'opml-to-json'
 import ytch from 'yt-channel-info'
 
 const app = remote.app
@@ -357,7 +357,7 @@ export default Vue.extend({
             return
           }
 
-          opmlToJSON(data).then((json)=> {
+          opmlToJSON(data).then((json) => {
             let feedData = json.children[0].children
 
             if (typeof feedData === 'undefined') {
@@ -439,7 +439,6 @@ export default Vue.extend({
             this.showToast({
               message: `${message}: ${err}`
             })
-            return
           })
         })
       })

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -8,7 +8,7 @@ import FtPrompt from '../ft-prompt/ft-prompt.vue'
 
 import { remote } from 'electron'
 import fs from 'fs'
-import opmlToJson from 'opml-to-json'
+import { opmlToJSON } from "opml-to-json"
 import ytch from 'yt-channel-info'
 
 const app = remote.app
@@ -357,17 +357,7 @@ export default Vue.extend({
             return
           }
 
-          opmlToJson(data, async (err, json) => {
-            if (err) {
-              console.log(err)
-              console.log('error reading')
-              const message = this.$t('Settings.Data Settings.Invalid subscriptions file')
-              this.showToast({
-                message: `${message}: ${err}`
-              })
-              return
-            }
-
+          opmlToJSON(data).then((json)=> {
             let feedData = json.children[0].children
 
             if (typeof feedData === 'undefined') {
@@ -442,6 +432,14 @@ export default Vue.extend({
                 this.updateShowProgressBar(false)
               }
             })
+          }).catch((err) => {
+            console.log(err)
+            console.log('error reading')
+            const message = this.$t('Settings.Data Settings.Invalid subscriptions file')
+            this.showToast({
+              message: `${message}: ${err}`
+            })
+            return
           })
         })
       })


### PR DESCRIPTION
---
Fix OPML import issue
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation

**Related issue**
Fixes https://github.com/FreeTubeApp/FreeTube/issues/962

**Description**
FreeTubes dependencies were updated a few days ago. The library `opml-to-json` was also updated, but it had breaking changes. These changes now causes the opml import to break without an error message (in the interface). This PR implements the suggested changes from `opml-to-json`.  
https://github.com/azu/opml-to-json/releases/tag/v1.0.0

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested? Yes.
Please describe shortly how you tested it and whether there are any ramifications remaining. 
I have successfully imported an OPML file.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Arch Linux
 - OS Version: [e.g. 22] -
 - FreeTube version: [e.g. 0.8] 0.11.1