### PR TITLE
Make trending type selector not change background for current selection

### DIFF
--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -32,7 +32,7 @@
   transition: background 0.2s ease-out;
 }
 
-.tab:hover, .tab:focus {
+.tab:hover {
   background-color: var(--side-nav-hover-color);
   -moz-transition: background 0.2s ease-in;
   -o-transition: background 0.2s ease-in;


### PR DESCRIPTION
Bit hard to explain, so TLDR previews are below

Before:
![image](https://user-images.githubusercontent.com/72892531/130816138-7882458e-5d75-4b4b-9993-d2d5f88bc356.png)

After:
![image](https://user-images.githubusercontent.com/72892531/130816055-5b589db3-a925-4e60-bc87-670d5ad16306.png)

Basically active selection has no background color change. I made this pr because it looks strange next to hover.
