### PR TITLE
Add video reload button

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -416,6 +416,7 @@ export default defineComponent({
 
     this.stopPowerSaveBlocker()
     window.removeEventListener('beforeunload', this.stopPowerSaveBlocker)
+    this.$root.$emit('ft-video-player-ready', false)
   },
   methods: {
     initializePlayer: async function () {
@@ -601,6 +602,7 @@ export default defineComponent({
 
         this.player.on('ready', () => {
           this.$emit('ready')
+          this.$root.$emit('ft-video-player-ready', true)
           this.createStatsModal()
           if (this.captionHybridList.length !== 0) {
             this.transformAndInsertCaptions()

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -26,7 +26,8 @@ export default defineComponent({
       historyIndex: 1,
       isForwardOrBack: false,
       searchSuggestionsDataList: [],
-      lastSuggestionQuery: ''
+      lastSuggestionQuery: '',
+      isVideoPlayerActive: false,
     }
   },
   computed: {
@@ -91,6 +92,7 @@ export default defineComponent({
       }
     }, 0)
 
+    this.$root.$on('ft-video-player-ready', (isReady) => { this.isVideoPlayerActive = isReady })
     window.addEventListener('resize', () => {
       // Don't change the status of showSearchContainer if only the height of the window changes
       // Opening the virtual keyboard can trigger this resize event, but it won't change the width
@@ -312,6 +314,10 @@ export default defineComponent({
           this.$refs.historyArrowForward.classList.add('fa-arrow-right')
         }
       }
+    },
+
+    refreshVideoPlayer: function() {
+      this.$root.$emit('refresh-video-player', null)
     },
 
     toggleSideNav: function () {

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -34,6 +34,17 @@
         @keydown.enter.prevent="historyForward"
       />
       <font-awesome-icon
+        v-if="isVideoPlayerActive"
+        id="videoReloadButton"
+        role="button"
+        tabindex="0"
+        :icon="['fas', 'refresh']"
+        class="navIcon"
+        :title="$t('Video.Reload Video')"
+        @click="refreshVideoPlayer"
+        @keydown.enter.prevent="refreshVideoPlayer"
+      />
+      <font-awesome-icon
         v-if="!hideSearchBar"
         class="navSearchIcon navIcon"
         :icon="['fas', 'search']"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -119,7 +119,7 @@ export default defineComponent({
       playNextCountDownIntervalId: null,
       infoAreaSticky: true,
       commentsEnabled: true,
-      videoPlayerRefreshKey: 542,
+      videoPlayerRefreshKey: 0,
     }
   },
   computed: {
@@ -211,25 +211,30 @@ export default defineComponent({
     }
   },
   mounted: function () {
-    this.videoId = this.$route.params.id
-    this.activeFormat = this.defaultVideoFormat
-    this.useTheatreMode = this.defaultTheatreMode
-
-    this.checkIfPlaylist()
-    this.checkIfTimestamp()
-
-    if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
-      this.getVideoInformationInvidious()
-    } else {
-      this.getVideoInformationLocal()
-    }
-
-    this.$root.$on('refresh-video-player', () => this.refreshVideoPlayer())
-    window.addEventListener('beforeunload', this.handleWatchProgress)
+    this.mounted()
   },
   methods: {
+    mounted: function() {
+      this.videoId = this.$route.params.id
+      this.activeFormat = this.defaultVideoFormat
+      this.useTheatreMode = this.defaultTheatreMode
+
+      this.checkIfPlaylist()
+      this.checkIfTimestamp()
+
+      if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
+        this.getVideoInformationInvidious()
+      } else {
+        this.getVideoInformationLocal()
+      }
+
+      this.$root.$on('refresh-video-player', this.refreshVideoPlayer)
+      window.addEventListener('beforeunload', this.handleWatchProgress)
+      // window.addEventListener('refresh-video-player', this.refreshVideoPlayer)
+    },
     beforeLeave: function() {
       this.handleRouteChange(this.videoId)
+      this.$root.$off('refresh-video-player', this.refreshVideoPlayer)
       window.removeEventListener('beforeunload', this.handleWatchProgress)
     },
     route: function() {
@@ -263,9 +268,10 @@ export default defineComponent({
       }
     },
     refreshVideoPlayer: function() {
-      this.beforeLeave()
+      // this.beforeLeave()
       this.videoPlayerRefreshKey++
       this.route()
+      // await this.handleRouteChange(this.videoId)
     },
     changeTimestamp: function (timestamp) {
       this.$refs.videoPlayer.player.currentTime(timestamp)

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -19,6 +19,7 @@
         <ft-video-player
           v-if="!isLoading && !hidePlayer && !isUpcoming"
           ref="videoPlayer"
+          :key="videoPlayerRefreshKey"
           :dash-src="dashSrc"
           :source-list="activeSourceList"
           :audio-tracks="audioTracks"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -597,6 +597,7 @@ Video:
   Save Video: Save Video
   Video has been saved: Video has been saved
   Video has been removed from your saved list: Video has been removed from your saved list
+  Reload Video: Reload Video
   Open in YouTube: Open in YouTube
   Copy YouTube Link: Copy YouTube Link
   Open YouTube Embedded Player: Open YouTube Embedded Player


### PR DESCRIPTION
---
Add video reload button
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
closes #1005 

**Description**
This PR introduces a reload button to force re-render of the video player component as a convenient workaround for assorted infrequent video player issues.

**Screenshot & Video**
![Screenshot of the video page featuring the new video reload button.](https://user-images.githubusercontent.com/84899178/130314270-5afb1c81-ff28-4bdf-89ab-4fa0daaa3638.png)

Here is a short video showcasing the video reload button:

https://user-images.githubusercontent.com/84899178/131056788-87ab7527-a017-440a-aac0-94aadd9c9fa0.mov

Screenshot and video of the older version in this PR are accessible through this post's edit history.

**Testing (for code that is not small enough to be easily understandable)**
Pressed the reload button on three videos with DASH, Legacy, and Audio formats (three clicks each).

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.13.2 Beta