### PR TITLE
Added fix for wrongly applied publishedText template

### DIFF
--- a/src/renderer/store/modules/ytdl.js
+++ b/src/renderer/store/modules/ytdl.js
@@ -347,7 +347,7 @@ const actions = {
       }
 
       ytdl.getInfo(videoId, {
-        lang: localStorage.getItem('locale'),
+        lang: 'en-US',
         requestOptions: { agent }
       }).then((result) => {
         resolve(result)


### PR DESCRIPTION
---
Added fix for wrongly applied publishedText template
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes issue #1094 

**Description**
Problem was that ytdl-core module was called with the selected language of the user. While this works great in theory to give everyone the translation right from YouTube, it creates new and massive overhead. The problem is that all other modules that return strings to display from YouTube, do not allow the selection of languages, so for some correctly translated strings will be returned automatically while others need a translation. Now it is forced that every string needs a translation or will be English otherwise.

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes, tested on a few videos

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: v12.0.0

**Additional context**
When all modules support language selection the whole tolocalestring function in utils can be removed. Otherwise not. However with the new API this is not as easy
