### PR TITLE
Stay in Picture in Picture when using autoplay or wathing a playlist

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -144,6 +144,10 @@ export default Vue.extend({
 
     autoplayVideos: function () {
       return this.$store.getters.getAutoplayVideos
+    },
+
+    lastPlayedAsPip: function() {
+      return this.$store.getters.getLastPlayedAsPip
     }
   },
   mounted: function () {
@@ -267,6 +271,10 @@ export default Vue.extend({
             this.powerSaveBlocker = null
           }
         })
+
+        this.player.on('loadedmetadata', function () {
+          v.checkPipAutoplay()
+        })
       }
     },
 
@@ -285,6 +293,13 @@ export default Vue.extend({
         this.player.fluid(false)
         this.player.aspectRatio('16:9')
       }
+    },
+
+    checkPipAutoplay() {
+      if (this.lastPlayedAsPip && !this.player.isInPictureInPicture()) {
+        this.player.requestPictureInPicture()
+      }
+      this.updateLastPlayedAsPip(false)
     },
 
     updateVolume: function (event) {
@@ -1100,7 +1115,8 @@ export default Vue.extend({
     },
 
     ...mapActions([
-      'calculateColorLuminance'
+      'calculateColorLuminance',
+      'updateLastPlayedAsPip'
     ])
   }
 })

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -51,6 +51,7 @@ const state = {
   autoplayVideos: true,
   autoplayPlaylists: true,
   playNextVideo: false,
+  lastPlayedAsPip: false,
   enableSubtitles: true,
   forceLocalBackendForLegacy: false,
   proxyVideos: false,
@@ -156,6 +157,10 @@ const getters = {
 
   getPlayNextVideo: () => {
     return state.playNextVideo
+  },
+
+  getLastPlayedAsPip: () => {
+    return state.lastPlayedAsPip
   },
 
   getEnableSubtitles: () => {
@@ -346,6 +351,9 @@ const actions = {
                 break
               case 'playNextVideo':
                 commit('setPlayNextVideo', result.value)
+                break
+              case 'lastPlayedAsPip':
+                commit('setLastPlayedAsPip', result.value)
                 break
               case 'enableSubtitles':
                 commit('setEnableSubtitles', result.value)
@@ -591,6 +599,14 @@ const actions = {
     settingsDb.update({ _id: 'playNextVideo' }, { _id: 'playNextVideo', value: playNextVideo }, { upsert: true }, (err, numReplaced) => {
       if (!err) {
         commit('setPlayNextVideo', playNextVideo)
+      }
+    })
+  },
+
+  updateLastPlayedAsPip ({ commit }, lastPlayedAsPip) {
+    settingsDb.update({ _id: 'lastPlayedAsPip' }, { _id: 'lastPlayedAsPip', value: lastPlayedAsPip }, { upsert: true }, (err, numReplaced) => {
+      if (!err) {
+        commit('setLastPlayedAsPip', lastPlayedAsPip)
       }
     })
   },
@@ -851,6 +867,9 @@ const mutations = {
   },
   setPlayNextVideo (state, playNextVideo) {
     state.playNextVideo = playNextVideo
+  },
+  setLastPlayedAsPip (state, lastPlayedAsPip) {
+    state.lastPlayedAsPip = lastPlayedAsPip
   },
   setEnableSubtitles (state, enableSubtitles) {
     state.enableSubtitles = enableSubtitles

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -885,9 +885,15 @@ export default Vue.extend({
       }
 
       const nextVideoInterval = this.defaultInterval
-      this.playNextTimeout = setTimeout(() => {
+      this.playNextTimeout = setTimeout(async () => {
         const player = this.$refs.videoPlayer.player
+        const playerInPictureInPicture = player.isInPictureInPicture()
         if (player !== null && player.paused()) {
+          if (playerInPictureInPicture) {
+            this.updateLastPlayedAsPip(true)
+          } else {
+            this.updateLastPlayedAsPip(false)
+          }
           if (this.watchingPlaylist) {
             this.$refs.watchVideoPlaylist.playNextVideo()
           } else {
@@ -1197,7 +1203,8 @@ export default Vue.extend({
       'showToast',
       'buildVTTFileLocally',
       'updateHistory',
-      'updateWatchProgress'
+      'updateWatchProgress',
+      'updateLastPlayedAsPip'
     ])
   }
 })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -887,12 +887,9 @@ export default Vue.extend({
       const nextVideoInterval = this.defaultInterval
       this.playNextTimeout = setTimeout(async () => {
         const player = this.$refs.videoPlayer.player
-        const playerInPictureInPicture = player.isInPictureInPicture()
         if (player !== null && player.paused()) {
-          if (playerInPictureInPicture) {
+          if (player.isInPictureInPicture()) {
             this.updateLastPlayedAsPip(true)
-          } else {
-            this.updateLastPlayedAsPip(false)
           }
           if (this.watchingPlaylist) {
             this.$refs.watchVideoPlaylist.playNextVideo()


### PR DESCRIPTION
---
Stay in Picture in Picture when using autoplay or watching a playlist in PiP
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
#927 

**Description**
If a video is in Picture in Picture mode when it has ended and the user has autoplay enabled or is watching a playlist, the next video will continue playing in that same Picture in Picture view. 

This replaces the current functionality which just keeps the ended video in the PiP view and plays the next video in the regular video mode essentially creating two videos on screen.

**Screenshots (if appropriate)**
[Video](https://flic.kr/p/2kYqJE3) (Hosted on flickr)

**Testing**
Manually Tested

Open a video in Picture in Picture mode and make sure Autoplay is on
Watch, or skip, to the end of the video and wait for the 5 second countdown to finish
The next video in the Up Next tab should then play in the Picture in Picture view replacing the old video

**Desktop (please complete the following information):**
 - OS: Mac OS
 - OS Version: 10.15.7
 - FreeTube version: latest Development branch
