### PR TITLE
Add command line argument mapping for the VLC player

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -19,5 +19,21 @@
             "playlistShuffle": "--shuffle",
             "playlistLoop": "--loop-playlist"
         }
+    },
+    {
+        "name": "VLC",
+        "value": "vlc",
+        "cmdArguments": {
+            "defaultExecutable": "vlc",
+            "supportsYtdlProtocol": false,
+            "videoUrl": "",
+            "playlistUrl": null,
+            "startOffset": "--start-time=",
+            "playbackRate": "--rate=",
+            "playlistIndex": null,
+            "playlistReverse": null,
+            "playlistShuffle": "--random",
+            "playlistLoop": "--loop"
+        }
     }
 ]


### PR DESCRIPTION
---
Add command line argument mapping for the VLC player
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
#418 

**Description**
This PR adds command line argument mapping for the VLC player.

**Testing (for code that is not small enough to be easily understandable)**
- Opening videos
- Opening videos at a specified start offset
- Opening videos with different playback rates

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.13.1 Beta

**Additional context**
VLC doesn't seem to have support for YouTube playlists out-of-the-box.
While I did add flags for  playlist shuffle/reverse, they are essentially useless, since opening playlists isn't supported.
Just wanted to note this here.
