### PR TITLE
fixes: trending text in small window

### DIFF
--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
@@ -26,7 +26,7 @@
           class="navIcon"
         />
         <p class="navLabel">
-          {{ $t("Trending") }}
+          {{ $t("Trending.Trending") }}
         </p>
       </div>
       <div


### PR DESCRIPTION
---
fix trending text in small window
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to.
None

**Description**
Please write a clear and concise description of what the pull request does.
Side-nav-more-options wasn't updated in #1483 so the trending text wasn't displaying properly in small window

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/78101139/132105160-dd7e80f4-1b22-4949-b152-84eea3f46716.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 
Yes, I ran the application and checked that the trending string was correct when the screen was small

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.13.2

**Additional context**
Add any other context about the problem here.
