### PR TITLE
[Fix] Invidious API not used for channels icons in search 

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -66,7 +66,13 @@ export default Vue.extend({
     },
 
     parseInvidiousData: function () {
-      this.thumbnail = this.data.authorThumbnails[2].url.replace('https://yt3.ggpht.com', `${this.invidiousInstance}/ggpht/`)
+      this.thumbnail = this.data.authorThumbnails[2].url
+
+      if (!this.thumbnail.includes('https:')) {
+        this.thumbnail = `https:${this.thumbnail}`
+      }
+
+      this.thumbnail = this.thumbnail.replace('https://yt3.ggpht.com', `${this.invidiousInstance}/ggpht/`)
       this.channelName = this.data.author
       this.id = this.data.authorId
       if (this.hideChannelSubscriptions) {


### PR DESCRIPTION
---
[Fix] Invidious API not used for channels icons in search 
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1476

**Description**
Adds https to image urls so they get properly replaced

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.13.2

