### PR TITLE
Update electron to 16.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^16.2.0",
+    "electron": "^16.2.2",
     "electron-builder": "^22.11.7",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,10 +3543,10 @@ electron-to-chromium@^1.3.830:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.836.tgz#823cb9c98f28c64c673920f1c90ea3826596eaf9"
   integrity sha512-Ney3pHOJBWkG/AqYjrW0hr2AUCsao+2uvq9HUlRP8OlpSdk/zOHOUJP7eu0icDvePC9DlgffuelP4TnOJmMRUg==
 
-electron@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.2.0.tgz#89f1c29c7581046c61e3d488d1fa05afa12c17b2"
-  integrity sha512-AJOvd0725vYTynviokL97XQ9SEIqoSLWBaJYFnMuoXbg89g0kLkCnMPp5Nx038Xh4emHuHmIAMwU+iR/OQ2QCQ==
+electron@^16.2.2:
+  version "16.2.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-16.2.2.tgz#abb8863ae5309744f90aa55991e812a40ffe7601"
+  integrity sha512-MOZCewpDvhiuYCw8UnJnQxU/9cni4tlHHWBdi0JWbcdBOrGsDMSt17nuPwR5wSf1e7mSfofGIUPg9iHS5KA8Eg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
Update electron to [16.2.2](https://github.com/electron/electron/releases/tag/v16.2.2)
Several security fixes included

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
N/A

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 5c54862a765ca2d229bb7df72307bb56ebee18b1

**Additional context**
Add any other context about the problem here.
