### PR TITLE
Update webpack config to remove explicit HMR plugin

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -149,7 +149,6 @@ const config = {
 if (isDevMode) {
   // any dev only config
   config.plugins.push(
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
       __static: `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`,
     })

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -147,7 +147,6 @@ const config = {
 if (isDevMode) {
   // any dev only config
   config.plugins.push(
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
       __static: `"${path.join(__dirname, '../static').replace(/\\/g, '\\\\')}"`,
     })

--- a/_scripts/webpack.workers.config.js
+++ b/_scripts/webpack.workers.config.js
@@ -62,7 +62,6 @@ const config = {
  */
 if (isDevMode) {
   // any dev only config
-  config.plugins.push(new webpack.HotModuleReplacementPlugin())
 } else {
   config.plugins.push(
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
Update webpack config to remove explicit HMR plugin
This change suppresses warning
"<w> [webpack-dev-server] "hot: true" automatically applies HMR plugin, you don't have to add it manually to your webpack configuration."

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
- Run app via `npm run debug`
- Change any renderer component related code (visible condition/style/class name)
- See running app renders according to updated code without restart

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 11.6
 - FreeTube version: Git SHA f69e55342cfb507cb83a6c16f07267eae0ec425e

**Additional context**
Just a clean up to suppress a warning that might be harmless
