### PR TITLE
Hide trending and most popular when set to hidden (Portrait Mode)

### DIFF
--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.js
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.js
@@ -7,6 +7,14 @@ export default Vue.extend({
       openMoreOptions: false
     }
   },
+  computed: {
+    hidePopularVideos: function () {
+      return this.$store.getters.getHidePopularVideos
+    },
+    hideTrendingVideos: function () {
+      return this.$store.getters.getHideTrendingVideos
+    }
+  },
   methods: {
     navigate: function (route) {
       this.openMoreOptions = false

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
@@ -17,6 +17,7 @@
       class="moreOptionContainer"
     >
       <div
+        v-if="!hideTrendingVideos"
         class="navOption"
         @click="navigate('trending')"
       >
@@ -29,6 +30,7 @@
         </p>
       </div>
       <div
+        v-if="!hidePopularVideos"
         class="navOption"
         @click="navigate('popular')"
       >


### PR DESCRIPTION
---
Hide trending and most popular when set to hidden (Portrait Mode)
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1291 

**Description**
When you make your screen smaller, trending and most popular won't display if you disable them in settings.

**Screenshots (if appropriate)**
Before (Trending & Most Popular set to hidden):
![image](https://user-images.githubusercontent.com/78101139/119279088-61f9a900-bbf7-11eb-8109-c71004cd1344.png)
After  (Trending & Most Popular set to hidden):
![image](https://user-images.githubusercontent.com/78101139/119279097-7342b580-bbf7-11eb-9ab7-690e493c6563.png)

**Testing (for code that is not small enough to be easily understandable)**
Yes

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: Windows 10
 - FreeTube version: 0.13
