### PR TITLE
Only fetch the most recent update from the GitHub releases

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -200,7 +200,7 @@ export default Vue.extend({
     checkForNewUpdates: function () {
       if (this.checkForUpdates) {
         const { version } = require('../../package.json')
-        const requestUrl = 'https://api.github.com/repos/freetubeapp/freetube/releases'
+        const requestUrl = 'https://api.github.com/repos/freetubeapp/freetube/releases?per_page=1'
 
         $.getJSON(requestUrl, (response) => {
           const tagName = response[0].tag_name


### PR DESCRIPTION
---
Only fetch the most recent update from the GitHub releases
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
n/a

**Description**

Instead of fetching a full page (default 30) releases from the GitHub API when checking for updates, only fetch the first item, this reduces the response from ~50kB to ~4.4kB. This should make checking for updates significantly faster.

**Screenshots (if appropriate)**
n/a

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested? **Yes**
Please describe shortly how you tested it and whether there are any ramifications remaining. **No additional errors were logged in the devtools console during the update check, additionally the request was successful in the network tab of the devtools**

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: commit 5c54862a765ca2d229bb7df72307bb56ebee18b1

**Additional context**

[GitHub releases API docs](https://docs.github.com/en/rest/reference/releases#list-releases)