### PR TITLE
Update "Open Link" button to include playlist ID

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -399,7 +399,8 @@ export default Vue.extend({
       'grabHistory',
       'grabAllPlaylists',
       'getRegionData',
-      'getYoutubeUrlInfo'
+      'getYoutubeUrlInfo',
+      'getLocale'
     ]),
 
     ...mapMutations([

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -19,6 +19,10 @@ export default Vue.extend({
       type: String,
       required: true
     },
+    playlistId: {
+      type: String,
+      required: true
+    },
     getTimestamp: {
       type: Function,
       required: true
@@ -35,7 +39,13 @@ export default Vue.extend({
     },
 
     invidiousURL() {
-      return `${this.invidiousInstance}/watch?v=${this.id}`
+      let videoUrl = `${this.invidiousInstance}/watch?v=${this.id}`
+      // `playlistId` can be undefined
+      if (this.playlistId && this.playlistId.length !== 0) {
+        // `index` seems can be ignored
+        videoUrl += `&list=${this.playlistId}`
+      }
+      return videoUrl
     },
 
     invidiousEmbedURL() {
@@ -43,10 +53,21 @@ export default Vue.extend({
     },
 
     youtubeURL() {
-      return `https://www.youtube.com/watch?v=${this.id}`
+      let videoUrl = `https://www.youtube.com/watch?v=${this.id}`
+      // `playlistId` can be undefined
+      if (this.playlistId && this.playlistId.length !== 0) {
+        // `index` seems can be ignored
+        videoUrl += `&list=${this.playlistId}`
+      }
+      return videoUrl
     },
 
     youtubeShareURL() {
+      // `playlistId` can be undefined
+      if (this.playlistId && this.playlistId.length !== 0) {
+        // `index` seems can be ignored
+        return `https://www.youtube.com/watch?v=${this.id}&list=${this.playlistId}`
+      }
       return `https://youtu.be/${this.id}`
     },
 

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -111,7 +111,7 @@ export default Vue.extend({
       this.$refs.iconButton.focusOut()
     },
 
-    updateincludeTimestamp() {
+    updateIncludeTimestamp() {
       this.includeTimestamp = !this.includeTimestamp
     },
 

--- a/src/renderer/components/ft-share-button/ft-share-button.vue
+++ b/src/renderer/components/ft-share-button/ft-share-button.vue
@@ -12,7 +12,7 @@
         :label="$t('Share.Include Timestamp')"
         :compact="true"
         :default-value="includeTimestamp"
-        @change="updateincludeTimestamp"
+        @change="updateIncludeTimestamp"
       />
     </ft-flex-box>
     <div class="shareLinks">

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -82,6 +82,10 @@ export default Vue.extend({
       type: Boolean,
       required: true
     },
+    playlistId: {
+      type: String,
+      required: true
+    },
     theatrePossible: {
       type: Boolean,
       required: true

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -101,6 +101,7 @@
         <ft-share-button
           :id="id"
           :get-timestamp="getTimestamp"
+          :playlist-id="playlistId"
           class="option"
         />
       </div>

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -83,6 +83,7 @@
         :is-upcoming="isUpcoming"
         :download-links="downloadLinks"
         :watching-playlist="watchingPlaylist"
+        :playlist-id="playlistId"
         :theatre-possible="theatrePossible"
         :length-seconds="videoLengthSeconds"
         :video-thumbnail="thumbnail"


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Feature Implementation

**Related issue**
None

**Description**
Update Video Info Panel -> Share Button -> Youtube Side -> "Open Link" button
To open webpage for current video **with** active playlist if there is one in FreeTube

**Screenshots (if appropriate)**
Just screenshot for specifying the button updated
![image](https://user-images.githubusercontent.com/1018543/117411144-da007780-af45-11eb-95a7-dc1af60443db.png)

**Testing (for code that is not small enough to be easily understandable)**
Test case A (video without playlist):
- Input URL https://www.youtube.com/watch?v=eBZ2vA9D2RA into FT
- Press "Open Link" button
- Inspect URL

Test case B (video with playlist):
- Input URL https://www.youtube.com/playlist?list=PLzFTGYa_evXiOHCB_cb1Sqsk-LIARmLgd into FT
- View one of videos
- Press "Open Link" button
- Inspect URL

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

**Additional context**
Not sure if other buttons should be updated too, but let's leave them for later
