### PR TITLE
Fix handling of youtube link middle mouse click

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -421,10 +421,11 @@ function runApp() {
     return powerSaveBlocker.start('prevent-display-sleep')
   })
 
-  ipcMain.on(IpcChannels.CREATE_NEW_WINDOW, () => {
+  ipcMain.on(IpcChannels.CREATE_NEW_WINDOW, (_e, { windowStartupUrl = null } = { }) => {
     createWindow({
       replaceMainWindow: false,
-      showWindowNow: true
+      showWindowNow: true,
+      windowStartupUrl: windowStartupUrl
     })
   })
 


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
#1809

**Description**
2be2301d92e37d13a4839ded1fc436836292b7d4 only fixes the issue partially so that any click results in opening in **current** window
But the expected behaviour is to open links clicked by middle mouse button in **new** window

**Screenshots (if appropriate)**

https://user-images.githubusercontent.com/1018543/154211025-302ab845-91ef-4a00-8bf0-f06a4b39f255.mov



**Testing (for code that is not small enough to be easily understandable)**
- Use app to view https://youtu.be/qNWNArktMvY
- Open comment to find comment with video URL (which should be https://www.youtube.com/watch?v=uh24rV65Amg&list=PLzFTGYa_evXjqH9QWC2xwdfS87fYxtBcv&index=5&t=0s)
- Click on the link (try with both left & middle mouse button)

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 7a4b600d621fd9eb661e91a049da52afcf2e0c08

**Additional context**
Too busy, only tested with video URL
Add back more test cases later
