### PR TITLE
Feature/channelblocker (part of #1070)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,11 +17,13 @@ const IpcChannels = {
   DB_HISTORY: 'db-history',
   DB_PROFILES: 'db-profiles',
   DB_PLAYLISTS: 'db-playlists',
+  DB_CHANNELBLOCKER: 'db-channelblocker',
 
   SYNC_SETTINGS: 'sync-settings',
   SYNC_HISTORY: 'sync-history',
   SYNC_PROFILES: 'sync-profiles',
-  SYNC_PLAYLISTS: 'sync-playlists'
+  SYNC_PLAYLISTS: 'sync-playlists',
+  SYNC_CHANNELBLOCKER: 'sync-channelblocker'
 }
 
 const DBActions = {
@@ -64,6 +66,11 @@ const SyncEvents = {
   PLAYLISTS: {
     UPSERT_VIDEO: 'sync-playlists-upsert-video',
     DELETE_VIDEO: 'sync-playlists-delete-video'
+  },
+
+  CHANNELBLOCKER: {
+    UPSERT_CHANNEL: 'sync-channelblocker-upsert-channel',
+    DELETE_CHANNEL: 'sync-channelblocker-delete-channel'
   }
 }
 

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -148,11 +148,34 @@ class Playlists {
   }
 }
 
+class ChannelBlocker {
+  static find(query) {
+    return db.channelblocker.find(query).sort({ name: 1 })
+  }
+
+  static upsert(channel) {
+    return db.channelblocker.update(
+      { _id: channel._id },
+      { $set: { _id: channel._id, name: channel.name } },
+      { upsert: true }
+    )
+  }
+
+  static delete(id) {
+    return db.channelblocker.remove({ _id: id })
+  }
+
+  static persist() {
+    db.channelblocker.persistence.compactDatafile()
+  }
+}
+
 const baseHandlers = {
   settings: Settings,
   history: History,
   profiles: Profiles,
-  playlists: Playlists
+  playlists: Playlists,
+  channelblocker: ChannelBlocker
 }
 
 export default baseHandlers

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -195,11 +195,42 @@ class Playlists {
   }
 }
 
+class ChannelBlocker {
+  static find(query) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_CHANNELBLOCKER,
+      { action: DBActions.GENERAL.FIND, data: query }
+    )
+  }
+
+  static upsert(channel) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_CHANNELBLOCKER,
+      { action: DBActions.GENERAL.UPSERT, data: channel }
+    )
+  }
+
+  static delete(id) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_CHANNELBLOCKER,
+      { action: DBActions.GENERAL.DELETE, data: id }
+    )
+  }
+
+  static persist() {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_CHANNELBLOCKER,
+      { action: DBActions.GENERAL.PERSIST }
+    )
+  }
+}
+
 const handlers = {
   settings: Settings,
   history: History,
   profiles: Profiles,
-  playlists: Playlists
+  playlists: Playlists,
+  channelblocker: ChannelBlocker
 }
 
 export default handlers

--- a/src/datastores/handlers/index.js
+++ b/src/datastores/handlers/index.js
@@ -10,10 +10,12 @@ const DBSettingHandlers = handlers.settings
 const DBHistoryHandlers = handlers.history
 const DBProfileHandlers = handlers.profiles
 const DBPlaylistHandlers = handlers.playlists
+const DBChannelBlockerHandlers = handlers.channelblocker
 
 export {
   DBSettingHandlers,
   DBHistoryHandlers,
   DBProfileHandlers,
-  DBPlaylistHandlers
+  DBPlaylistHandlers,
+  DBChannelBlockerHandlers
 }

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -114,11 +114,30 @@ class Playlists {
   }
 }
 
