### PR TITLE
fix: translated menu("more" option on small screen)

### DIFF
--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
@@ -9,7 +9,7 @@
         class="navIcon"
       />
       <p class="navLabel">
-        More
+        {{ $t("More") }}
       </p>
     </div>
     <div
@@ -25,7 +25,7 @@
           class="navIcon"
         />
         <p class="navLabel">
-          Trending
+          {{ $t("Trending") }}
         </p>
       </div>
       <div
@@ -37,7 +37,7 @@
           class="navIcon"
         />
         <p class="navLabel">
-          Most Popular
+          {{ $t("Most Popular") }}
         </p>
       </div>
       <div
@@ -49,7 +49,7 @@
           class="navIcon"
         />
         <p class="navLabel">
-          About
+          {{ $t("About.About") }}
         </p>
       </div>
     </div>
@@ -62,7 +62,7 @@
         class="navIcon"
       />
       <p class="navLabel">
-        History
+        {{ $t("History.History") }}
       </p>
     </div>
     <hr>
@@ -75,7 +75,7 @@
         class="navIcon"
       />
       <p class="navLabel">
-        Settings
+        {{ $t("Settings.Settings") }}
       </p>
     </div>
     <div
@@ -87,7 +87,7 @@
         class="navIcon"
       />
       <p class="navLabel">
-        About
+        {{ $t("About.About") }}
       </p>
     </div>
   </div>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -81,6 +81,7 @@ Subscriptions:
   'Getting Subscriptions. Please wait.': Getting Subscriptions. Please wait.
   Refresh Subscriptions: Refresh Subscriptions
   Load More Videos: Load More Videos
+More: More
 Trending: Trending
 Most Popular: Most Popular
 Playlists: Playlists


### PR DESCRIPTION
---
Translated menu option(small screen)
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
#793 

**Description**
Before this menu for "more" options wasn't able to translate to other languages, this PR replaces the hard-coded strings to vue-i18n strings "$t()".

**Screenshots (if appropriate)**

![Screenshot (5)](https://user-images.githubusercontent.com/43727167/105813775-5b0ab300-5fd6-11eb-8900-e4300bd8fefa.png)


**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.11.1

**Additional context**
Add any other context about the problem here.
