### PR TITLE
Update top nav search input to disable spellcheck

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -35,6 +35,10 @@ export default Vue.extend({
       type: Boolean,
       default: false
     },
+    spellcheck: {
+      type: Boolean,
+      default: true
+    },
     dataList: {
       type: Array,
       default: () => { return [] }

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -26,6 +26,7 @@
       type="text"
       :placeholder="placeholder"
       :disabled="disabled"
+      :spellcheck="spellcheck"
       @input="e => handleInput(e.target.value)"
       @focus="handleFocus"
       @blur="handleInputBlur"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -61,6 +61,7 @@
           :is-search="true"
           :select-on-focus="true"
           :data-list="searchSuggestionsDataList"
+          :spellcheck="false"
           @input="getSearchSuggestionsDebounce"
           @click="goToSearch"
         />


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
#1317 

**Description**
Update top nav search input to disable spellcheck

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/1018543/119771830-dfbbfe00-bef0-11eb-846d-9034a72a1835.png)

**Testing (for code that is not small enough to be easily understandable)**
- Enter `joyner` into top nav search input

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 13.0.0 (latest on `development` actually)
 
**Additional context**
Add any other context about the problem here.
