### PR TITLE
Updated frame-by-frame function to cover previous edge cases.

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -848,14 +848,20 @@ export default Vue.extend({
 
     framebyframe: function (step) {
       this.player.pause()
-      const qualityHeight = this.useDash ? this.player.qualityLevels()[this.player.qualityLevels().selectedIndex].height : 0
-      let fps
+      const quality = this.useDash ? this.player.qualityLevels()[this.player.qualityLevels().selectedIndex] : 0
+      let fps = 30
       // Non-Dash formats are 30fps only
-      if (qualityHeight >= 480 && this.maxFramerate === 60) {
-        fps = 60
-      } else {
-        fps = 30
+      if (quality.height >= 480 && this.maxFramerate === 60) {
+        for (let i = 0; i < this.adaptiveFormats.length; i++) {
+          if (this.adaptiveFormats[i].bitrate === quality.bitrate) {
+            if (this.adaptiveFormats[i].fps === 60) {
+              fps = 60
+              break
+            }
+          }
+        }
       }
+
       // The 3 lines below were taken from the videojs-framebyframe node module by Helena Rasche
       const frameTime = 1 / fps
       const dist = frameTime * step


### PR DESCRIPTION
---
Updated frame-by-frame function to cover previous edge cases.
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x ] Feature Implementation

**Description**
Recent changes now allow the distinction between 30fps and 60fps videos for 720p+ qualities. Method was changed to reflect this and catch edge cases that were left behind last time.

**Desktop (please complete the following information):**
 - OS: [Artix Linux]
 - OS Version: [N/A]
 - FreeTube version: [0.13.1]

**Additional context**
The adaptiveFormats object does not specify which quality is being used, and it has a different size from the object that does tell you. To verify which one it was I had to run a for loop that felt unnecessary, I'm all hears for a better solution.
