### PR TITLE
Add command line argument mapping for iina player

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -35,5 +35,22 @@
             "playlistShuffle": "--random",
             "playlistLoop": "--loop"
         }
+    },
+    {
+        "name": "iina",
+        "value": "iina",
+        "cmdArguments": {
+            "defaultExecutable": "iina",
+            "defaultCustomArguments": "--no-stdin",
+            "supportsYtdlProtocol": true,
+            "videoUrl": "",
+            "playlistUrl": "",
+            "startOffset": "--mpv-start=",
+            "playbackRate": "--mpv-speed=",
+            "playlistIndex": "--mpv-playlist-start=",
+            "playlistReverse": null,
+            "playlistShuffle": "--mpv-shuffle",
+            "playlistLoop": "--mpv-loop-playlist"
+        }
     }
 ]


### PR DESCRIPTION
---
Add command line argument mapping for iina player
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
#418 

**Description**
This PR adds command line argument mapping for [iina](https://github.com/iina/iina).

**_Note:_** this PR requires #1415 to be merged, since iina can't be opened by third party apps without a `--no-stdin` argument, which previously couldn't be 'hard-coded' since the support for default custom arguments wasn't available.

**Testing (for code that is not small enough to be easily understandable)**
- [x] Opening videos with iina
- [x] Opening videos at custom time with iina
- [x] Opening videos at custom speed with iina
- [x] Opening videos in playlists with iina

**Desktop (please complete the following information):**
 - OS: macOS
 - OS Version: 11.04
 - Freetube Version: 0.13.1

**Additional context**
- iina supports almost all the exact same arguments as mpv, thus it doesn't require extensive testing
- I wasn't able to build the latest nightly version of Freetube, but when I tested this change two days ago, everything was working fine. I was waiting for #1415 to be merged, but decided to make a PR for iina anyway - in hopes that both get merged when possible.
