### PR TITLE
Update playlist page thumbnail to start playing first video on click

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.css
+++ b/src/renderer/components/playlist-info/playlist-info.css
@@ -4,6 +4,8 @@
 
 .playlistThumbnail img {
   width: 100%;
+
+  cursor: pointer;
 }
 
 .playlistChannel {

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -3,7 +3,7 @@ import { mapActions } from 'vuex'
 import FtListDropdown from '../ft-list-dropdown/ft-list-dropdown.vue'
 
 export default Vue.extend({
-  name: 'FtElementList',
+  name: 'PlaylistInfo',
   components: {
     'ft-list-dropdown': FtListDropdown
   },
@@ -16,7 +16,7 @@ export default Vue.extend({
   data: function () {
     return {
       id: '',
-      randomVideoId: '',
+      firstVideoId: '',
       title: '',
       channelThumbnail: '',
       channelName: '',
@@ -59,20 +59,20 @@ export default Vue.extend({
     thumbnail: function () {
       switch (this.thumbnailPreference) {
         case 'start':
-          return `https://i.ytimg.com/vi/${this.randomVideoId}/mq1.jpg`
+          return `https://i.ytimg.com/vi/${this.firstVideoId}/mq1.jpg`
         case 'middle':
-          return `https://i.ytimg.com/vi/${this.randomVideoId}/mq2.jpg`
+          return `https://i.ytimg.com/vi/${this.firstVideoId}/mq2.jpg`
         case 'end':
-          return `https://i.ytimg.com/vi/${this.randomVideoId}/mq3.jpg`
+          return `https://i.ytimg.com/vi/${this.firstVideoId}/mq3.jpg`
         default:
-          return `https://i.ytimg.com/vi/${this.randomVideoId}/mqdefault.jpg`
+          return `https://i.ytimg.com/vi/${this.firstVideoId}/mqdefault.jpg`
       }
     }
   },
   mounted: function () {
     console.log(this.data)
     this.id = this.data.id
-    this.randomVideoId = this.data.randomVideoId
+    this.firstVideoId = this.data.firstVideoId
     this.title = this.data.title
     this.channelName = this.data.channelName
     this.channelThumbnail = this.data.channelThumbnail
@@ -110,6 +110,19 @@ export default Vue.extend({
           this.openExternalLink(invidiousUrl)
           break
       }
+    },
+
+    playFirstVideo() {
+      const playlistInfo = {
+        playlistId: this.id
+      }
+
+      this.$router.push(
+        {
+          path: `/watch/${this.firstVideoId}`,
+          query: playlistInfo
+        }
+      )
     },
 
     ...mapActions([

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -5,6 +5,7 @@
     >
       <img
         :src="thumbnail"
+        @click="playFirstVideo"
       >
     </div>
     <h2>

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -67,13 +67,11 @@ export default Vue.extend({
         console.log('done')
         console.log(result)
 
-        const randomVideoIndex = Math.floor((Math.random() * result.items.length))
-
         this.infoData = {
           id: result.id,
           title: result.title,
           description: result.description ? result.description : '',
-          randomVideoId: result.items[randomVideoIndex].id,
+          firstVideoId: result.items[0].id,
           viewCount: result.views,
           videoCount: result.estimatedItemCount,
           lastUpdated: result.lastUpdated ? result.lastUpdated : '',
@@ -125,13 +123,11 @@ export default Vue.extend({
         console.log('done')
         console.log(result)
 
-        const randomVideoIndex = Math.floor((Math.random() * result.videos.length) + 1)
-
         this.infoData = {
           id: result.playlistId,
           title: result.title,
           description: result.description,
-          randomVideoId: result.videos[randomVideoIndex].videoId,
+          firstVideoId: result.videos[0].videoId,
           viewCount: result.viewCount,
           videoCount: result.videoCount,
           channelName: result.author,


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
#1340

**Description**
Update playlist page thumbnail to start playing first video on click

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/119954006-26812500-bfd1-11eb-83b2-635531b85ee9.mp4

**Testing (for code that is not small enough to be easily understandable)**
- Open a playlist
- Click on thumbnail

**Desktop (please complete the following information):**
- OS: MacOS
- OS Version: 10.15.7
- FreeTube version: 13.0.0 (latest on `development` actually)

**Additional context**
Add any other context about the problem here.
