### PR TITLE
Fix icons of featured channels

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -258,9 +258,9 @@ export default Vue.extend({
         this.thumbnailUrl = response.authorThumbnails[2].url
         this.channelDescription = autolinker.link(response.description)
         this.relatedChannels = response.relatedChannels.items.map((channel) => {
-          let curThumb= channel.authorThumbnails[channel.authorThumbnails.length - 1]
-          if (curThumb.url.substring(0,2) === '//') {
-            curThumb.url = 'https:'+curThumb.url
+          const curThumb = channel.authorThumbnails[channel.authorThumbnails.length - 1]
+          if (curThumb.url.substring(0, 2) === '//') {
+            curThumb.url = 'https:' + curThumb.url
           } else {
             curThumb.url = curThumb.url.replace('file://', 'https://')
           }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -257,7 +257,15 @@ export default Vue.extend({
         }
         this.thumbnailUrl = response.authorThumbnails[2].url
         this.channelDescription = autolinker.link(response.description)
-        this.relatedChannels = response.relatedChannels.items
+        this.relatedChannels = response.relatedChannels.items.map((channel) => {
+          let curThumb= channel.authorThumbnails[channel.authorThumbnails.length - 1]
+          if (curThumb.url.substring(0,2) === '//') {
+            curThumb.url = 'https:'+curThumb.url
+          } else {
+            curThumb.url = curThumb.url.replace('file://', 'https://')
+          }
+          return channel
+        })
 
         if (response.authorBanners !== null) {
           const bannerUrl = response.authorBanners[response.authorBanners.length - 1].url


### PR DESCRIPTION
---
Fix icons of featured channels
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1322

**Description**
It changes the links to featured icons for local api to valid links
**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/78101139/119272923-7aa59700-bbd6-11eb-9b5e-b3b607ca53e7.png)

After:
![image](https://user-images.githubusercontent.com/78101139/119274145-8300d080-bbdc-11eb-928f-4c212ece115f.png)

**Testing (for code that is not small enough to be easily understandable)**
I went to a channel that has featured channels and their icons loaded then I went to a channel that didn't have featured channels and it didn't crash

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.13

**Additional context**
Featured channel section doesn't load when using invidious as the api (unrelated to my changes)