### PR TITLE
Allow large changelog messages to scroll

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -32,6 +32,12 @@ body {
   margin-bottom: -75px;
 }
 
+#changeLogText {
+  overflow-y: scroll;
+  height: 40vh;
+  display: block
+}
+
 .fade-enter-active, .fade-leave-active {
   transition: opacity .15s;
 }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -46,7 +46,10 @@
       <h2>
         {{ changeLogTitle }}
       </h2>
-      <span v-html="updateChangelog" />
+      <span
+        id="changeLogText"
+        v-html="updateChangelog"
+      />
       <ft-flex-box>
         <ft-button
           :label="$t('Download From Site')"


### PR DESCRIPTION
---
Allow large changelogs to scroll
---

**Pull Request Type**
- [x] Bugfix

**Related issue**
N/A

**Description**
Fixes the changelog message -- you know, the one that pops up when there is a new release out -- to scroll when there is a sizable enough amount of text.

**Screenshots**
Before:
![fix-changelog-before](https://user-images.githubusercontent.com/84899178/132023595-e1538660-7ba7-4584-b1d0-af093dea6a6b.png)
After:
![fix-changelog](https://user-images.githubusercontent.com/84899178/132023600-6badca09-cbbd-45ef-a3cf-8a2ced35bf23.png)


**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: bleeding edge

**Additional context**
This pull request about large changelogs is, of course, just a spontaneous fix & is completely unrelated to anything. 😉