### PR TITLE
Fix volume in session not persisted probably when muted

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -432,8 +432,10 @@ export default Vue.extend({
       }
     },
 
-    updateVolume: function (event) {
-      const volume = this.player.volume()
+    updateVolume: function (_event) {
+      // 0 means muted
+      // https://docs.videojs.com/html5#volume
+      const volume = this.player.muted() ? 0 : this.player.volume()
       sessionStorage.setItem('volume', volume)
     },
 


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
#1328

**Description**
After change, muting video via mute button would save the mute state to next video

**Screenshots (if appropriate)**
Too lazy
But you want video instead of testing I can make one :P

**Testing (for code that is not small enough to be easily understandable)**
- Open a video
- Mute it via mute button
- Play next video (in playlist or recommended or autoplay)
- Ensure the new video also muted

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 13.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
