### PR TITLE
SponsorBlock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13739,8 +13739,7 @@
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "dev": true
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-gyp": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "markdown": "^0.5.0",
     "material-design-icons": "^3.0.1",
     "nedb": "^1.8.0",
+    "node-forge": "^0.10.0",
     "opml-to-json": "^1.0.1",
     "rss-parser": "^3.12.0",
     "socks-proxy-agent": "^5.0.0",

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -157,6 +157,10 @@ export default Vue.extend({
 
     useSponsorBlock: function () {
       return this.$store.getters.getUseSponsorBlock
+    },
+
+    sponsorBlockShowSkippedToast: function () {
+      return this.$store.getters.getSponsorBlockShowSkippedToast
     }
   },
   mounted: function () {
@@ -311,13 +315,45 @@ export default Vue.extend({
     skipSponsorBlocks(skipSegments) {
       const currentTime = this.player.currentTime()
       let newTime = null
-      skipSegments.forEach(({ segment: [startTime, endTime] }) => {
+      let skippedCategory = null
+      skipSegments.forEach(({ category, segment: [startTime, endTime] }) => {
         if (startTime <= currentTime && currentTime < endTime) {
           newTime = endTime
+          skippedCategory = category
         }
       })
       if (newTime !== null) {
+        if (this.sponsorBlockShowSkippedToast) {
+          this.showSkippedSponsorSegmentInformation(skippedCategory)
+        }
         this.player.currentTime(newTime)
+      }
+    },
+
+    showSkippedSponsorSegmentInformation(category) {
+      const translatedCategory = this.sponsorBlockTranslatedCategory(category)
+      this.showToast({
+        message: `${this.$t('Video.Skipped segment')} ${translatedCategory}`
+      })
+    },
+
+    sponsorBlockTranslatedCategory(category) {
+      switch (category) {
+        case 'sponsor':
+          return this.$t('Video.Sponsor Block category.sponsor')
+        case 'intro':
+          return this.$t('Video.Sponsor Block category.intro')
+        case 'outro':
+          return this.$t('Video.Sponsor Block category.outro')
+        case 'selfpromo':
+          return this.$t('Video.Sponsor Block category.self-promotion')
+        case 'interaction':
+          return this.$t('Video.Sponsor Block category.interaction')
+        case 'music_offtopic':
+          return this.$t('Video.Sponsor Block category.music offtopic')
+        default:
+          console.error(`Unknown translation for SponsorBlock category ${category}`)
+          return category
       }
     },
 
@@ -1265,6 +1301,7 @@ export default Vue.extend({
     },
 
     ...mapActions([
+      'showToast',
       'calculateColorLuminance'
     ])
   }

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -289,9 +289,12 @@ export default Vue.extend({
       if (this.useSponsorBlock) {
         this.$store.dispatch('sponsorBlockSkipSegments', {
           videoId: this.videoId,
-          categories: ['sponsor', 'intro']
-        }).then((response) => {
-          response.forEach(({
+          categories: ['sponsor']
+        }).then((skipSegments) => {
+          this.player.on('timeupdate', () => {
+            this.skipSponsorBlocks(skipSegments)
+          })
+          skipSegments.forEach(({
             category,
             segment: [startTime, endTime]
           }) => {
@@ -302,6 +305,19 @@ export default Vue.extend({
             })
           })
         })
+      }
+    },
+
+    skipSponsorBlocks(skipSegments) {
+      const currentTime = this.player.currentTime()
+      let newTime = null
+      skipSegments.forEach(({ segment: [startTime, endTime] }) => {
+        if (startTime <= currentTime && currentTime < endTime) {
+          newTime = endTime
+        }
+      })
+      if (newTime !== null) {
+        this.player.currentTime(newTime)
       }
     },
 

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.css
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.css
@@ -1,0 +1,25 @@
+.relative {
+  position: relative;
+}
+
+.card {
+  width: 85%;
+  margin: 0 auto;
+  margin-bottom: 10px;
+}
+
+.center {
+  text-align: center;
+}
+
+@media only screen and (max-width: 680px) {
+  .card {
+    width: 90%;
+  }
+}
+
+@media only screen and (max-width: 500px) {
+  .subscriptionSettingsFlexBox {
+    justify-content: flex-start;
+  }
+}

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.css
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.css
@@ -19,7 +19,7 @@
 }
 
 @media only screen and (max-width: 500px) {
-  .subscriptionSettingsFlexBox {
+  .sponsorBlockSettingsFlexBox {
     justify-content: flex-start;
   }
 }

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
@@ -1,0 +1,38 @@
+import Vue from 'vue'
+import { mapActions } from 'vuex'
+import FtCard from '../ft-card/ft-card.vue'
+import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
+import FtInput from '../ft-input/ft-input.vue'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+
+export default Vue.extend({
+  name: 'SponsorBlockSettings',
+  components: {
+    'ft-card': FtCard,
+    'ft-toggle-switch': FtToggleSwitch,
+    'ft-input': FtInput,
+    'ft-flex-box': FtFlexBox
+  },
+  computed: {
+    useSponsorBlock: function () {
+      return this.$store.getters.getUseSponsorBlock
+    },
+    sponsorBlockUrl: function () {
+      return this.$store.getters.getSponsorBlockUrl
+    }
+  },
+  methods: {
+    handleUpdateSponsorBlock: function (value) {
+      this.updateUseSponsorBlock(value)
+    },
+
+    handleUpdateSponsorBlockUrl: function (value) {
+      this.updateSponsorBlockUrl(value)
+    },
+
+    ...mapActions([
+      'updateUseSponsorBlock',
+      'updateSponsorBlockUrl'
+    ])
+  }
+})

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
@@ -19,6 +19,9 @@ export default Vue.extend({
     },
     sponsorBlockUrl: function () {
       return this.$store.getters.getSponsorBlockUrl
+    },
+    sponsorBlockShowSkippedToast: function () {
+      return this.$store.getters.getSponsorBlockShowSkippedToast
     }
   },
   methods: {
@@ -30,9 +33,14 @@ export default Vue.extend({
       this.updateSponsorBlockUrl(value)
     },
 
+    handleUpdateSponsorBlockShowSkippedToast: function (value) {
+      this.updateSponsorBlockShowSkippedToast(value)
+    },
+
     ...mapActions([
       'updateUseSponsorBlock',
-      'updateSponsorBlockUrl'
+      'updateSponsorBlockUrl',
+      'updateSponsorBlockShowSkippedToast'
     ])
   }
 })

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
@@ -30,7 +30,9 @@ export default Vue.extend({
     },
 
     handleUpdateSponsorBlockUrl: function (value) {
-      this.updateSponsorBlockUrl(value)
+      const sponsorBlockUrlWithoutTrailingSlash = value.replace(/\/$/, '')
+      const sponsorBlockUrlWithoutApiSuffix = sponsorBlockUrlWithoutTrailingSlash.replace(/\/api$/, '')
+      this.updateSponsorBlockUrl(sponsorBlockUrlWithoutApiSuffix)
     },
 
     handleUpdateSponsorBlockShowSkippedToast: function (value) {

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -1,0 +1,30 @@
+<template>
+  <ft-card
+    class="relative card"
+  >
+    <h3
+      class="videoTitle"
+    >
+      {{ $t("Settings.SponsorBlock Settings.SponsorBlock Settings") }}
+    </h3>
+    <ft-flex-box class="subscriptionSettingsFlexBox">
+      <ft-toggle-switch
+        :label="$t('Settings.SponsorBlock Settings.Enable SponsorBlock')"
+        :default-value="useSponsorBlock"
+        @change="handleUpdateSponsorBlock"
+      />
+    </ft-flex-box>
+    <ft-flex-box>
+      <ft-input
+        :placeholder="$t('Settings.SponsorBlock Settings[\'SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)\']')"
+        :show-arrow="false"
+        :show-label="true"
+        :value="sponsorBlockUrl"
+        @input="handleUpdateSponsorBlockUrl"
+      />
+    </ft-flex-box>
+  </ft-card>
+</template>
+
+<script src="./sponsor-block-settings.js" />
+<style scoped src="./sponsor-block-settings.css" />

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -7,11 +7,18 @@
     >
       {{ $t("Settings.SponsorBlock Settings.SponsorBlock Settings") }}
     </h3>
-    <ft-flex-box class="subscriptionSettingsFlexBox">
+    <ft-flex-box class="sponsorBlockSettingsFlexBox">
       <ft-toggle-switch
         :label="$t('Settings.SponsorBlock Settings.Enable SponsorBlock')"
         :default-value="useSponsorBlock"
         @change="handleUpdateSponsorBlock"
+      />
+    </ft-flex-box>
+    <ft-flex-box class="sponsorBlockSettingsFlexBox">
+      <ft-toggle-switch
+        :label="$t('Settings.SponsorBlock Settings.Notify when sponsor segment is skipped')"
+        :default-value="sponsorBlockShowSkippedToast"
+        @change="handleUpdateSponsorBlockShowSkippedToast"
       />
     </ft-flex-box>
     <ft-flex-box>

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -23,7 +23,7 @@
     </ft-flex-box>
     <ft-flex-box>
       <ft-input
-        :placeholder="$t('Settings.SponsorBlock Settings[\'SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)\']')"
+        :placeholder="$t('Settings.SponsorBlock Settings[\'SponsorBlock API Url (Default is https://sponsor.ajay.app)\']')"
         :show-arrow="false"
         :show-label="true"
         :value="sponsorBlockUrl"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -78,7 +78,9 @@ const state = {
   hidePopularVideos: false,
   hidePlaylists: false,
   hideLiveChat: false,
-  hideActiveSubscriptions: false
+  hideActiveSubscriptions: false,
+  useSponsorBlock: false,
+  sponsorBlockUrl: 'https://sponsor.ajay.app/api/'
 }
 
 const getters = {
@@ -264,6 +266,14 @@ const getters = {
 
   getHideActiveSubscriptions: () => {
     return state.hideActiveSubscriptions
+  },
+
+  getUseSponsorBlock: () => {
+    return state.useSponsorBlock
+  },
+
+  getSponsorBlockUrl: () => {
+    return state.sponsorBlockUrl
   }
 }
 
@@ -416,6 +426,12 @@ const actions = {
                 break
               case 'hideActiveSubscriptions':
                 commit('setHideActiveSubscriptions', result.value)
+                break
+              case 'useSponsorBlock':
+                commit('setUseSponsorBlock', result.value)
+                break
+              case 'sponsorBlockUrl':
+                commit('setSponsorBlockUrl', result.value)
                 break
             }
           })
@@ -786,6 +802,22 @@ const actions = {
         commit('setHideLiveChat', hideLiveChat)
       }
     })
+  },
+
+  updateUseSponsorBlock ({ commit }, useSponsorBlock) {
+    settingsDb.update({ _id: 'useSponsorBlock' }, { _id: 'useSponsorBlock', value: useSponsorBlock }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setUseSponsorBlock', useSponsorBlock)
+      }
+    })
+  },
+
+  updateSponsorBlockUrl ({ commit }, sponsorBlockUrl) {
+    settingsDb.update({ _id: 'sponsorBlockUrl' }, { _id: 'sponsorBlockUrl', value: sponsorBlockUrl }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setSponsorBlockUrl', sponsorBlockUrl)
+      }
+    })
   }
 }
 
@@ -944,6 +976,12 @@ const mutations = {
   },
   setHideActiveSubscriptions (state, hideActiveSubscriptions) {
     state.hideActiveSubscriptions = hideActiveSubscriptions
+  },
+  setUseSponsorBlock (state, useSponsorBlock) {
+    state.useSponsorBlock = useSponsorBlock
+  },
+  setSponsorBlockUrl (state, sponsorBlockUrl) {
+    state.sponsorBlockUrl = sponsorBlockUrl
   }
 }
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -80,7 +80,7 @@ const state = {
   hideLiveChat: false,
   hideActiveSubscriptions: false,
   useSponsorBlock: false,
-  sponsorBlockUrl: 'https://sponsor.ajay.app/api/',
+  sponsorBlockUrl: 'https://sponsor.ajay.app',
   sponsorBlockShowSkippedToast: true
 }
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -80,7 +80,8 @@ const state = {
   hideLiveChat: false,
   hideActiveSubscriptions: false,
   useSponsorBlock: false,
-  sponsorBlockUrl: 'https://sponsor.ajay.app/api/'
+  sponsorBlockUrl: 'https://sponsor.ajay.app/api/',
+  sponsorBlockShowSkippedToast: true
 }
 
 const getters = {
@@ -274,6 +275,10 @@ const getters = {
 
   getSponsorBlockUrl: () => {
     return state.sponsorBlockUrl
+  },
+
+  getSponsorBlockShowSkippedToast: () => {
+    return state.sponsorBlockShowSkippedToast
   }
 }
 
@@ -433,6 +438,8 @@ const actions = {
               case 'sponsorBlockUrl':
                 commit('setSponsorBlockUrl', result.value)
                 break
+              case 'sponsorBlockShowSkippedToast':
+                commit('setSponsorBlockShowSkippedToast', result.value)
             }
           })
           resolve()
