### PR TITLE
Video meta file removal option

### DIFF
--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -33,6 +33,10 @@ export default Vue.extend({
     saveWatchedProgress: function () {
       return this.$store.getters.getSaveWatchedProgress
     },
+    removeVideoMetaFiles: function () {
+      return this.$store.getters.getRemoveVideoMetaFiles
+    },
+
     profileList: function () {
       return this.$store.getters.getProfileList
     },
@@ -64,6 +68,13 @@ export default Vue.extend({
       }
 
       this.updateRememberHistory(value)
+    },
+
+    handleVideoMetaFiles: function (value) {
+      if (!value) {
+        this.updateRemoveVideoMetaFiles(false)
+      }
+      this.updateRemoveVideoMetaFiles(value)
     },
 
     handleRemoveHistory: function (option) {
@@ -102,6 +113,7 @@ export default Vue.extend({
 
     ...mapActions([
       'updateRememberHistory',
+      'updateRemoveVideoMetaFiles',
       'removeAllHistory',
       'updateSaveWatchedProgress',
       'clearSessionSearchHistory',

--- a/src/renderer/components/privacy-settings/privacy-settings.vue
+++ b/src/renderer/components/privacy-settings/privacy-settings.vue
@@ -23,6 +23,15 @@
           @change="updateSaveWatchedProgress"
         />
       </div>
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Privacy Settings.Automatically Remove Video Meta Files')"
+          :compact="true"
+          :default-value="removeVideoMetaFiles"
+          :tooltip="$t('Tooltips.Privacy Settings.Remove Video Meta Files')"
+          @change="handleVideoMetaFiles"
+        />
+      </div>
     </div>
     <br>
     <ft-flex-box>

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -47,6 +47,7 @@ const state = {
   enableSearchSuggestions: true,
   rememberHistory: true,
   saveWatchedProgress: true,
+  removeVideoMetaFiles: true,
   autoplayVideos: true,
   autoplayPlaylists: true,
   playNextVideo: false,
@@ -139,6 +140,10 @@ const getters = {
 
   getSaveWatchedProgress: () => {
     return state.saveWatchedProgress
+  },
+
+  getRemoveVideoMetaFiles: () => {
+    return state.removeVideoMetaFiles
   },
 
   getAutoplayVideos: () => {
@@ -329,6 +334,9 @@ const actions = {
                 break
               case 'saveWatchedProgress':
                 commit('setSaveWatchedProgress', result.value)
+                break
+              case 'removeVideoMetaFiles':
+                commit('setRemoveVideoMetaFiles', result.value)
                 break
               case 'autoplayVideos':
                 commit('setAutoplayVideos', result.value)
@@ -551,6 +559,14 @@ const actions = {
     settingsDb.update({ _id: 'saveWatchedProgress' }, { _id: 'saveWatchedProgress', value: saveWatchedProgress }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
         commit('setSaveWatchedProgress', saveWatchedProgress)
+      }
+    })
+  },
+
+  updateRemoveVideoMetaFiles ({ commit }, removeVideoMetaFiles) {
+    settingsDb.update({ _id: 'removeVideoMetaFiles' }, { _id: 'removeVideoMetaFiles', value: removeVideoMetaFiles }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setRemoveVideoMetaFiles', removeVideoMetaFiles)
       }
     })
   },
@@ -822,6 +838,11 @@ const mutations = {
   setSaveWatchedProgress (state, saveWatchedProgress) {
     state.saveWatchedProgress = saveWatchedProgress
   },
+
+  setRemoveVideoMetaFiles (state, removeVideoMetaFiles) {
+    state.removeVideoMetaFiles = removeVideoMetaFiles
+  },
+
   setAutoplayVideos (state, autoplayVideos) {
     state.autoplayVideos = autoplayVideos
   },

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1114,7 +1114,7 @@ export default Vue.extend({
       'showToast',
       'buildVTTFileLocally',
       'updateHistory',
-      'updateWatchProgress',
+      'updateWatchProgress'
     ])
   }
 })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -91,6 +91,9 @@ export default Vue.extend({
     rememberHistory: function () {
       return this.$store.getters.getRememberHistory
     },
+    removeVideoMetaFiles: function () {
+      return this.$store.getters.getRemoveVideoMetaFiles
+    },
     saveWatchedProgress: function () {
       return this.$store.getters.getSaveWatchedProgress
     },
@@ -899,8 +902,6 @@ export default Vue.extend({
             videoId: this.videoId,
             watchProgress: currentTime
           }
-
-          console.log('update watch progress')
           this.updateWatchProgress(payload)
         }
       }
@@ -926,6 +927,31 @@ export default Vue.extend({
               player.dispose()
             })
           }, 200)
+        }
+      }
+
+      if (this.removeVideoMetaFiles) {
+        const userData = remote.app.getPath('userData')
+        if (this.isDev) {
+          const dashFileLocation = `dashFiles/${this.videoId}.xml`
+          const vttFileLocation = `storyboards/${this.videoId}.vtt`
+          // only delete the file it actually exists
+          if (fs.existsSync('dashFiles/') && fs.existsSync(dashFileLocation)) {
+            fs.rmSync(dashFileLocation)
+          }
+          if (fs.existsSync('storyboards/') && fs.existsSync(vttFileLocation)) {
+            fs.rmSync(vttFileLocation)
+          }
+        } else {
+          const dashFileLocation = `${userData}/dashFiles/${this.videoId}.xml`
+          const vttFileLocation = `${userData}/storyboards/${this.videoId}.vtt`
+
+          if (fs.existsSync(`${userData}/dashFiles/`) && fs.existsSync(dashFileLocation)) {
+            fs.rmSync(dashFileLocation)
+          }
+          if (fs.existsSync(`${userData}/storyboards/`) && fs.existsSync(vttFileLocation)) {
+            fs.rmSync(vttFileLocation)
+          }
         }
       }
     },
@@ -1088,7 +1114,7 @@ export default Vue.extend({
       'showToast',
       'buildVTTFileLocally',
       'updateHistory',
-      'updateWatchProgress'
+      'updateWatchProgress',
     ])
   }
 })

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -195,6 +195,7 @@ Settings:
     Privacy Settings: Privacy Settings
     Remember History: Remember History
     Save Watched Progress: Save Watched Progress
+    Automatically Remove Video Meta Files: Automatically Remove Video Meta Files
     Clear Search Cache: Clear Search Cache
     Are you sure you want to clear out your search cache?: Are you sure you want to
       clear out your search cache?
@@ -571,6 +572,9 @@ Tooltips:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
       but doesn't provide certain information like video duration or live status
+  Privacy Settings:
+    Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files created during video playback,
+      when the watch page is closed.
 
 # Toast Messages
 Local API Error (Click to copy): Local API Error (Click to copy)


### PR DESCRIPTION
---
Video meta file removal option
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Description**
The user now has the option to automatically delete all storyboard and DASH files from a video when the view is closed. The setting is especially useful for debugging purposes, but by default reduces the memory footprint of the application.

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Tested with different videos and different route changes.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 12.0.0
