### PR TITLE
Fix thumbnail being obstructed by time tooltip

### DIFF
--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1023,7 +1023,7 @@ body.vjs-full-window {
   padding: 6px 8px 8px 8px;
   pointer-events: none;
   position: absolute;
-  top: -3.4em;
+  top: -2.7em;
   visibility: hidden;
   z-index: 2;
 }
@@ -2136,7 +2136,7 @@ video::-webkit-media-text-track-display {
 .video-js .vjs-vtt-thumbnail-display {
     position: absolute;
     transition: transform .1s, opacity .2s;
-    bottom: 20px;
+    bottom:56px;
     pointer-events: none;
     box-shadow: 0 0 7px rgba(0,0,0,.6);
     z-index: 3;

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2136,7 +2136,8 @@ video::-webkit-media-text-track-display {
 .video-js .vjs-vtt-thumbnail-display {
     position: absolute;
     transition: transform .1s, opacity .2s;
-    bottom:56px;
+    /* `bottom` was 20px, to avoid obstruction by time tooltip updated to current value */
+    bottom: 56px;
     pointer-events: none;
     box-shadow: 0 0 7px rgba(0,0,0,.6);
     z-index: 3;


### PR DESCRIPTION
---
Title
---
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes #2077 

**Description**
Fixes thumbnail being obstructed by time tooltip by moving the thumbnail up.

**Screenshots**
Before:
![1cceb243add2a516219f6e4859682d77684e3b02194ea7d676bc3d1f392a4a45](https://user-images.githubusercontent.com/97211491/153809893-ff2e6b51-f21c-4412-a702-79a6654ea36c.png)

After:
![87303890f4ab8c7586f74e8a5f35c845c62d74413c868f144b229d0f60e38366](https://user-images.githubusercontent.com/97211491/153809977-54d47858-a8a7-465c-876f-6b68b0c1a7a3.png)

**Testing**
Has this pull request been tested? Yes
UI scale works fine after the patch.

**Desktop:**
 - OS: [Fedora Workstation]
 - OS Version: [35]
 - FreeTube version: [16.0 Beta]