+class ChannelBlocker {
+  static find(query) {
+    return baseHandlers.channelblocker.find(query)
+  }
+
+  static upsert(channel) {
+    return baseHandlers.channelblocker.upsert(channel)
+  }
+
+  static delete(id) {
+    return baseHandlers.channelblocker.delete(id)
+  }
+
+  static persist() {
+    baseHandlers.channelblocker.persist()
+  }
+}
+
 const handlers = {
   settings: Settings,
   history: History,
   profiles: Profiles,
-  playlists: Playlists
+  playlists: Playlists,
+  channelblocker: ChannelBlocker
 }
 
 export default handlers

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -16,6 +16,7 @@ const db = {}
 db.settings = Datastore.create({ filename: dbPath('settings'), autoload: true })
 db.profiles = Datastore.create({ filename: dbPath('profiles'), autoload: true })
 db.playlists = Datastore.create({ filename: dbPath('playlists'), autoload: true })
+db.channelblocker = Datastore.create({ filename: dbPath('channelblocker'), autoload: true })
 db.history = Datastore.create({ filename: dbPath('history'), autoload: true })
 
 db.history.ensureIndex({ fieldName: 'author' })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -624,6 +624,46 @@ function runApp() {
   })
 
   // *********** //
+  // ChannelBlocker
+  ipcMain.handle(IpcChannels.DB_CHANNELBLOCKER, async (event, { action, data }) => {
+    try {
+      switch (action) {
+        case DBActions.GENERAL.FIND:
+          return await baseHandlers.channelblocker.find(data)
+
+        case DBActions.GENERAL.UPSERT:
+          await baseHandlers.channelblocker.upsert(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_CHANNELBLOCKER,
+            event,
+            { event: SyncEvents.CHANNELBLOCKER.UPSERT_CHANNEL, data }
+          )
+          return null
+
+        case DBActions.GENERAL.DELETE:
+          await baseHandlers.channelblocker.delete(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_CHANNELBLOCKER,
+            event,
+            { event: SyncEvents.CHANNELBLOCKER.DELETE_CHANNEL, data }
+          )
+          return null
+
+        case DBActions.GENERAL.PERSIST:
+          baseHandlers.channelblocker.persist()
+          return null
+
+        default:
+          // eslint-disable-next-line no-throw-literal
+          throw 'invalid channelblocker db action'
+      }
+    } catch (err) {
+      if (typeof err === 'string') throw err
+      else throw err.toString()
+    }
+  })
+
+  // *********** //
 
   function syncOtherWindows(channel, event, payload) {
     const otherWindows = BrowserWindow.getAllWindows().filter((window) => {

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -134,6 +134,7 @@ export default Vue.extend({
       this.grabAllProfiles(this.$t('Profile.All Channels')).then(async () => {
         this.grabHistory()
         this.grabAllPlaylists()
+        await this.grabBlockedChannels()
 
         if (this.usingElectron) {
           console.log('User is using Electron')
@@ -469,6 +470,7 @@ export default Vue.extend({
       'grabAllProfiles',
       'grabHistory',
       'grabAllPlaylists',
+      'grabBlockedChannels',
       'getYoutubeUrlInfo',
       'getExternalPlayerCmdArgumentsData',
       'fetchInvidiousInstances',

--- a/src/renderer/components/channel-blocker-settings-list/channel-blocker-settings-list.css
+++ b/src/renderer/components/channel-blocker-settings-list/channel-blocker-settings-list.css
@@ -1,0 +1,35 @@
+.channelBlockerSettingsBlockedList {
+    display: grid;
+    margin: auto 1rem;
+    list-style: none;
+    padding-inline-start: 0;
+    max-height: 20rem;
+    overflow-y: scroll;
+    border: 2px solid var(--scrollbar-color-hover);
+    border-radius: 5px;
+  }
+  
+  .channelBlockerSettingsBlockedListItem {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.5rem;
+  }
+  
+  .channelBlockerSettingsBlockedListItem:hover {
+    backdrop-filter: invert(0.1);
+  }
+  
+  .channelBlockerSettingsBlockedListButton {
+    color: OrangeRed;
+    cursor: pointer;
+  }
+  
+  .channelBlockerSettingsBlockedListName {
+    margin-left: 0.5rem;
+  }
+  
+  .channelBlockerSettingsBlockedListName a:link {
+    color: var(--secondary-text-color)
+  }
+  

--- a/src/renderer/components/channel-blocker-settings-list/channel-blocker-settings-list.js
+++ b/src/renderer/components/channel-blocker-settings-list/channel-blocker-settings-list.js
@@ -1,0 +1,25 @@
+import Vue from 'vue'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+
+export default Vue.extend({
+  name: 'ChannelBlockerSettingsList',
+  components: {
+    'ft-flex-box': FtFlexBox
+  },
+  props: {
+    data: {
+      type: Array,
+      required: true
+    }
+  },
+  computed: {
+    listType: function () {
+      return this.$store.getters.getListType
+    }
+  },
+  methods: {
+    handleIconClick: function (_id) {
+      this.$emit('cbRemoveChannel', _id)
+    }
+  }
+})

--- a/src/renderer/components/channel-blocker-settings-list/channel-blocker-settings-list.vue
+++ b/src/renderer/components/channel-blocker-settings-list/channel-blocker-settings-list.vue
@@ -1,0 +1,31 @@
+<template>
+  <ul class="channelBlockerSettingsBlockedList">
+    <li
+      v-for="item in data"
+      :key="item._id"
+      class="channelBlockerSettingsBlockedListItem"
+    >
+      <span
+        class="channelBlockerSettingsBlockedListButton"
+        @click="handleIconClick(item._id)"
+      >
+        <font-awesome-icon
+          icon="times"
+        />
+      </span>
+      <span
+        class="channelBlockerSettingsBlockedListName"
+      >
+        <a
+          class="channelName"
+          :href="`#/channel/${item._id}`"
+        >
+          {{ item.name }}
+        </a>
+      </span>
+    </li>
+  </ul>
+</template>
+
+<script src="./channel-blocker-settings-list.js" />
+<style scoped src="./channel-blocker-settings-list.css" />

--- a/src/renderer/components/channel-blocker-settings/channel-blocker-settings.js
+++ b/src/renderer/components/channel-blocker-settings/channel-blocker-settings.js
@@ -1,0 +1,58 @@
+import Vue from 'vue'
+import { mapActions } from 'vuex'
+import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
+import FtInput from '../ft-input/ft-input.vue'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import ChannelBlockerSettingsList from '../channel-blocker-settings-list/channel-blocker-settings-list.vue'
+
+export default Vue.extend({
+  name: 'ChannlBlockerSettings',
+  components: {
+    'ft-toggle-switch': FtToggleSwitch,
+    'ft-input': FtInput,
+    'ft-flex-box': FtFlexBox,
+    'channel-blocker-settings-list': ChannelBlockerSettingsList
+  },
+  data: function () {
+    return {
+      hasQuery: false
+    }
+  },
+  computed: {
+    useChannelBlocker: function () {
+      return this.$store.getters.getUseChannelBlocker
+    },
+
+    channelBlockerCache: function () {
+      if (!this.hasQuery) {
+        return this.$store.getters.getChannelBlockerCache
+      } else {
+        return this.$store.getters.getSearchChannelBlockerCache
+      }
+    }
+  },
+  methods: {
+    handleUpdateChannelBlocker: function (value) {
+      this.updateUseChannelBlocker(value)
+    },
+
+    filterChannelsList: function (query) {
+      this.hasQuery = query !== ''
+      this.$store.dispatch('searchBlockedChannels', query)
+    },
+
+    removeChannelFromBlockList: function (_id) {
+      this.channelBlockerRemoveChannelById(_id).then(_ => {
+        this.compactBlockedChannels()
+      }).catch(err => {
+        console.error(err)
+      })
+    },
+
+    ...mapActions([
+      'updateUseChannelBlocker',
+      'channelBlockerRemoveChannelById',
+      'compactBlockedChannels'
+    ])
+  }
+})

--- a/src/renderer/components/channel-blocker-settings/channel-blocker-settings.sass
+++ b/src/renderer/components/channel-blocker-settings/channel-blocker-settings.sass
@@ -1,0 +1,13 @@
+@use "../../sass-partials/settings"
+
+.channelBlockerSettingsSearchFlexBox
+  flex: 0 auto
+  align-items: center
+  column-gap: 1rem
+  margin: auto 1rem
+
+  :first-child
+    margin-bottom: 10px
+
+#cb-settings-search-input
+  flex-grow: 1

--- a/src/renderer/components/channel-blocker-settings/channel-blocker-settings.vue
+++ b/src/renderer/components/channel-blocker-settings/channel-blocker-settings.vue
@@ -1,0 +1,56 @@
+<template>
+  <details>
+    <summary>
+      <h3>
+        {{ $t('Settings.ChannelBlocker Settings.ChannelBlocker Settings') }}
+      </h3>
+    </summary>
+    <hr>
+    <ft-flex-box>
+      <ft-toggle-switch
+        :label="$t('Settings.ChannelBlocker Settings.Enable ChannelBlocker')"
+        :default-value="useChannelBlocker"
+        @change="handleUpdateChannelBlocker"
+      />
+    </ft-flex-box>
+    <div
+      v-if="useChannelBlocker"
+    >
+      <ft-flex-box class="channelBlockerSettingsSearchFlexBox">
+        <div>{{ $t('Settings.ChannelBlocker Settings.Blocked Channels') }}</div>
+        <ft-input
+          id="cb-settings-search-input"
+          ref="searchBar"
+          :show-action-button="false"
+          :show-clear-text-button="true"
+          :placeholder="$t('Settings.ChannelBlocker Settings.Search bar placeholder')"
+          @input="filterChannelsList"
+        />
+      </ft-flex-box>
+      <ft-flex-box
+        v-if="channelBlockerCache.length === 0"
+      >
+        <p
+          v-if="!hasQuery"
+          class="message"
+        >
+          {{ $t('Settings.ChannelBlocker Settings.Empty List') }}
+        </p>
+        <p
+          v-else
+          class="message"
+        >
+          {{ $t('Settings.ChannelBlocker Settings.Empty Search Result') }}
+        </p>
+      </ft-flex-box>
+      <channel-blocker-settings-list
+        v-else
+        :data="channelBlockerCache"
+        @cbRemoveChannel="removeChannelFromBlockList"
+      />
+    </div>
+  </details>
+</template>
+
+<script src="./channel-blocker-settings.js" />
+<style scoped lang="sass" src="./channel-blocker-settings.sass" />

--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.sass
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.sass
@@ -8,3 +8,6 @@
   &.list
     display: grid
     grid-gap: 4px
+
+  .cb-hidden
+    display: none

--- a/src/renderer/components/ft-list-video/ft-list-video-channel-blocker-event.js
+++ b/src/renderer/components/ft-list-video/ft-list-video-channel-blocker-event.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+
+const events = new Vue()
+export default events

--- a/src/renderer/sass-partials/_ft-list-item.sass
+++ b/src/renderer/sass-partials/_ft-list-item.sass
@@ -221,5 +221,8 @@ $watched-transition-duration: 0.5s
       margin-top: 8px
       font-size: 13px
 
+  &.cb-hidden
+    display: none
+
 .videoWatched, .live
   text-transform: uppercase

--- a/src/renderer/store/modules/channelblocker.js
+++ b/src/renderer/store/modules/channelblocker.js
@@ -1,0 +1,128 @@
+import { DBChannelBlockerHandlers } from '../../../datastores/handlers/index'
+import FtListVideoChannelBlockerEvents from '../../components/ft-list-video/ft-list-video-channel-blocker-event.js'
+
+const state = {
+  channelBlockerCache: [], // array of {_id, name}
+  searchChannelBlockerCache: [] // same
+}
+
+const getters = {
+  getChannelBlockerCache: () => {
+    return state.channelBlockerCache
+  },
+
+  getSearchChannelBlockerCache: () => {
+    return state.searchChannelBlockerCache
+  }
+}
+
+const actions = {
+  async grabBlockedChannels({ commit }) {
+    try {
+      const results = await DBChannelBlockerHandlers.find({})
+      commit('setChannelBlockerCache', results)
+    } catch (errMessage) {
+      console.error(errMessage)
+    }
+  },
+
+  async channelBlockerAddChannel ({ commit }, channel) {
+    try {
+      commit('upsertToChannelBlockerCache', channel)
+      await DBChannelBlockerHandlers.upsert(channel)
+    } catch (errMessage) {
+      console.error(errMessage)
+    }
+  },
+
+  async channelBlockerRemoveChannelById ({ commit }, channelId) {
+    try {
+      commit('removeFromChannelBlockerCacheById', channelId)
+      await DBChannelBlockerHandlers.delete(channelId)
+    } catch (errMessage) {
+      console.error(errMessage)
+    }
+  },
+
+  async channelBlockerIsBlockedById ({ commit }, channelId) {
+    try {
+      const results = await DBChannelBlockerHandlers.find({ _id: channelId })
+      if (results.length > 0) {
+        return true
+      }
+      return false
+    } catch (errMessage) {
+      console.error(errMessage)
+    }
+  },
+
+  async searchBlockedChannels({ commit }, query) {
+    try {
+      const results = await DBChannelBlockerHandlers.find({ name: { $regex: new RegExp(query, 'i') } })
+      commit('setSearchChannelBlockerCache', results)
+    } catch (errMessage) {
+      console.error(errMessage)
+    }
+  },
+
+  compactBlockedChannels(_) {
+    DBChannelBlockerHandlers.persist()
+  }
+}
+
+const mutations = {
+  setChannelBlockerCache(state, channelBlockerCache) {
+    state.channelBlockerCache = channelBlockerCache.sort((a, b) => {
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    })
+  },
+
+  setSearchChannelBlockerCache(state, result) {
+    state.searchChannelBlockerCache = result
+  },
+
+  upsertToChannelBlockerCache(state, channel) {
+    state.channelBlockerCache.findIndex((blockedChannel) => {
+      return channel._id === blockedChannel._id
+    })
+
+    // sort() by name doesn't work so manually inserting
+    const nameLocaleUpper = channel.name.toLocaleUpperCase()
+    for (let i = 0; i < state.channelBlockerCache.length; i++) {
+      if (state.channelBlockerCache[i].name.toLocaleUpperCase() > nameLocaleUpper) {
+        state.channelBlockerCache.splice(i, 0, channel)
+        FtListVideoChannelBlockerEvents.$emit('cbUpdateChannel', channel._id)
+        return
+      }
+    }
+    state.channelBlockerCache.push(channel)
+    FtListVideoChannelBlockerEvents.$emit('cbUpdateChannel', channel._id)
+  },
+
+  removeFromChannelBlockerCacheById(state, channelId) {
+    for (let i = state.channelBlockerCache.length - 1; i >= 0; i--) {
+      if (state.channelBlockerCache[i]._id === channelId) {
+        state.channelBlockerCache.splice(i, 1)
+        break
+      }
+    }
+
+    if (state.searchChannelBlockerCache.length > 0) {
+      for (let i = state.searchChannelBlockerCache.length - 1; i >= 0; i--) {
+        if (state.searchChannelBlockerCache[i]._id === channelId) {
+          state.searchChannelBlockerCache.splice(i, 1)
+          break
+        }
+      }
+    }
+
+    FtListVideoChannelBlockerEvents.$emit('cbUpdateChannel', channelId)
+  }
+}
+
+export default {
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -215,6 +215,7 @@ const state = {
   useProxy: false,
   useRssFeeds: false,
   useSponsorBlock: false,
+  useChannelBlocker: false,
   videoVolumeMouseScroll: false,
   videoPlaybackRateMouseScroll: false,
   downloadFolderPath: ''
@@ -403,6 +404,21 @@ const customActions = {
 
         default:
           console.error('playlists: invalid sync event received')
+      }
+    })
+
+    ipcRenderer.on(IpcChannels.SYNC_CHANNELBLOCKER, (_, { event, data }) => {
+      switch (event) {
+        case SyncEvents.CHANNELBLOCKER.UPSERT_CHANNEL:
+          commit('upsertToChannelBlockerCache', data)
+          break
+
+        case SyncEvents.CHANNELBLOCKER.DELETE_CHANNEL:
+          commit('removeFromChannelBlockerCacheById', data)
+          break
+
+        default:
+          console.error('channelblocker: invalid sync event received')
       }
     })
   }

--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -12,6 +12,7 @@ import DataSettings from '../../components/data-settings/data-settings.vue'
 import DistractionSettings from '../../components/distraction-settings/distraction-settings.vue'
 import ProxySettings from '../../components/proxy-settings/proxy-settings.vue'
 import SponsorBlockSettings from '../../components/sponsor-block-settings/sponsor-block-settings.vue'
+import ChannelBlockerSettings from '../../components/channel-blocker-settings/channel-blocker-settings.vue'
 
 export default Vue.extend({
   name: 'Settings',
@@ -28,7 +29,8 @@ export default Vue.extend({
     'distraction-settings': DistractionSettings,
     'proxy-settings': ProxySettings,
     'sponsor-block-settings': SponsorBlockSettings,
-    'download-settings': DownloadSettings
+    'download-settings': DownloadSettings,
+    'channel-blocker-settings': ChannelBlockerSettings
   },
   computed: {
     usingElectron: function () {

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -21,6 +21,8 @@
     <download-settings v-if="usingElectron" />
     <hr>
     <sponsor-block-settings />
+    <hr>
+    <channel-blocker-settings />
   </div>
 </template>
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -336,6 +336,13 @@ Settings:
     Download Settings: Download Settings
     Ask Download Path: Ask for download path
     Choose Path: Choose Path
+  ChannelBlocker Settings:
+    ChannelBlocker Settings: ChannelBlocker Settings
+    Enable ChannelBlocker: Enable ChannelBlocker
+    Blocked Channels: Blocked Channels
+    Search bar placeholder: Search channels
+    Empty List: No channels blocked
+    Empty Search Result: No channels found
 About:
   #On About page
   About: About
@@ -459,6 +466,10 @@ Video:
   Copy YouTube Channel Link: Copy YouTube Channel Link
   Open Channel in Invidious: Open Channel in Invidious
   Copy Invidious Channel Link: Copy Invidious Channel Link
+  Block Channel: Block Channel
+  Unblock Channel: Unblock Channel
+  Channel has been added to the block list: has been added to the block list
+  Channel has been removed from the block list: has been removed from the block list
   View: View
   Views: Views
   Loop Playlist: Loop Playlist


### PR DESCRIPTION
---
Feature/channelblocker
---
**Pull Request Type**
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
#1070

**Description**
Hide videos from channels you hate on Search results (except ft-list-channel), Trending, Most popular and "Up Next" .
(Will not hide when viewing Subscriptions, Channel page, History and Playlist)
Sync between multiple windows.

**Screenshots**
<div style="display:flex;">
<img src="https://user-images.githubusercontent.com/80553357/154798526-626778e2-70fb-4bbd-a4d3-5dc76a410455.png" width=240>
<img src="https://user-images.githubusercontent.com/80553357/154798531-3bfe0550-0faa-44b2-8111-8f9f8d570bf9.png" width=240>
<img src="https://user-images.githubusercontent.com/80553357/154798525-c1cff616-9306-49b7-9433-f9f67e942070.png" width=240>
</div>
<br>

**Testing**
Opened multiple windows and added/removed channels by hand.

**Desktop**
 - OS: Windows 10
 - OS Version: 21H2 (19043.1503)
 - FreeTube version: 0.16.0 Beta
