### PR TITLE
Feat: SponsorBlock improvements

### DIFF
--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
@@ -83,7 +83,7 @@ export default Vue.extend({
         this.$t('Settings.SponsorBlock Settings.Skip Options.Auto Skip'),
         // this.$t('Settings.SponsorBlock Settings.Skip Options.Prompt To Skip'),
         this.$t('Settings.SponsorBlock Settings.Skip Options.Show In Seek Bar'),
-        this.$t('Settings.SponsorBlock Settings.Skip Options.Dont Skip')
+        this.$t('Settings.SponsorBlock Settings.Skip Options.Do Nothing')
       ]
     },
     colorNames: function () {

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
@@ -22,35 +22,22 @@ export default Vue.extend({
         // 'promptToSkip',
         'showInSeekBar',
         'doNothing'
-      ],
-      colorValues: [
-        'Red',
-        'Pink',
-        'Purple',
-        'DeepPurple',
-        'Indigo',
-        'Blue',
-        'LightBlue',
-        'Cyan',
-        'Teal',
-        'Green',
-        'LightGreen',
-        'Lime',
-        'Yellow',
-        'Amber',
-        'Orange',
-        'DeepOrange',
-        'DraculaCyan',
-        'DraculaGreen',
-        'DraculaOrange',
-        'DraculaPink',
-        'DraculaPurple',
-        'DraculaRed',
-        'DraculaYellow'
       ]
     }
   },
   computed: {
+    colorValues: function () {
+      return this.$store.getters.getColorNames
+    },
+
+    colorNames: function () {
+      return this.colorValues.map(colorVal => {
+        // add spaces before capital letters
+        const colorName = colorVal.replace(/([A-Z])/g, ' $1').trim()
+        return this.$t(`Settings.Theme Settings.Main Color Theme.${colorName}`)
+      })
+    },
+
     sponsorBlockValues: function() {
       let sponsorVal = ''
       switch (this.categoryName.toLowerCase()) {
@@ -75,42 +62,19 @@ export default Vue.extend({
         case 'music offtopic':
           sponsorVal = this.$store.getters.getSponsorBlockMusicOffTopic
           break
+        case 'filler':
+          sponsorVal = this.$store.getters.getSponsorBlockFiller
+          break
       }
       return sponsorVal
     },
+
     skipNames: function() {
       return [
         this.$t('Settings.SponsorBlock Settings.Skip Options.Auto Skip'),
         // this.$t('Settings.SponsorBlock Settings.Skip Options.Prompt To Skip'),
         this.$t('Settings.SponsorBlock Settings.Skip Options.Show In Seek Bar'),
         this.$t('Settings.SponsorBlock Settings.Skip Options.Do Nothing')
-      ]
-    },
-    colorNames: function () {
-      return [
-        this.$t('Settings.Theme Settings.Main Color Theme.Red'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Pink'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Purple'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Deep Purple'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Indigo'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Blue'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Light Blue'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Cyan'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Teal'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Green'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Light Green'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Lime'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Yellow'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Amber'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Orange'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Deep Orange'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Cyan'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Green'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Orange'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Pink'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Purple'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Red'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Yellow')
       ]
     }
   },
@@ -156,6 +120,9 @@ export default Vue.extend({
         case 'music offtopic':
           this.updateSponsorBlockMusicOffTopic(payload)
           break
+        case 'filler':
+          this.updateSponsorBlockFiller(payload)
+          break
       }
     },
 
@@ -168,7 +135,8 @@ export default Vue.extend({
       'updateSponsorBlockIntro',
       'updateSponsorBlockOutro',
       'updateSponsorBlockRecap',
-      'updateSponsorBlockMusicOffTopic'
+      'updateSponsorBlockMusicOffTopic',
+      'updateSponsorBlockFiller'
     ])
   }
 })

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
@@ -1,0 +1,174 @@
+import Vue from 'vue'
+import { mapActions } from 'vuex'
+import FtSelect from '../ft-select/ft-select.vue'
+
+export default Vue.extend({
+  name: 'FtSponsorBlockCategory',
+  components: {
+    'ft-select': FtSelect
+  },
+  props: {
+    categoryName: {
+      type: String,
+      required: true
+    }
+  },
+  data: function () {
+    return {
+      categoryColor: '',
+      skipOption: '',
+      skipValues: [
+        'Auto Skip',
+        // 'Prompt to skip',
+        'Show In Seek Bar',
+        'Don\'t Skip'
+      ],
+      colorValues: [
+        'Red',
+        'Pink',
+        'Purple',
+        'DeepPurple',
+        'Indigo',
+        'Blue',
+        'LightBlue',
+        'Cyan',
+        'Teal',
+        'Green',
+        'LightGreen',
+        'Lime',
+        'Yellow',
+        'Amber',
+        'Orange',
+        'DeepOrange',
+        'DraculaCyan',
+        'DraculaGreen',
+        'DraculaOrange',
+        'DraculaPink',
+        'DraculaPurple',
+        'DraculaRed',
+        'DraculaYellow'
+      ]
+    }
+  },
+  computed: {
+    sponsorBlockValues: function() {
+      let sponsorVal = ''
+      switch (this.categoryName.toLowerCase()) {
+        case 'sponsor':
+          sponsorVal = this.$store.getters.getSponsorBlockSponsor
+          break
+        case 'self-promotion':
+          sponsorVal = this.$store.getters.getSponsorBlockSelfPromo
+          break
+        case 'interaction':
+          sponsorVal = this.$store.getters.getSponsorBlockInteraction
+          break
+        case 'intro':
+          sponsorVal = this.$store.getters.getSponsorBlockIntro
+          break
+        case 'outro':
+          sponsorVal = this.$store.getters.getSponsorBlockOutro
+          break
+        case 'recap':
+          sponsorVal = this.$store.getters.getSponsorBlockRecap
+          break
+        case 'music offtopic':
+          sponsorVal = this.$store.getters.getSponsorBlockMusicOffTopic
+          break
+      }
+      return sponsorVal
+    },
+    skipNames: function() {
+      return [
+        this.$t('Settings.SponsorBlock Settings.Skip Options.Auto Skip'),
+        // this.$t('Settings.SponsorBlock Settings.Skip Options.Prompt To Skip'),
+        this.$t('Settings.SponsorBlock Settings.Skip Options.Show In Seek Bar'),
+        this.$t('Settings.SponsorBlock Settings.Skip Options.Dont Skip')
+      ]
+    },
+    colorNames: function () {
+      return [
+        this.$t('Settings.Theme Settings.Main Color Theme.Red'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Pink'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Purple'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Deep Purple'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Indigo'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Blue'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Light Blue'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Cyan'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Teal'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Green'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Light Green'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Lime'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Yellow'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Amber'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Orange'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Deep Orange'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Cyan'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Green'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Orange'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Pink'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Purple'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Red'),
+        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Yellow')
+      ]
+    }
+  },
+
+  methods: {
+    updateColor: function (color) {
+      const payload = {
+        color: color,
+        skip: this.sponsorBlockValues.skip
+      }
+      this.updateSponsorCategory(payload)
+    },
+
+    updateSkipOption: function (skipOption) {
+      const payload = {
+        color: this.sponsorBlockValues.color,
+        skip: skipOption
+      }
+
+      this.updateSponsorCategory(payload)
+    },
+
+    updateSponsorCategory: function (payload) {
+      switch (this.categoryName.toLowerCase()) {
+        case 'sponsor':
+          this.updateSponsorBlockSponsor(payload)
+          break
+        case 'self-promotion':
+          this.updateSponsorBlockSelfPromo(payload)
+          break
+        case 'interaction':
+          this.updateSponsorBlockInteraction(payload)
+          break
+        case 'intro':
+          this.updateSponsorBlockIntro(payload)
+          break
+        case 'outro':
+          this.updateSponsorBlockOutro(payload)
+          break
+        case 'recap':
+          this.updateSponsorBlockRecap(payload)
+          break
+        case 'music offtopic':
+          this.updateSponsorBlockMusicOffTopic(payload)
+          break
+      }
+    },
+
+    ...mapActions([
+      'showToast',
+      'openExternalLink',
+      'updateSponsorBlockSponsor',
+      'updateSponsorBlockSelfPromo',
+      'updateSponsorBlockInteraction',
+      'updateSponsorBlockIntro',
+      'updateSponsorBlockOutro',
+      'updateSponsorBlockRecap',
+      'updateSponsorBlockMusicOffTopic'
+    ])
+  }
+})

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
@@ -18,10 +18,10 @@ export default Vue.extend({
       categoryColor: '',
       skipOption: '',
       skipValues: [
-        'Auto Skip',
-        // 'Prompt to skip',
-        'Show In Seek Bar',
-        'Don\'t Skip'
+        'autoSkip',
+        // 'promptToSkip',
+        'showInSeekBar',
+        'doNothing'
       ],
       colorValues: [
         'Red',

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.sass
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.sass
@@ -1,0 +1,1 @@
+@use "../../sass-partials/settings"

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.sass
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.sass
@@ -1,1 +1,6 @@
 @use "../../sass-partials/settings"
+.sponsorBlockCategory
+    margin-top: 30px
+    padding: 0 10px
+    .sponsorTitle
+        font-size: x-large

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.vue
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="sponsorBlockCategory">
-    <h2>
+    <div class="sponsorTitle">
       {{ $t("Video.Sponsor Block category."+categoryName) }}
-    </h2>
+    </div>
     <ft-select
       :placeholder="$t('Settings.SponsorBlock Settings.Category Color')"
       :value="sponsorBlockValues.color"

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.vue
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="sponsorBlockCategory">
+    <h2>
+      {{ $t("Video.Sponsor Block category."+categoryName) }}
+    </h2>
+    <ft-select
+      :placeholder="$t('Settings.SponsorBlock Settings.Category Color')"
+      :value="sponsorBlockValues.color"
+      :select-names="colorNames"
+      :select-values="colorValues"
+      @change="updateColor"
+    />
+    <ft-select
+      :placeholder="$t('Settings.SponsorBlock Settings.Skip Options.Skip Option')"
+      :value="sponsorBlockValues.skip"
+      :select-names="skipNames"
+      :select-values="skipValues"
+      @change="updateSkipOption"
+    />
+  </div>
+</template>
+<script src="./ft-sponsor-block-category.js" />
+<style scoped lang="sass" src="./ft-sponsor-block-category.sass" />

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -195,7 +195,8 @@ export default Vue.extend({
         'intro',
         'outro',
         'preview',
-        'music_offtopic'
+        'music_offtopic',
+        'filler'
       ]
       const autoSkip = {}
       const seekBar = []
@@ -224,6 +225,9 @@ export default Vue.extend({
             break
           case 'music_offtopic':
             sponsorVal = this.$store.getters.getSponsorBlockMusicOffTopic
+            break
+          case 'filler':
+            sponsorVal = this.$store.getters.getSponsorBlockFiller
             break
         }
         if (sponsorVal.skip !== 'doNothing') {
@@ -552,6 +556,8 @@ export default Vue.extend({
           return this.$t('Video.Sponsor Block category.interaction')
         case 'music_offtopic':
           return this.$t('Video.Sponsor Block category.music offtopic')
+        case 'filler':
+          return this.$t('Video.Sponsor Block category.filler')
         default:
           console.error(`Unknown translation for SponsorBlock category ${category}`)
           return category

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -226,13 +226,13 @@ export default Vue.extend({
             sponsorVal = this.$store.getters.getSponsorBlockMusicOffTopic
             break
         }
-        if (sponsorVal.skip !== 'Don\'t Skip') {
+        if (sponsorVal.skip !== 'doNothing') {
           seekBar.push(x)
         }
-        if (sponsorVal.skip === 'Auto Skip') {
+        if (sponsorVal.skip === 'autoSkip') {
           autoSkip[x] = true
         }
-        if (sponsorVal.skip === 'Prompt to skip') {
+        if (sponsorVal.skip === 'promptToSkip') {
           promptSkip[x] = true
         }
         categoryData[x] = sponsorVal

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -188,6 +188,58 @@ export default Vue.extend({
       return this.$store.getters.getDisplayVideoPlayButton
     },
 
+    sponsorSkips: function () {
+      const sponsorCats = ['sponsor',
+        'selfpromo',
+        'interaction',
+        'intro',
+        'outro',
+        'preview',
+        'music_offtopic'
+      ]
+      const autoSkip = {}
+      const seekBar = []
+      const promptSkip = {}
+      const categoryData = {}
+      sponsorCats.forEach(x => {
+        let sponsorVal = {}
+        switch (x) {
+          case 'sponsor':
+            sponsorVal = this.$store.getters.getSponsorBlockSponsor
+            break
+          case 'selfpromo':
+            sponsorVal = this.$store.getters.getSponsorBlockSelfPromo
+            break
+          case 'interaction':
+            sponsorVal = this.$store.getters.getSponsorBlockInteraction
+            break
+          case 'intro':
+            sponsorVal = this.$store.getters.getSponsorBlockIntro
+            break
+          case 'outro':
+            sponsorVal = this.$store.getters.getSponsorBlockOutro
+            break
+          case 'preview':
+            sponsorVal = this.$store.getters.getSponsorBlockRecap
+            break
+          case 'music_offtopic':
+            sponsorVal = this.$store.getters.getSponsorBlockMusicOffTopic
+            break
+        }
+        if (sponsorVal.skip !== 'Don\'t Skip') {
+          seekBar.push(x)
+        }
+        if (sponsorVal.skip === 'Auto Skip') {
+          autoSkip[x] = true
+        }
+        if (sponsorVal.skip === 'Prompt to skip') {
+          promptSkip[x] = true
+        }
+        categoryData[x] = sponsorVal
+      })
+      return {autoSkip, seekBar, promptSkip, categoryData}
+    },
+
     maxVideoPlaybackRate: function () {
       return parseInt(this.$store.getters.getMaxVideoPlaybackRate)
     },
@@ -432,7 +484,7 @@ export default Vue.extend({
     initializeSponsorBlock() {
       this.sponsorBlockSkipSegments({
         videoId: this.videoId,
-        categories: ['sponsor']
+        categories: this.sponsorSkips.seekBar
       }).then((skipSegments) => {
         if (skipSegments.length === 0) {
           return
@@ -450,7 +502,8 @@ export default Vue.extend({
             this.addSponsorBlockMarker({
               time: startTime,
               duration: endTime - startTime,
-              color: this.sponsorBlockCategoryColor(category)
+              color: 'var(--primary-color)',
+              category: category
             })
           })
         })
@@ -469,10 +522,12 @@ export default Vue.extend({
         }
       })
       if (newTime !== null && Math.abs(duration - currentTime) > 0.500) {
-        if (this.sponsorBlockShowSkippedToast) {
-          this.showSkippedSponsorSegmentInformation(skippedCategory)
+        if (this.sponsorSkips.autoSkip[skippedCategory]) {
+          if (this.sponsorBlockShowSkippedToast) {
+            this.showSkippedSponsorSegmentInformation(skippedCategory)
+          }
+          this.player.currentTime(newTime)
         }
-        this.player.currentTime(newTime)
       }
     },
 
@@ -503,36 +558,16 @@ export default Vue.extend({
       }
     },
 
-    sponsorBlockCategoryColor(category) {
-      // TODO: allow to set these colors in settings
-      switch (category) {
-        case 'sponsor':
-          return 'var(--accent-color)'
-        case 'intro':
-          return 'var(--accent-color)'
-        case 'outro':
-          return 'var(--accent-color)'
-        case 'selfpromo':
-          return 'var(--accent-color)'
-        case 'interaction':
-          return 'var(--accent-color)'
-        case 'music_offtopic':
-          return 'var(--accent-color)'
-        default:
-          console.error(`Unknown SponsorBlock category ${category}`)
-          return 'var(--accent-color)'
-      }
-    },
-
     addSponsorBlockMarker(marker) {
       const markerDiv = videojs.dom.createEl('div', {}, {})
 
-      markerDiv.className = 'sponsorBlockMarker'
+      markerDiv.className = `sponsorBlockMarker main${this.sponsorSkips.categoryData[marker.category].color}`
       markerDiv.style.height = '100%'
       markerDiv.style.position = 'absolute'
       markerDiv.style['background-color'] = marker.color
       markerDiv.style.width = (marker.duration / this.player.duration()) * 100 + '%'
       markerDiv.style.marginLeft = (marker.time / this.player.duration()) * 100 + '%'
+      markerDiv.title = this.sponsorBlockTranslatedCategory(marker.category)
 
       this.player.el().querySelector('.vjs-progress-holder').appendChild(markerDiv)
     },

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -570,6 +570,7 @@ export default Vue.extend({
       markerDiv.className = `sponsorBlockMarker main${this.sponsorSkips.categoryData[marker.category].color}`
       markerDiv.style.height = '100%'
       markerDiv.style.position = 'absolute'
+      markerDiv.style.opacity = '0.4'
       markerDiv.style['background-color'] = marker.color
       markerDiv.style.width = (marker.duration / this.player.duration()) * 100 + '%'
       markerDiv.style.marginLeft = (marker.time / this.player.duration()) * 100 + '%'

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -241,7 +241,7 @@ export default Vue.extend({
         }
         categoryData[x] = sponsorVal
       })
-      return {autoSkip, seekBar, promptSkip, categoryData}
+      return { autoSkip, seekBar, promptSkip, categoryData }
     },
 
     maxVideoPlaybackRate: function () {

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -570,7 +570,7 @@ export default Vue.extend({
       markerDiv.className = `sponsorBlockMarker main${this.sponsorSkips.categoryData[marker.category].color}`
       markerDiv.style.height = '100%'
       markerDiv.style.position = 'absolute'
-      markerDiv.style.opacity = '0.4'
+      markerDiv.style.opacity = '0.6'
       markerDiv.style['background-color'] = marker.color
       markerDiv.style.width = (marker.duration / this.player.duration()) * 100 + '%'
       markerDiv.style.marginLeft = (marker.time / this.player.duration()) * 100 + '%'

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
@@ -24,7 +24,8 @@ export default Vue.extend({
         'intro',
         'outro',
         'recap',
-        'music offtopic'
+        'music offtopic',
+        'filler'
       ]
     }
   },

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
@@ -4,6 +4,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import FtSponsorBlockCategory from '../ft-sponsor-block-category/ft-sponsor-block-category.vue'
 
 export default Vue.extend({
   name: 'SponsorBlockSettings',
@@ -11,7 +12,21 @@ export default Vue.extend({
     'ft-card': FtCard,
     'ft-toggle-switch': FtToggleSwitch,
     'ft-input': FtInput,
-    'ft-flex-box': FtFlexBox
+    'ft-flex-box': FtFlexBox,
+    'ft-sponsor-block-category': FtSponsorBlockCategory
+  },
+  data: function () {
+    return {
+      categories: [
+        'sponsor',
+        'self-promotion',
+        'interaction',
+        'intro',
+        'outro',
+        'recap',
+        'music offtopic'
+      ]
+    }
   },
   computed: {
     useSponsorBlock: function () {

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -32,6 +32,13 @@
           @input="handleUpdateSponsorBlockUrl"
         />
       </ft-flex-box>
+      <ft-flex-box>
+        <ft-sponsor-block-category
+          v-for="category in categories"
+          :key="category"
+          :category-name="category"
+        />
+      </ft-flex-box>
     </div>
   </details>
 </template>

--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -34,31 +34,6 @@ export default Vue.extend({
         'dark',
         'black',
         'dracula'
-      ],
-      colorValues: [
-        'Red',
-        'Pink',
-        'Purple',
-        'DeepPurple',
-        'Indigo',
-        'Blue',
-        'LightBlue',
-        'Cyan',
-        'Teal',
-        'Green',
-        'LightGreen',
-        'Lime',
-        'Yellow',
-        'Amber',
-        'Orange',
-        'DeepOrange',
-        'DraculaCyan',
-        'DraculaGreen',
-        'DraculaOrange',
-        'DraculaPink',
-        'DraculaPurple',
-        'DraculaRed',
-        'DraculaYellow'
       ]
     }
   },
@@ -120,32 +95,16 @@ export default Vue.extend({
       ]
     },
 
+    colorValues: function () {
+      return this.$store.getters.getColorNames
+    },
+
     colorNames: function () {
-      return [
-        this.$t('Settings.Theme Settings.Main Color Theme.Red'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Pink'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Purple'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Deep Purple'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Indigo'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Blue'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Light Blue'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Cyan'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Teal'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Green'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Light Green'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Lime'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Yellow'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Amber'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Orange'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Deep Orange'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Cyan'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Green'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Orange'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Pink'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Purple'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Red'),
-        this.$t('Settings.Theme Settings.Main Color Theme.Dracula Yellow')
-      ]
+      return this.colorValues.map(colorVal => {
+        // add spaces before capital letters
+        const colorName = colorVal.replace(/([A-Z])/g, ' $1').trim()
+        return this.$t(`Settings.Theme Settings.Main Color Theme.${colorName}`)
+      })
     }
   },
   mounted: function () {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -215,6 +215,34 @@ const state = {
   saveWatchedProgress: true,
   sponsorBlockShowSkippedToast: true,
   sponsorBlockUrl: 'https://sponsor.ajay.app',
+  sponsorBlockSponsor: {
+    color: 'Blue',
+    skip: 'Auto Skip'
+  },
+  sponsorBlockSelfPromo: {
+    color: 'Yellow',
+    skip: 'Show In Seek Bar'
+  },
+  sponsorBlockInteraction: {
+    color: 'Green',
+    skip: 'Show In Seek Bar'
+  },
+  sponsorBlockIntro: {
+    color: 'Orange',
+    skip: 'Don\'t Skip'
+  },
+  sponsorBlockOutro: {
+    color: 'Orange',
+    skip: 'Don\'t Skip'
+  },
+  sponsorBlockRecap: {
+    color: 'Orange',
+    skip: 'Don\'t Skip'
+  },
+  sponsorBlockMusicOffTopic: {
+    color: 'Orange',
+    skip: 'Don\'t Skip'
+  },
   thumbnailPreference: '',
   useProxy: false,
   useRssFeeds: false,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -217,31 +217,31 @@ const state = {
   sponsorBlockUrl: 'https://sponsor.ajay.app',
   sponsorBlockSponsor: {
     color: 'Blue',
-    skip: 'Auto Skip'
+    skip: 'autoSkip'
   },
   sponsorBlockSelfPromo: {
     color: 'Yellow',
-    skip: 'Show In Seek Bar'
+    skip: 'showInSeekBar'
   },
   sponsorBlockInteraction: {
     color: 'Green',
-    skip: 'Show In Seek Bar'
+    skip: 'showInSeekBar'
   },
   sponsorBlockIntro: {
     color: 'Orange',
-    skip: 'Don\'t Skip'
+    skip: 'doNothing'
   },
   sponsorBlockOutro: {
     color: 'Orange',
-    skip: 'Don\'t Skip'
+    skip: 'doNothing'
   },
   sponsorBlockRecap: {
     color: 'Orange',
-    skip: 'Don\'t Skip'
+    skip: 'doNothing'
   },
   sponsorBlockMusicOffTopic: {
     color: 'Orange',
-    skip: 'Don\'t Skip'
+    skip: 'doNothing'
   },
   thumbnailPreference: '',
   useProxy: false,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -243,6 +243,10 @@ const state = {
     color: 'Orange',
     skip: 'doNothing'
   },
+  sponsorBlockFiller: {
+    color: 'Orange',
+    skip: 'doNothing'
+  },
   thumbnailPreference: '',
   useProxy: false,
   useRssFeeds: false,

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -26,30 +26,30 @@ const state = {
     type: 'all',
     duration: ''
   },
-  colorClasses: [
-    'mainRed',
-    'mainPink',
-    'mainPurple',
-    'mainDeepPurple',
-    'mainIndigo',
-    'mainBlue',
-    'mainLightBlue',
-    'mainCyan',
-    'mainTeal',
-    'mainGreen',
-    'mainLightGreen',
-    'mainLime',
-    'mainYellow',
-    'mainAmber',
-    'mainOrange',
-    'mainDeepOrange',
-    'mainDraculaCyan',
-    'mainDraculaGreen',
-    'mainDraculaOrange',
-    'mainDraculaPink',
-    'mainDraculaPurple',
-    'mainDraculaRed',
-    'mainDraculaYellow'
+  colorNames: [
+    'Red',
+    'Pink',
+    'Purple',
+    'DeepPurple',
+    'Indigo',
+    'Blue',
+    'LightBlue',
+    'Cyan',
+    'Teal',
+    'Green',
+    'LightGreen',
+    'Lime',
+    'Yellow',
+    'Amber',
+    'Orange',
+    'DeepOrange',
+    'DraculaCyan',
+    'DraculaGreen',
+    'DraculaOrange',
+    'DraculaPink',
+    'DraculaPurple',
+    'DraculaRed',
+    'DraculaYellow'
   ],
   colorValues: [
     '#d50000',
@@ -104,6 +104,10 @@ const getters = {
 
   getSearchSettings () {
     return state.searchSettings
+  },
+
+  getColorNames () {
+    return state.colorNames
   },
 
   getColorValues () {
@@ -296,8 +300,8 @@ const actions = {
   },
 
   getRandomColorClass () {
-    const randomInt = Math.floor(Math.random() * state.colorClasses.length)
-    return state.colorClasses[randomInt]
+    const randomInt = Math.floor(Math.random() * state.colorNames.length)
+    return 'main' + state.colorNames[randomInt]
   },
 
   getRandomColor () {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -551,6 +551,7 @@ Video:
     interaction: Interaction
     music offtopic: Music Offtopic
     recap: Recap
+    filler: Filler
   External Player:
     # $ is replaced with the external player
     OpenInTemplate: Open in $

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -337,6 +337,13 @@ Settings:
     Enable SponsorBlock: Enable SponsorBlock
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API Url (Default is https://sponsor.ajay.app)
     Notify when sponsor segment is skipped: Notify when sponsor segment is skipped
+    Skip Options:
+      Skip Option: Skip Option
+      Auto Skip: Auto Skip
+      Show In Seek Bar: Show In Seek Bar
+      Prompt To Skip: Prompt To Skip
+      Dont Skip: Don't Skip
+    Category Color: Category Color
   Download Settings:
     Download Settings: Download Settings
     Ask Download Path: Ask for download path
@@ -537,12 +544,13 @@ Video:
   Publicationtemplate: $ % ago
   Skipped segment: Skipped segment
   Sponsor Block category:
-    sponsor: sponsor
-    intro: intro
-    outro: outro
-    self-promotion: self-promotion
-    interaction: interaction
-    music offtopic: music offtopic
+    sponsor: Sponsor
+    intro: Intro
+    outro: Outro
+    self-promotion: Self-Promotion
+    interaction: Interaction
+    music offtopic: Music Offtopic
+    recap: Recap
   External Player:
     # $ is replaced with the external player
     OpenInTemplate: Open in $

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -342,7 +342,7 @@ Settings:
       Auto Skip: Auto Skip
       Show In Seek Bar: Show In Seek Bar
       Prompt To Skip: Prompt To Skip
-      Dont Skip: Don't Skip
+      Do Nothing: Do Nothing
     Category Color: Category Color
   Download Settings:
     Download Settings: Download Settings


### PR DESCRIPTION
---
Sponsorblock improvements
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
closes #1840 (All categories implemented)
closes #1440 (User decides color for each category)
#1380 (Auto-skip is now optional, no prompt to skip however)

**Description**
This PR allows users to configure each SponsorBlock category individually (Color + Skip Mode)

Skip Modes:
- Don't Skip (No indication of sponsor will be shown in seek bar)
- Show In Seek Bar (Show the sponsored segment in the seek bar but don't autoskip)
- AutoSkip (AutoSkip when the video reaches the sponsored segment)

Mode not included (Might do a future PR to implement it):
- Prompt To Skip (Have a "Skip Sponsored Segment" button appear when a sponsored segment is reached)

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/78101139/138558210-ddfe03a0-9cdf-49cf-9742-2a1586e6a0ed.png)

![image](https://user-images.githubusercontent.com/78101139/138558410-87785d99-c338-42d4-9b34-2497e9a62ee9.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes, tested by updating each category to make sure the setting works and loading a video with multiple categories involved

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.15.0
