### PR TITLE
Focus in input after text clear

### DIFF
--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -88,7 +88,7 @@
 
 .inputAction {
   position: absolute;
-  padding: 10px;
+  padding: 10px 8px;
   top: 5px;
   right: 0px;
   cursor: pointer;

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -11,13 +11,19 @@
   cursor: pointer;
   border-radius: 200px 200px 200px 200px;
   color: var(--primary-text-color);
+
+  opacity: 0;
+
+  -moz-transition: background 0.2s ease-in, opacity 0.2s ease-in;
+  -o-transition: background 0.2s ease-in, opacity 0.2s ease-in;
+  transition: background 0.2s ease-in, opacity 0.2s ease-in;
 }
 
 .clearInputTextButton:hover {
   background-color: var(--side-nav-hover-color);
-  -moz-transition: background 0.2s ease-in;
-  -o-transition: background 0.2s ease-in;
-  transition: background 0.2s ease-in;
+}
+.clearInputTextButton.visible {
+  opacity: 1;
 }
 
 .forceTextColor .clearInputTextButton:hover {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -74,6 +74,10 @@ export default Vue.extend({
 
     idDataList: function () {
       return `${this.id}_datalist`
+    },
+
+    inputDataPresent: function () {
+      return this.inputData.length > 0
     }
   },
   watch: {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -104,6 +104,10 @@ export default Vue.extend({
     handleClearTextClick: function () {
       this.inputData = ''
       this.$emit('input', this.inputData)
+
+      // Focus on input element after text is clear for better UX
+      const inputElement = document.getElementById(this.id)
+      inputElement.focus()
     },
 
     addListener: function () {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -61,7 +61,9 @@ export default Vue.extend({
         selectedOption: -1,
         isPointerInList: false
       },
-      clearTextButtonVisible: true
+      // This button should be invisible on app start
+      // As the text input box should be empty
+      clearTextButtonVisible: false
     }
   },
   computed: {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -60,7 +60,8 @@ export default Vue.extend({
         showOptions: false,
         selectedOption: -1,
         isPointerInList: false
-      }
+      },
+      clearTextButtonVisible: true
     }
   },
   computed: {
@@ -83,6 +84,19 @@ export default Vue.extend({
   watch: {
     value: function (val) {
       this.inputData = val
+    },
+    inputDataPresent: function (newVal, oldVal) {
+      if (newVal) {
+        // The button needs to be visible **immediately**
+        // To allow user to see the transition
+        this.clearTextButtonVisible = true
+      } else {
+        // Hide the button after the transition
+        // 0.2s in CSS = 200ms in JS
+        setTimeout(() => {
+          this.clearTextButtonVisible = false
+        }, 200)
+      }
     }
   },
   mounted: function () {

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -21,7 +21,7 @@
       />
     </label>
     <font-awesome-icon
-      v-if="showClearTextButton"
+      v-if="showClearTextButton && inputDataPresent"
       icon="times-circle"
       class="clearInputTextButton"
       tabindex="0"

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -21,7 +21,7 @@
       />
     </label>
     <font-awesome-icon
-      v-if="showClearTextButton"
+      v-if="showClearTextButton && clearTextButtonVisible"
       icon="times-circle"
       class="clearInputTextButton"
       :class="{

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -21,9 +21,12 @@
       />
     </label>
     <font-awesome-icon
-      v-if="showClearTextButton && inputDataPresent"
+      v-if="showClearTextButton"
       icon="times-circle"
       class="clearInputTextButton"
+      :class="{
+        visible: inputDataPresent
+      }"
       tabindex="0"
       role="button"
       title="$t('Search Bar.Clear Input')"

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -29,7 +29,7 @@
       }"
       tabindex="0"
       role="button"
-      title="$t('Search Bar.Clear Input')"
+      :title="$t('Search Bar.Clear Input')"
       @click="handleClearTextClick"
       @keydown.space.prevent="handleClearTextClick"
       @keydown.enter.prevent="handleClearTextClick"


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
#1387
Missing change for #1392

**Description**
Update text input box to focus on text input element after "reset button" clicked

**Screenshots (if appropriate)**

https://user-images.githubusercontent.com/1018543/132451601-ee44e74b-d7ff-4226-a7fd-42c7e4e239e0.mov

**Testing (for code that is not small enough to be easily understandable)**
- Type something
- Press reset button

**Desktop (please complete the following information):**
- OS: MacOS
- OS Version: 11.5.2
- FreeTube version: based on 4a871578bfb468ddae152147f3f40d1788c2a4ec

**Additional context**
Add any other context about the problem here.
