### PR TITLE
added logic to hide playlist views

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -47,6 +47,10 @@ export default Vue.extend({
       return this.$store.getters.getThumbnailPreference
     },
 
+    hideViews: function () {
+      return this.$store.getters.getHideVideoViews
+    },
+
     shareHeaders: function () {
       return [
         this.$t('Playlist.Share Playlist.Copy YouTube Link'),
@@ -83,7 +87,7 @@ export default Vue.extend({
 
     // Causes errors if not put inside of a check
     if (typeof (this.data.viewCount) !== 'undefined') {
-      this.viewCount = this.data.viewCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+      this.viewCount = this.hideViews ? null : this.data.viewCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
     }
 
     if (typeof (this.data.videoCount) !== 'undefined') {

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -12,7 +12,7 @@
       {{ title }}
     </h2>
     <p>
-      {{ videoCount }} {{ $t("Playlist.Videos") }} - {{ viewCount }} {{ $t("Playlist.Views") }} -
+      {{ videoCount }} {{ $t("Playlist.Videos") }} - <span v-if="!hideViews">{{ viewCount }} {{ $t("Playlist.Views") }} -</span>
       <span v-if="infoSource !== 'local'">
         {{ $t("Playlist.Last Updated On") }}
       </span>


### PR DESCRIPTION
---
Hide playlist views on playlist summary screen
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #1905 

**Description**
Hides playlist views on playlist summary screen

**Screenshots (if appropriate)**
![no_views](https://user-images.githubusercontent.com/35084775/143489271-1160f050-01ac-4a66-8195-f51401f23b80.PNG)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested? Yes, locally
Please describe shortly how you tested it and whether there are any ramifications remaining. 

**Desktop (please complete the following information):**
 - OS: [Windows]
 - OS Version: [10]
 - FreeTube version: [0.15.1]

**Additional context**

