### PR TITLE
Fix for missing import of marked as watched videos & publish date displayed

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -929,7 +929,7 @@ export default Vue.extend({
               }
             })
 
-            if (Object.keys(historyObject).length < requiredKeys.length) {
+            if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
               this.showToast({
                 message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
               })

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -383,7 +383,7 @@ export default Vue.extend({
         title: this.title,
         author: this.channelName,
         authorId: this.channelId,
-        published: '',
+        published: this.publishedText.split(',')[0],
         description: this.description,
         viewCount: this.viewCount,
         lengthSeconds: this.data.lengthSeconds,
@@ -393,9 +393,7 @@ export default Vue.extend({
         paid: false,
         type: 'video'
       }
-
       this.updateHistory(videoData)
-
       this.showToast({
         message: this.$t('Video.Video has been marked as watched')
       })


### PR DESCRIPTION
---
Fix for missing import of marked as watched videos & publish date displayed
---
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes issue #1173 

**Description**
During import videos with 2 missing keys are now allowed in as well, because they are the missing description and view count from videos added through the 'Mark as watched' when using RSS.

Additionally videos marked as watched are now also showing the publishing date in history

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Tested with exported histories. 

