### PR TITLE
feat: Optimize caption sort order

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1107,7 +1107,7 @@ export default Vue.extend({
     sortCaptions: function (captionList) {
       return captionList.sort((captionA, captionB) => {
         const aCode = captionA.languageCode.split('-') // ex. [en,US]
-        const bCode = captionB.languageCode.split('-') 
+        const bCode = captionB.languageCode.split('-')
         const aName = (captionA.label || captionA.name.simpleText) // ex: english (auto-generated)
         const bName = (captionB.label || captionB.name.simpleText)
         const userLocale = this.currentLocale.split(/-|_/) // ex. [en,US]

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1106,31 +1106,42 @@ export default Vue.extend({
 
     sortCaptions: function (captionList) {
       return captionList.sort((captionA, captionB) => {
-        const aCode = captionA.languageCode.split('-')
-        const bCode = captionB.languageCode.split('-')
-        const userLocale = this.currentLocale.split(/-|_/)
-        if (aCode[0] === userLocale[0]) {
-          if (bCode[0] === userLocale[0]) {
-            if ((captionB?.name?.simpleText?.search('auto') ?? -1) !== -1 && (captionB?.label?.search('auto') ?? -1) !== -1) {
+        const aCode = captionA.languageCode.split('-') // ex. [en,US]
+        const bCode = captionB.languageCode.split('-') 
+        const aName = (captionA.label || captionA.name.simpleText) // ex: english (auto-generated)
+        const bName = (captionB.label || captionB.name.simpleText)
+        const userLocale = this.currentLocale.split(/-|_/) // ex. [en,US]
+        if (aCode[0] === userLocale[0]) { // caption a has same language as user's locale
+          if (bCode[0] === userLocale[0]) { // caption b has same language as user's locale
+            if (bName.search('auto') !== -1) {
+              // prefer caption a: b is auto-generated captions
               return -1
-            } else if ((captionA?.name?.simpleText?.search('auto') ?? -1) !== -1 && (captionA.label.search('auto') ?? -1) !== -1) {
+            } else if (aName.search('auto') !== -1) {
+              // prefer caption b: a is auto-generated captions
               return 1
             } else if (aCode[1] === userLocale[1]) {
+              // prefer caption a: caption a has same county code as user's locale
               return -1
             } else if (bCode[1] === userLocale[1]) {
+              // prefer caption b: caption b has same county code as user's locale
               return 1
             } else if (aCode[1] === undefined) {
+              // prefer caption a: no country code is better than wrong country code
               return -1
             } else if (bCode[1] === undefined) {
+              // prefer caption b: no country code is better than wrong country code
               return 1
             }
           } else {
+            // prefer caption a: b does not match user's language
             return -1
           }
         } else if (bCode[0] === userLocale[0]) {
+          // prefer caption b: a does not match user's language
           return 1
         }
-        return (captionA.label || captionA.name.simpleText).localeCompare((captionB.label || captionB.name.simpleText))
+        // sort alphabetically
+        return aName.localeCompare(bName)
       })
     },
 


### PR DESCRIPTION
---
feat: Optimize caption sort order
---

**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
Closes #1444

**Description**
This PR will place captions with a matching locale (language +country) at the top (full string ex: english (United States)) followed by locales for the same language (ex: English(United Kingdom), English (Canada) ) then locales for that language that are auto-generated (ex: English (auto-generated) ) and finally it will go alphabetically (ex: Albanian)

**Screenshots (if appropriate)**
The [example video](https://www.youtube.com/watch?v=r1bUcNeyMpM) (provided by in the issue) will look like this: 
![image](https://user-images.githubusercontent.com/78101139/132222431-b76d28f8-a924-49e4-a836-1e69655718d4.png)

German as selected language:
![image](https://user-images.githubusercontent.com/78101139/132222561-98c26daa-4e39-4d78-82e7-7dabcd0c3b63.png)

English (GB) as selected language: (English GB=> English => English (CA) => English (US) => Albanian => Arabic)
![image](https://user-images.githubusercontent.com/78101139/132224689-fbad02ba-1463-42f1-9373-55e088c746bb.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
I found videos with multiple languages & tried out different locales

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.14.0


