### PR TITLE
YT-Like show save-icon on hover on thumbnails

### DIFF
--- a/src/renderer/sass-partials/_ft-list-item.sass
+++ b/src/renderer/sass-partials/_ft-list-item.sass
@@ -89,12 +89,16 @@ $thumbnail-overlay-opacity: 0.85
       @include is-watch-playlist-item
         font-size: 12px
 
-    .favoritesIcon
-      position: absolute
-      top: 3px
-      right: 3px
-      font-size: 17px
-      opacity: $thumbnail-overlay-opacity
+  .favoritesIcon
+    display: none
+
+  &:hover .favoritesIcon
+    display: inline-block
+    position: absolute
+    top: 3px
+    right: 3px
+    font-size: 17px
+    opacity: $thumbnail-overlay-opacity
 
     .watchedProgressBar
       height: 2px


### PR DESCRIPTION
---
YT-Like show save icon on hover
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
None, this is just a proposal kind of a thing

**Description**
So on Youtube, we can only see the watch-later and add-to-queue icons only we hover on the thumbnail, this PR clones that type of behaviour, currently on FreeTube there's the save-video icon visible on every video thumbnail by default.

**Screenshots (if appropriate)**

Before 

![Screenshot (26)](https://user-images.githubusercontent.com/43727167/108386850-0d7b1200-7233-11eb-900c-aebdd49034b6.png)


After

![savevideo](https://user-images.githubusercontent.com/43727167/108386161-67c7a300-7232-11eb-92a8-c24d3fb2e8e6.gif)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version:10
 - FreeTube version:0.11.3

Should I create an Issue for this?
