### PR TITLE
Feedback when copying playlist link

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -99,12 +99,18 @@ export default Vue.extend({
 
       switch (method) {
         case 'copyYoutube':
+          this.showToast({
+            message: this.$t('Share.YouTube URL copied to clipboard')
+          })
           navigator.clipboard.writeText(youtubeUrl)
           break
         case 'openYoutube':
           this.openExternalLink(youtubeUrl)
           break
         case 'copyInvidious':
+          this.showToast({
+            message: this.$t('Share.Invidious URL copied to clipboard')
+          })
           navigator.clipboard.writeText(invidiousUrl)
           break
         case 'openInvidious':
@@ -131,6 +137,7 @@ export default Vue.extend({
     },
 
     ...mapActions([
+      'showToast',
       'openExternalLink'
     ])
   }

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -99,19 +99,19 @@ export default Vue.extend({
 
       switch (method) {
         case 'copyYoutube':
+          navigator.clipboard.writeText(youtubeUrl)
           this.showToast({
             message: this.$t('Share.YouTube URL copied to clipboard')
           })
-          navigator.clipboard.writeText(youtubeUrl)
           break
         case 'openYoutube':
           this.openExternalLink(youtubeUrl)
           break
         case 'copyInvidious':
+          navigator.clipboard.writeText(invidiousUrl)
           this.showToast({
             message: this.$t('Share.Invidious URL copied to clipboard')
           })
-          navigator.clipboard.writeText(invidiousUrl)
           break
         case 'openInvidious':
           this.openExternalLink(invidiousUrl)


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Fixes #1351

**Description**
When copying the link of a playlist FreeTube doesn't show any feedback to the user that the link has been copied like it does when copying a video URL. This PR makes it show the "URL copied to clipboard" message when copying playlist links.

**Screenshots (if appropriate)**
Before

https://user-images.githubusercontent.com/73130443/119911710-5ab10300-bf49-11eb-9435-b2104ce6f06c.mp4

After

https://user-images.githubusercontent.com/82644961/132214284-d6db1b65-c554-4cb0-ab9c-914a178139f8.mp4

**Desktop (please complete the following information):**
 - OS: Arch Linux
 - FreeTube version: Based on be58077