### PR TITLE
Add support for the 'defaultCustomArguments' external player mapping field

### DIFF
--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -40,7 +40,21 @@ export default Vue.extend({
     },
     externalPlayerCustomArgs: function () {
       return this.$store.getters.getExternalPlayerCustomArgs
-    }
+    },
+    externalPlayerCustomArgsTooltip: function () {
+      const tooltip = this.$t('Tooltips.External Player Settings.Custom External Player Arguments')
+
+      const cmdArgs = this.$store.getters.getExternalPlayerCmdArguments[this.externalPlayer]
+      console.log('externalPlayerCustomArgsTooltip', cmdArgs)
+      if (cmdArgs && typeof cmdArgs.defaultCustomArguments === 'string' && cmdArgs.defaultCustomArguments !== '') {
+        const defaultArgs = this.$t('Tooltips.External Player Settings.DefaultCustomArgumentsTemplate')
+          .replace('$', cmdArgs.defaultCustomArguments)
+        return `${tooltip} ${defaultArgs}`
+      }
+
+      return tooltip
+    },
+
   },
   methods: {
     ...mapActions([

--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -45,7 +45,6 @@ export default Vue.extend({
       const tooltip = this.$t('Tooltips.External Player Settings.Custom External Player Arguments')
 
       const cmdArgs = this.$store.getters.getExternalPlayerCmdArguments[this.externalPlayer]
-      console.log('externalPlayerCustomArgsTooltip', cmdArgs)
       if (cmdArgs && typeof cmdArgs.defaultCustomArguments === 'string' && cmdArgs.defaultCustomArguments !== '') {
         const defaultArgs = this.$t('Tooltips.External Player Settings.DefaultCustomArgumentsTemplate')
           .replace('$', cmdArgs.defaultCustomArguments)
@@ -53,8 +52,7 @@ export default Vue.extend({
       }
 
       return tooltip
-    },
-
+    }
   },
   methods: {
     ...mapActions([

--- a/src/renderer/components/external-player-settings/external-player-settings.vue
+++ b/src/renderer/components/external-player-settings/external-player-settings.vue
@@ -45,7 +45,7 @@
         :show-arrow="false"
         :show-label="true"
         :value="externalPlayerCustomArgs"
-        :tooltip="$t('Tooltips.External Player Settings.Custom External Player Arguments')"
+        :tooltip="externalPlayerCustomArgsTooltip"
         @input="updateExternalPlayerCustomArgs"
       />
     </ft-flex-box>

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -662,6 +662,16 @@ const actions = {
     const ignoreWarnings = rootState.settings.externalPlayerIgnoreWarnings
     const customArgs = rootState.settings.externalPlayerCustomArgs
 
+    // Append custom user-defined arguments,
+    // or use the default ones specified for the external player.
+    if (typeof customArgs === 'string' && customArgs !== '') {
+      const custom = customArgs.split(';')
+      args.push(...custom)
+    } else if (typeof cmdArgs.defaultCustomArguments === 'string' && cmdArgs.defaultCustomArguments !== '') {
+      const defaultCustomArguments = cmdArgs.defaultCustomArguments.split(';')
+      args.push(...defaultCustomArguments)
+    }
+
     if (payload.watchProgress > 0) {
       if (typeof cmdArgs.startOffset === 'string') {
         args.push(`${cmdArgs.startOffset}${payload.watchProgress}`)
@@ -762,12 +772,6 @@ const actions = {
           args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
         }
       }
-    }
-
-    // Append custom user-defined arguments
-    if (customArgs !== null) {
-      const custom = customArgs.split(';')
-      args.push(...custom)
     }
 
     const openingToast = payload.strings.OpeningTemplate

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -9,6 +9,7 @@
         "value": "mpv",
         "cmdArguments": {
             "defaultExecutable": "mpv",
+            "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
             "playlistUrl": "",

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -619,6 +619,8 @@ Tooltips:
       the current action (e.g. reversing playlists, etc.).
     Custom External Player Arguments: Any custom command line arguments, separated by semicolons (';'),
       you want to be passed to the external player.
+    # $ is replaced with the default custom arguments for the current player, if defined.
+    DefaultCustomArgumentsTemplate: '(Default: ''$'')'
   Subscription Settings:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -689,6 +689,8 @@ Tooltips:
       the current action (e.g. reversing playlists, etc.).
     Custom External Player Arguments: Any custom command line arguments, separated by semicolons (';'),
       you want to be passed to the external player.
+    # $ is replaced with the default custom arguments for the current player, if defined.
+    DefaultCustomArgumentsTemplate: '(Default: ''$'')'
   Privacy Settings:
     Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files
       created during video playback, when the watch page is closed.


### PR DESCRIPTION
---
Add support for the 'defaultCustomArguments' external player mapping field
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
While there isn't a directly related issue, this PR was created in response to a discussion in PR #1409, which pointed out the need for being able to pass default arguments to specific external players (in this case iina).

**Description**
This PR adds support for another external player argument mapping: `defaultCustomArguments`
Any arguments defined via this field (arguments should be separated by semicolons `;`, like user-defined custom arguments), will be only used, if the user hasn't defined any custom arguments themselves. I decided on this approach, since that gives the user more control on what is passed to the external player. Additionally, if defined, the default custom arguments will be displayed in the help tooltip for the custom arguments text input in the external player settings (see screenshot below).

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/7832423/121964331-ec4aae00-cd5a-11eb-82c0-ba1c769f34c7.png)

**Testing (for code that is not small enough to be easily understandable)**
- Tested the new `defaultCustomArguments` field

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.13.1 Beta
