### PR TITLE
Bumped yt-comment-scraper version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18326,9 +18326,9 @@
       }
     },
     "yt-comment-scraper": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-3.0.2.tgz",
-      "integrity": "sha512-vWg/2D0eCJ0DTRayBmxqjZdBXSjArDFp/UAlK/r9tOq+x89hyQwuvP5r5URzLeRXGyv0g0COXsNapZGQR5aaPA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/yt-comment-scraper/-/yt-comment-scraper-4.0.1.tgz",
+      "integrity": "sha512-5uReiiLnaBhTBBsTfxIYcoV62EATe8dXAkkUCkCG3pgLU+qty9iCjNQvSgY8tZhnCPNAPO+lJaxzbGJ3hJRm4g==",
       "requires": {
         "axios": "^0.21.1",
         "node-html-parser": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "youtube-chat": "git+https://github.com/IcedCoffeee/youtube-chat.git",
     "youtube-suggest": "^1.1.1",
     "yt-channel-info": "^2.0.0",
-    "yt-comment-scraper": "^3.0.2",
+    "yt-comment-scraper": "^4.0.1",
     "yt-dash-manifest-generator": "1.1.0",
     "yt-trending-scraper": "^1.1.1",
     "yt-xml2vtt": "^1.2.0",


### PR DESCRIPTION
---
Bumped yt-comment-scraper version
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Description**
Published a new module version which supports the setCookie flag with the new cookie that is needed, but also keeps freetube comments running.

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Tested on a new vm

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: v12.0.0