@@ -818,6 +825,14 @@ const actions = {
         commit('setSponsorBlockUrl', sponsorBlockUrl)
       }
     })
+  },
+
+  updateSponsorBlockShowSkippedToast ({ commit }, sponsorBlockShowSkippedToast) {
+    settingsDb.update({ _id: 'sponsorBlockShowSkippedToast' }, { _id: 'sponsorBlockShowSkippedToast', value: sponsorBlockShowSkippedToast }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setSponsorBlockShowSkippedToast', sponsorBlockShowSkippedToast)
+      }
+    })
   }
 }
 
@@ -982,6 +997,9 @@ const mutations = {
   },
   setSponsorBlockUrl (state, sponsorBlockUrl) {
     state.sponsorBlockUrl = sponsorBlockUrl
+  },
+  setSponsorBlockShowSkippedToast (state, sponsorBlockShowSkippedToast) {
+    state.sponsorBlockShowSkippedToast = sponsorBlockShowSkippedToast
   }
 }
 

--- a/src/renderer/store/modules/sponsorblock.js
+++ b/src/renderer/store/modules/sponsorblock.js
@@ -1,4 +1,5 @@
 import $ from 'jquery'
+import forge from 'node-forge'
 
 const state = {}
 const getters = {}
@@ -6,10 +7,16 @@ const getters = {}
 const actions = {
   sponsorBlockSkipSegments ({ rootState }, { videoId, categories }) {
     return new Promise((resolve, reject) => {
-      const requestUrl = `${rootState.settings.sponsorBlockUrl}skipSegments?videoID=${videoId}&categories=${JSON.stringify(categories)}`
+      const messageDigestSha256 = forge.md.sha256.create()
+      messageDigestSha256.update(videoId)
+      const videoIdHashPrefix = messageDigestSha256.digest().toHex().substring(0, 4)
+      const requestUrl = `${rootState.settings.sponsorBlockUrl}skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
 
       $.getJSON(requestUrl, (response) => {
-        resolve(response)
+        const segments = response
+          .filter((result) => result.videoID === videoId)
+          .flatMap((result) => result.segments)
+        resolve(segments)
       }).fail((xhr, textStatus, error) => {
         console.log(xhr)
         console.log(textStatus)

--- a/src/renderer/store/modules/sponsorblock.js
+++ b/src/renderer/store/modules/sponsorblock.js
@@ -1,0 +1,31 @@
+import $ from 'jquery'
+
+const state = {}
+const getters = {}
+
+const actions = {
+  sponsorBlockSkipSegments ({ rootState }, { videoId, categories }) {
+    return new Promise((resolve, reject) => {
+      const requestUrl = `${rootState.settings.sponsorBlockUrl}skipSegments?videoID=${videoId}&categories=${JSON.stringify(categories)}`
+
+      $.getJSON(requestUrl, (response) => {
+        resolve(response)
+      }).fail((xhr, textStatus, error) => {
+        console.log(xhr)
+        console.log(textStatus)
+        console.log(requestUrl)
+        console.log(error)
+        reject(xhr)
+      })
+    })
+  }
+}
+
+const mutations = {}
+
+export default {
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/src/renderer/store/modules/sponsorblock.js
+++ b/src/renderer/store/modules/sponsorblock.js
@@ -10,7 +10,7 @@ const actions = {
       const messageDigestSha256 = forge.md.sha256.create()
       messageDigestSha256.update(videoId)
       const videoIdHashPrefix = messageDigestSha256.digest().toHex().substring(0, 4)
-      const requestUrl = `${rootState.settings.sponsorBlockUrl}skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
+      const requestUrl = `${rootState.settings.sponsorBlockUrl}/api/skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
 
       $.getJSON(requestUrl, (response) => {
         const segments = response

--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -9,6 +9,7 @@ import PrivacySettings from '../../components/privacy-settings/privacy-settings.
 import DataSettings from '../../components/data-settings/data-settings.vue'
 import DistractionSettings from '../../components/distraction-settings/distraction-settings.vue'
 import ProxySettings from '../../components/proxy-settings/proxy-settings.vue'
+import SponsorBlockSettings from '../../components/sponsor-block-settings/sponsor-block-settings.vue'
 
 export default Vue.extend({
   name: 'Settings',
@@ -22,6 +23,7 @@ export default Vue.extend({
     'privacy-settings': PrivacySettings,
     'data-settings': DataSettings,
     'distraction-settings': DistractionSettings,
-    'proxy-settings': ProxySettings
+    'proxy-settings': ProxySettings,
+    'sponsor-block-settings': SponsorBlockSettings
   }
 })

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -8,6 +8,7 @@
     <privacy-settings />
     <data-settings />
     <proxy-settings />
+    <sponsor-block-settings />
   </div>
 </template>
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -23,6 +23,7 @@
           :storyboard-src="videoStoryboardSrc"
           :format="activeFormat"
           :thumbnail="thumbnail"
+          :video-id="videoId"
           class="videoPlayer"
           :class="{ theatrePlayer: useTheatreMode }"
           @ready="checkIfWatched"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -280,6 +280,10 @@ Settings:
     Region: Region
     City: City
     Error getting network information. Is your proxy configured properly?: Error getting network information. Is your proxy configured properly?
+  SponsorBlock Settings:
+    SponsorBlock Settings: SponsorBlock Settings
+    Enable SponsorBlock: Enable SponsorBlock
+    'SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)': SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)
 About:
   #On About page
   About: About

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -283,7 +283,7 @@ Settings:
   SponsorBlock Settings:
     SponsorBlock Settings: SponsorBlock Settings
     Enable SponsorBlock: Enable SponsorBlock
-    'SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)': SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)
+    'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API Url (Default is https://sponsor.ajay.app)
     Notify when sponsor segment is skipped: Notify when sponsor segment is skipped
 About:
   #On About page

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -284,6 +284,7 @@ Settings:
     SponsorBlock Settings: SponsorBlock Settings
     Enable SponsorBlock: Enable SponsorBlock
     'SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)': SponsorBlock API Url (Default is https://sponsor.ajay.app/api/)
+    Notify when sponsor segment is skipped: Notify when sponsor segment is skipped
 About:
   #On About page
   About: About
@@ -476,6 +477,14 @@ Video:
   translated from English: translated from English
   # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: $ % ago
+  Skipped segment: Skipped segment
+  Sponsor Block category:
+    sponsor: sponsor
+    intro: intro
+    outro: outro
+    self-promotion: self-promotion
+    interaction: interaction
+    music offtopic: music offtopic
 #& Videos
 Videos:
   #& Sort By


### PR DESCRIPTION
---
SponsorBlock
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Fixes #798 

**Description**
Simple implementation of SponsorBlock.
- added SponsorBlock section in settings with enable toggle and api url
- sponsor segments are marked on video timeline
- I observe on [timeupdate](https://docs.videojs.com/player#event:timeupdate) event. If currentTime is within some sponsor segment I jump to the end of this segment.
- colors from https://github.com/polymorphicshade/NewPipe/blob/b1faacc4a9070bde4686f016fd4cf530b412e3f6/app/src/main/res/values/colors.xml#L86-L92 (GPLv3)

**Screenshots**
Settings section
![image](https://user-images.githubusercontent.com/2798728/111918042-81534900-8a83-11eb-8f53-09783e246879.png)
Skipped sponsor segments are green
![image](https://user-images.githubusercontent.com/2798728/111918077-a8aa1600-8a83-11eb-8b15-99148aac1e85.png)

**Desktop (please complete the following information):**
 - OS: Linux Mint
 - OS Version: 20.1
 - FreeTube version: 0.12.0

**Plans (in this or a new PR)**
- [ ] configurable skipping for each [category](https://github.com/ajayyy/SponsorBlock/wiki/Types#category)
- [ ] configurable color for each category
- [ ] clarification of a feature and links in SponsorBlock settings section and about tab?
- [x] show information when segment is skipped
