### PR TITLE
Fixed old trending page api call

### DIFF
--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -68,7 +68,13 @@ export default Vue.extend({
       this.isLoading = true
 
       console.log('getting local trending')
-      ytrend.scrape_trending_page(this.region).then((result) => {
+      const param = {
+        parseCreatorOnRise: false,
+        page: 'default',
+        geoLocation: this.region
+      }
+
+      ytrend.scrape_trending_page(param).then((result) => {
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
         })


### PR DESCRIPTION
---
Fixed old trending page api call
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes #1295 

**Description**
When the trending page module was updated, the api call was not adjusted to the new api


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Has been tested for japanese and us american trends

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: v13.0.0


