### PR TITLE
* Update "toggle theatre mode" button icon

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -74,7 +74,7 @@
           v-if="theatrePossible"
           :title="$t('Toggle Theatre Mode')"
           class="theatreModeButton option"
-          icon="expand-alt"
+          icon="tv"
           theme="secondary"
           @click="$emit('theatre-mode')"
         />


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1180

**Description**
Update "toggle theatre mode" button icon to [`tv`](https://fontawesome.com/icons/tv?style=solid)

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/1018543/115490662-1a4acf00-a291-11eb-93f0-49ca6bceb48f.png)

**Testing (for code that is not small enough to be easily understandable)**
- View a video
- Check button icon

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)
