### PR TITLE
Sidebar compact issue1293

### DIFF
--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -112,7 +112,7 @@
 
 .closed .navOption {
   width: 100%;
-  height: 45px;
+  height: 35px;
   padding: 0px;
   padding-top: 5px;
   padding-bottom: 5px;

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -56,6 +56,7 @@
 
 .navIcon {
   margin-left: 10px;
+  height: 1.3em;
 }
 
 .navOption .navLabel {
@@ -125,18 +126,15 @@
 }
 
 .closed .navLabel {
-  margin-left: 0px;
-  width: 100%;
-  text-align: center;
-  left: 0px;
-  font-size: 11px;
+  display:none;
 }
 
 .closed .navChannel {
   width: 100%;
+  height: 45px;
   padding: 0px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .closed .thumbnailContainer {
@@ -148,6 +146,8 @@
   top: 0px;
   -ms-transform: none;
   transform: none;
+  margin-block-start: 0.3em;
+  margin-block-end: 0.3em;
 }
 
 @media only screen and (max-width: 680px) {
@@ -192,13 +192,6 @@
     text-align: center;
     left: 0px;
     font-size: 11px;
-  }
-
-  .navIcon {
-    margin-left: 0px;
-    width: 100%;
-    display: block;
-    margin-bottom: 0px;
   }
 
   .moreOption {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -58,13 +58,18 @@
   margin-left: 10px;
 }
 
-.navLabel {
-  margin-left: 5px;
-  display: inline-block;
+.navOption .navLabel {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 150px;
+  margin-left: 40px;
 }
 
 .navChannel .navLabel {
-  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   width: 150px;
   margin-left: 40px;
 }
@@ -108,8 +113,8 @@
   width: 100%;
   height: 45px;
   padding: 0px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .closed .navIcon {

--- a/src/renderer/components/side-nav/side-nav.vue
+++ b/src/renderer/components/side-nav/side-nav.vue
@@ -6,16 +6,21 @@
   >
     <div class="inner">
       <div
-        class="navOption topNavOption mobileShow"
+        class="navOption topNavOption mobileShow "
         role="button"
         tabindex="0"
+        :title="$t('Subscriptions.Subscriptions')"
         @click="navigate('subscriptions')"
       >
-        <font-awesome-icon
-          icon="rss"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="rss"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
           {{ $t("Subscriptions.Subscriptions") }}
         </p>
@@ -25,14 +30,19 @@
         class="navOption mobileHidden"
         role="button"
         tabindex="0"
+        :title="$t('Trending')"
         @click="navigate('trending')"
         @keypress="navigate('trending')"
       >
-        <font-awesome-icon
-          icon="fire"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="fire"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
           {{ $t("Trending") }}
         </p>
@@ -42,14 +52,19 @@
         class="navOption mobileHidden"
         role="button"
         tabindex="0"
+        :title="$t('Most Popular')"
         @click="navigate('popular')"
         @keypress="navigate('popular')"
       >
-        <font-awesome-icon
-          icon="users"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="users"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
           {{ $t("Most Popular") }}
         </p>
@@ -59,14 +74,19 @@
         class="navOption mobileShow"
         role="button"
         tabindex="0"
+        :title="$t('Playlists')"
         @click="navigate('userplaylists')"
         @keypress="navigate('userplaylists')"
       >
-        <font-awesome-icon
-          icon="bookmark"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="bookmark"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
           {{ $t("Playlists") }}
         </p>
@@ -78,14 +98,19 @@
         class="navOption mobileShow"
         role="button"
         tabindex="0"
+        :title="$t('History.History')"
         @click="navigate('history')"
         @keypress="navigate('history')"
       >
-        <font-awesome-icon
-          icon="history"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="history"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
           {{ $t("History.History") }}
         </p>
@@ -95,30 +120,40 @@
         class="navOption mobileShow"
         role="button"
         tabindex="0"
+        :title="$t('Settings.Settings')"
         @click="navigate('settings')"
         @keypress="navigate('settings')"
       >
-        <font-awesome-icon
-          icon="sliders-h"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="sliders-h"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
-          {{ $t("Settings.Settings") }}
+          {{ $t('Settings.Settings') }}
         </p>
       </div>
       <div
         class="navOption mobileHidden"
         role="button"
         tabindex="0"
+        :title="$t('About.About')"
         @click="navigate('about')"
         @keypress="navigate('about')"
       >
-        <font-awesome-icon
-          icon="info-circle"
-          class="navIcon"
-          fixed-width
-        />
+        <div
+          class="thumbnailContainer"
+        >
+          <font-awesome-icon
+            icon="info-circle"
+            class="navIcon"
+            fixed-width
+          />
+        </div>
         <p class="navLabel">
           {{ $t("About.About") }}
         </p>


### PR DESCRIPTION
---
Issue #1293. Sidebar text labels and sizes
---
**Pull Request Type**
- [ ] Bugfix
- [X] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1293

**Description**
This commits revise the size of the icons in the sidebar and how the text labels displays using ellipsis on long texts, making use of CSS properties and the HTML title atributte.

**Screenshots (if appropriate)**
![Freetube_1293_ex1](https://user-images.githubusercontent.com/7262829/123556561-717e8b80-d77b-11eb-9790-a04fda329dc7.png)
![Freetube_1293_ex2](https://user-images.githubusercontent.com/7262829/123556563-72172200-d77b-11eb-8002-9b0cd5132d38.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
As a CSS and HTML modification without touching anything more complex or critical, code changes are easily understandable. No test required

**Desktop (please complete the following information):**
 - OS: Ubuntu Linux
 - OS Version: 20.04
 - FreeTube version: 0.13.0
