### PR TITLE
External player choice 'None' translated in Settings

### DIFF
--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -5,6 +5,7 @@ import FtSelect from '../ft-select/ft-select.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import i18n from '../../i18n/index.js'
 
 export default Vue.extend({
   name: 'ExternalPlayerSettings',
@@ -24,7 +25,7 @@ export default Vue.extend({
     },
 
     externalPlayerNames: function () {
-      return this.$store.getters.getExternalPlayerNames
+      return this.$store.getters.getExternalPlayerNames.map((value) => i18n.t(value))
     },
     externalPlayerValues: function () {
       return this.$store.getters.getExternalPlayerValues

--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -5,7 +5,6 @@ import FtSelect from '../ft-select/ft-select.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
-import i18n from '../../i18n/index.js'
 
 export default Vue.extend({
   name: 'ExternalPlayerSettings',
@@ -25,7 +24,7 @@ export default Vue.extend({
     },
 
     externalPlayerNames: function () {
-      return this.$store.getters.getExternalPlayerNames.map((value) => i18n.t(value))
+      return this.$store.getters.getExternalPlayerNames.map((value) => this.$t(value))
     },
     externalPlayerValues: function () {
       return this.$store.getters.getExternalPlayerValues

--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -24,7 +24,10 @@ export default Vue.extend({
     },
 
     externalPlayerNames: function () {
-      return this.$store.getters.getExternalPlayerNames.map((value) => this.$t(value))
+      const fallbackNames = this.$store.getters.getExternalPlayerNames
+      const nameTranslationKeys = this.$store.getters.getExternalPlayerNameTranslationKeys
+
+      return nameTranslationKeys.map((translationKey, idx) => this.$te(translationKey) ? this.$t(translationKey) : fallbackNames[idx])
     },
     externalPlayerValues: function () {
       return this.$store.getters.getExternalPlayerValues

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -78,6 +78,7 @@ const state = {
     '#F1FA8C'
   ],
   externalPlayerNames: [],
+  externalPlayerNameTranslationKeys: [],
   externalPlayerValues: [],
   externalPlayerCmdArguments: {}
 }
@@ -133,6 +134,10 @@ const getters = {
 
   getExternalPlayerNames () {
     return state.externalPlayerNames
+  },
+
+  getExternalPlayerNameTranslationKeys () {
+    return state.externalPlayerNameTranslationKeys
   },
 
   getExternalPlayerValues () {
@@ -797,10 +802,11 @@ const actions = {
     }
 
     const externalPlayerMap = JSON.parse(fileData).map((entry) => {
-      return { name: entry.name, value: entry.value, cmdArguments: entry.cmdArguments }
+      return { name: entry.name, nameTranslationKey: entry.nameTranslationKey, value: entry.value, cmdArguments: entry.cmdArguments }
     })
 
     const externalPlayerNames = externalPlayerMap.map((entry) => { return entry.name })
+    const externalPlayerNameTranslationKeys = externalPlayerMap.map((entry) => { return entry.nameTranslationKey })
     const externalPlayerValues = externalPlayerMap.map((entry) => { return entry.value })
     const externalPlayerCmdArguments = externalPlayerMap.reduce((result, item) => {
       result[item.value] = item.cmdArguments
@@ -808,6 +814,7 @@ const actions = {
     }, {})
 
     commit('setExternalPlayerNames', externalPlayerNames)
+    commit('setExternalPlayerNameTranslationKeys', externalPlayerNameTranslationKeys)
     commit('setExternalPlayerValues', externalPlayerValues)
     commit('setExternalPlayerCmdArguments', externalPlayerCmdArguments)
   },
@@ -1018,6 +1025,10 @@ const mutations = {
 
   setExternalPlayerNames (state, value) {
     state.externalPlayerNames = value
+  },
+
+  setExternalPlayerNameTranslationKeys (state, value) {
+    state.externalPlayerNameTranslationKeys = value
   },
 
   setExternalPlayerValues (state, value) {

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -1,11 +1,13 @@
 [
     {
-        "name": "Settings.External Player Settings.None",
+        "name": "None",
+        "nameTranslationKey": "Settings.External Player Settings.Players.None.Name",
         "value": "",
         "cmdArguments": null
     },
     {
         "name": "mpv",
+        "nameTranslationKey": "Settings.External Player Settings.Players.mpv.Name",
         "value": "mpv",
         "cmdArguments": {
             "defaultExecutable": "mpv",
@@ -23,6 +25,7 @@
     },
     {
         "name": "VLC",
+        "nameTranslationKey": "Settings.External Player Settings.Players.VLC.Name",
         "value": "vlc",
         "cmdArguments": {
             "defaultExecutable": "vlc",
@@ -40,6 +43,7 @@
     },
     {
         "name": "iina",
+        "nameTranslationKey": "Settings.External Player Settings.Players.iina.Name",
         "value": "iina",
         "cmdArguments": {
             "defaultExecutable": "iina",

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "None",
+        "name": "Settings.External Player Settings.None",
         "value": "",
         "cmdArguments": null
     },

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -230,6 +230,7 @@ Settings:
   External Player Settings:
     External Player Settings: External Player Settings
     External Player: External Player
+    None: None
     Ignore Unsupported Action Warnings: Ignore Unsupported Action Warnings
     Custom External Player Executable: Custom External Player Executable
     Custom External Player Arguments: Custom External Player Arguments

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -230,10 +230,12 @@ Settings:
   External Player Settings:
     External Player Settings: External Player Settings
     External Player: External Player
-    None: None
     Ignore Unsupported Action Warnings: Ignore Unsupported Action Warnings
     Custom External Player Executable: Custom External Player Executable
     Custom External Player Arguments: Custom External Player Arguments
+    Players:
+      None:
+        Name: None
   Privacy Settings:
     Privacy Settings: Privacy Settings
     Remember History: Remember History

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -362,6 +362,9 @@ Settings:
     Ignore Unsupported Action Warnings: Omitir advertencias sobre acciones no soportadas
     External Player: Reproductor externo
     External Player Settings: Reproductor externo
+    Players:
+      None:
+        Name: Ninguno
   Download Settings:
     Download Settings: Descargas
     Ask Download Path: Preguntar ruta de descarga


### PR DESCRIPTION
---
External player choice 'None' translatable in Settings
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
closes #1670

**Description**
Enables the translation of the word 'None' in the external player selector in the Settings menu. In order to do that the name of the first player is changed from 'None' to a translatable string and the whole array of names is translated. (Only the 'none' one has a translation, the other ones remain the same)

**Testing (for code that is not small enough to be easily understandable)**
Just tested if the word is substituted by the one on the locales file

**Desktop (please complete the following information):**
 - OS: GNU/Linux
 - OS Version: Pop!_OS 21.04
 - FreeTube version: v0.16.0 Beta

**Additional context**
Is the first time I contribute to a project and also the first time using Vue, and haven't done a lot of things in JS, so if there is anything wrong with Vue or the format of the code tell me and I will try fix it
