### PR TITLE
* Update top nav search input to direct to channel panel when channel URL provided

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -260,6 +260,144 @@ const actions = {
     return extractors.reduce((a, c) => a || c(), null) || false
   },
 
+  getYoutubeUrlInfo (_, urlStr) {
+    // Returns
+    // - urlType [String] `video`, `playlist`
+    //
+    // If `urlType` is "video"
+    // - videoId [String]
+    // - timestamp [String]
+    //
+    // If `urlType` is "playlist"
+    // - playlistId [String]
+    // - query [Object]
+    //
+    // If `urlType` is "search"
+    // - searchQuery [String]
+    // - query [Object]
+    //
+    // If `urlType` is "hashtag"
+    // Nothing else
+    //
+    // If `urlType` is "channel"
+    // - channelId [String]
+    //
+    // If `urlType` is "unknown"
+    // Nothing else
+    //
+    // If `urlType` is "invalid_url"
+    // Nothing else
+    const { videoId, timestamp } = actions.getVideoParamsFromUrl(null, urlStr)
+    if (videoId) {
+      return {
+        urlType: 'video',
+        videoId,
+        timestamp
+      }
+    }
+
+    let url
+    try {
+      url = new URL(urlStr)
+    } catch {
+      return {
+        urlType: 'invalid_url'
+      }
+    }
+    let urlType = 'unknown'
+
+    const channelPattern =
+      /^\/(?:c\/|channel\/|user\/)?([^/]+)(?:\/join)?\/?$/
+
+    const typePatterns = new Map([
+      ['playlist', /^\/playlist\/?$/],
+      ['search', /^\/results\/?$/],
+      ['hashtag', /^\/hashtag\/([^/?&#]+)$/],
+      ['channel', channelPattern]
+    ])
+
+    for (const [type, pattern] of typePatterns) {
+      const matchFound = pattern.test(url.pathname)
+      if (matchFound) {
+        urlType = type
+        break
+      }
+    }
+
+    switch (urlType) {
+      case 'playlist': {
+        if (!url.searchParams.has('list')) {
+          throw new Error('Playlist: "list" field not found')
+        }
+
+        const playlistId = url.searchParams.get('list')
+        url.searchParams.delete('list')
+
+        const query = {}
+        for (const [param, value] of url.searchParams) {
+          query[param] = value
+        }
+
+        return {
+          urlType: 'playlist',
+          playlistId,
+          query
+        }
+      }
+
+      case 'search': {
+        if (!url.searchParams.has('search_query')) {
+          throw new Error('Search: "search_query" field not found')
+        }
+
+        const searchQuery = url.searchParams.get('search_query')
+        url.searchParams.delete('search_query')
+
+        const query = {
+          sortBy: this.searchSettings.sortBy,
+          time: this.searchSettings.time,
+          type: this.searchSettings.type,
+          duration: this.searchSettings.duration
+        }
+
+        for (const [param, value] of url.searchParams) {
+          query[param] = value
+        }
+
+        return {
+          urlType: 'search',
+          searchQuery,
+          query
+        }
+      }
+
+      case 'hashtag': {
+        return {
+          urlType: 'hashtag'
+        }
+      }
+
+      case 'channel': {
+        const channelId = url.pathname.match(channelPattern)[1]
+        if (!channelId) {
+          throw new Error('Channel: could not extract id')
+        }
+
+        return {
+          urlType: 'channel',
+          channelId
+        }
+      }
+
+      default: {
+        // Unknown URL type
+        return {
+          urlType: 'unknown'
+        }
+      }
+    }
+  },
+
   padNumberWithLeadingZeros(_, payload) {
     let numberString = payload.number.toString()
     while (numberString.length < payload.length) {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -239,27 +239,6 @@ const actions = {
     return extractors.reduce((a, c) => a || c(), null) || paramsObject
   },
 
-  getPlaylistIdFromUrl (_, url) {
-    /** @type {URL} */
-    let urlObject
-    try {
-      urlObject = new URL(url)
-    } catch (e) {
-      return false
-    }
-
-    const extractors = [
-      // anything with /playlist?list=
-      function() {
-        if (urlObject.pathname === '/playlist' && urlObject.searchParams.has('list')) {
-          return urlObject.searchParams.get('list')
-        }
-      }
-    ]
-
-    return extractors.reduce((a, c) => a || c(), null) || false
-  },
-
   getYoutubeUrlInfo (_, urlStr) {
     // Returns
     // - urlType [String] `video`, `playlist`


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1218

**Description**
This PR makes channel URL input in search input box in top nav handled by redirecting to channel view.
Instead of searching with it
Channel URL expected to be like `/channel/{channelID}`

**Screenshots (if appropriate)**

https://user-images.githubusercontent.com/1018543/115644811-c48a2b80-a351-11eb-9504-39f0982c24b8.mp4



**Testing (for code that is not small enough to be easily understandable)**
- Enter channel URL (e.g. https://www.youtube.com/channel/UCkRfArvrzheW2E7b6SVT7vQ)
- Press Enter/"Go To" button
- Ensure channel view shown instead of search result view

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
