### PR TITLE
Make video utility buttons square

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -180,8 +180,9 @@ function runApp() {
     /**
      * Initial window options
      */
+
     const newWindow = new BrowserWindow({
-      backgroundColor: '#fff',
+      backgroundColor: '#212121',
       icon: isDev
         ? path.join(__dirname, '../../_icons/iconColor.png')
         /* eslint-disable-next-line */

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -5,6 +5,7 @@
 
 body {
   min-height: 100vh;
+  background-color: #212121;
 }
 
 #app {

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -103,6 +103,7 @@ export default Vue.extend({
   },
   created () {
     this.setWindowTitle()
+    this.checkThemeSettings()
   },
   mounted: function () {
     this.grabUserSettings().then(async () => {
@@ -110,11 +111,9 @@ export default Vue.extend({
       if (this.defaultInvidiousInstance === '') {
         await this.setRandomCurrentInvidiousInstance()
       }
-
       this.grabAllProfiles(this.$t('Profile.All Channels')).then(async () => {
         this.grabHistory()
         this.grabAllPlaylists()
-        this.checkThemeSettings()
 
         if (this.usingElectron) {
           console.log('User is using Electron')

--- a/src/renderer/components/ft-icon-button/ft-icon-button.sass
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.sass
@@ -8,7 +8,7 @@
 .iconButton
   width: 1em
   height: 1em
-  border-radius: 50%
+  border-radius: 22%
   cursor: pointer
   transition: background 0.15s ease-out
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -22,7 +22,6 @@
   --logo-text: url("~../../_icons/textColorSmall.png");
 }
 
-
 .dark {
   --primary-text-color: #EEEEEE;
   --secondary-text-color: #ddd;


### PR DESCRIPTION
**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Closes #1452 

**Description**
Changes border radius of video util buttons buttons

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/72892531/130438160-c1e3bec3-26d7-4cdb-af80-1b145df6ef80.png)

After:
![image](https://user-images.githubusercontent.com/72892531/130438126-fdcb891a-94b7-42a9-9be5-22332f99ecdc.png)

Before:
![image](https://user-images.githubusercontent.com/72892531/130438573-c50ccf7f-f91a-4815-9949-f439c343d20d.png)

After:
![image](https://user-images.githubusercontent.com/72892531/130438547-7dfbcec3-a20f-4e80-9cd8-f2a007c9315b.png)

Before:
![image](https://user-images.githubusercontent.com/72892531/130438935-6ff68c04-e325-4007-a455-689496b024ad.png)

After:
![image](https://user-images.githubusercontent.com/72892531/130438902-6be58d1e-492e-4465-bc67-ee27da1b2f17.png)

Before:
![image](https://user-images.githubusercontent.com/72892531/130439084-8fa37bb7-d5fe-4828-bd25-01e263d485b4.png)

After:
![image](https://user-images.githubusercontent.com/72892531/130439040-55e6d6da-191c-40d3-97e3-d0288dc673f0.png)

Also happens for profile-select three line button.
This change changes the border-radius from 50% to 22%

Has this pull request been tested?
Yes

**Desktop (please complete the following information):**
 - OS Version: Ubuntu 20.04
 - FreeTube version: Latest Stable