### PR TITLE
Restore subtitle player setting

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -367,7 +367,9 @@ export default Vue.extend({
 
             if (this.enableSubtitles) {
               const tracks = this.player.textTracks().tracks_
-              const userLocaleTrack = tracks.find(track => track.language == this.currentLocale)
+              const userLocaleTrack = tracks.find((track) => {
+                return track.language === this.currentLocale
+              })
 
               if (userLocaleTrack) {
                 userLocaleTrack.mode = 'showing'

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -165,6 +165,10 @@ export default Vue.extend({
       return parseInt(this.$store.getters.getDefaultQuality)
     },
 
+    enableSubtitles: function () {
+      return this.$store.getters.getEnableSubtitles
+    },
+
     defaultCaptionSettings: function () {
       try {
         return JSON.parse(this.$store.getters.getDefaultCaptionSettings)
@@ -354,12 +358,17 @@ export default Vue.extend({
         this.player.on('fullscreenchange', this.fullscreenOverlay)
         this.player.on('fullscreenchange', this.toggleFullscreenClass)
 
-        this.player.on('ready', () => {
+        this.player.on('ready', async () => {
           this.$emit('ready')
           this.checkAspectRatio()
           this.createStatsModal()
           if (this.captionHybridList.length !== 0) {
-            this.transformAndInsertCaptions()
+            await this.transformAndInsertCaptions()
+
+            if (this.enableSubtitles) {
+              const tracks = this.player.textTracks().tracks_
+              tracks[1].mode = 'showing'
+            }
           }
         })
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -367,7 +367,11 @@ export default Vue.extend({
 
             if (this.enableSubtitles) {
               const tracks = this.player.textTracks().tracks_
-              tracks[1].mode = 'showing'
+              const userLocaleTrack = tracks.find(track => track.language == this.currentLocale)
+
+              if (userLocaleTrack) {
+                userLocaleTrack.mode = 'showing'
+              }
             }
           }
         })

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -52,6 +52,7 @@
           :label="$t('Settings.Player Settings.Turn on Subtitles by Default')"
           :compact="true"
           :default-value="enableSubtitles"
+          :tooltip="$t('Tooltips.Player Settings.Turn on Subtitles by Default')"
           @change="updateEnableSubtitles"
         />
       </div>

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -9,12 +9,6 @@
     <div class="switchColumnGrid">
       <div class="switchColumn">
         <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Turn on Subtitles by Default')"
-          :compact="true"
-          :default-value="enableSubtitles"
-          @change="updateEnableSubtitles"
-        />
-        <ft-toggle-switch
           :label="$t('Settings.Player Settings.Force Local Backend for Legacy Formats')"
           :compact="true"
           :disabled="backendPreference === 'local'"
@@ -53,6 +47,12 @@
           :compact="true"
           :default-value="displayVideoPlayButton"
           @change="updateDisplayVideoPlayButton"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Turn on Subtitles by Default')"
+          :compact="true"
+          :default-value="enableSubtitles"
+          @change="updateEnableSubtitles"
         />
       </div>
       <div class="switchColumn">

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -9,8 +9,7 @@
     <div class="switchColumnGrid">
       <div class="switchColumn">
         <ft-toggle-switch
-          v-if="false"
-          label="Enable Subtitles by Default"
+          :label="$t('Settings.Player Settings.Turn on Subtitles by Default')"
           :compact="true"
           :default-value="enableSubtitles"
           @change="updateEnableSubtitles"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -181,7 +181,7 @@ const state = {
   disableSmoothScrolling: false,
   displayVideoPlayButton: true,
   enableSearchSuggestions: true,
-  enableSubtitles: true,
+  enableSubtitles: false,
   externalLinkHandling: '',
   externalPlayer: '',
   externalPlayerExecutable: '',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -676,6 +676,8 @@ Tooltips:
       hold the Control key (Command Key on Mac) and scroll the mouse wheel forwards or backwards to control
       the playback rate. Press and hold the Control key (Command Key on Mac) and left click the mouse
       to quickly return to the default playback rate (1x unless it has been changed in the settings).
+    Turn on Subtitles by Default: If a video does not have subtitles (auto-generated
+      or otherwise) in your selected locale they will not be enabled by default.
   External Player Settings:
     External Player: Choosing an external player will display an icon, for opening the
       video (playlist if supported) in the external player, on the thumbnail.

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -740,6 +740,8 @@ Tooltips:
       or backwards to control the playback rate. Press and hold the Control key (Command
       Key on Mac) and left click the mouse to quickly return to the default playback
       rate (1x unless it has been changed in the settings).
+    Turn on Subtitles by Default: If a video does not have subtitles (auto-generated
+      or otherwise) in your selected locale they will not be enabled by default.
   General Settings:
     Region for Trending: The region of trends allows you to pick which country’s trending
       videos you want to have displayed. Not all countries displayed are actually


### PR DESCRIPTION
---
Restore subtitle player setting
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
Closes #62 

**Description**
Restores a setting in the player settings section for enabling subtitles/captions on by default

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Debian
 - OS Version: [e.g. 22] 11
 - FreeTube version: [e.g. 0.8] 0.16.0

**Additional context**
I disabled the setting by default because I think it's better not to confuse users with subtitles always being on before going through the settings.
