### PR TITLE
Make elements not highlightable where they shouldn't be

### DIFF
--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -34,6 +34,7 @@
   position: relative;
   padding: 5px;
   cursor: pointer;
+  user-select: none;
 }
 
 .moreOption {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Fix

**Relevant issue**
closes #1048 

**Description**
When dragging/selecting on the page, some elements highlight where they shouldn't. 
Examples are below.

**Changes**
Nav menu when shortened and expanded is not selectable.

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/72892531/130817827-350a39dc-4ac2-49a8-a380-41d2e1620fb2.png)

After:
![image](https://user-images.githubusercontent.com/72892531/130817910-f740de9e-30b4-4eb9-b67f-1cec11bc010c.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes