### PR TITLE
* Implement divider for video "more dropdown menu"

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -119,7 +119,10 @@ function startRenderer(callback) {
     static: {
       directory: path.join(process.cwd(), 'static'),
       watch: {
-        ignored: /(dashFiles|storyboards)\/*/
+        ignored: [
+          /(dashFiles|storyboards)\/*/,
+          '/**/.DS_Store',
+        ]
       }
     },
     port

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -51,41 +51,16 @@ export default Vue.extend({
       // - value: String (if type == 'labelValue')
       type: Array,
       default: () => { return [] }
-    },
-    dropdownNames: {
-      type: Array,
-      default: () => { return [] }
-    },
-    dropdownValues: {
-      type: Array,
-      default: () => { return [] }
-    },
-    dropdownConvertNullNamesToDividers: {
-      type: Boolean,
-      default: false
     }
   },
   data: function () {
     return {
       dropdownShown: false,
-      dropdownOptionsWithFallback: [],
       id: ''
     }
   },
   mounted: function () {
     this.id = `iconButton${this._uid}`
-
-    if (this.dropdownOptions.length > 0) {
-      this.dropdownOptionsWithFallback = this.dropdownOptions
-    } else if (this.dropdownOptions.length === 0 && this.dropdownNames.length > 0) {
-      // Backward compatibility
-      this.dropdownOptionsWithFallback = this.dropdownNames.map((dropdownName, index) => {
-        return {
-          label: dropdownName,
-          value: this.dropdownValues[index]
-        }
-      })
-    }
   },
   methods: {
     toggleDropdown: function () {
@@ -132,7 +107,7 @@ export default Vue.extend({
     },
 
     handleIconClick: function () {
-      if (this.forceDropdown || (this.dropdownOptionsWithFallback.length > 0)) {
+      if (this.forceDropdown || (this.dropdownOptions.length > 0)) {
         this.toggleDropdown()
       } else {
         this.$emit('click')

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -51,6 +51,10 @@ export default Vue.extend({
     dropdownValues: {
       type: Array,
       default: () => { return [] }
+    },
+    dropdownConvertNullNamesToDividers: {
+      type: Boolean,
+      default: false
     }
   },
   data: function () {
@@ -114,7 +118,12 @@ export default Vue.extend({
       }
     },
 
-    handleDropdownClick: function (index) {
+    handleDropdownClick: function (index, label) {
+      if (label === null && this.dropdownConvertNullNamesToDividers) {
+        // Divider click
+        return
+      }
+
       if (this.returnIndex) {
         this.$emit('click', index)
       } else {

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -44,6 +44,14 @@ export default Vue.extend({
       type: String,
       default: 'bottom'
     },
+    dropdownOptions: {
+      // Array of objects with these properties
+      // - type: ('labelValue'|'divider', default to 'labelValue' for less typing)
+      // - label: String (if type == 'labelValue')
+      // - value: String (if type == 'labelValue')
+      type: Array,
+      default: () => { return [] }
+    },
     dropdownNames: {
       type: Array,
       default: () => { return [] }
@@ -60,11 +68,24 @@ export default Vue.extend({
   data: function () {
     return {
       dropdownShown: false,
+      dropdownOptionsWithFallback: [],
       id: ''
     }
   },
   mounted: function () {
     this.id = `iconButton${this._uid}`
+
+    if (this.dropdownOptions.length > 0) {
+      this.dropdownOptionsWithFallback = this.dropdownOptions
+    } else if (this.dropdownOptions.length === 0 && this.dropdownNames.length > 0) {
+      // Backward compatibility
+      this.dropdownOptionsWithFallback = this.dropdownNames.map((dropdownName, index) => {
+        return {
+          label: dropdownName,
+          value: this.dropdownValues[index]
+        }
+      })
+    }
   },
   methods: {
     toggleDropdown: function () {
@@ -111,23 +132,18 @@ export default Vue.extend({
     },
 
     handleIconClick: function () {
-      if (this.forceDropdown || (this.dropdownNames.length > 0 && this.dropdownValues.length > 0)) {
+      if (this.forceDropdown || (this.dropdownOptionsWithFallback.length > 0)) {
         this.toggleDropdown()
       } else {
         this.$emit('click')
       }
     },
 
-    handleDropdownClick: function (index, label) {
-      if (label === null && this.dropdownConvertNullNamesToDividers) {
-        // Divider click
-        return
-      }
-
+    handleDropdownClick: function ({ url, index }) {
       if (this.returnIndex) {
         this.$emit('click', index)
       } else {
-        this.$emit('click', this.dropdownValues[index])
+        this.$emit('click', url)
       }
 
       this.focusOut()

--- a/src/renderer/components/ft-icon-button/ft-icon-button.sass
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.sass
@@ -83,7 +83,7 @@
     list-style-type: none
 
   .listItem
-    padding: 10px
+    padding: 6px 10px
     margin: 0
     white-space: nowrap
     cursor: pointer
@@ -96,3 +96,9 @@
     &:active
       background-color: var(--side-nav-active-color)
       transition: background 0.1s ease-in
+
+  .listItemDivider
+    width: 95%
+    margin: 1px auto
+    border-top: 1px solid var(--tertiary-text-color)
+

--- a/src/renderer/components/ft-icon-button/ft-icon-button.sass
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.sass
@@ -101,4 +101,6 @@
     width: 95%
     margin: 1px auto
     border-top: 1px solid var(--tertiary-text-color)
+    // Too "visible" with current color
+    opacity: 50%
 

--- a/src/renderer/components/ft-icon-button/ft-icon-button.sass
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.sass
@@ -83,7 +83,7 @@
     list-style-type: none
 
   .listItem
-    padding: 6px 10px
+    padding: 8px 10px
     margin: 0
     white-space: nowrap
     cursor: pointer

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -34,10 +34,10 @@
           <li
             v-for="(label, index) in dropdownNames"
             :key="index"
-            class="listItem"
-            @click="handleDropdownClick(index)"
+            :class="label === null && dropdownConvertNullNamesToDividers ? 'listItemDivider' : 'listItem'"
+            @click="handleDropdownClick(index, label)"
           >
-            {{ label }}
+            {{ label === null && dropdownConvertNullNamesToDividers ? '' : label }}
           </li>
         </ul>
       </slot>

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -28,16 +28,16 @@
     >
       <slot>
         <ul
-          v-if="dropdownNames.length > 0"
+          v-if="dropdownOptionsWithFallback.length > 0"
           class="list"
         >
           <li
-            v-for="(label, index) in dropdownNames"
+            v-for="(option, index) in dropdownOptionsWithFallback"
             :key="index"
-            :class="label === null && dropdownConvertNullNamesToDividers ? 'listItemDivider' : 'listItem'"
-            @click="handleDropdownClick(index, label)"
+            :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
+            @click="handleDropdownClick({url: option.value, index: index})"
           >
-            {{ label === null && dropdownConvertNullNamesToDividers ? '' : label }}
+            {{ option.type === 'divider' ? '' : option.label }}
           </li>
         </ul>
       </slot>

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -28,11 +28,11 @@
     >
       <slot>
         <ul
-          v-if="dropdownOptionsWithFallback.length > 0"
+          v-if="dropdownOptions.length > 0"
           class="list"
         >
           <li
-            v-for="(option, index) in dropdownOptionsWithFallback"
+            v-for="(option, index) in dropdownOptions"
             :key="index"
             :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
             @click="handleDropdownClick({url: option.value, index: index})"

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -61,17 +61,22 @@ export default Vue.extend({
       isPremium: false,
       hideViews: false,
       optionsValues: [
+        // `null` values represent dividers
         'history',
-        'openYoutube',
+        null,
         'copyYoutube',
-        'openYoutubeEmbed',
         'copyYoutubeEmbed',
-        'openInvidious',
         'copyInvidious',
-        'openYoutubeChannel',
+        null,
+        'openYoutube',
+        'openYoutubeEmbed',
+        'openInvidious',
+        null,
         'copyYoutubeChannel',
-        'openInvidiousChannel',
-        'copyInvidiousChannel'
+        'copyInvidiousChannel',
+        null,
+        'openYoutubeChannel',
+        'openInvidiousChannel'
       ]
     }
   },
@@ -131,24 +136,28 @@ export default Vue.extend({
     },
 
     optionsNames: function () {
-      const names = [
-        this.$t('Video.Open in YouTube'),
-        this.$t('Video.Copy YouTube Link'),
-        this.$t('Video.Open YouTube Embedded Player'),
-        this.$t('Video.Copy YouTube Embedded Player Link'),
-        this.$t('Video.Open in Invidious'),
-        this.$t('Video.Copy Invidious Link'),
-        this.$t('Video.Open Channel in YouTube'),
-        this.$t('Video.Copy YouTube Channel Link'),
-        this.$t('Video.Open Channel in Invidious'),
-        this.$t('Video.Copy Invidious Channel Link')
-      ]
+      const names = []
 
-      if (this.watched) {
-        names.unshift(this.$t('Video.Remove From History'))
-      } else {
-        names.unshift(this.$t('Video.Mark As Watched'))
-      }
+      names.push(
+        // `null` values represent dividers
+        this.watched
+          ? this.$t('Video.Remove From History')
+          : this.$t('Video.Mark As Watched'),
+        null,
+        this.$t('Video.Copy YouTube Link'),
+        this.$t('Video.Copy YouTube Embedded Player Link'),
+        this.$t('Video.Copy Invidious Link'),
+        null,
+        this.$t('Video.Open in YouTube'),
+        this.$t('Video.Open YouTube Embedded Player'),
+        this.$t('Video.Open in Invidious'),
+        null,
+        this.$t('Video.Copy YouTube Channel Link'),
+        this.$t('Video.Copy Invidious Channel Link'),
+        null,
+        this.$t('Video.Open Channel in YouTube'),
+        this.$t('Video.Open Channel in Invidious')
+      )
 
       return names
     },

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -59,25 +59,7 @@ export default Vue.extend({
       isFavorited: false,
       isUpcoming: false,
       isPremium: false,
-      hideViews: false,
-      optionsValues: [
-        // `null` values represent dividers
-        'history',
-        null,
-        'copyYoutube',
-        'copyYoutubeEmbed',
-        'copyInvidious',
-        null,
-        'openYoutube',
-        'openYoutubeEmbed',
-        'openInvidious',
-        null,
-        'copyYoutubeChannel',
-        'copyInvidiousChannel',
-        null,
-        'openYoutubeChannel',
-        'openInvidiousChannel'
-      ]
+      hideViews: false
     }
   },
   computed: {
@@ -135,31 +117,71 @@ export default Vue.extend({
       return (this.watchProgress / this.data.lengthSeconds) * 100
     },
 
-    optionsNames: function () {
-      const names = []
+    dropdownOptions: function () {
+      const options = []
 
-      names.push(
-        // `null` values represent dividers
-        this.watched
-          ? this.$t('Video.Remove From History')
-          : this.$t('Video.Mark As Watched'),
-        null,
-        this.$t('Video.Copy YouTube Link'),
-        this.$t('Video.Copy YouTube Embedded Player Link'),
-        this.$t('Video.Copy Invidious Link'),
-        null,
-        this.$t('Video.Open in YouTube'),
-        this.$t('Video.Open YouTube Embedded Player'),
-        this.$t('Video.Open in Invidious'),
-        null,
-        this.$t('Video.Copy YouTube Channel Link'),
-        this.$t('Video.Copy Invidious Channel Link'),
-        null,
-        this.$t('Video.Open Channel in YouTube'),
-        this.$t('Video.Open Channel in Invidious')
+      options.push(
+        {
+          label: this.watched
+            ? this.$t('Video.Remove From History')
+            : this.$t('Video.Mark As Watched'),
+          value: 'history'
+        },
+        {
+          type: 'divider'
+        },
+        {
+          label: this.$t('Video.Copy YouTube Link'),
+          value: 'copyYoutube'
+        },
+        {
+          label: this.$t('Video.Copy YouTube Embedded Player Link'),
+          value: 'copyYoutubeEmbed'
+        },
+        {
+          label: this.$t('Video.Copy Invidious Link'),
+          value: 'copyInvidious'
+        },
+        {
+          type: 'divider'
+        },
+        {
+          label: this.$t('Video.Open in YouTube'),
+          value: 'openYoutube'
+        },
+        {
+          label: this.$t('Video.Open YouTube Embedded Player'),
+          value: 'openYoutubeEmbed'
+        },
+        {
+          label: this.$t('Video.Open in Invidious'),
+          value: 'openInvidious'
+        },
+        {
+          type: 'divider'
+        },
+        {
+          label: this.$t('Video.Copy YouTube Channel Link'),
+          value: 'copyYoutubeChannel'
+        },
+        {
+          label: this.$t('Video.Copy Invidious Channel Link'),
+          value: 'copyInvidiousChannel'
+        },
+        {
+          type: 'divider'
+        },
+        {
+          label: this.$t('Video.Open Channel in YouTube'),
+          value: 'openYoutubeChannel'
+        },
+        {
+          label: this.$t('Video.Open Channel in Invidious'),
+          value: 'openInvidiousChannel'
+        }
       )
 
-      return names
+      return options
     },
 
     thumbnail: function () {

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -66,6 +66,7 @@
     <div class="info">
       <ft-icon-button
         class="optionsButton"
+        icon="ellipsis-v"
         title="More Options"
         theme="base-no-default"
         :size="16"
@@ -73,6 +74,7 @@
         dropdown-position-x="left"
         :dropdown-names="optionsNames"
         :dropdown-values="optionsValues"
+        :dropdown-convert-null-names-to-dividers="true"
         @click="handleOptionsClick"
       />
       <router-link

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -72,9 +72,7 @@
         :size="16"
         :use-shadow="false"
         dropdown-position-x="left"
-        :dropdown-names="optionsNames"
-        :dropdown-values="optionsValues"
-        :dropdown-convert-null-names-to-dividers="true"
+        :dropdown-options="dropdownOptions"
         @click="handleOptionsClick"
       />
       <router-link

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -118,12 +118,7 @@ export default Vue.extend({
   },
   data: function () {
     return {
-      formatTypeLabel: 'VIDEO FORMATS',
-      formatTypeValues: [
-        'dash',
-        'legacy',
-        'audio'
-      ]
+      formatTypeLabel: 'VIDEO FORMATS'
     }
   },
   computed: {
@@ -175,23 +170,29 @@ export default Vue.extend({
       return this.inFavoritesPlaylist ? 'base favorite' : 'base'
     },
 
-    downloadLinkNames: function () {
+    downloadLinkOptions: function () {
       return this.downloadLinks.map((download) => {
-        return download.label
+        return {
+          label: download.label,
+          value: download.url
+        }
       })
     },
 
-    downloadLinkValues: function () {
-      return this.downloadLinks.map((download) => {
-        return download.url
-      })
-    },
-
-    formatTypeNames: function () {
+    formatTypeOptions: function () {
       return [
-        this.$t('Change Format.Use Dash Formats').toUpperCase(),
-        this.$t('Change Format.Use Legacy Formats').toUpperCase(),
-        this.$t('Change Format.Use Audio Formats').toUpperCase()
+        {
+          label: this.$t('Change Format.Use Dash Formats').toUpperCase(),
+          value: 'dash'
+        },
+        {
+          label: this.$t('Change Format.Use Legacy Formats').toUpperCase(),
+          value: 'legacy'
+        },
+        {
+          label: this.$t('Change Format.Use Audio Formats').toUpperCase(),
+          value: 'audio'
+        }
       ]
     },
 
@@ -409,8 +410,9 @@ export default Vue.extend({
     },
 
     handleDownload: function (index) {
-      const url = this.downloadLinkValues[index]
-      const linkName = this.downloadLinkNames[index]
+      const selectedDownloadLinkOption = this.downloadLinkOptions[index]
+      const url = selectedDownloadLinkOption.value
+      const linkName = selectedDownloadLinkOption.label
       const extension = this.grabExtensionFromUrl(linkName)
 
       this.downloadMedia({

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -100,8 +100,7 @@
           theme="secondary"
           icon="download"
           :return-index="true"
-          :dropdown-names="downloadLinkNames"
-          :dropdown-values="downloadLinkValues"
+          :dropdown-options="downloadLinkOptions"
           @click="handleDownload"
         />
         <ft-icon-button
@@ -110,8 +109,7 @@
           class="option"
           theme="secondary"
           icon="file-video"
-          :dropdown-names="formatTypeNames"
-          :dropdown-values="formatTypeValues"
+          :dropdown-options="formatTypeOptions"
           @click="handleFormatChange"
         />
         <ft-share-button


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
IRC chat:
```
Non-pressing question: if we were to ever have breakout sections on hover of the three dots video section dropdown, would the better organization be "Open >" & "Copy >" or "YouTube >" & "Invidious >"?
```

**Description**
- Update the dropdown opened by a button with title "More Options",  
  located on video card/box rendered in views like search result/history/trending,  
  so that the options are reordered and group together.  
  Dividers are used for grouping.  
- Menu item spacing reduced slightly.

**Screenshots (if appropriate)**
New screenshots (all dropdown updated by this PR, too lazy to take for all themes)
![image](https://user-images.githubusercontent.com/1018543/134648400-5aaaafa6-ad12-4abd-8b0b-591436e5c902.png)
![image](https://user-images.githubusercontent.com/1018543/134648415-025cfae3-a725-461f-885a-fa311dabbb72.png)
![image](https://user-images.githubusercontent.com/1018543/134648435-767d7eea-d3fc-4aed-8807-126441bd980e.png)


Old screenshots (before divider opacity reduced):
![image](https://user-images.githubusercontent.com/1018543/134623977-e441f182-4d36-44e7-b856-918b76d97fcb.png)
![image](https://user-images.githubusercontent.com/1018543/134623991-760c93fe-cf29-4322-bdeb-f28c1adc793c.png)
![image](https://user-images.githubusercontent.com/1018543/134623999-87765ca7-e78f-4bf8-b5da-a394cfac3159.png)
![image](https://user-images.githubusercontent.com/1018543/134624002-068ebc4e-9d52-4bb1-a2f3-ee6dbbc3bbd1.png)


**Testing (for code that is not small enough to be easily understandable)**
A: More Options
- Visit Trending
- Click "More Options" button
- Click on each item to if works as labeled

B: Download Video
- View a video (e.g. https://youtu.be/vyuJRJ6GQ5k)
- Click "Download Video" button
- Click on each item to if works as labeled (I only tested limited options)

C: Change Video Formats
- View a video (e.g. https://youtu.be/vyuJRJ6GQ5k)
- Click "Change Video Formats" button
- Click on each item to if works as labeled


**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 11.6
 - FreeTube version: 732b2d642df36f1417a3aae1a7867bd0b48fb54d

**Additional context**
Add any other context about the problem here.
