### PR TITLE
Fix playlist countdown message keeps appearing even when current page…

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -74,7 +74,8 @@ export default Vue.extend({
       watchingPlaylist: false,
       playlistId: '',
       timestamp: null,
-      playNextTimeout: null
+      playNextTimeout: null,
+      playNextCountDownIntervalId: null
     }
   },
   computed: {
@@ -900,7 +901,7 @@ export default Vue.extend({
         // Will not display "Playing next video in no time" as it's too late to cancel
         // Also there is a separate message when playing next video
         if (countDownTimeLeftInSecond <= 0) {
-          clearInterval(countDownIntervalId)
+          clearInterval(this.playNextCountDownIntervalId)
           return
         }
 
@@ -911,7 +912,7 @@ export default Vue.extend({
           time: 700,
           action: () => {
             clearTimeout(this.playNextTimeout)
-            clearInterval(countDownIntervalId)
+            clearInterval(this.playNextCountDownIntervalId)
             this.showToast({
               message: this.$t('Canceled next video autoplay')
             })
@@ -923,11 +924,12 @@ export default Vue.extend({
       }
       // Execute once before scheduling it
       showCountDownMessage()
-      const countDownIntervalId = setInterval(showCountDownMessage, 1000)
+      this.playNextCountDownIntervalId = setInterval(showCountDownMessage, 1000)
     },
 
     handleRouteChange: async function () {
       clearTimeout(this.playNextTimeout)
+      clearInterval(this.playNextCountDownIntervalId)
 
       this.handleWatchProgress()
 


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
(Comment)
https://github.com/FreeTubeApp/FreeTube/issues/1214#issuecomment-841879796

**Description**
Update play next video message shown per second to stop showing after current page changed

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/118452302-9a494500-b728-11eb-88b9-17672b149d74.mp4

**Testing (for code that is not small enough to be easily understandable)**
- Update setting to have "time for next video" to be >= 3s (difficult to test with small value)
- Find a playlist, view one of them, jump to near the end
- Let play next message appear once/twice, switch to settings page (or any other page)
- Confirm play next message not appearing

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 12.0.0 (latest on `development` actually)
