### PR TITLE
Fix wrongly sized comment channel links, Added links to comment reply channels

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -37,11 +37,15 @@
   cursor: pointer;
 }
 
-.commentAuthor {
+.commentAuthorWrapper {
   font-weight: bold;
   font-size: 14px;
   margin-left: 68px;
   margin-top: 0px;
+}
+
+
+.commentAuthor {
   cursor: pointer;
 }
 

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -48,10 +48,14 @@
           @click="goToChannel(comment.authorLink)"
         >
         <p
-          class="commentAuthor"
-          @click="goToChannel(comment.authorLink)"
+          class="commentAuthorWrapper"
         >
-          {{ comment.author }}
+          <span
+            class="commentAuthor"
+            @click="goToChannel(comment.authorLink)"
+          >
+            {{ comment.author }}
+          </span>
           <span class="commentDate">
             {{ comment.time }}
           </span>
@@ -108,8 +112,13 @@
               :src="reply.authorThumb"
               class="commentThumbnail"
             >
-            <p class="commentAuthor">
-              {{ reply.author }}
+            <p class="commentAuthorWrapper">
+              <span
+                class="commentAuthor"
+                @click="goToChannel(reply.authorLink)"
+              >
+                {{ reply.author }}
+              </span>
               <span class="commentDate">
                 {{ reply.time }}
               </span>


### PR DESCRIPTION
---
Fix wrongly sized comment channel links, Added links to comment reply channels
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
#1286 

**Description**
I added a new span element around the comment author's name, which now has registers the click event and changes the cursor to pointer, instead of the whole <p> line. Same goes for comments.

Additionally I added the click event to comment replies, with the reply.authorLink, so you can now go to the channel of comment replies.

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Tested on a few videos with normal comments and replies.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: v13.0.0