### PR TITLE
Prevent comments from overflowing their container

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -42,6 +42,8 @@
   font-size: 14px;
   margin-left: 68px;
   margin-top: 0px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 
@@ -54,6 +56,7 @@
   font-size: 14px;
   margin-top: -10px;
   margin-left: 70px;
+  word-wrap: break-word;
 }
 
 .commentDate {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Fixes #1851

**Description**
Prevents commenter's username and comment content from overflowing the container.

**Screenshots (if appropriate)**
Before:
![freetube-comments-overflow2](https://user-images.githubusercontent.com/49721209/138934950-9f595f93-bec3-40f2-82db-450189013448.png)

After:
![freetube-comments-overflow3](https://user-images.githubusercontent.com/49721209/138934978-3d775f9f-8604-40b1-9207-1c308f13a714.png)

**Testing (for code that is not small enough to be easily understandable)**
Use dev tools to replace username and comment content with a long word.

**Desktop (please complete the following information):**
 - OS: Debian
 - OS Version: 11
 - FreeTube version: 0.15.0

**Additional context**
None.