### PR TITLE
Replaces outdated links to FreeTube GH wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ follow the [Contribution
 Guidelines](https://github.com/FreeTubeApp/FreeTube/blob/development/CONTRIBUTING.md)
 before sending your pull request.
 
-Thank you very much to the [People and Projects](https://github.com/FreeTubeApp/FreeTube/wiki/Credits) that make FreeTube possible!
+Thank you very much to the [People and Projects](https://docs.freetubeapp.io/credits/) that make FreeTube possible!
 
 ## Localization
 <a href="https://hosted.weblate.org/engage/free-tube/">
@@ -90,7 +90,7 @@ We are actively looking for translations!  We use Weblate to make it easy for tr
 
 ## Contact
 
-If you ever have any questions, feel free to make an issue here on GitHub.  Alternatively, you can email me at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://github.com/FreeTubeApp/FreeTube/wiki/Matrix-Server-Info-&-Rules) before joining.
+If you ever have any questions, feel free to make an issue here on GitHub.  Alternatively, you can email me at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://docs.freetubeapp.io/community/matrix/) before joining.
 
 You can also stay up to date by reading the [FreeTube Blog](https://write.as/freetube/).  [View the welcome blog](https://write.as/freetube/welcome-to-freetube-blogs).
 

--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -30,7 +30,7 @@
     <ft-flex-box>
       <a
         class="center"
-        href="https://github.com/FreeTubeApp/FreeTube/wiki/Importing-Your-YouTube-Subscriptions"
+        href="https://docs.freetubeapp.io/usage/importing-subscriptions/"
       >
         <p>
           {{ $t("Settings.Data Settings.How do I import my subscriptions?") }}

--- a/src/renderer/views/About/About.js
+++ b/src/renderer/views/About/About.js
@@ -59,7 +59,7 @@ export default Vue.extend({
         {
           icon: 'comment-dots',
           title: this.$t('About.Chat on Matrix'),
-          content: `<a href="https://matrix.to/#/#freetube:matrix.org?via=matrix.org&via=privacytools.io&via=tchncs.de">#freetube:matrix.org</a><br>${this.$t('About.Please read the')} <a href="https://github.com/FreeTubeApp/FreeTube/wiki/Matrix-Channel-Info-&-Rules">${this.$t('About.room rules')}</a>`
+          content: `<a href="https://matrix.to/#/#freetube:matrix.org?via=matrix.org&via=privacytools.io&via=tchncs.de">#freetube:matrix.org</a><br>${this.$t('About.Please read the')} <a href="https://docs.freetubeapp.io/community/matrix/">${this.$t('About.room rules')}</a>`
         },
         {
           icon: 'language',


### PR DESCRIPTION
---
Replaces outdated links to FreeTube GH wiki
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
Replaces links to the now-deprecated FreeTube GitHub wiki with links to our docs site, https://docs.freetubeapp.io.

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: bleeding edge