### PR TITLE
Fixes comment formatting

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -50,6 +50,7 @@
 }
 
 .commentText {
+  white-space: pre-wrap;
   font-size: 14px;
   margin-top: -10px;
   margin-left: 70px;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -264,7 +264,7 @@ export default Vue.extend({
         if (this.hideCommentLikes) {
           comment.likes = null
         }
-        comment.text = autolinker.link(comment.text.replace(/(<([^>]+)>)/ig, ''))
+        comment.text = autolinker.link(comment.text.replace(/(<(?!br>)([^>]+)>)/ig, ''))
 
         return comment
       })
@@ -296,7 +296,7 @@ export default Vue.extend({
           } else {
             comment.likes = comment.likeCount
           }
-          comment.text = autolinker.link(comment.content.replace(/(<([^>]+)>)/ig, ''))
+          comment.text = autolinker.link(comment.content.replace(/(<(?!br>)([^>]+)>)/ig, ''))
           comment.dataType = 'invidious'
 
           if (typeof (comment.replies) !== 'undefined' && typeof (comment.replies.replyCount) !== 'undefined') {
@@ -362,7 +362,7 @@ export default Vue.extend({
           } else {
             comment.likes = comment.likeCount
           }
-          comment.text = autolinker.link(comment.content.replace(/(<([^>]+)>)/ig, ''))
+          comment.text = autolinker.link(comment.content.replace(/(<(?!br>)([^>]+)>)/ig, ''))
           comment.time = comment.publishedText
           comment.dataType = 'invidious'
           comment.numReplies = 0


### PR DESCRIPTION
---
Fixes comment formatting
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
closes #1588

**Description**
Fixes line breaks in comments & replies not being rendered properly. This problem was caused from 1. a missing style and 2. `<br>` characters wrongly being removed from #1342. It is worth noting that this problem had always existed because of point number 1, so #1342 is not to blame for this bug's existence ([verified by this older build](https://github.com/FreeTubeApp/FreeTube/actions/runs/1041348454)).

**Screenshots (if appropriate)**
![Screenshot_20210918_131204](https://user-images.githubusercontent.com/84899178/133905340-fa92d50d-8f7d-45c4-9062-00daacaa554b.png)

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: bleeding edge

**Additional context**
Did not have to do this for live chat because line breaks are not possible in live chat comments.