### PR TITLE
Fixes thumbnail width

### DIFF
--- a/src/renderer/sass-partials/_ft-list-item.sass
+++ b/src/renderer/sass-partials/_ft-list-item.sass
@@ -207,7 +207,7 @@ $thumbnail-overlay-opacity: 0.85
       margin-bottom: 12px
 
       .thumbnailImage
-        width: 100%
+        width: 250px
 
     .title
       font-size: 18px


### PR DESCRIPTION
---
Fixes thumbnail width
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Closes #1641

**Description**
Fixes the thumbnail width in listed videos from 231px to 250px.

**Testing (for code that is not small enough to be easily understandable)**
Tested on dev and a linux-unpacked build. Checked video thumbnails on subscription page, recommended videos, channel videos, and playlist videos.

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: v0.14.0

**Additional context**
Thanks to @ChunkyProgrammer for this unforgettable tip: `npm install` before you test code, write code, or push code!!