### PR TITLE
Switch debug and picture in picture shortcuts for consistency

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1647,6 +1647,7 @@ export default Vue.extend({
             break
           case 68:
             // D Key
+            event.preventDefault()
             this.toggleShowStatsModal()
             break
           case 27:

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1568,7 +1568,12 @@ export default Vue.extend({
           case 73:
             // I Key
             event.preventDefault()
-            this.toggleShowStatsModal()
+            // Toggle Picture in Picture Mode
+            if (!this.player.isInPictureInPicture()) {
+              this.player.requestPictureInPicture()
+            } else if (this.player.isInPictureInPicture()) {
+              this.player.exitPictureInPicture()
+            }
             break
           case 49:
             // 1 Key
@@ -1642,12 +1647,7 @@ export default Vue.extend({
             break
           case 68:
             // D Key
-            // Toggle Picture in Picture Mode
-            if (!this.player.isInPictureInPicture()) {
-              this.player.requestPictureInPicture()
-            } else if (this.player.isInPictureInPicture()) {
-              this.player.exitPictureInPicture()
-            }
+            this.toggleShowStatsModal()
             break
           case 27:
             // esc Key


### PR DESCRIPTION
---
Switch debug and picture in picture shortcuts for consistency
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
Partially addresses #2138 

**Description**
Switches the PiP shortcut (d) with the debug shortcut (i) for consistency with Youtube's own shortcuts. See the related issue.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Debian
 - OS Version: [e.g. 22] 11
 - FreeTube version: [e.g. 0.8] v0.16.0 Beta
