### PR TITLE
Fix: parsing video info of videos with like count disabled

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -199,21 +199,21 @@ export default Vue.extend({
     },
 
     parsedLikeCount: function () {
-      if (this.hideVideoLikesAndDislikes) {
+      if (this.hideVideoLikesAndDislikes || this.likeCount === null) {
         return null
       }
 
       const locale = this.currentLocale.replace('_', '-')
-      return (this.likeCount ?? 0).toLocaleString([locale, 'en'])
+      return this.likeCount.toLocaleString([locale, 'en'])
     },
 
     parsedDislikeCount: function () {
-      if (this.hideVideoLikesAndDislikes) {
+      if (this.hideVideoLikesAndDislikes || this.dislikeCount === null) {
         return null
       }
 
       const locale = this.currentLocale.replace('_', '-')
-      return (this.dislikeCount ?? 0).toLocaleString([locale, 'en'])
+      return this.dislikeCount.toLocaleString([locale, 'en'])
     },
 
     likePercentageRatio: function () {

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -204,7 +204,7 @@ export default Vue.extend({
       }
 
       const locale = this.currentLocale.replace('_', '-')
-      return this.likeCount.toLocaleString([locale, 'en'])
+      return (this.likeCount ?? 0).toLocaleString([locale, 'en'])
     },
 
     parsedDislikeCount: function () {
@@ -213,7 +213,7 @@ export default Vue.extend({
       }
 
       const locale = this.currentLocale.replace('_', '-')
-      return this.dislikeCount.toLocaleString([locale, 'en'])
+      return (this.dislikeCount ?? 0).toLocaleString([locale, 'en'])
     },
 
     likePercentageRatio: function () {


### PR DESCRIPTION
---
Fix: parsing video info of videos with like count disabled
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1911 

**Description**
Please write a clear and concise description of what the pull request does.
It will change the like/dislike count to '0' if likes/ dislikes are disabled

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/78101139/143316841-264f5f5a-6cfa-4799-9bb7-dc68b3106613.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Yes

**Desktop (please complete the following information):**
 - OS: Windows
 - OS 10
 - FreeTube version:  Latest Nightly
