### PR TITLE
fix arm32 building

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -20,7 +20,7 @@ if (platform == 'darwin') {
     arch = Arch.arm64
   }
 
-  if (args[3] === 'arm32') {
+  if (args[2] === 'arm32') {
     arch = Arch.armv7l
   }
 


### PR DESCRIPTION
---
fix arm32 building
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Description**
was
```javascript
  if (args[3] === 'arm32') {
    arch = Arch.armv7l
  }
```
instead of
```javascript
  if (args[2] === 'arm32') {
    arch = Arch.armv7l
  }
```

**Testing**
I have tested this fix.

**Desktop (please complete the following information):**
 - OS: Ubuntu Linux
 - OS Version: 20.04 lts
 - FreeTube version: 0.12

