### PR TITLE
Hide filter on history and playlist page when page is empty

### DIFF
--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -10,11 +10,11 @@
     >
       <h3>{{ $t("History.History") }}</h3>
       <ft-input
+        v-show="activeData.length > 0"
         ref="searchBar"
         :placeholder="$t('History.Search bar placeholder')"
         :show-clear-text-button="true"
         :show-action-button="false"
-        v-show="activeData.length > 0"
         @input="(input) => query = input"
       />
       <ft-flex-box

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -14,8 +14,8 @@
         :placeholder="$t('History.Search bar placeholder')"
         :show-clear-text-button="true"
         :show-action-button="false"
-        @input="(input) => query = input"
         v-show="activeData.length > 0"
+        @input="(input) => query = input"
       />
       <ft-flex-box
         v-show="activeData.length === 0"

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -15,6 +15,7 @@
         :show-clear-text-button="true"
         :show-action-button="false"
         @input="(input) => query = input"
+        v-show="activeData.length > 0"
       />
       <ft-flex-box
         v-show="activeData.length === 0"

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -22,6 +22,7 @@
         :show-clear-text-button="true"
         :show-action-button="false"
         @input="(input) => query = input"
+        v-show="activeData.length > 0"
       />
       <ft-flex-box
         v-show="activeData.length === 0"

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -21,8 +21,8 @@
         :placeholder="$t('User Playlists.Search bar placeholder')"
         :show-clear-text-button="true"
         :show-action-button="false"
-        @input="(input) => query = input"
         v-show="activeData.length > 0"
+        @input="(input) => query = input"
       />
       <ft-flex-box
         v-show="activeData.length === 0"

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -17,11 +17,11 @@
         />
       </h3>
       <ft-input
+        v-show="activeData.length > 0"
         ref="searchBar"
         :placeholder="$t('User Playlists.Search bar placeholder')"
         :show-clear-text-button="true"
         :show-action-button="false"
-        v-show="activeData.length > 0"
         @input="(input) => query = input"
       />
       <ft-flex-box


### PR DESCRIPTION
---
Hide filter on history and playlist page when page is empty
---

**Pull Request Type**

- [x] Feature Implementation

**Related issue**
Closes #2174 

**Description**
Hides the search bar on history and playlist pages when they pages are empty

**Screenshots (if appropriate)**

_Playlists:_
![before playlists](https://user-images.githubusercontent.com/48293849/162486125-ef895340-ae24-4182-b311-81d74a509901.png)
![after playlists](https://user-images.githubusercontent.com/48293849/162486442-9828a7aa-b13d-4bd3-afe2-0714cf016a7f.png)

_History:_
![before history](https://user-images.githubusercontent.com/48293849/162486262-cf7a3b0b-fe95-49ea-8a9c-3ad5da4cc878.png)
![after history](https://user-images.githubusercontent.com/48293849/162486547-d1f7517a-2173-45f1-a8bc-cda7d1b55da8.png)

**Testing (for code that is not small enough to be easily understandable)**
I tested this by adding and removing videos from the playlists and watching and removing items from the watch history.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 06a7298ded743c1db59f6b946ed038f996bd3340