### PR TITLE
Fixed Importing subscriptions from NewPipe when subscribed to channels on other services

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -485,8 +485,10 @@ export default Vue.extend({
             return
           }
 
-          const newPipeSubscriptions = newPipeData.subscriptions
-
+          const newPipeSubscriptions = newPipeData.subscriptions.filter((channel, index) => {
+            return channel.service_id === 0
+          })
+          
           const primaryProfile = JSON.parse(JSON.stringify(this.profileList[0]))
           const subscriptions = []
 


### PR DESCRIPTION
---
Fixed Importing subscriptions from NewPipe when subscribed to channels on other services
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1304

**Description**
I added a filter to NewPipe subscriptions to exclude subscriptions from services that aren't YouTube (ex. BandCamp)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes.
Please describe shortly how you tested it and whether there are any ramifications remaining. 
I built it and was able to import from NewPipe successfully when subscribed to channels from other services.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: Latest development branch