### PR TITLE
* Update all GH workflow config to update node 14.x > 16.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         runtime: [ linux-x64, linux-arm64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,10 +18,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 14.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v2
       with:
-        node-version: 14.x
+        node-version: 16.x
         cache: "yarn"
     - run: npm run ci
     - run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         runtime: [ linux-x64, linux-arm64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] CI Update

**Related issue**
N/A

**Description**
Update all GH Action config to use Node 16.x instead of 14.x
[16.x is the latest LTS version now](https://nodejs.org/en/blog/release/v16.13.0/)

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
No testing done...
Well I am using Node 16.x locally for running FT in dev

**Desktop (please complete the following information):**
 - OS: N/A
 - OS Version: N/A
 - FreeTube version: N/A

**Additional context**
Add any other context about the problem here.
