### PR TITLE
Fix watching video in development

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -116,7 +116,12 @@ function startRenderer(callback) {
   })
 
   const server = new WebpackDevServer(compiler, {
-    static: path.join(process.cwd(), 'static'),
+    static: {
+      directory: path.join(process.cwd(), 'static'),
+      watch: {
+        ignored: /(dashFiles|storyboards)\/*/
+      }
+    },
     port
   })
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1014,9 +1014,10 @@ export default Vue.extend({
           fs.mkdirSync('static/dashFiles/')
         }
 
-        fs.rm(fileLocation, () => {
-          fs.writeFileSync(fileLocation, xmlData)
-        })
+        if (fs.existsSync(fileLocation)) {
+          fs.rmSync(fileLocation)
+        }
+        fs.writeFileSync(fileLocation, xmlData)
       } else {
         fileLocation = `${userData}/dashFiles/${this.videoId}.xml`
         uriSchema = `file://${fileLocation}`

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -960,13 +960,13 @@ export default Vue.extend({
       if (this.removeVideoMetaFiles) {
         const userData = await this.getUserDataPath()
         if (this.isDev) {
-          const dashFileLocation = `dashFiles/${this.videoId}.xml`
-          const vttFileLocation = `storyboards/${this.videoId}.vtt`
+          const dashFileLocation = `static/dashFiles/${this.videoId}.xml`
+          const vttFileLocation = `static/storyboards/${this.videoId}.vtt`
           // only delete the file it actually exists
-          if (fs.existsSync('dashFiles/') && fs.existsSync(dashFileLocation)) {
+          if (fs.existsSync('static/dashFiles/') && fs.existsSync(dashFileLocation)) {
             fs.rmSync(dashFileLocation)
           }
-          if (fs.existsSync('storyboards/') && fs.existsSync(vttFileLocation)) {
+          if (fs.existsSync('static/storyboards/') && fs.existsSync(vttFileLocation)) {
             fs.rmSync(vttFileLocation)
           }
         } else {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Closes #1627

**Description**
Fix infinite reloading issue when trying to watch a watched video
This seems to be caused by having an existing matching file in `dashFiles` or `storyboards`
Removing `static/dashFiles` & `static/storyboards` once manually is still required after this change is introduced.

**Screenshots (if appropriate)**
https://user-images.githubusercontent.com/1018543/132454627-8e41cbe0-fe6a-4705-bcd4-80ddd4fdbe30.mov

**Testing (for code that is not small enough to be easily understandable)**
- Checkout source code
- `npm ci`
- `npm run debug`

- Go Trending
- Pick a video to watch
- Go Trending again
- Pick the same video to watch

**Desktop (please complete the following information):**
- OS: MacOS
- OS Version: 11.5.2
- FreeTube version: based on 4a871578bfb468ddae152147f3f40d1788c2a4ec

**Additional context**
Add any other context about the problem here.
