### PR TITLE
* Update player to hide full window button when in full screen mode

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -231,6 +231,7 @@ export default Vue.extend({
         this.player.controlBar.getChild('volumePanel').on('mousewheel', this.mouseScrollVolume)
 
         this.player.on('fullscreenchange', this.fullscreenOverlay)
+        this.player.on('fullscreenchange', this.toggleFullscreenClass)
 
         const v = this
 
@@ -651,8 +652,11 @@ export default Vue.extend({
           v.toggleFullWindow()
         },
         createControlTextEl: function (button) {
-          return $(button).html($('<div id="fullwindow" class="vjs-icon-fullwindow-enter vjs-button"></div>')
-            .attr('title', 'Fullwindow'))
+          // Add class name to button to be able to target it with CSS selector
+          return $(button)
+            .addClass('vjs-button-fullwindow')
+            .html($('<div id="fullwindow" class="vjs-icon-fullwindow-enter vjs-button"></div>')
+              .attr('title', 'Full Window'))
         }
       })
       videojs.registerComponent('fullWindowButton', fullWindowButton)
@@ -818,6 +822,14 @@ export default Vue.extend({
             }]
           })
         })
+      }
+    },
+
+    toggleFullscreenClass: function () {
+      if (this.player.isFullscreen()) {
+        $('body').addClass('vjs--full-screen-enabled')
+      } else {
+        $('body').removeClass('vjs--full-screen-enabled')
       }
     },
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -448,6 +448,10 @@ body.vjs-full-window {
 .vjs-icon-fullwindow-enter:before, .video-js .vjs-fullwindow-control .vjs-icon-placeholder:before {
   content: url(assets/img/open_fullwindow.svg);
 }
+/* Hide button in full screen mode */
+.vjs--full-screen-enabled .vjs-button-fullwindow {
+  display: none;
+}
 
 .vjs-icon-fullwindow-exit, .video-js.vjs-fullwindow .vjs-fullwindow-control .vjs-icon-placeholder {
   font-family: VideoJS;


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1178

**Description**
This PR makes the player hide "Full Window" button when in full screen mode

**Screenshots (if appropriate)**
Before
![Screen Shot 2021-04-22 at 10 46 22 ](https://user-images.githubusercontent.com/1018543/115648463-103fd380-a358-11eb-8f9b-d44cd6bdd7a7.png)

After
![Screen Shot 2021-04-22 at 10 44 55 ](https://user-images.githubusercontent.com/1018543/115648484-1635b480-a358-11eb-925d-40655e921443.png)
![Screen Shot 2021-04-22 at 10 45 02 ](https://user-images.githubusercontent.com/1018543/115648489-17ff7800-a358-11eb-8d4a-40b743d8f909.png)

**Testing (for code that is not small enough to be easily understandable)**
- View a video
- Enter full screen mode
- Ensure full window button hidden

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
