### PR TITLE
Fix: trending cache

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -982,7 +982,7 @@ const mutations = {
     state.popularCache = value
   },
 
-  setTrendingCache (state, value, page) {
+  setTrendingCache (state, { value, page }) {
     state.trendingCache[page] = value
   },
 

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -127,7 +127,8 @@ export default Vue.extend({
 
         this.shownResults = returnData
         this.isLoading = false
-        this.$store.commit('setTrendingCache', this.shownResults, this.currentTab)
+        const currentTab = this.currentTab
+        this.$store.commit('setTrendingCache', { value: returnData, page: currentTab })
       }).then(() => {
         document.querySelector(`#${this.currentTab}Tab`).focus()
       }).catch((err) => {
@@ -177,7 +178,8 @@ export default Vue.extend({
 
         this.shownResults = returnData
         this.isLoading = false
-        this.$store.commit('setTrendingCache', this.shownResults, this.trendingCache)
+        const currentTab = this.currentTab
+        this.$store.commit('setTrendingCache', { value: returnData, page: currentTab })
       }).then(() => {
         document.querySelector(`#${this.currentTab}Tab`).focus()
       }).catch((err) => {

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -52,7 +52,11 @@ export default Vue.extend({
     }
   },
   mounted: function () {
-    this.getTrendingInfo()
+    if (this.trendingCache[this.currentTab] && this.trendingCache[this.currentTab].length > 0) {
+      this.getTrendingInfoCache()
+    } else {
+      this.getTrendingInfo()
+    }
   },
   methods: {
     changeTab: function (tab, event) {
@@ -88,17 +92,15 @@ export default Vue.extend({
       currentTabNode.attr('aria-selected', 'false')
       newTabNode.attr('aria-selected', 'true')
       this.currentTab = tab
-      this.getTrendingInfo()
+      if (this.trendingCache[this.currentTab] && this.trendingCache[this.currentTab].length > 0) {
+        this.getTrendingInfoCache()
+      } else {
+        this.getTrendingInfo()
+      }
     },
 
     getTrendingInfo () {
-      if (this.trendingCache[this.currentTab] && this.trendingCache[this.currentTab].length > 0) {
-        this.isLoading = true
-        setTimeout(() => {
-          this.shownResults = this.trendingCache[this.currentTab]
-          this.isLoading = false
-        })
-      } else if (!this.usingElectron) {
+      if (!this.usingElectron) {
         this.getVideoInformationInvidious()
       } else {
         switch (this.backendPreference) {
@@ -151,6 +153,14 @@ export default Vue.extend({
         } else {
           this.isLoading = false
         }
+      })
+    },
+
+    getTrendingInfoCache: function() {
+      this.isLoading = true
+      setTimeout(() => {
+        this.shownResults = this.trendingCache[this.currentTab]
+        this.isLoading = false
       })
     },
 

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -52,11 +52,7 @@ export default Vue.extend({
     }
   },
   mounted: function () {
-    if (this.trendingCache[this.currentTab] && this.trendingCache[this.currentTab].length > 0) {
-      this.shownResults = this.trendingCache
-    } else {
-      this.getTrendingInfo()
-    }
+    this.getTrendingInfo()
   },
   methods: {
     changeTab: function (tab, event) {
@@ -96,7 +92,13 @@ export default Vue.extend({
     },
 
     getTrendingInfo () {
-      if (!this.usingElectron) {
+      if (this.trendingCache[this.currentTab] && this.trendingCache[this.currentTab].length > 0) {
+        this.isLoading = true
+        setTimeout(() => {
+          this.shownResults = this.trendingCache[this.currentTab]
+          this.isLoading = false
+        })
+      } else if (!this.usingElectron) {
         this.getVideoInformationInvidious()
       } else {
         switch (this.backendPreference) {


### PR DESCRIPTION
---
Fix: trending cache
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
None

**Description**
Trending pages weren't getting cached properly so multiple requests could have been made that weren't wanted/needed when navigating through the trending pages

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Switch the trending page tabs and see it load properly without logging (invidious and local api use console logging)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.16.0

