### PR TITLE
Fix long single worded search suggestions leaving suggestion box container

### DIFF
--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -158,6 +158,7 @@
   padding: 5px 0;
   z-index: 10;
   border-radius: 0 0 5px 5px;
+  word-wrap: break-word;
   box-shadow: 0 0 10px var(--scrollbar-color-hover);
   background-color: var(--search-bar-color);
 }


### PR DESCRIPTION
---
Fix long single worded search suggestions leaving suggestion box container
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Please link the issue your pull request is referring to. If this pull request fully resolves the relevant issue, put "closes" before the issue number. Example: "closes #123456".
closes #1769

**Description**
Please write a clear and concise description of what the pull request does.
This fixes the issue where a very long single word search suggestion e.g. (abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz) visually doesn't stay within the suggestion box.


**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.
Before
![image](https://user-images.githubusercontent.com/74797538/148579708-38a44639-ee71-4425-9645-7a117fa09ca3.png)
After
![image](https://user-images.githubusercontent.com/74797538/148577994-c3cd4d08-8e34-47e3-b57f-4fd9e3bb3e85.png)


**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 

I tested:
   - shrinking the overall freetube window to check the long search suggestion is broken into more lines as the box gets smaller
   - a long search of multiple words - these are still split into multiple lines at the spaces between words - this was already the case before this change. I just wanted to check for regression.
   - the given example for failure: abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz

**Desktop (please complete the following information):**
 - OS: [Manjaro]
 - OS Version: [20]
 - FreeTube version: [0.15.1]

**Additional context**
Add any other context about the problem here.
