### PR TITLE
Fix/SearchHistoryDuplicate

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -69,7 +69,7 @@ export default Vue.extend({
     },
 
     backwardText: function () {
-      return this.$t('Backward')
+      return this.$t('Back')
     },
 
     newWindowText: function () {

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -18,7 +18,7 @@
         icon="arrow-left"
         role="button"
         tabindex="0"
-        :title="forwardText"
+        :title="backwardText"
         @click="historyBack"
         @keypress="historyBack"
       />

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -971,7 +971,7 @@ const mutations = {
     })
 
     if (sameSearch !== -1) {
-      state.sessionSearchHistory[sameSearch].data = state.sessionSearchHistory[sameSearch].data.concat(payload.data)
+      state.sessionSearchHistory[sameSearch].data = payload.data
       state.sessionSearchHistory[sameSearch].nextPageRef = payload.nextPageRef
     } else {
       state.sessionSearchHistory.push(payload)


### PR DESCRIPTION
Title
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #2123
closes #1659

**Description**
Fix `addToSessionSearchHistory` in utils.js
(`payload.data` is already concatenated in Search.js)

**Screenshots (if appropriate)**
First page
![1](https://user-images.githubusercontent.com/80553357/158093142-e3e609a8-6bfb-4303-90b5-6be3824164d4.PNG)

No duplicates
![2](https://user-images.githubusercontent.com/80553357/158093148-180ce741-9515-42c9-9b86-c30b82515189.PNG)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 
>search ltt >
click on fetch more results >
wait a few seconds >
press the backward button on the left top side of the screen >
press the forward button on the left top side of the screen >
see duplicated videos/channel

**Desktop (please complete the following information):**
 - OS: Windows10
 - OS Version: 21H1
 - FreeTube version: 0.16.0
