### PR TITLE
Add ReturnYoutubeDislikes as optional way to get video dislike counter

### DIFF
--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -79,6 +79,9 @@ export default Vue.extend({
     checkForUpdates: function () {
       return this.$store.getters.getCheckForUpdates
     },
+    useReturnYoutubeDislikes: function () {
+      return this.$store.getters.getUseReturnYoutubeDislikes
+    },
     checkForBlogPosts: function () {
       return this.$store.getters.getCheckForBlogPosts
     },
@@ -226,6 +229,7 @@ export default Vue.extend({
       'updateEnableSearchSuggestions',
       'updateBackendFallback',
       'updateCheckForUpdates',
+      'updateUseReturnYoutubeDislikes',
       'updateCheckForBlogPosts',
       'updateBarColor',
       'updateBackendPreference',

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -21,6 +21,13 @@
           :tooltip="$t('Tooltips.General Settings.Fallback to Non-Preferred Backend on Failure')"
           @change="updateBackendFallback"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.General Settings.Use ReturnYoutubeDislikes')"
+          :default-value="useReturnYoutubeDislikes"
+          :compact="true"
+          :tooltip="$t('Tooltips.General Settings.Use ReturnYoutubeDislikes')"
+          @change="updateUseReturnYoutubeDislikes"
+        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -155,6 +155,10 @@ export default Vue.extend({
       return this.$store.getters.getHideVideoLikesAndDislikes
     },
 
+    useReturnYoutubeDislikes: function () {
+      return this.$store.getters.getUseReturnYoutubeDislikes
+    },
+
     hideVideoViews: function () {
       return this.$store.getters.getHideVideoViews
     },

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -58,7 +58,9 @@
           />
           <div>
             <span class="likeCount"><font-awesome-icon icon="thumbs-up" /> {{ parsedLikeCount }}</span>
-            <span class="dislikeCount"><font-awesome-icon icon="thumbs-down" /> {{ parsedDislikeCount }}</span>
+            <span
+              v-if="useReturnYoutubeDislikes"
+              class="dislikeCount"><font-awesome-icon icon="thumbs-down" /> {{ parsedDislikeCount }}</span>
           </div>
         </div>
       </div>

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -52,6 +52,7 @@
           class="likeSection"
         >
           <div
+            v-if="useReturnYoutubeDislikes"
             class="likeBar"
             :style="{ background: `linear-gradient(to right, var(--accent-color) ${likePercentageRatio}%, #9E9E9E ${likePercentageRatio}%` }"
           />

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -60,7 +60,8 @@
             <span class="likeCount"><font-awesome-icon icon="thumbs-up" /> {{ parsedLikeCount }}</span>
             <span
               v-if="useReturnYoutubeDislikes"
-              class="dislikeCount"><font-awesome-icon icon="thumbs-down" /> {{ parsedDislikeCount }}</span>
+              class="dislikeCount"
+            ><font-awesome-icon icon="thumbs-down" /> {{ parsedDislikeCount }}</span>
           </div>
         </div>
       </div>

--- a/src/renderer/store/modules/returnytdislikes.js
+++ b/src/renderer/store/modules/returnytdislikes.js
@@ -1,0 +1,34 @@
+
+import $ from 'jquery'
+
+const state = {}
+const getters = {}
+
+const actions = {
+  // Dislike counter data taken from https://github.com/Anarios/return-youtube-dislike
+  // see https://returnyoutubedislikeapi.com/swagger/index.html for api documentation
+  ytGetDislikes ({ rootState }, videoId) {
+    return new Promise((resolve, reject) => {
+      const requestUrl = `https://returnyoutubedislikeapi.com/Votes?videoId=${videoId}`
+
+      $.getJSON(requestUrl, (response) => {
+        resolve(response)
+      }).fail((xhr, textStatus, error) => {
+        console.log(xhr)
+        console.log(textStatus)
+        console.log(requestUrl)
+        console.log(error)
+        reject(xhr)
+      })
+    })
+  }
+}
+
+const mutations = {}
+
+export default {
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -211,7 +211,7 @@ const state = {
   saveWatchedProgress: true,
   sponsorBlockShowSkippedToast: true,
   sponsorBlockUrl: 'https://sponsor.ajay.app',
-  useReturnYoutubeDislikes: true,
+  useReturnYoutubeDislikes: false,
   thumbnailPreference: '',
   useProxy: false,
   useRssFeeds: false,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -211,6 +211,7 @@ const state = {
   saveWatchedProgress: true,
   sponsorBlockShowSkippedToast: true,
   sponsorBlockUrl: 'https://sponsor.ajay.app',
+  useReturnYoutubeDislikes: true,
   thumbnailPreference: '',
   useProxy: false,
   useRssFeeds: false,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -294,7 +294,6 @@ export default Vue.extend({
             if (this.useReturnYoutubeDislikes) {
               this.ytGetDislikes(this.videoId)
                 .then(async result => {
-                  console.log(result)
                   this.videoDislikeCount = isNaN(result.dislikes) ? 0 : result.dislikes
                 })
             }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -143,6 +143,9 @@ export default Vue.extend({
     hideVideoLikesAndDislikes: function () {
       return this.$store.getters.getHideVideoLikesAndDislikes
     },
+    useReturnYoutubeDislikes: function () {
+      return this.$store.getters.getUseReturnYoutubeDislikes
+    },
     theatrePossible: function() {
       return !this.hideRecommendedVideos || (!this.hideLiveChat && this.isLive) || this.watchingPlaylist
     }
@@ -211,7 +214,6 @@ export default Vue.extend({
       if (this.firstLoad) {
         this.isLoading = true
       }
-
       this.ytGetVideoInformation(this.videoId)
         .then(async result => {
           console.log(result)
@@ -289,6 +291,13 @@ export default Vue.extend({
           } else {
             this.videoLikeCount = isNaN(result.videoDetails.likes) ? 0 : result.videoDetails.likes
             this.videoDislikeCount = isNaN(result.videoDetails.dislikes) ? 0 : result.videoDetails.dislikes
+            if (this.useReturnYoutubeDislikes) {
+              this.ytGetDislikes(this.videoId)
+                .then(async result => {
+                  console.log(result)
+                  this.videoDislikeCount = isNaN(result.dislikes) ? 0 : result.dislikes
+                })
+            }
           }
           this.isLive = result.player_response.videoDetails.isLive
           this.isLiveContent = result.player_response.videoDetails.isLiveContent
@@ -1240,6 +1249,7 @@ export default Vue.extend({
       'updateWatchProgress',
       'getUserDataPath',
       'ytGetVideoInformation',
+      'ytGetDislikes',
       'invidiousGetVideoInformation'
     ])
   }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -540,6 +540,12 @@ export default Vue.extend({
           } else {
             this.videoLikeCount = result.likeCount
             this.videoDislikeCount = result.dislikeCount
+            if (this.useReturnYoutubeDislikes) {
+              this.ytGetDislikes(this.videoId)
+                .then(async result => {
+                  this.videoDislikeCount = isNaN(result.dislikes) ? 0 : result.dislikes
+                })
+            }
           }
           if (this.hideChannelSubscriptions) {
             this.channelSubscriptionCountText = ''

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -119,6 +119,7 @@ Settings:
     Check for Latest Blog Posts: Check for Latest Blog Posts
     Fallback to Non-Preferred Backend on Failure: Fallback to Non-Preferred Backend
       on Failure
+    Use ReturnYoutubeDislikes: 'Use dislike numbers from ReturnYoutubeDislike.com'
     Enable Search Suggestions: Enable Search Suggestions
     Default Landing Page: Default Landing Page
     Locale Preference: Locale Preference
@@ -637,6 +638,9 @@ Tooltips:
     Fallback to Non-Preferred Backend on Failure: When your preferred API has a problem,
       FreeTube will automatically attempt to use your non-preferred API as a fallback
       method when enabled.
+    Use ReturnYoutubeDislikes: Youtube no longer publicly shows dislike numbers on videos.
+      This setting will instead retrieve and show
+      video dislike numbers from returnyoutubedislike.com
     Thumbnail Preference: All thumbnails throughout FreeTube will be replaced with
       a frame of the video instead of the default thumbnail.
     Invidious Instance: The Invidious instance that FreeTube will connect to for API

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -113,6 +113,7 @@ Settings:
     Check for Latest Blog Posts: 'Check for latest blog posts'
     Fallback to Non-Preferred Backend on Failure: 'Revert to non-preferred backend
       on failure'
+    Use ReturnYoutubeDislikes: 'Use dislike numbers from ReturnYoutubeDislike.com'
     Enable Search Suggestions: 'Enable search suggestions'
     Default Landing Page: 'Default landing page'
     Locale Preference: 'Language preference'
@@ -727,6 +728,9 @@ Tooltips:
     Fallback to Non-Preferred Backend on Failure: When your preferred API has a problem,
       FreeTube will automatically attempt to use your non-preferred API as a fallback
       method when enabled.
+    Use ReturnYoutubeDislikes: Youtube no longer publicly shows dislike numbers on videos.
+      This setting will instead retrieve and show
+      video dislike numbers from returnyoutubedislike.com
     Preferred API Backend: Choose the back-end that FreeTube uses to obtain data.
       The local API is a built-in extractor. The Invidious API requires an Invidious
       server to connect to.


### PR DESCRIPTION
---
Add ReturnYoutubeDislikes as optional way to get video dislike counter
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to. If this pull request fully resolves the relevant issue, put "closes" before the issue number. Example: "closes #123456".
closes #1927

**Description**
This PR adds the usage of the https://www.returnyoutubedislike.com/ api to get a videos dislike number. Note their service gets the dislike number via 'A combination of archived data from before the offical YouTube dislike API shut down, and extrapolated extension user behavior.'
Since this feature reaches out to a external service the PR also adds a toggle switch in the settings menu to enable/disable this functionality. It is set to false by default for the same reason.

To comply with the requirements of their service (see below) I added the website name to the text on the setting button.
```
Third party use of this open API is allowed with the following restrictions:

Attribution: This project should be clearly attributed with either a link to this repo or a link to returnyoutubedislike.com.
Rate Limiting: There are per client rate limits in place of 100 per minute and 10'000 per day. This will return a 429 status code indicating that your application should back off.
```



**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

Picture of the settings page - please point out the best place for this setting.
![image](https://user-images.githubusercontent.com/74797538/148235718-864821c9-ddc5-46fe-af35-62c74906ac99.png)
In the below picture you can see the dislike number now appears.
![image](https://user-images.githubusercontent.com/74797538/148235886-8a04383c-0e2d-4581-b4be-0794fe5e8cd0.png)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 
I have tested the following:
  - Local api
     - With return dislikes setting true, checked dislike value showed up for a video pre dislike change, and post dislikes being removed
     - With return dislikes setting false, checked dislike counter was zero for same two videos
     - With Hide Video likes/dislikes enabled and return dislikes enabled. ( no like/dislikes were shown as expected )
     - With Hide Video likes/dislikes enabled and return dislikes disabled. ( no like/dislikes were shown as expected )
 - Invidious api
     - With return dislikes setting true, checked dislike value showed up for a video pre dislike change, and post dislikes being removed
     - With return dislikes setting false, checked dislike counter was zero for same two videos
     - With Hide Video likes/dislikes enabled and return dislikes enabled. ( no like/dislikes were shown as expected )
     - With Hide Video likes/dislikes enabled and return dislikes disabled. ( no like/dislikes were shown as expected )

Lastly running npm run lint 

**Desktop (please complete the following information):**
 - OS: Manjaro
 - OS Version: 20
 - FreeTube version: 0.15.1

**Additional context**
I didn't know the best place to put the setting. So I've just added it to General for now, Please suggest the best place for it to go.
