### PR TITLE
Update build script to build ARM64 version on Apple Silicon machines

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -7,13 +7,13 @@ const { name, productName } = require('../package.json')
 const args = process.argv
 
 let targets
-var platform = os.platform()
+const platform = os.platform()
 
-if (platform == 'darwin') {
+if (platform === 'darwin') {
   targets = Platform.MAC.createTarget()
-} else if (platform == 'win32') {
+} else if (platform === 'win32') {
   targets = Platform.WINDOWS.createTarget()
-} else if (platform == 'linux') {
+} else if (platform === 'linux') {
   let arch = Arch.x64
 
   if (args[2] === 'arm64') {

--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -8,9 +8,18 @@ const args = process.argv
 
 let targets
 const platform = os.platform()
+const cpus = os.cpus()
 
 if (platform === 'darwin') {
-  targets = Platform.MAC.createTarget()
+  let arch = Arch.x64
+
+// Macbook Air 2020 with M1 = 'Apple M1'
+  // Macbook Pro 2021 with M1 Pro = 'Apple M1 Pro'
+  if (cpus[0].model.startsWith('Apple')) {
+    arch = Arch.arm64
+  }
+
+  targets = Platform.MAC.createTarget(['dmg'], arch)
 } else if (platform === 'win32') {
   targets = Platform.WINDOWS.createTarget()
 } else if (platform === 'linux') {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
Extracted from #1888 in case that PR is not updated

**Description**
Build script run on MacOS would detect CPU type (name matching) and build binary with corresponding architecture
which is `x64`/`arm64`

**Screenshots (if appropriate)**
Running process of locally built binary:
![image](https://user-images.githubusercontent.com/1018543/143516191-d008e5d0-d34b-494d-935c-63f7627cc6c8.png)

**Testing (for code that is not small enough to be easily understandable)**
- `npm run build --if-present`
- Run built binary
- Check "Kind" in activity monitor

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.0.1
 - FreeTube version: 341968c8223873db084b8ad80ed1e723d0feaa58

**Additional context**
This does **not** include build action update
[GH runner does not support it yet](https://github.com/actions/virtual-environments/issues/2187)
