### PR TITLE
Hiding thumbs-up icon when the hide Comment Likes setting is enabled

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -79,6 +79,7 @@
         />
         <p class="commentLikeCount">
           <font-awesome-icon
+            v-if="!hideCommentLikes"
             icon="thumbs-up"
           />
           {{ comment.likes }}
@@ -147,6 +148,7 @@
             />
             <p class="commentLikeCount">
               <font-awesome-icon
+                v-if="!hideCommentLikes"
                 icon="thumbs-up"
               />
               {{ reply.likes }}


### PR DESCRIPTION
---
Title
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to. If this pull request fully resolves the relevant issue, put "closes" before the issue number. Example: "closes #123456".

Closes #1906
https://github.com/FreeTubeApp/FreeTube/issues/1906

**Description**
The PR wraps the font thumbs-up icons in the comments section in a v-if that checks if the hideCommentLikes is disabled.

**Screenshots (if appropriate)**

***BEFORE***
![1906Before](https://user-images.githubusercontent.com/343890/142958874-7af6d49e-6c47-499e-a57e-bbeca3b9c668.png)

***AFTER***
![1906After](https://user-images.githubusercontent.com/343890/142958886-06341988-4acf-42fa-a93b-f3da83ea1a47.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
I ran it before and after and observed the comments section.

**Desktop (please complete the following information):**
 - OS: Ubuntu
 - OS Version: 20.04
 - FreeTube version: v0.15.1 Beta

**Additional context**
Add any other context about the problem here.
