### PR TITLE
Fast forward = Playback rate × Interval

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1497,7 +1497,7 @@ export default Vue.extend({
             // J Key
             // Rewind by 2x the time-skip interval (in seconds)
             event.preventDefault()
-            this.changeDurationBySeconds(-this.defaultSkipInterval * 2)
+            this.changeDurationBySeconds(-this.defaultSkipInterval * this.player.playbackRate() * 2)
             break
           case 75:
             // K Key
@@ -1509,7 +1509,7 @@ export default Vue.extend({
             // L Key
             // Fast-Forward by 2x the time-skip interval (in seconds)
             event.preventDefault()
-            this.changeDurationBySeconds(this.defaultSkipInterval * 2)
+            this.changeDurationBySeconds(this.defaultSkipInterval * this.player.playbackRate() * 2)
             break
           case 79:
             // O Key
@@ -1557,13 +1557,13 @@ export default Vue.extend({
             // Left Arrow Key
             // Rewind by the time-skip interval (in seconds)
             event.preventDefault()
-            this.changeDurationBySeconds(-this.defaultSkipInterval * 1)
+            this.changeDurationBySeconds(-this.defaultSkipInterval * this.player.playbackRate())
             break
           case 39:
             // Right Arrow Key
             // Fast-Forward by the time-skip interval (in seconds)
             event.preventDefault()
-            this.changeDurationBySeconds(this.defaultSkipInterval * 1)
+            this.changeDurationBySeconds(this.defaultSkipInterval * this.player.playbackRate())
             break
           case 73:
             // I Key


### PR DESCRIPTION
**Pull Request Type**
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
closes #2146

**Description**
>On YT if the playback speed is 2x and fast forward one time, it will fast forward 10sec instead of 5sec.

It also skips less when rate < 1 (same as youtube)

**Testing (for code that is not small enough to be easily understandable)**
Change playback rate and interval then press J, L Left arrow & Right arrow.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: 21H1
 - FreeTube version: 2bbb875749e52b6f8e70f20560edf9d584a0e2ff
