### PR TITLE
Prevent search input reset from overwriting clipboard on Linux

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -139,10 +139,11 @@ export default Vue.extend({
       this.inputData = ''
       this.handleActionIconChange()
       this.updateVisibleDataList()
-      this.$emit('input', this.inputData)
+
+      const inputElement = document.getElementById(this.id)
+      inputElement.value = ''
 
       // Focus on input element after text is clear for better UX
-      const inputElement = document.getElementById(this.id)
       inputElement.focus()
     },
 


### PR DESCRIPTION
---
Prevent search input reset from overwriting clipboard on Linux
---

**Pull Request Type**
- [x] Bugfix

**Related issue**
Closes #2019

**Description**
Removes the input event emitter in favour of a more standard way of clearing an input field to prevent clipboards being overwritten.

**Testing (for code that is not small enough to be easily understandable)**
Test with any form of selection-based clipboards (middle mouse button on most Linux systems). Select any text, use middle mouse button to paste, type something else into FreeTube search, click the X button to clear it, paste again.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Debian
 - OS Version: [e.g. 22] 11
 - FreeTube version: [e.g. 0.8] v0.16.0 Beta

**Additional context**
https://github.com/FreeTubeApp/FreeTube/issues/2019#issuecomment-1019418085 user confirms that this is the expected behaviour for the X button. Cheers
