### PR TITLE
Update yt-channel-info module

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "xml2json": "^0.12.0",
     "youtube-chat": "git+https://github.com/IcedCoffeee/youtube-chat.git",
     "youtube-suggest": "^1.1.2",
-    "yt-channel-info": "^2.0.0",
+    "yt-channel-info": "^2.1.0",
     "yt-comment-scraper": "^4.0.1",
     "yt-dash-manifest-generator": "1.1.0",
     "yt-trending-scraper": "^1.1.1",


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1101

**Description**
There was a bug on yt-channel-info, which got fixed in the latest release. https://github.com/FreeTubeApp/yt-channel-info/pull/22
