### PR TITLE
Update top nav input box action button icon depends on input

### DIFF
--- a/src/renderer/components/external-player-settings/external-player-settings.vue
+++ b/src/renderer/components/external-player-settings/external-player-settings.vue
@@ -33,7 +33,7 @@
     >
       <ft-input
         :placeholder="$t('Settings.External Player Settings.Custom External Player Executable')"
-        :show-arrow="false"
+        :show-action-button="false"
         :show-label="true"
         :value="externalPlayerExecutable"
         :tooltip="$t('Tooltips.External Player Settings.Custom External Player Executable')"
@@ -41,7 +41,7 @@
       />
       <ft-input
         :placeholder="$t('Settings.External Player Settings.Custom External Player Arguments')"
-        :show-arrow="false"
+        :show-action-button="false"
         :show-label="true"
         :value="externalPlayerCustomArgs"
         :tooltip="$t('Tooltips.External Player Settings.Custom External Player Arguments')"

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -90,7 +90,7 @@
   position: absolute;
   padding: 10px 8px;
   top: 5px;
-  right: 0px;
+  right: 0;
   cursor: pointer;
   border-radius: 200px 200px 200px 200px;
   color: var(--primary-text-color);

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -108,7 +108,7 @@
   color: #EEEEEE;
 }
 
