### PR TITLE
Fix search input shortcut

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -311,7 +311,7 @@ export default Vue.extend({
           if (document.activeElement === this.$refs.topNav.searchInput) {
             break
           }
-          
+
           // Prevent slash from appearing in search box.
           event.preventDefault()
           this.$refs.topNav.focusSearch()

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -303,19 +303,12 @@ export default Vue.extend({
           case 'ArrowLeft':
             this.$refs.topNav.historyBack()
             break
+          case 'KeyD':
+            this.$refs.topNav.focusSearch()
+            break
         }
       }
       switch (event.code) {
-        case 'Slash':
-          // If the search input is already focused, do nothing.
-          if (document.activeElement === this.$refs.topNav.searchInput) {
-            break
-          }
-
-          // Prevent slash from appearing in search box.
-          event.preventDefault()
-          this.$refs.topNav.focusSearch()
-          break
         case 'Tab':
           this.hideOutlines = false
           break

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -306,6 +306,16 @@ export default Vue.extend({
         }
       }
       switch (event.code) {
+        case 'Slash':
+          // If the search input is already focused, do nothing.
+          if (document.activeElement === this.$refs.topNav.searchInput) {
+            break
+          }
+          
+          // Prevent slash from appearing in search box.
+          event.preventDefault()
+          this.$refs.topNav.focusSearch()
+          break
         case 'Tab':
           this.hideOutlines = false
           break

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -37,11 +37,11 @@
     />
     <input
       :id="id"
+      ref="input"
       v-model="inputData"
       :list="idDataList"
       class="ft-input"
       type="text"
-      ref="input"
       :placeholder="placeholder"
       :disabled="disabled"
       :spellcheck="spellcheck"

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -41,6 +41,7 @@
       :list="idDataList"
       class="ft-input"
       type="text"
+      ref="input"
       :placeholder="placeholder"
       :disabled="disabled"
       :spellcheck="spellcheck"

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -36,6 +36,10 @@ export default Vue.extend({
       return this.$store.getters.getEnableSearchSuggestions
     },
 
+    searchInput: function () {
+      return this.$refs.searchInput.$refs.input
+    },
+
     searchSettings: function () {
       return this.$store.getters.getSearchSettings
     },
@@ -195,6 +199,10 @@ export default Vue.extend({
 
       // Close the filter panel
       this.showFilters = false
+    },
+
+    focusSearch: function () {
+      this.searchInput.focus()
     },
 
     getSearchSuggestionsDebounce: function (query) {

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -73,6 +73,7 @@
           :data-list="searchSuggestionsDataList"
           :spellcheck="false"
           :show-clear-text-button="true"
+          ref="searchInput"
           @input="getSearchSuggestionsDebounce"
           @click="goToSearch"
         />

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -66,6 +66,7 @@
     <div class="middle">
       <div class="searchContainer">
         <ft-input
+          ref="searchInput"
           :placeholder="$t('Search / Go to URL')"
           class="searchInput"
           :is-search="true"
@@ -73,7 +74,6 @@
           :data-list="searchSuggestionsDataList"
           :spellcheck="false"
           :show-clear-text-button="true"
-          ref="searchInput"
           @input="getSearchSuggestionsDebounce"
           @click="goToSearch"
         />


### PR DESCRIPTION
---
 Fix search input shortcut
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
Partially addresses #2138
Closes #1463

**Description**
Adds a keyboard shortcut for focusing the search bar.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Debian
 - OS Version: [e.g. 22] 11
 - FreeTube version: [e.g. 0.8] v0.15.0 Beta

**Additional context**
I think we should think about adding styling for the focused state of inputs, currently it's not obvious when an input is focused due to the lack of visual changes.
