### PR TITLE
+ Add Reload Video button on video page

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -341,6 +341,10 @@ export default Vue.extend({
       }
     },
 
+    reloadVideo: function () {
+      this.$router.go(this.$router.currentRoute)
+    },
+
     addToPlaylist: function () {
       const videoData = {
         videoId: this.id,

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -103,6 +103,13 @@
           :get-timestamp="getTimestamp"
           class="option"
         />
+        <ft-icon-button
+          :title="$t('Video.Reload Video')"
+          class="theatreModeButton option"
+          icon="sync-alt"
+          theme="secondary"
+          @click="reloadVideo"
+        />
       </div>
     </div>
   </ft-card>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -397,6 +397,7 @@ Video:
   Save Video: Save Video
   Video has been saved: Video has been saved
   Video has been removed from your saved list: Video has been removed from your saved list
+  Reload Video: Reload Video
   Open in YouTube: Open in YouTube
   Copy YouTube Link: Copy YouTube Link
   Open YouTube Embedded Player: Open YouTube Embedded Player


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1005

**Description**
Adds a button to view video page, next to share button (can be repositioned)
Which reload the view/page actually on click

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/1018543/115679816-8b6bae80-a385-11eb-907f-16a2e9cac750.png)

**Testing (for code that is not small enough to be easily understandable)**
- View a video 
- Press the new button

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

