### PR TITLE
Update app to hide top nav filter panel on page change

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -99,7 +99,12 @@ export default Vue.extend({
     }
   },
   watch: {
-    windowTitle: 'setWindowTitle'
+    windowTitle: 'setWindowTitle',
+    $route () {
+      // react to route changes...
+      // Hide top nav filter panel on page change
+      this.$refs.topNav.hideFilters()
+    }
   },
   created () {
     this.setWindowTitle()

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -280,6 +280,9 @@ export default Vue.extend({
     navigate: function (route) {
       this.$router.push('/' + route)
     },
+    hideFilters: function () {
+      this.showFilters = false
+    },
     ...mapActions([
       'showToast',
       'getYoutubeUrlInfo',


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1337#issuecomment-869738146

**Description**
As title

**Screenshots (if appropriate)**

https://user-images.githubusercontent.com/1018543/123768697-22f7fb00-d8fb-11eb-9143-a35da6ae5350.mp4

**Testing (for code that is not small enough to be easily understandable)**
Open app, open filter, go to another page

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 10.15.7
 - FreeTube version: latest on `development`

**Additional context**
Add any other context about the problem here.
