### PR TITLE
added playlist next video interval setting

### DIFF
--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -62,6 +62,10 @@ export default Vue.extend({
       return this.$store.getters.getProxyVideos
     },
 
+    defaultInterval: function () {
+      return parseInt(this.$store.getters.getDefaultInterval)
+    },
+
     defaultVolume: function () {
       return parseFloat(this.$store.getters.getDefaultVolume) * 100
     },
@@ -119,6 +123,7 @@ export default Vue.extend({
       'updateForceLocalBackendForLegacy',
       'updateProxyVideos',
       'updateDefaultTheatreMode',
+      'updateDefaultInterval',
       'updateDefaultVolume',
       'updateDefaultPlayback',
       'updateDefaultVideoFormat',

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -62,6 +62,15 @@
     </div>
     <ft-flex-box>
       <ft-slider
+        :label="$t('Settings.Player Settings.Playlist Next Video Interval')"
+        :default-value="defaultInterval"
+        :min-value="0"
+        :max-value="60"
+        :step="1"
+        value-extension="s"
+        @change="updateDefaultInterval"
+      />
+      <ft-slider
         :label="$t('Settings.Player Settings.Default Volume')"
         :default-value="defaultVolume"
         :min-value="0"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -53,6 +53,7 @@ const state = {
   forceLocalBackendForLegacy: false,
   proxyVideos: false,
   defaultTheatreMode: false,
+  defaultInterval: 5,
   defaultVolume: 1,
   defaultPlayback: 1,
   defaultVideoFormat: 'dash',
@@ -180,6 +181,10 @@ const getters = {
 
   getDefaultTheatreMode: () => {
     return state.defaultTheatreMode
+  },
+
+  getDefaultInterval: () => {
+    return state.defaultInterval
   },
 
   getDefaultVolume: () => {
@@ -347,6 +352,9 @@ const actions = {
               break
             case 'defaultTheatreMode':
               commit('setDefaultTheatreMode', result.value)
+              break
+            case 'defaultInterval':
+              commit('setDefaultInterval', result.value)
               break
             case 'defaultVolume':
               commit('setDefaultVolume', result.value)
@@ -587,6 +595,14 @@ const actions = {
     })
   },
 
+  updateDefaultInterval ({ commit }, defaultInterval) {
+    settingsDb.update({ _id: 'defaultInterval' }, { _id: 'defaultInterval', value: defaultInterval }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setDefaultInterval', defaultInterval)
+      }
+    })
+  },
+
   updateDefaultVolume ({ commit }, defaultVolume) {
     settingsDb.update({ _id: 'defaultVolume' }, { _id: 'defaultVolume', value: defaultVolume }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
@@ -799,6 +815,9 @@ const mutations = {
   },
   setProxyVideos (state, proxyVideos) {
     state.proxyVideos = proxyVideos
+  },
+  setDefaultInterval (state, defaultInterval) {
+    state.defaultInterval = defaultInterval
   },
   setDefaultVolume (state, defaultVolume) {
     state.defaultVolume = defaultVolume

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -104,6 +104,9 @@ export default Vue.extend({
     proxyVideos: function () {
       return this.$store.getters.getProxyVideos
     },
+    defaultInterval: function () {
+      return this.$store.getters.getDefaultInterval
+    },
     defaultTheatreMode: function () {
       return this.$store.getters.getDefaultTheatreMode
     },
@@ -807,14 +810,15 @@ export default Vue.extend({
     },
 
     handleVideoEnded: function () {
+      const nextVideoInterval = this.defaultInterval
       if (this.watchingPlaylist) {
         this.playNextTimeout = setTimeout(() => {
           this.$refs.watchVideoPlaylist.playNextVideo()
-        }, 5000)
+        }, nextVideoInterval * 1000)
 
         this.showToast({
-          message: this.$t('Playing next video in 5 seconds.  Click to cancel'),
-          time: 5500,
+          message: this.$tc('Playing Next Video Interval', nextVideoInterval, { nextVideoInterval: nextVideoInterval }),
+          time: (nextVideoInterval * 1000) + 500,
           action: () => {
             clearTimeout(this.playNextTimeout)
             this.showToast({

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -170,6 +170,7 @@ Settings:
     Proxy Videos Through Invidious: Proxy Videos Through Invidious
     Autoplay Playlists: Autoplay Playlists
     Enable Theatre Mode by Default: Enable Theatre Mode by Default
+    Playlist Next Video Interval: Playlist Next Video Interval
     Default Volume: Default Volume
     Default Playback Rate: Default Playback Rate
     Default Video Format:
@@ -584,8 +585,7 @@ Shuffle is now enabled: Shuffle is now enabled
 The playlist has been reversed: The playlist has been reversed
 Playing Next Video: Playing Next Video
 Playing Previous Video: Playing Previous Video
-Playing next video in 5 seconds.  Click to cancel: Playing next video in 5 seconds.
-  Click to cancel.
+Playing Next Video Interval: Playing next video in no time. Click to cancel. | Playing next video in {nextVideoInterval} second. Click to cancel. | Playing next video in {nextVideoInterval} seconds. Click to cancel.
 Canceled next video autoplay: Canceled next video autoplay
 'The playlist has ended.  Enable loop to continue playing': 'The playlist has ended.  Enable
   loop to continue playing'


### PR DESCRIPTION
---
added playlist next video interval option
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#971 

**Description**
This pull adds the feature to control the playing next next video interval in the playlist, currently it has only 5 seconds, this PR brings the control from 0 to 60 secs.


**Desktop (please complete the following information):**
 - OS: Windows 
 - OS Version: 10
 - FreeTube version: 0.11.2

**Additional context**
I added string as "Playlist next video interval", because to avoid confusion.
