### PR TITLE
Fixed large custom emotes in live chats

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -161,7 +161,7 @@ export default Vue.extend({
             comment.messageHtml = comment.messageHtml + text.text
           }
         } else if (typeof (text.alt) !== 'undefined') {
-          const htmlImg = `<img src="${text.url}" alt="${text.alt}" height="15" width="15" />`
+          const htmlImg = `<img src="${text.url}" alt="${text.alt}" height="24" width="24" />`
           comment.messageHtml = comment.messageHtml + htmlImg
         } else {
           comment.messageHtml = comment.messageHtml + text.text

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -161,7 +161,7 @@ export default Vue.extend({
             comment.messageHtml = comment.messageHtml + text.text
           }
         } else if (typeof (text.alt) !== 'undefined') {
-          const htmlImg = `<img src="${text.url}" alt="${text.alt}" />`
+          const htmlImg = `<img src="${text.url}" alt="${text.alt}" height="15" width="15" />`
           comment.messageHtml = comment.messageHtml + htmlImg
         } else {
           comment.messageHtml = comment.messageHtml + text.text


### PR DESCRIPTION
---
Fixed large custom emotes in live chats
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
#1116

**Description**
Custom emotes are loaded as images. The problem was that these images are 64x64 in size by default, so they are huge compared to the default emojis and text size. I toned them down in the corresponding html element

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.
Before:
![image](https://user-images.githubusercontent.com/34301369/111295622-e524de80-864b-11eb-8ac8-e062af9b338b.png)

After:
![image](https://user-images.githubusercontent.com/34301369/111295591-da6a4980-864b-11eb-98b7-91731a9fd090.png)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Has been tested on a few live streams.

**Desktop (please complete the following information):**
 - OS: Win
 - OS Version: 10
 - FreeTube version: v12.0.0

**Additional context**
Custom setting to increase/decrease size could be implemented later