### PR TITLE
Update playback rate menu to put 1x in view when opened

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -222,6 +222,18 @@ export default Vue.extend({
         this.player.volume(this.volume)
         this.player.playbackRate(this.defaultPlayback)
 
+        // region playback rate menu focus hack
+        // Makes the playback rate menu focus on last item on  mouse hover
+        // last item is "0.25x" (video.js put lowest rate at last)
+        // This ensures "1x" is visible on menu open
+        const playbackRateMenuButton = this.player.controlBar.getChild('playbackRateMenuButton')
+        playbackRateMenuButton.on(playbackRateMenuButton.menuButton_, 'mouseenter', () => {
+          // Assuming this happens after original hover event handler
+          // Which shows the menu
+          playbackRateMenuButton.menu.focus(999)
+        })
+        // endregion playback rate menu focus hack
+
         if (this.storyboardSrc !== '') {
           this.player.vttThumbnails({
             src: this.storyboardSrc,


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
#1273

**Description**
Update playback rate menu to put 1x in view when opened

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/118444804-33c02900-b720-11eb-9e33-774ae80d7468.mp4


**Testing (for code that is not small enough to be easily understandable)**
- Open a video
- Open playback rate menu
- Observe the menu items

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)

**Additional context**
`video.js` provide no option to control menu behaviour  
Already check source code about `PlaybackRateMenuButton` & its parent `MenuButton`
