### PR TITLE
Implement state sync for setting `useProxy`

### DIFF
--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -75,6 +75,13 @@ export default Vue.extend({
         commitOnly: true
       })
     })
+    electron.ipcRenderer.on('settings.update.updateProxyProtocol', (_e, value) => {
+      // Update this window's state, without sending the event again
+      this.updateProxyProtocol({
+        proxyProtocol: value,
+        commitOnly: true
+      })
+    })
   },
   beforeDestroy: function () {
     if (this.proxyHostname === '') {
@@ -101,7 +108,9 @@ export default Vue.extend({
       if (this.useProxy) {
         this.enableProxy()
       }
-      this.updateProxyProtocol(value)
+      this.updateProxyProtocol({
+        proxyProtocol: value
+      })
     },
 
     handleUpdateProxyHostname: function (value) {

--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -67,6 +67,14 @@ export default Vue.extend({
   },
   mounted: function () {
     this.debounceEnableProxy = debounce(this.enableProxy, 200)
+
+    electron.ipcRenderer.on('settings.update.updateUseProxy', (_e, value) => {
+      // Update this window's state, without sending the event again
+      this.updateUseProxy({
+        useProxy: value,
+        commitOnly: true
+      })
+    })
   },
   beforeDestroy: function () {
     if (this.proxyHostname === '') {
@@ -84,7 +92,9 @@ export default Vue.extend({
       } else {
         this.disableProxy()
       }
-      this.updateUseProxy(value)
+      this.updateUseProxy({
+        useProxy: value
+      })
     },
 
     handleUpdateProxyProtocol: function (value) {

--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -82,6 +82,20 @@ export default Vue.extend({
         commitOnly: true
       })
     })
+    electron.ipcRenderer.on('settings.update.updateProxyHostname', (_e, value) => {
+      // Update this window's state, without sending the event again
+      this.updateProxyHostname({
+        proxyHostname: value,
+        commitOnly: true
+      })
+    })
+    electron.ipcRenderer.on('settings.update.updateProxyPort', (_e, value) => {
+      // Update this window's state, without sending the event again
+      this.updateProxyPort({
+        proxyPort: value,
+        commitOnly: true
+      })
+    })
   },
   beforeDestroy: function () {
     if (this.proxyHostname === '') {
@@ -117,14 +131,18 @@ export default Vue.extend({
       if (this.useProxy) {
         this.debounceEnableProxy()
       }
-      this.updateProxyHostname(value)
+      this.updateProxyHostname({
+        proxyHostname: value
+      })
     },
 
     handleUpdateProxyPort: function (value) {
       if (this.useProxy) {
         this.debounceEnableProxy()
       }
-      this.updateProxyPort(value)
+      this.updateProxyPort({
+        proxyPort: value
+      })
     },
 
     enableProxy: function () {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -711,18 +711,44 @@ const actions = {
     })
   },
 
-  updateProxyHostname ({ commit }, proxyHostname) {
+  updateProxyHostname ({ commit }, { proxyHostname, commitOnly }) {
+    if (commitOnly) {
+      commit('setProxyHostname', proxyHostname)
+      return
+    }
+
     settingsDb.update({ _id: 'proxyHostname' }, { _id: 'proxyHostname', value: proxyHostname }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
         commit('setProxyHostname', proxyHostname)
+
+        // Send event to other windows to notify about setting value update
+        const currentWebContents = remote.getCurrentWebContents()
+        remote.webContents.getAllWebContents().forEach((item) => {
+          if (item !== currentWebContents) {
+            item.send('settings.update.updateProxyHostname', proxyHostname) // notify other renderer process
+          }
+        })
       }
     })
   },
 
-  updateProxyPort ({ commit }, proxyPort) {
+  updateProxyPort ({ commit }, { proxyPort, commitOnly }) {
+    if (commitOnly) {
+      commit('setProxyPort', proxyPort)
+      return
+    }
+
     settingsDb.update({ _id: 'proxyPort' }, { _id: 'proxyPort', value: proxyPort }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
         commit('setProxyPort', proxyPort)
+
+        // Send event to other windows to notify about setting value update
+        const currentWebContents = remote.getCurrentWebContents()
+        remote.webContents.getAllWebContents().forEach((item) => {
+          if (item !== currentWebContents) {
+            item.send('settings.update.updateProxyPort', proxyPort) // notify other renderer process
+          }
+        })
       }
     })
   },


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix

**Related issue**
https://github.com/FreeTubeApp/FreeTube/pull/1203

**Description**
Implement setting sync (for some settings) for multiple opened windows

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/116529275-59bb9000-a90f-11eb-942d-0f236b60e6ee.mp4

**Testing (for code that is not small enough to be easily understandable)**
See video

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

**Additional context**
Since this require implementation **per setting entry** only 1 setting is updated for preview
(Might update before merge)

Implemented after looking at
https://github.com/chenjietao/vuex-electron-sync-state/blob/master/src/index.js
