### PR TITLE
Improve search filter appearance

### DIFF
--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -1,6 +1,3 @@
-.searchFilter {
-}
-
 .searchFilterInner {
   max-width: 800px;
   margin-left: auto;

--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -1,10 +1,19 @@
 .searchFilter {
-  background-color: var(--card-bg-color);
-  padding: 20px;
-  padding-bottom: 70px;
+}
+
+.searchFilterInner {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+
+  padding: 20px 20px 70px 20px;
   max-height: 410px;
   overflow-y: auto;
+
+  background-color: var(--card-bg-color);
   box-shadow: 0 1px 2px rgba(0,0,0,.1);
+
+  opacity: 0.9;
 }
 
 .center {
@@ -22,6 +31,6 @@
 
 @media only screen and (max-width: 600px) {
   .searchRadio {
-    border-right: 0px;
+    border-right: 0;
   }
 }

--- a/src/renderer/components/ft-search-filters/ft-search-filters.vue
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.vue
@@ -1,42 +1,44 @@
 <template>
-  <div class="searchFilter">
-    <h2 class="center">
-      {{ $t("Search Filters.Search Filters") }}
-    </h2>
-    <ft-flex-box class="radioFlexBox">
-      <ft-radio-button
-        ref="sortByRadio"
-        :title="$t('Search Filters.Sort By.Sort By')"
-        :labels="sortByLabels"
-        :values="sortByValues"
-        class="searchRadio"
-        @change="updateSortBy"
-      />
-      <ft-radio-button
-        ref="timeRadio"
-        :title="$t('Search Filters.Time.Time')"
-        :labels="timeLabels"
-        :values="timeValues"
-        class="searchRadio"
-        @change="updateTime"
-      />
-      <ft-radio-button
-        ref="typeRadio"
-        :title="$t('Search Filters.Type.Type')"
-        :labels="typeLabels"
-        :values="typeValues"
-        class="searchRadio"
-        @change="updateType"
-      />
-      <ft-radio-button
-        ref="durationRadio"
-        :title="$t('Search Filters.Duration.Duration')"
-        :labels="durationLabels"
-        :values="durationValues"
-        class="searchRadio"
-        @change="updateDuration"
-      />
-    </ft-flex-box>
+  <div>
+    <div class="searchFilterInner">
+      <h2 class="center">
+        {{ $t("Search Filters.Search Filters") }}
+      </h2>
+      <ft-flex-box class="radioFlexBox">
+        <ft-radio-button
+          ref="sortByRadio"
+          :title="$t('Search Filters.Sort By.Sort By')"
+          :labels="sortByLabels"
+          :values="sortByValues"
+          class="searchRadio"
+          @change="updateSortBy"
+        />
+        <ft-radio-button
+          ref="timeRadio"
+          :title="$t('Search Filters.Time.Time')"
+          :labels="timeLabels"
+          :values="timeValues"
+          class="searchRadio"
+          @change="updateTime"
+        />
+        <ft-radio-button
+          ref="typeRadio"
+          :title="$t('Search Filters.Type.Type')"
+          :labels="typeLabels"
+          :values="typeValues"
+          class="searchRadio"
+          @change="updateType"
+        />
+        <ft-radio-button
+          ref="durationRadio"
+          :title="$t('Search Filters.Duration.Duration')"
+          :labels="durationLabels"
+          :values="durationValues"
+          class="searchRadio"
+          @change="updateDuration"
+        />
+      </ft-flex-box>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
#1337

**Description**
Update search filter style so it's smaller in size and has 10% transparency

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/119937349-32fb8280-bfbd-11eb-84b6-188895103df4.mp4

**Testing (for code that is not small enough to be easily understandable)**
- Open filter
- Keep resizing the window

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: 13.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
