### PR TITLE
Style improvements to Channel & Trending pages

### DIFF
--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -21,6 +21,7 @@
   width: 100%;
   position: relative;
   background-color: var(--card-bg-color);
+  margin-top: 10px;
 }
 
 .channelInfo {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -53,7 +53,8 @@
 .subscribeButton {
   height: 50px;
   min-width: 150px;
-  align-self: center
+  align-self: center;
+  margin-bottom: 10px;
 }
 
 .channelSearch {
@@ -68,6 +69,8 @@
 .channelInfoTabs {
   position: relative;
   width: 100%;
+  margin-top: -16px;
+  margin-bottom: -13px;
 }
 
 .tab {
@@ -75,21 +78,19 @@
   font-size: 15px;
   cursor: pointer;
   align-self: flex-end;
-  -webkit-transition: background 0.2s ease-out;
-  -moz-transition: background 0.2s ease-out;
-  -o-transition: background 0.2s ease-out;
-  transition: background 0.2s ease-out;
+  color: var(--tertiary-text-color);
 }
 
 .selectedTab {
-  text-decoration: underline;
+  color: var(--primary-text-color);
+  border-bottom: 3px solid var(--primary-color);
+  margin-bottom: -3px;
+  font-weight: bold;
+  box-sizing: border-box;
 }
 
 .tab:hover {
-  background-color: var(--side-nav-hover-color);
-  -moz-transition: background 0.2s ease-in;
-  -o-transition: background 0.2s ease-in;
-  transition: background 0.2s ease-in;
+  font-weight: bold;
 }
 
 .aboutTab {
@@ -104,6 +105,10 @@
   font-family: 'Roboto', sans-serif;
   font-size: 17px;
   white-space: pre-wrap;
+}
+
+.channelSearch {
+  margin-top: 10px;
 }
 
 .elementList {

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -14,10 +14,17 @@
   width: 100%;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
+  margin-top: -3px;
+  color: var(--tertiary-text-color);
+  margin-bottom: 10px;
 }
 
 .selectedTab {
-  text-decoration: underline;
+  border-bottom: 3px solid var(--primary-color);
+  color: var(--primary-text-color);
+  font-weight: bold;
+  box-sizing: border-box;
+  margin-bottom: -3px;
 }
 
 .tab {
@@ -26,17 +33,10 @@
   font-size: 15px;
   cursor: pointer;
   align-self: flex-end;
-  -webkit-transition: background 0.2s ease-out;
-  -moz-transition: background 0.2s ease-out;
-  -o-transition: background 0.2s ease-out;
-  transition: background 0.2s ease-out;
 }
 
-.tab:hover, .tab:focus {
-  background-color: var(--side-nav-hover-color);
-  -moz-transition: background 0.2s ease-in;
-  -o-transition: background 0.2s ease-in;
-  transition: background 0.2s ease-in;
+.tab:hover {
+  font-weight: bold;
 }
 
 @media only screen and (max-width: 350px) {


### PR DESCRIPTION
---
Style improvements to Channel & Trending pages
---

**Pull Request Type**
- [x] Bugfix
- [x] Feature Implementation

**Related issue**
closes #1733

**Description**
*Bug fix:* Adds 10px margin between between Channel info section & channel banner.

*Additional improvements:* 

- Removes :focus styling for unintended effects with auto-focusing on Trending page. 
- Replaces underline with bold text weight & primary color bottom border on selected/active tab. 
- Replaces animated background color change with bold text weight on tab:hover. 
- Changes inactive tabs' color to tertiary text color. 
- Removes unnecessary margin beneath tabs. 
- Removes some of the empty vertical space on Channel top section. 

**Screenshots (if appropriate)**
_Before:_

![Screenshot_20210922_160402](https://user-images.githubusercontent.com/84899178/134421768-34c91aa0-910c-4b87-9b1e-2af15b14344e.png)

![Screenshot_20210922_160423](https://user-images.githubusercontent.com/84899178/134421806-7673a4bb-46d6-4c19-8d98-a5429857ae40.png)

_After:_

![Screenshot_20210922_154156](https://user-images.githubusercontent.com/84899178/134420127-49a9d68f-a4d5-4ee6-a302-f7467282d5a9.png)

![Screenshot_20210922_154236](https://user-images.githubusercontent.com/84899178/134420136-db699734-4355-462f-aecd-0023db8fec80.png)

![Screenshot_20210922_154317](https://user-images.githubusercontent.com/84899178/134420167-113d0e6d-88d9-45f5-a6cb-841f65850daf.png)

**Testing (for code that is not small enough to be easily understandable)**
Tested on multiple screen sizes.

**Desktop (please complete the following information):**
 - OS: OpenSUSE
 - OS Version: Tumbleweed
 - FreeTube version: bleeding edge