### PR TITLE
Calculate dislikes using the likes and average rating

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -535,7 +535,11 @@ export default Vue.extend({
             this.videoDislikeCount = null
           } else {
             this.videoLikeCount = result.likeCount
-            this.videoDislikeCount = result.dislikeCount
+            if (result.dislikeCount === 0 && result.likeCount && result.rating) {
+              this.videoDislikeCount = Math.round((result.likeCount * (5 - result.rating)) / (result.rating - 1))
+            } else {
+              this.videoDislikeCount = result.dislikeCount
+            }
           }
           if (this.hideChannelSubscriptions) {
             this.channelSubscriptionCountText = ''

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -295,7 +295,11 @@ export default Vue.extend({
           this.isUpcoming = result.player_response.videoDetails.isUpcoming ? result.player_response.videoDetails.isUpcoming : false
 
           if (this.videoDislikeCount === null && !this.hideVideoLikesAndDislikes) {
-            this.videoDislikeCount = 0
+            if (this.videoLikeCount !== 0 && result.videoDetails.averageRating) {
+              this.videoDislikeCount = Math.round((this.videoLikeCount * (5 - result.videoDetails.averageRating)) / (result.videoDetails.averageRating - 1))
+            } else {
+              this.videoDislikeCount = 0
+            }
           }
 
           const subCount = result.videoDetails.author.subscriber_count


### PR DESCRIPTION
---
Calculate dislikes using the likes and average rating
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to. If this pull request fully resolves the relevant issue, put "closes" before the issue number. Example: "closes #123456".

Closes #1927
Closes #1904
Closes #1891

**Description**
Please write a clear and concise description of what the pull request does.

This pull request reimplements the dislike display and also fixes the ratio bar. It does this by calculating the dislikes using the likes and average rating with an adapted version of [this formula](https://github.com/ytdl-org/youtube-dl/issues/29663#issuecomment-889501832). If YouTube removes the average rating as well, this will silently fall back to `0`, which is what FreeTube currently does.

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

![guess who's back, back again](https://user-images.githubusercontent.com/48293849/145095111-11b32c1a-ccff-453b-9f10-7fb4160a9d09.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 

- Open any YouTube video
- Look at the dislike counter and ratio bar.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: latest `development` commit

**Additional context**
Add any other context about the problem here.

If YouTube keeps the average rating around, this is a better solution than implementing the Return Dislikes API as the calculation happens locally.