### PR TITLE
Adding a 'Follow System' option to the 'Locale Preference'

### DIFF
--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -103,12 +103,15 @@ export default Vue.extend({
       const names = []
 
       Object.keys(this.$i18n.messages).forEach((locale) => {
-        const localeName = this.$i18n.messages[locale]['Locale Name']
-        if (typeof localeName !== 'undefined' && locale !== 'system') {
-          names.push(localeName)
-        } else if (typeof localeName !== 'undefined' && locale === 'system') {
+        if (locale === 'system') {
           names.push('Follow System')
-        } else {
+          return
+        }
+        const localeName = this.$i18n.messages[locale]['Locale Name']
+        if (typeof localeName !== 'undefined') {
+          names.push(localeName)
+        }
+        else {
           names.push(locale)
         }
       })

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -104,8 +104,10 @@ export default Vue.extend({
 
       Object.keys(this.$i18n.messages).forEach((locale) => {
         const localeName = this.$i18n.messages[locale]['Locale Name']
-        if (typeof localeName !== 'undefined') {
+        if (typeof localeName !== 'undefined' && locale !== "system") {
           names.push(localeName)
+        } else if (typeof localeName !== 'undefined' && locale === "system") { // adds Follow System to localeNames if system locale was found
+          names.push("Follow System")
         } else {
           names.push(locale)
         }

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -106,7 +106,7 @@ export default Vue.extend({
         const localeName = this.$i18n.messages[locale]['Locale Name']
         if (typeof localeName !== 'undefined' && locale !== 'system') {
           names.push(localeName)
-        } else if (typeof localeName !== 'undefined' && locale === 'system') { // adds Follow System to localeNames if system locale was found
+        } else if (typeof localeName !== 'undefined' && locale === 'system') {
           names.push('Follow System')
         } else {
           names.push(locale)

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -104,7 +104,7 @@ export default Vue.extend({
 
       Object.keys(this.$i18n.messages).forEach((locale) => {
         if (locale === 'system') {
-          names.push('Follow System')
+          names.push('System Language')
           return
         }
         const localeName = this.$i18n.messages[locale]['Locale Name']

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -110,8 +110,7 @@ export default Vue.extend({
         const localeName = this.$i18n.messages[locale]['Locale Name']
         if (typeof localeName !== 'undefined') {
           names.push(localeName)
-        }
-        else {
+        } else {
           names.push(locale)
         }
       })

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -104,10 +104,10 @@ export default Vue.extend({
 
       Object.keys(this.$i18n.messages).forEach((locale) => {
         const localeName = this.$i18n.messages[locale]['Locale Name']
-        if (typeof localeName !== 'undefined' && locale !== "system") {
+        if (typeof localeName !== 'undefined' && locale !== 'system') {
           names.push(localeName)
-        } else if (typeof localeName !== 'undefined' && locale === "system") { // adds Follow System to localeNames if system locale was found
-          names.push("Follow System")
+        } else if (typeof localeName !== 'undefined' && locale === 'system') { // adds Follow System to localeNames if system locale was found
+          names.push('Follow System')
         } else {
           names.push(locale)
         }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -35,8 +35,7 @@ const fileLocation = isDev ? 'static/locales/' : `${__dirname}/static/locales/`
 // Take active locales and load respective YAML file
 activeLocales.forEach((locale) => {
   // Import elctrons app object to access getLocale function
-  const { remote } = require('electron')
-  const { app } = remote
+  const { app } = require('@electron/remote')
   try {
     // File location when running in dev
     if (locale === 'system') {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -27,26 +27,40 @@ Vue.component('FontAwesomeIcon', FontAwesomeIcon)
 Vue.use(VueI18n)
 
 // List of locales approved for use
-const activeLocales = ['en-US', 'en_GB', 'ar', 'bg', 'cs', 'da', 'de-DE', 'el', 'es', 'es-MX', 'fi', 'fr-FR', 'gl', 'he', 'hu', 'hr', 'id', 'is', 'it', 'ja', 'nb_NO', 'nl', 'nn', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
+const activeLocales = ['system', 'en-US', 'en_GB', 'ar', 'bg', 'cs', 'da', 'de-DE', 'el', 'es', 'es-MX', 'fi', 'fr-FR', 'gl', 'he', 'hu', 'hr', 'id', 'is', 'it', 'ja', 'nb_NO', 'nl', 'nn', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
 const messages = {}
 /* eslint-disable-next-line */
 const fileLocation = isDev ? 'static/locales/' : `${__dirname}/static/locales/`
 
 // Take active locales and load respective YAML file
 activeLocales.forEach((locale) => {
+  // Import elctrons app object to access getLocale function  
+  const { remote } = require('electron')
+  const { app } = remote
   try {
     // File location when running in dev
-    const doc = yaml.load(fs.readFileSync(`${fileLocation}${locale}.yaml`))
-    messages[locale] = doc
+    if (locale === "system") {
+      // trying to find the corresponding .yaml file to systems locale   
+      try {
+        const doc = yaml.load(fs.readFileSync(`${fileLocation}${app.getLocale()}.yaml`))
+        messages[locale] = doc
+      } catch (e) {
+        console.log(e)
+      }
+    }
+    else {
+      const doc = yaml.load(fs.readFileSync(`${fileLocation}${locale}.yaml`))
+      messages[locale] = doc
+    }
   } catch (e) {
     console.log(e)
   }
 })
 
 const i18n = new VueI18n({
-  locale: 'en-US', // set locale
+  locale: 'system', // set locale standard is to follow the systems locale
   fallbackLocale: {
-    default: 'en-US'
+    default: 'en-US' // for the case systems locale has no corresponding .yaml file en-US gets set 
   },
   messages // set locale messages
 })

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -39,13 +39,9 @@ activeLocales.forEach((locale) => {
   try {
     // File location when running in dev
     if (locale === 'system') {
-      const systemsLocale = app.getLocale()
-      if (activeLocales.indexOf(systemsLocale) !== -1) {
-        const doc = yaml.load(fs.readFileSync(`${fileLocation}${systemsLocale}.yaml`))
-        messages[locale] = doc
-      } else {
-        const regex = new RegExp(`${systemsLocale}-\\w+`, 'g')
-        const doc = yaml.load(fs.readFileSync(`${fileLocation}${activeLocales.join(' ').match(regex)[0]}.yaml`))
+      const systemsLocale = activeLocales.filter((currentValue) => { return currentValue.startsWith(app.getLocale()) })
+      if (systemsLocale.length) {
+        const doc = yaml.load(fs.readFileSync(`${fileLocation}${systemsLocale[0]}.yaml`))
         messages[locale] = doc
       }
     } else {

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -39,12 +39,14 @@ activeLocales.forEach((locale) => {
   try {
     // File location when running in dev
     if (locale === 'system') {
-      // trying to find the corresponding .yaml file to systems locale
-      try {
-        const doc = yaml.load(fs.readFileSync(`${fileLocation}${app.getLocale()}.yaml`))
+      const systemsLocale = app.getLocale()
+      if (activeLocales.indexOf(systemsLocale) !== -1) {
+        const doc = yaml.load(fs.readFileSync(`${fileLocation}${systemsLocale}.yaml`))
         messages[locale] = doc
-      } catch (e) {
-        console.log(e)
+      } else {
+        const regex = new RegExp(`${systemsLocale}-\\w+`, 'g')
+        const doc = yaml.load(fs.readFileSync(`${fileLocation}${activeLocales.join(' ').match(regex)[0]}.yaml`))
+        messages[locale] = doc
       }
     } else {
       const doc = yaml.load(fs.readFileSync(`${fileLocation}${locale}.yaml`))

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -34,21 +34,20 @@ const fileLocation = isDev ? 'static/locales/' : `${__dirname}/static/locales/`
 
 // Take active locales and load respective YAML file
 activeLocales.forEach((locale) => {
-  // Import elctrons app object to access getLocale function  
+  // Import elctrons app object to access getLocale function
   const { remote } = require('electron')
   const { app } = remote
   try {
     // File location when running in dev
-    if (locale === "system") {
-      // trying to find the corresponding .yaml file to systems locale   
+    if (locale === 'system') {
+      // trying to find the corresponding .yaml file to systems locale
       try {
         const doc = yaml.load(fs.readFileSync(`${fileLocation}${app.getLocale()}.yaml`))
         messages[locale] = doc
       } catch (e) {
         console.log(e)
       }
-    }
-    else {
+    } else {
       const doc = yaml.load(fs.readFileSync(`${fileLocation}${locale}.yaml`))
       messages[locale] = doc
     }
@@ -60,7 +59,7 @@ activeLocales.forEach((locale) => {
 const i18n = new VueI18n({
   locale: 'system', // set locale standard is to follow the systems locale
   fallbackLocale: {
-    default: 'en-US' // for the case systems locale has no corresponding .yaml file en-US gets set 
+    default: 'en-US' // for the case systems locale has no corresponding .yaml file en-US gets set
   },
   messages // set locale messages
 })


### PR DESCRIPTION
---
# Adding a 'Follow System' option to the 'Locale Preference'
---

 ## **Pull Request Type**

- [ ] Bugfix
- [x] Feature Implementation

## **Related issue**
#1205 

## **Description**
- New locale option created
- Option sets the local to the same local that the system running freetube is using  
- Option is the new standard Locale Preference 
- Option only shows up in case of a supported system locale if the system locale is not support `en-US` gets set 

## **Screenshots**

### Before
![image](https://user-images.githubusercontent.com/43616825/116680404-ee73cb80-a9ab-11eb-8fd2-05c7d6595bcb.png)

### After
![image](https://user-images.githubusercontent.com/43616825/116680712-49a5be00-a9ac-11eb-8a72-9a331eb914be.png)


## **Testing (for code that is not small enough to be easily understandable)**
I tested it with system locale: English(US) `en-US.yaml` most of the time and it works fine. But if I change to just English without (US) it tries to access `en.yaml`, which is not existing. Same would be for `fr-FR`, `de-DE`. For `pt-Pt` and `pt` it should be working fine, because there is a  `pt.yaml` file. 

Maybe something for a new Issue or for this Issue #673

## **Desktop:**
 - OS: Manjaro Linux 
 - OS Version: 21.0.3
 - FreeTube version: 7.11.1



**Feel free to correct the code :D**
