### PR TITLE
Implemented the ability to return to the regular viewing mode from the PiP window after navigating away from the video

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -967,7 +967,7 @@ export default Vue.extend({
 
                 if (!videoPaused) {
                   if (window.location.href !== videoUrl) {
-                    window.location.assign(videoUrl)
+                    this.$router.push({ path: `/watch/${this.videoId}` })
                   } else {
                     const activePlayer = $('.ftVideoPlayer video').get(0)
                     activePlayer.currentTime = watchTime

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -54,7 +54,6 @@ export default Vue.extend({
       videoTitle: '',
       videoDescription: '',
       videoDescriptionHtml: '',
-      videoUrl: window.location.href,
       videoViewCount: 0,
       videoLikeCount: 0,
       videoDislikeCount: 0,
@@ -941,7 +940,7 @@ export default Vue.extend({
 
       if (!this.isUpcoming && !this.isLoading) {
         const player = this.$refs.videoPlayer.player
-        const videoUrl = this.videoUrl
+        const videoUrl = window.location.href
 
         if (player !== null && !player.paused() && player.isInPictureInPicture()) {
           const playerId = this.videoId


### PR DESCRIPTION
---
Added the ability to return to the regular viewing mode from the PiP window after navigating away from the video
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
#966 ?
#624 

**Description**
When using Picture In Picture mode and the user navigates away from the video page:
* Return to the video page if the user clicks on the 'Back to video player' button and the PiP video is not paused
* Close the PiP view if the user clicks the 'Close' button or if they click the 'Back to video player' button and the video is paused

**Testing (for code that is not small enough to be easily understandable)**
1.  Open any video
2. Click to watch the video in Picture in Picture mode
3. Navigate away from the video by either starting another video or going to Settings/Subscriptions/etc. page

Test returning to regular viewing mode from PiP mode
* Perform steps 1-3
* Make sure the PiP video is not paused
* Click 'Back to video player' button 

Test closing PiP mode
* Perform steps 1-3
* Click 'Close' button
OR
* Perform steps 1-3
* Make sure the PiP video is paused
* Click 'Back to video player' button

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: Latest development branch
 
**Additional context**
Due to the inability to properly track 'Close' vs 'Back to video player' button clicks, the Picture in Picture window will treat both the 'Close' and 'Back to video player' buttons as close buttons when the video is paused. 
