### PR TITLE
Link app views to related YouTube url navigations

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -47,8 +47,9 @@
           class="commentThumbnail"
           @click="goToChannel(comment.authorLink)"
         >
-        <p class="commentAuthor"
-           @click="goToChannel(comment.authorLink)"
+        <p
+          class="commentAuthor"
+          @click="goToChannel(comment.authorLink)"
         >
           {{ comment.author }}
           <span class="commentDate">

--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -55,9 +55,8 @@ export default Vue.extend({
       descriptionText = descriptionText.replace(/&v.+?(?=")/g, '')
       descriptionText = descriptionText.replace(/&redirect-token.+?(?=")/g, '')
       descriptionText = descriptionText.replace(/&redir_token.+?(?=")/g, '')
-      descriptionText = descriptionText.replace(/href="http(s)?:\/\/youtube\.com/g, 'href="freetube://https://youtube.com')
-      descriptionText = descriptionText.replace(/href="\/watch/g, 'href="freetube://https://youtube.com')
-      descriptionText = descriptionText.replace(/href="\/results\?search_query=/g, 'href="freetube://')
+      descriptionText = descriptionText.replace(/href="\//g, 'href="https://www.youtube.com/')
+      // TODO: Implement hashtag support
       descriptionText = descriptionText.replace(/href="\/hashtag\//g, 'href="freetube://')
       descriptionText = descriptionText.replace(/yt\.www\.watch\.player\.seekTo/g, 'changeDuration')
 


### PR DESCRIPTION
**Pull Request Type**
- [X] Feature Implementation

**Related issue**
Closes #811

**Description**
This PR makes it so certain YouTube links present in user related data (e.g. description of a video) open the appropriate view in the app when clicked.
This has been implement for video, playlist, search and channel URL types.

**Testing**
Fully tested

**Desktop:**
 - FreeTube version: development

TODO?
- Handle a certain amount of URL shortening services (but I'm not sure I wanna go down that rabbit hole... if I do, I'll do so in a future PR)

