### PR TITLE
Fixes video volume scroll from activating in mediaplayer menus

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -466,7 +466,7 @@ export default Vue.extend({
     },
 
     mouseScrollVolume: function (event) {
-      if (event.target) {
+      if (event.target && !event.currentTarget.querySelector('.vjs-menu:hover')) {
         event.preventDefault()
 
         if (this.player.muted() && event.wheelDelta > 0) {


### PR DESCRIPTION
---
Fixes video volume scroll from activating in mediaplayer menus
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
#1643 

**Description**
Prevents menus on the mediaplayer (e.g., video quality level selection, caption settings, playback rate) from being unable to be scrolled through when "Scroll Volume Over Video Player" is active. Now, the volume does not change when scrolling over a menu on the mediaplayer, and the menus can be scrolled through with ease.

**Testing (for code that is not small enough to be easily understandable)**
Tested scrolling on video quality level selection, caption settings, and playback rate menus while the setting was active.

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: 0.14.0 Beta
