### PR TITLE
Replace '/hashtag' refs with freetube:// links

### DIFF
--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -58,6 +58,7 @@ export default Vue.extend({
       descriptionText = descriptionText.replace(/href="http(s)?:\/\/youtube\.com/g, 'href="freetube://https://youtube.com')
       descriptionText = descriptionText.replace(/href="\/watch/g, 'href="freetube://https://youtube.com')
       descriptionText = descriptionText.replace(/href="\/results\?search_query=/g, 'href="freetube://')
+      descriptionText = descriptionText.replace(/href="\/hashtag\//g, 'href="freetube://')
       descriptionText = descriptionText.replace(/yt\.www\.watch\.player\.seekTo/g, 'changeDuration')
 
       return descriptionText


### PR DESCRIPTION
When pulling video information from Invidious, hashtag-related links present in the description need to be replaced with valid links.
In this case, a freetube:// link was deemed the most appropriate.

Fixes #932