### PR TITLE
Changed command line input to only allows youtube video links.

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -399,7 +399,8 @@ app.on('open-url', (event, url) => {
  * Remove freetube:// protocol if present
  */
 const url = getLinkUrl(process.argv)
-if (url) {
+if (url && (url.match(/https?:\/\/(www\.)?youtube\.com\/watch\?v=\S+/) ||
+    url.match(/https?:\/\/youtu\.be\/\S+/))) {
   startupUrl = url
 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -399,8 +399,7 @@ app.on('open-url', (event, url) => {
  * Remove freetube:// protocol if present
  */
 const url = getLinkUrl(process.argv)
-if (url && (url.match(/https?:\/\/(www\.)?youtube\.com\/watch\?v=\S+/) ||
-    url.match(/https?:\/\/youtu\.be\/\S+/))) {
+if (url) {
   startupUrl = url
 }
 

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -289,16 +289,6 @@ export default Vue.extend({
               v.$router.push({
                 path: `/watch/${result}`
               })
-            } else {
-              v.$router.push({
-                path: `/search/${encodeURIComponent(url)}`,
-                query: {
-                  sortBy: v.searchSettings.sortBy,
-                  time: v.searchSettings.time,
-                  type: v.searchSettings.type,
-                  duration: v.searchSettings.duration
-                }
-              })
             }
           })
         }


### PR DESCRIPTION
---
Changed command line input to only allows youtube video links.
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
#955 
#1020 

**Description**
Instances of Freetube running through app.asar have extra arguments in the command line which were being mistaken as search terms. Hoping that this is a infrequently used feature and at Preston's tentative suggestion, anything that isn't a youtube link is discarded from the command line input.

**Desktop (please complete the following information):**
 - OS: Artix
 - OS Version: N/A
 - FreeTube version: 0.11.3 (commit b37fab46227198af7977a574dafe5f988b21c0c2)