### PR TITLE
Escape HTML in chat & comments

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -7,6 +7,14 @@ import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timesta
 import autolinker from 'autolinker'
 import ytcm from 'yt-comment-scraper'
 
+const SYMBOLS = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#039;'
+}
+
 export default Vue.extend({
   name: 'WatchVideoComments',
   components: {
@@ -249,7 +257,9 @@ export default Vue.extend({
         if (this.hideCommentLikes) {
           comment.likes = null
         }
-        comment.text = autolinker.link(comment.text)
+        comment.text = autolinker.link(comment.text.replace(/[&<>"']/g, function(index) {
+          return SYMBOLS[index]
+        }))
 
         return comment
       })
@@ -281,7 +291,9 @@ export default Vue.extend({
           } else {
             comment.likes = comment.likeCount
           }
-          comment.text = autolinker.link(comment.content)
+          comment.text = autolinker.link(comment.content.replace(/[&<>"']/g, function(index) {
+            return SYMBOLS[index]
+          }))
           comment.dataType = 'invidious'
 
           if (typeof (comment.replies) !== 'undefined' && typeof (comment.replies.replyCount) !== 'undefined') {
@@ -347,7 +359,9 @@ export default Vue.extend({
           } else {
             comment.likes = comment.likeCount
           }
-          comment.text = autolinker.link(comment.content)
+          comment.text = autolinker.link(comment.content.replace(/[&<>"']/g, function(index) {
+            return SYMBOLS[index]
+          }))
           comment.time = comment.publishedText
           comment.dataType = 'invidious'
           comment.numReplies = 0

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -8,6 +8,14 @@ import $ from 'jquery'
 import autolinker from 'autolinker'
 import { LiveChat } from 'youtube-chat'
 
+const SYMBOLS = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#039;'
+}
+
 export default Vue.extend({
   name: 'WatchVideoLiveChat',
   components: {
@@ -168,7 +176,9 @@ export default Vue.extend({
         }
       })
 
-      comment.messageHtml = autolinker.link(comment.messageHtml)
+      comment.messageHtml = autolinker.link(comment.messageHtml.replace(/[&<>"']/g, function(index) {
+        return SYMBOLS[index]
+      }))
 
       const liveChatComments = $('.liveChatComments')
       const liveChatMessage = $('.liveChatMessage')


### PR DESCRIPTION
---
Escape HTML in chat & comments
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1307

**Description**
It replaces angle brackets, quotation marks and ampersands with html char codes.

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/78101139/119201487-04c9f000-ba5d-11eb-8d27-8fe703ae172c.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested? 
Partially, I didn't test live chat or loading with invidious but I tested using local api.

Please describe shortly how you tested it and whether there are any ramifications remaining. 
I went to this video and sorted by new https://www.youtube.com/watch?v=AWzKGOAru-8 to see if the comment(in the issue) still dispayed as html

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: [e.g. 0.13]

**Additional context**
Add any other context about the problem here.
