### PR TITLE
Add the alternate search keyboard shortcuts COMMAND+L on MacOS and CTRL+L on other platforms

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -312,6 +312,12 @@ export default Vue.extend({
         case 'Tab':
           this.hideOutlines = false
           break
+        case 'KeyL':
+          if ((process.platform !== 'darwin' && event.ctrlKey) ||
+            (process.platform === 'darwin' && event.metaKey)) {
+            this.$refs.topNav.focusSearch()
+          }
+          break
       }
     },
 


### PR DESCRIPTION
---
Add the alternate search keyboard shortcuts COMMAND+L on MacOS and CTRL+L on other platforms
---

**Pull Request Type**

- [x] Feature Implementation

**Related issue**
Implements the alternate shortcuts discussed here: https://github.com/FreeTubeApp/FreeTube/pull/2140#issuecomment-1092388334

**Description**

This pull requests adds an alternative keyboard shortcut to focus the search bar, `COMMAND+L` on MacOS and `CTRL+L` on other platforms.

**Desktop (please complete the following information):**
 - OS: Windows/MacOS
 - OS Version: 10/Monterey
 - FreeTube version: 06a7298ded743c1db59f6b946ed038f996bd3340