### PR TITLE
Update video player to remove default big play button shown when paused

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -217,6 +217,9 @@ export default Vue.extend({
 
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)
+        // Remove big play button
+        // https://github.com/videojs/video.js/blob/v7.12.1/docs/guides/components.md#basic-example
+        this.player.removeChild('BigPlayButton')
 
         if (this.storyboardSrc !== '') {
           this.player.vttThumbnails({


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Feature Implementation

**Related issue**
#347

**Description**
Remove the big play button shown when video paused

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/117793853-3c77b180-b27f-11eb-9d62-da45da7c267d.mp4

**Testing (for code that is not small enough to be easily understandable)**
- Play a video
- Pause it
- Check for the big play button

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
