### PR TITLE
Upgrade electron from 13 to 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^13.5.1",
+    "electron": "^15.3.1",
     "electron-builder": "^22.11.7",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -180,7 +180,7 @@ function runApp() {
     /**
      * Initial window options
      */
-    const newWindow = new BrowserWindow({
+    const commonBrowserWindowOptions = {
       backgroundColor: '#212121',
       icon: isDev
         ? path.join(__dirname, '../../_icons/iconColor.png')
@@ -194,9 +194,35 @@ function runApp() {
         webSecurity: false,
         backgroundThrottling: false,
         contextIsolation: false
-      },
-      show: false
+      }
+    }
+    const newWindow = new BrowserWindow(
+      Object.assign(
+        {
+          // It will be shown later when ready via `ready-to-show` event
+          show: false
+        },
+        commonBrowserWindowOptions
+      )
+    )
+
+    // region Ensure child windows use same options since electron 14
+
+    // https://github.com/electron/electron/blob/14-x-y/docs/api/window-open.md#native-window-example
+    newWindow.webContents.setWindowOpenHandler(() => {
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: Object.assign(
+          {
+            // It should be visible on click
+            show: true
+          },
+          commonBrowserWindowOptions
+        )
+      }
     })
+
+    // endregion Ensure child windows use same options since electron 14
 
     if (replaceMainWindow) {
       mainWindow = newWindow

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,7 +937,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
   integrity sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==
 
-"@electron/get@^1.0.1":
+"@electron/get@^1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.13.0.tgz#95c6bcaff4f9a505ea46792424f451efea89228c"
   integrity sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==
@@ -3543,12 +3543,12 @@ electron-to-chromium@^1.3.830:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz#823cb9c98f28c64c673920f1c90ea3826596eaf9"
   integrity sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==
 
-electron@^13.5.1:
-  version "13.5.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.5.1.tgz#76c02c39be228532f886a170b472cbd3d93f0d0f"
-  integrity sha512-ZyxhIhmdaeE3xiIGObf0zqEyCyuIDqZQBv9NKX8w5FNzGm87j4qR0H1+GQg6vz+cA1Nnv1x175Zvimzc0/UwEQ==
+electron@^15.3.1:
+  version "15.3.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.3.1.tgz#38ce9dfcd4ec51a33d62de23de15fb5ceeaea25d"
+  integrity sha512-6/qp3Dor7HSGq28qhJEVD1zBFZoWicmo3/ZLvo7rhXPPZFwEMSJGPMEZM9WYSfWW4t/OozpWNuuDe970cF7g2Q==
   dependencies:
-    "@electron/get" "^1.0.1"
+    "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
# Blocking
- We need to wait for https://github.com/electron/electron/issues/31448 to be fixed before merging this PR

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [x] Feature Implementation

**Related issue**
Closes #1640
Closes #1651
Closes #1763 

**Description**
Upgrade electron 13.x > 15.x AND fix the issue caused by a breaking change in electron 14

Breaking change:
https://github.com/electron/electron/pull/28550
Child windows no longer inherit BrowserWindow construction options from their parents.

**Screenshots (if appropriate)**
Nothing visible should really changed

**Testing (for code that is not small enough to be easily understandable)**
All Dev team members should test this in
- Multiple OS
- Dev version (`npm run dev`) and built version afterward (can trigger nightly build manually)

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 11.6
 - FreeTube version: based on 7d0880ad05f69d9c46982f25c2885257632aa857

**Additional context**
Upgrade to electron 14 had caused issue like #1636
Upgrade to electron 15 to see if it's fixed 
(since our PiP implementation relies on `video.js` > Electron > Chromium)

References:
- [Electron 14 official blog post](https://www.electronjs.org/blog/electron-14-0/)
- [Electron 14.x release notes](https://www.electronjs.org/releases/stable?version=14)
- [Electron 15 official blog post](https://www.electronjs.org/blog/electron-15-0/)
- [Electron 15.x release notes](https://www.electronjs.org/releases/stable?version=15)

This might replace #1763 
