### PR TITLE
Fixes wrong variable name

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -982,7 +982,7 @@ export default Vue.extend({
         return
       }
 
-      const theatreModeActive = this.defaultTheatreModeActive ? ' vjs-icon-theatre-active' : ''
+      const theatreModeActive = this.defaultTheatreMode ? ' vjs-icon-theatre-active' : ''
 
       const VjsButton = videojs.getComponent('Button')
       const toggleTheatreModeButton = videojs.extend(VjsButton, {


### PR DESCRIPTION
---
Fixes wrong variable name
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
Fixes wrong variable name defaultTheatreModeActive to defaultTheatreMode. This bug resulted in the "enable theatre mode" icon being shown when theatre mode was set to active by default in the settings (which should have and now appropriately shows the icon for disabling theatre mode).

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: bleeding edge