### PR TITLE
Theater mode icon behavior fix

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -165,10 +165,6 @@ export default Vue.extend({
       return this.$store.getters.getDefaultVideoFormat
     },
 
-    defaultTheatreMode: function () {
-      return this.$store.getters.getDefaultTheatreMode
-    },
-
     autoplayVideos: function () {
       return this.$store.getters.getAutoplayVideos
     },
@@ -982,7 +978,7 @@ export default Vue.extend({
         return
       }
 
-      const theatreModeActive = this.defaultTheatreMode ? ' vjs-icon-theatre-active' : ''
+      const theatreModeActive = this.$parent.useTheatreMode ? ' vjs-icon-theatre-active' : ''
 
       const VjsButton = videojs.getComponent('Button')
       const toggleTheatreModeButton = videojs.extend(VjsButton, {


### PR DESCRIPTION
---
Theater mode icon behavior fix
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
The last silly fix for the theater mode icon. Thirty minutes ago, I just realized (and read under #1236) that theater mode's state when switching between videos is its last known state rather than the default setting. The icon was wrongly being determined by the default setting. My bad!

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: bleeding edge