### PR TITLE
Update build GH Action config to pin node version to 14.17.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build
 
 on:
   push:
-    branches: [ master, development ]
+    branches: [ master, development, fix/build ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.17.5]
         runtime: [ linux-x64, linux-arm64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ name: Build
 
 on:
   push:
-    branches: [ master, development, fix/build ]
+    branches: [ master, development ]
+  pull_request:
+    branches: [ master, development ]
 
 jobs:
   build:


### PR DESCRIPTION
**Important note**
Please note that only PrestoN is able to merge Pull Requests into master.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
The nightly build failed after actions/setup-node@v1 starts using node 14.17.6 / npm 6.14.15
Reported in FreeTube Dev Channel

**Description**
Try to workaround `npm ci` issue
`cb() never called!`

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/1018543/132289660-8c823709-a7a8-4d94-8895-8befd3010b1b.png)
![image](https://user-images.githubusercontent.com/1018543/132289693-b9afa3ae-205a-4cd9-ab51-bb51fbe40f18.png)


**Testing (for code that is not small enough to be easily understandable)**
Not sure how to test GH Action without merging

**Desktop (please complete the following information):**
 - OS: N/A
 - OS Version: N/A
 - FreeTube version: N/A

**Additional context**
Add any other context about the problem here.