-.ft-input-component.showArrow .ft-input {
+.ft-input-component.showActionButton .ft-input {
   /*
   With arrow present means
   the text might get under the arrow with normal padding

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -96,6 +96,10 @@
   color: var(--primary-text-color);
 }
 
+.inputAction.disabled {
+  opacity: 50%;
+}
+
 .search ::-webkit-calendar-picker-indicator {
   display: none;
 }

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -91,14 +91,16 @@
   padding: 10px 8px;
   top: 5px;
   right: 0;
-  cursor: pointer;
   border-radius: 200px 200px 200px 200px;
   color: var(--primary-text-color);
+  /* this should look disabled by default */
   opacity: 50%;
 }
 
 .inputAction.enabled {
   opacity: 100%;
+  /* Only look respond to cursor when enabled */
+  cursor: pointer;
 }
 
 .search ::-webkit-calendar-picker-indicator {

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -94,10 +94,11 @@
   cursor: pointer;
   border-radius: 200px 200px 200px 200px;
   color: var(--primary-text-color);
+  opacity: 50%;
 }
 
-.inputAction.disabled {
-  opacity: 50%;
+.inputAction.enabled {
+  opacity: 100%;
 }
 
 .search ::-webkit-calendar-picker-indicator {
@@ -120,25 +121,25 @@
   padding-right: 2em;
 }
 
-.inputAction:hover {
+.inputAction.enabled:hover {
   background-color: var(--side-nav-hover-color);
   -moz-transition: background 0.2s ease-in;
   -o-transition: background 0.2s ease-in;
   transition: background 0.2s ease-in;
 }
 
-.forceTextColor .inputAction:hover {
+.forceTextColor .inputAction.enabled:hover {
   background-color: var(--primary-color-hover);
 }
 
-.inputAction:active {
+.inputAction.enabled:active {
   background-color: var(--tertiary-text-color);
   -moz-transition: background 0.2s ease-in;
   -o-transition: background 0.2s ease-in;
   transition: background 0.2s ease-in;
 }
 
-.forceTextColor .inputAction:active {
+.forceTextColor .inputAction.enabled:active {
   background-color: var(--primary-color-active);
 }
 

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -119,6 +119,9 @@ export default Vue.extend({
   },
   methods: {
     handleClick: function () {
+      // No action if no input text
+      if (!this.inputDataPresent) { return }
+
       this.searchState.showOptions = false
       this.$emit('input', this.inputData)
       this.$emit('click', this.inputData)

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -66,6 +66,7 @@ export default Vue.extend({
       },
       // This button should be invisible on app start
       // As the text input box should be empty
+      clearTextButtonExisting: false,
       clearTextButtonVisible: false,
       actionButtonIconName: 'search'
     }
@@ -95,12 +96,19 @@ export default Vue.extend({
       if (newVal) {
         // The button needs to be visible **immediately**
         // To allow user to see the transition
-        this.clearTextButtonVisible = true
+        this.clearTextButtonExisting = true
+        // The transition is not rendered if this property is set right after
+        // It's visible
+        setTimeout(() => {
+          this.clearTextButtonVisible = true
+        }, 0)
       } else {
-        // Hide the button after the transition
+        // Hide the button with transition
+        this.clearTextButtonVisible = false
+        // Remove the button after the transition
         // 0.2s in CSS = 200ms in JS
         setTimeout(() => {
-          this.clearTextButtonVisible = false
+          this.clearTextButtonExisting = false
         }, 200)
       }
     }

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -158,31 +158,16 @@ export default Vue.extend({
           let isYoutubeLink = false
 
           switch (result.urlType) {
-            case 'video': {
+            case 'video':
+            case 'playlist':
+            case 'search':
+            case 'channel':
               isYoutubeLink = true
               break
-            }
-
-            case 'playlist': {
-              isYoutubeLink = true
-              break
-            }
-
-            case 'search': {
-              isYoutubeLink = true
-              break
-            }
-
-            case 'hashtag': {
+            case 'hashtag':
               // TODO: Implement a hashtag related view
               // isYoutubeLink is already `false`
               break
-            }
-
-            case 'channel': {
-              isYoutubeLink = true
-              break
-            }
 
             case 'invalid_url':
             default: {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -1,6 +1,9 @@
 import Vue from 'vue'
 import FtTooltip from '../ft-tooltip/ft-tooltip.vue'
 
+// Check if it's a YouTube link
+const youtubeUrlPattern = /^https?:\/\/((www\.)?youtube\.com(\/embed)?|youtu\.be)\/.*$/
+
 export default Vue.extend({
   name: 'FtInput',
   components: {
@@ -63,7 +66,8 @@ export default Vue.extend({
       },
       // This button should be invisible on app start
       // As the text input box should be empty
-      clearTextButtonVisible: false
+      clearTextButtonVisible: false,
+      actionButtonIconName: 'search'
     }
   },
   computed: {
@@ -118,16 +122,33 @@ export default Vue.extend({
       if (this.isSearch &&
         this.searchState.selectedOption !== -1 &&
         this.inputData === this.dataList[this.searchState.selectedOption]) { return }
+      this.handleActionIconChange()
       this.$emit('input', this.inputData)
     },
 
     handleClearTextClick: function () {
       this.inputData = ''
+      this.handleActionIconChange()
       this.$emit('input', this.inputData)
 
       // Focus on input element after text is clear for better UX
       const inputElement = document.getElementById(this.id)
       inputElement.focus()
+    },
+
+    handleActionIconChange: function() {
+      // Only need to update icon if visible
+      if (!this.showActionButton) { return }
+
+      // Update action button icon according to input
+      const isYoutubeLink = this.inputDataPresent && youtubeUrlPattern.test(this.inputData)
+      if (isYoutubeLink) {
+        // Go to URL (i.e. Video/Playlist/Channel
+        this.actionButtonIconName = 'arrow-right'
+      } else {
+        // Search with text
+        this.actionButtonIconName = 'search'
+      }
     },
 
     addListener: function () {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -15,7 +15,7 @@ export default Vue.extend({
       type: String,
       default: ''
     },
-    showArrow: {
+    showActionButton: {
       type: Boolean,
       default: true
     },

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -52,6 +52,9 @@
       v-if="showActionButton"
       :icon="actionButtonIconName"
       class="inputAction"
+      :class="{
+        disabled: !inputDataPresent
+      }"
       @click="handleClick"
     />
 

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -4,7 +4,7 @@
     :class="{
       search: isSearch,
       forceTextColor: forceTextColor,
-      showArrow: showArrow,
+      showActionButton: showActionButton,
       showClearTextButton: showClearTextButton
     }"
   >
@@ -49,7 +49,7 @@
       @keydown="e => handleKeyDown(e.keyCode)"
     >
     <font-awesome-icon
-      v-if="showArrow"
+      v-if="showActionButton"
       icon="arrow-right"
       class="inputAction"
       @click="handleClick"

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -21,11 +21,11 @@
       />
     </label>
     <font-awesome-icon
-      v-if="showClearTextButton && clearTextButtonVisible"
+      v-if="showClearTextButton && clearTextButtonExisting"
       icon="times-circle"
       class="clearInputTextButton"
       :class="{
-        visible: inputDataPresent
+        visible: clearTextButtonVisible
       }"
       tabindex="0"
       role="button"

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -50,7 +50,7 @@
     >
     <font-awesome-icon
       v-if="showActionButton"
-      icon="arrow-right"
+      :icon="actionButtonIconName"
       class="inputAction"
       @click="handleClick"
     />

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -53,7 +53,7 @@
       :icon="actionButtonIconName"
       class="inputAction"
       :class="{
-        disabled: !inputDataPresent
+        enabled: inputDataPresent
       }"
       @click="handleClick"
     />

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -7,7 +7,7 @@
           class="profileName"
           placeholder="Profile Name"
           :value="profileName"
-          :show-arrow="false"
+          :show-action-button="false"
           @input="e => profileName = e"
         />
       </ft-flex-box>
@@ -40,7 +40,7 @@
           class="profileName"
           placeholder=""
           :value="profileBgColor"
-          :show-arrow="false"
+          :show-action-button="false"
           :disabled="true"
         />
       </ft-flex-box>

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -96,7 +96,7 @@
     <ft-flex-box class="generalSettingsFlexBox">
       <ft-input
         :placeholder="$t('Settings.General Settings.Current Invidious Instance')"
-        :show-arrow="false"
+        :show-action-button="false"
         :show-label="true"
         :value="currentInvidiousInstance"
         :data-list="invidiousInstancesList"

--- a/src/renderer/components/proxy-settings/proxy-settings.vue
+++ b/src/renderer/components/proxy-settings/proxy-settings.vue
@@ -25,14 +25,14 @@
     <ft-flex-box>
       <ft-input
         :placeholder="$t('Settings.Proxy Settings.Proxy Host')"
-        :show-arrow="false"
+        :show-action-button="false"
         :show-label="true"
         :value="proxyHostname"
         @input="handleUpdateProxyHostname"
       />
       <ft-input
         :placeholder="$t('Settings.Proxy Settings.Proxy Port Number')"
-        :show-arrow="false"
+        :show-action-button="false"
         :show-label="true"
         :value="proxyPort"
         @input="handleUpdateProxyPort"

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -23,7 +23,7 @@
     <ft-flex-box>
       <ft-input
         :placeholder="$t('Settings.SponsorBlock Settings[\'SponsorBlock API Url (Default is https://sponsor.ajay.app)\']')"
-        :show-arrow="false"
+        :show-action-button="false"
         :show-label="true"
         :value="sponsorBlockUrl"
         @input="handleUpdateSponsorBlockUrl"


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
It's [a comment/feedback in another PR](https://github.com/FreeTubeApp/FreeTube/pull/1669#issuecomment-918015016)

**Description**
Before: Top nav input box action button icon is always "arrow right"
After: Action button icon changes depend on input text "looks like a youtube URL" or not
- Initial: icon = "search"
- Looks like YT URL: icon = "arrow right"
- Otherwise: icon = "search"

Also implements
["Having the disappear animation of the Clear Text button also occur on appear/re-appear for visual consistency."](https://github.com/FreeTubeApp/FreeTube/pull/1669#issuecomment-924003650)

**Screenshots (if appropriate)**
Icon change:
![Screenshot 2021-09-23 at 3 04 46 PM](https://user-images.githubusercontent.com/1018543/134467373-62469cb2-e6de-42e6-accb-0310a13a39e2.png)
![Screenshot 2021-09-23 at 3 04 30 PM](https://user-images.githubusercontent.com/1018543/134467362-312f197c-8252-46a7-84f3-ecf6bd4c9fee.png)

Button animation change:

https://user-images.githubusercontent.com/1018543/134470580-c3f004b7-4b2a-4dff-8352-fa35f41797b5.mov

"Update action button to look & act as disabled when input text is empty"

https://user-images.githubusercontent.com/1018543/134834657-3931df76-608a-4af7-91d6-7cccc3561600.mov

**Testing (for code that is not small enough to be easily understandable)**
- Enter Youtube URLs (e.g. Video, Playlist, Channel), look at icon changed
- Clear text via different methods after Youtube URLs entered
- Enter non Youtube URLs (any text)
- Clear text via different methods after text entered

**Desktop (please complete the following information):**
- OS: MacOS
- OS Version: 11.6
- FreeTube version: based on b1a310ef09cdad6f2eda5b65a544e5b2e0880648

**Additional context**
Add any other context about the problem here.
