### PR TITLE
Fix: Recognize YT short links in search & for external apps

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -303,6 +303,13 @@ const actions = {
           return paramsObject
         }
       },
+      // youtube.com/shorts
+      function() {
+        if (urlObject.pathname.match(/^\/shorts\/[A-Za-z0-9_-]+$/)) {
+          extractParams(urlObject.pathname.replace('/shorts/', ''))
+          return paramsObject
+        }
+      },
       // cloudtube
       function() {
         if (urlObject.host.match(/^cadence\.(gq|moe)$/) && urlObject.pathname.match(/^\/cloudtube\/video\/[A-Za-z0-9_-]+$/)) {


### PR DESCRIPTION
---
Recognize YT short links in search & for external apps
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1604

**Description**
This PR adds a shorts endpoint to the "getVideoParamsFromUrl" method

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 
Search "https://youtube.com/shorts/MS82yTaKRjQ?feature=share" without using this PR (no search results)
Search "https://youtube.com/shorts/MS82yTaKRjQ?feature=share" while using this PR (video loads)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: Windows 10
 - FreeTube version: 0.13.2
