### PR TITLE
Select current playback rate in playback rate selector

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -260,15 +260,12 @@ export default Vue.extend({
           const rates = this.player.playbackRates()
 
           // iterate through the items in reverse order as the highest is displayed first
-          let index = 0
-          for (let i = rates.length - 1; i >= 0; i--) {
-            if (rates[i] === playbackRate || rates[i] < playbackRate) {
-              break
-            }
-            index++
-          }
+          // `slice` must be used as `reverse` does reversing in place
+          const targetPlaybackRateMenuItemIndex = rates.slice().reverse().findIndex((rate) => {
+            return rate === playbackRate || rate < playbackRate
+          })
 
-          playbackRateMenuButton.menu.focus(index)
+          playbackRateMenuButton.menu.focus(targetPlaybackRateMenuItemIndex)
         })
 
         if (this.storyboardSrc !== '') {

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -251,6 +251,26 @@ export default Vue.extend({
           this.player.removeChild('BigPlayButton')
         }
 
+        // Makes the playback rate menu focus the current item on mouse hover
+        // or the closest item if the playback rate is between two items
+        // which is likely to be the case when the playback rate is changed by scrolling
+        const playbackRateMenuButton = this.player.controlBar.getChild('playbackRateMenuButton')
+        playbackRateMenuButton.on(playbackRateMenuButton.menuButton_, 'mouseenter', () => {
+          const playbackRate = this.player.playbackRate()
+          const rates = this.player.playbackRates()
+
+          // iterate through the items in reverse order as the highest is displayed first
+          let index = 0
+          for (let i = rates.length - 1; i >= 0; i--) {
+            if (rates[i] === playbackRate || rates[i] < playbackRate) {
+              break
+            }
+            index++
+          }
+
+          playbackRateMenuButton.menu.focus(index)
+        })
+
         if (this.storyboardSrc !== '') {
           this.player.vttThumbnails({
             src: this.storyboardSrc,

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -265,7 +265,20 @@ export default Vue.extend({
             return rate === playbackRate || rate < playbackRate
           })
 
-          playbackRateMenuButton.menu.focus(targetPlaybackRateMenuItemIndex)
+          // center the selected item in the middle of the visible area
+          // the first and last items will never be in the center so it can be skipped for them
+          if (targetPlaybackRateMenuItemIndex !== 0 && targetPlaybackRateMenuItemIndex !== rates.length - 1) {
+            const playbackRateMenu = playbackRateMenuButton.menu
+            const menuElement = playbackRateMenu.contentEl()
+
+            const itemHeight = playbackRateMenu.children()[targetPlaybackRateMenuItemIndex].contentEl().clientHeight
+
+            // clientHeight is the height of the visible part of an element
+            const centerOfVisibleArea = (menuElement.clientHeight - itemHeight) / 2
+            const menuScrollOffset = (itemHeight * targetPlaybackRateMenuItemIndex) - centerOfVisibleArea
+
+            menuElement.scrollTo({ top: menuScrollOffset })
+          }
         })
 
         if (this.storyboardSrc !== '') {


### PR DESCRIPTION
---
Select current playback rate in video player playback rate selector
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Closes: https://github.com/FreeTubeApp/FreeTube/issues/1273
Related to: #1274
Related to: #1745

**Description**
This pull request ensures that the currently selected playback speed is always visible in the list of playback speeds. It also works if the playback speed is between two of the selectable values which is likely to occur if you use the CTRL + scroll setting in #1745, in which case it will scroll to the next lowest value. A previous pull request #1274, which wasn't merged, implemented scrolling right to the bottom of the list every time. This implementation will also work once #1745 is merged.

**Screenshots (if appropriate)**


https://user-images.githubusercontent.com/48293849/142489059-3bce1513-4225-4179-a4fe-3b881402f9c3.mp4


**Testing (for code that is not small enough to be easily understandable)**
- Open a video
- Hover over playback speed
- Observe the menu items
- Adjust the playback speed
- Hover over playback speed again
- Observe the menu items again

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10.0.19043.1348
 - FreeTube version: latest `development` and `4c8f889d84e3ca1ff4d03bbc2f55423d456437e0` in #1745

**Additional context**
Add any other context about the problem here.
