### PR TITLE
feat: added ability to hide Playlists

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -37,6 +37,9 @@ export default Vue.extend({
     hidePopularVideos: function () {
       return this.$store.getters.getHidePopularVideos
     },
+    hidePlaylists: function () {
+      return this.$store.getters.getHidePlaylists
+    },
     hideLiveChat: function () {
       return this.$store.getters.getHideLiveChat
     },
@@ -61,6 +64,7 @@ export default Vue.extend({
       'updateHideRecommendedVideos',
       'updateHideTrendingVideos',
       'updateHidePopularVideos',
+      'updateHidePlaylists',
       'updateHideLiveChat',
       'updateHideActiveSubscriptions',
       'updatePlayNextVideo',

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -60,6 +60,12 @@
           @change="updateHidePopularVideos"
         />
         <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Playlists')"
+          :compact="true"
+          :default-value="hidePlaylists"
+          @change="updateHidePlaylists"
+        />
+        <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Hide Live Chat')"
           :compact="true"
           :default-value="hideLiveChat"

--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -48,6 +48,9 @@ export default Vue.extend({
     hidePopularVideos: function () {
       return this.$store.getters.getHidePopularVideos
     },
+    hidePlaylists: function () {
+      return this.$store.getters.getHidePlaylists
+    },
     hideTrendingVideos: function () {
       return this.$store.getters.getHideTrendingVideos
     },

--- a/src/renderer/components/side-nav/side-nav.vue
+++ b/src/renderer/components/side-nav/side-nav.vue
@@ -44,6 +44,7 @@
         </p>
       </div>
       <div
+        v-if="!hidePlaylists"
         class="navOption mobileShow"
         @click="navigate('userplaylists')"
       >

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -73,6 +73,7 @@ const state = {
   hideRecommendedVideos: false,
   hideTrendingVideos: false,
   hidePopularVideos: false,
+  hidePlaylists: false,
   hideLiveChat: false,
   hideActiveSubscriptions: false
 }
@@ -241,9 +242,15 @@ const getters = {
   getHidePopularVideos: () => {
     return state.hidePopularVideos
   },
+
+  getHidePlaylists: () => {
+    return state.hidePlaylists
+  },
+
   getHideLiveChat: () => {
     return state.hideLiveChat
   },
+
   getHideActiveSubscriptions: () => {
     return state.hideActiveSubscriptions
   }
@@ -381,6 +388,9 @@ const actions = {
               break
             case 'hidePopularVideos':
               commit('setHidePopularVideos', result.value)
+              break
+            case 'hidePlaylists':
+              commit('setHidePlaylists', result.value)
               break
             case 'hideLiveChat':
               commit('setHideLiveChat', result.value)
@@ -716,6 +726,14 @@ const actions = {
     })
   },
 
+  updateHidePlaylists ({ commit }, hidePlaylists) {
+    settingsDb.update({ _id: 'hidePlaylists' }, { _id: 'hidePlaylists', value: hidePlaylists }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setHidePlaylists', hidePlaylists)
+      }
+    })
+  },
+
   updateHideActiveSubscriptions ({ commit }, hideActiveSubscriptions) {
     settingsDb.update({ _id: 'hideActiveSubscriptions' }, { _id: 'hideActiveSubscriptions', value: hideActiveSubscriptions }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
@@ -871,6 +889,9 @@ const mutations = {
   },
   setHidePopularVideos (state, hidePopularVideos) {
     state.hidePopularVideos = hidePopularVideos
+  },
+  setHidePlaylists (state, hidePlaylists) {
+    state.hidePlaylists = hidePlaylists
   },
   setHideLiveChat (state, hideLiveChat) {
     state.hideLiveChat = hideLiveChat

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -214,6 +214,7 @@ Settings:
     Hide Recommended Videos: Hide Recommended Videos
     Hide Trending Videos: Hide Trending Videos
     Hide Popular Videos: Hide Popular Videos
+    Hide Playlists: Hide Playlists
     Hide Live Chat: Hide Live Chat
     Hide Active Subscriptions: Hide Active Subscriptions
   Data Settings:


### PR DESCRIPTION
---
Added ability to hide Playlists
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#952 

**Description**
Right in "Distraction Settings" there's no toggle to show/hide side-bar playlists, so this pr adds ability to show/hide playlists
hide Playlists

**Screenshots (if appropriate)**
![hide playlists](https://user-images.githubusercontent.com/43727167/105472138-900ac300-5cc1-11eb-8c10-d9b9d4f3cb92.gif)


**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.11.1
