### PR TITLE
Upgrade electron 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^13.5.1",
+    "electron": "^14.2.1",
     "electron-builder": "^22.11.7",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -180,7 +180,7 @@ function runApp() {
     /**
      * Initial window options
      */
-    const newWindow = new BrowserWindow({
+    const commonBrowserWindowOptions = {
       backgroundColor: '#212121',
       icon: isDev
         ? path.join(__dirname, '../../_icons/iconColor.png')
@@ -194,9 +194,35 @@ function runApp() {
         webSecurity: false,
         backgroundThrottling: false,
         contextIsolation: false
-      },
-      show: false
+      }
+    }
+    const newWindow = new BrowserWindow(
+      Object.assign(
+        {
+          // It will be shown later when ready via `ready-to-show` event
+          show: false
+        },
+        commonBrowserWindowOptions
+      )
+    )
+
+    // region Ensure child windows use same options since electron 14
+
+    // https://github.com/electron/electron/blob/14-x-y/docs/api/window-open.md#native-window-example
+    newWindow.webContents.setWindowOpenHandler(() => {
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: Object.assign(
+          {
+            // It should be visible on click
+            show: true
+          },
+          commonBrowserWindowOptions
+        )
+      }
     })
+
+    // endregion Ensure child windows use same options since electron 14
 
     if (replaceMainWindow) {
       mainWindow = newWindow

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,10 +3543,10 @@ electron-to-chromium@^1.3.830:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz#823cb9c98f28c64c673920f1c90ea3826596eaf9"
   integrity sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==
 
-electron@^13.5.1:
-  version "13.5.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.1.tgz#76c02c39be228532f886a170b472cbd3d93f0d0f"
-  integrity sha512-ZyxhIhmdaeE3xiIGObf0zqEyCyuIDqZQBv9NKX8w5FNzGm87j4qR0H1+GQg6vz+cA1Nnv1x175Zvimzc0/UwEQ==
+electron@^14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-14.2.1.tgz#ee8b9cfa8c04ad4d9456daa5bbac562c2c2517a1"
+  integrity sha512-20cLOVpmjIgYMgsDLpI36VQhv0bIy54sSBAP3rLFtrs/kVVHLu0educMVZkkMm5GJPd2vvU4mcK7f43JgVRcNg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [x] Feature Implementation

**Related issue**
N/A

**Description**
Upgrade electron 13.x > 14.x AND fix the issue caused by a breaking change in electron 14

Breaking change:
https://github.com/electron/electron/pull/28550
Child windows no longer inherit BrowserWindow construction options from their parents.

**Screenshots (if appropriate)**
Nothing visible should really changed

**Testing (for code that is not small enough to be easily understandable)**
All Dev team members should test this in
- Multiple OS
- Dev version (`npm run dev`) and built version afterward (can trigger nightly build manually)

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 11.6
 - FreeTube version: based on 7d0880ad05f69d9c46982f25c2885257632aa857

**Additional context**
The upgrade had caused issue like #1636

References:
- [Electron 14 official blog post](https://www.electronjs.org/blog/electron-14-0/)
- [Electron 14.x release notes](https://www.electronjs.org/releases/stable?version=14)
