### PR TITLE
! Fix user fav list having "scroll to top" effect when "load more" clicked

### DIFF
--- a/src/renderer/views/UserPlaylists/UserPlaylists.js
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.js
@@ -37,12 +37,16 @@ export default Vue.extend({
     }
   },
   watch: {
-    activeData() {
-      this.isLoading = true
-      setTimeout(() => {
-        this.isLoading = false
-      }, 100)
-    }
+    // This implementation of loading effect
+    // causes "scroll to top" side effect which is reported as a bug
+    // https://github.com/FreeTubeApp/FreeTube/issues/1507
+    //
+    // activeData() {
+    //   this.isLoading = true
+    //   setTimeout(() => {
+    //     this.isLoading = false
+    //   }, 100)
+    // }
   },
   mounted: function () {
     const limit = sessionStorage.getItem('favoritesLimit')


### PR DESCRIPTION

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
closes #1507

**Description**
Update user fav list view (by playlists on sidebar) to NOT have scroll to top effect when "load more" is pressed.

**Screenshots (if appropriate)**
The code is temporarily changed to load 5 per batch for easier testing

https://user-images.githubusercontent.com/1018543/138631307-a28be726-c5f9-4856-88db-18e2754df5c2.mov

**Testing (for code that is not small enough to be easily understandable)**
- Add many videos to fav
- Press "Load more"

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 11.6
 - FreeTube version: based on 8f3f4adcf3a562ad9c570e8716b7b6b00ee37654

**Additional context**
Add any other context about the problem here.
