### PR TITLE
* Update playlist info page's channel info box to redirect to channel…

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.css
+++ b/src/renderer/components/playlist-info/playlist-info.css
@@ -8,12 +8,14 @@
 
 .playlistChannel {
   height: 70px;
+
+  /* Indicates the box can be clicked to navigate */
+  cursor: pointer;
 }
 
 .playlistChannel img {
   width: 70px;
   float: left;
-  cursor: pointer;
   border-radius: 200px 200px 200px 200px;
   -webkit-border-radius: 200px 200px 200px 200px;
 }
@@ -21,7 +23,6 @@
 .playlistChannel h3 {
   float: left;
   position: relative;
-  cursor: pointer;
   width: 200px;
   margin-left: 10px;
   top: 5px;

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -76,6 +76,7 @@ export default Vue.extend({
     this.title = this.data.title
     this.channelName = this.data.channelName
     this.channelThumbnail = this.data.channelThumbnail
+    this.channelId = this.data.channelId
     this.uploadedTime = this.data.uploaded_at
     this.description = this.data.description
     this.infoSource = this.data.infoSource
@@ -110,6 +111,10 @@ export default Vue.extend({
           this.openExternalLink(invidiousUrl)
           break
       }
+    },
+
+    goToChannel: function () {
+      this.$router.push({ path: `/channel/${this.channelId}` })
     },
 
     ...mapActions([

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -23,6 +23,7 @@
     <hr>
     <div
       class="playlistChannel"
+      @click="goToChannel"
     >
       <img :src="channelThumbnail">
       <h3>


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [X] Feature Implementation

**Related issue**
#1334

**Description**
Update playlist info page's channel info box to redirect to channel page on click

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/119774276-81911a00-bef4-11eb-8ec3-79d54554f848.mp4

**Testing (for code that is not small enough to be easily understandable)**
- Open https://youtube.com/playlist?list=PLzFTGYa_evXjrYYxeY6HAQyqnkJju2t84
- Click on Channel Name / Icon

![Screen Shot 2021-05-27 at 14 05 38 ](https://user-images.githubusercontent.com/1018543/119774377-a9807d80-bef4-11eb-89a1-ec682ce3af3e.png)

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 13.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
