### PR TITLE
Minor typographical typo in en-US.yaml

### DIFF
--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -564,7 +564,7 @@ Tooltips:
       play higher qualities. Legacy formats are limited to a max of 720p but use less
       bandwidth. Audio formats are audio only streams
   Subscription Settings:
-    Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of it's default
+    Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
       but doesn't provide certain information like video duration or live status
 


### PR DESCRIPTION
---
Minor typographical typo in en-US.yaml
---

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation

**Related issue**
Would close #1031

**Description**
This fixes a typographical typo (from "it's" to "its"); this is in the description of "Fetch Feeds from RSS" toggle button (when you hover your cursor over the circled question mark)

**Screenshots (if appropriate)**
What currently looks like: 
![cropped](https://user-images.githubusercontent.com/47955724/107887173-0c2cab00-6efc-11eb-90df-47ebfd1a9321.png)

(I don't have any after screenshots.)

**Testing (for code that is not small enough to be easily understandable)**
N/A (untested, though this is typographical and not code related)

**Desktop (please complete the following information):**
 - OS: Manjaro Linux
 - OS Version: 20.2.1
 - FreeTube version: 0.11.2 Beta

**Additional context**
N/A
