### PR TITLE
Bump the node version used by the workflows from 14 to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [ 16 ]
         runtime: [ linux-x64, linux-arm64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64
@@ -29,9 +29,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,11 +17,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js 14.x
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16
         cache: "yarn"
-    - run: npm run ci
-    - run: npm run lint
+    - run: yarn run ci
+    - run: yarn run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [ 16 ]
         runtime: [ linux-x64, linux-arm64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64
@@ -30,9 +30,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"


### PR DESCRIPTION
---
Bump the node version used by the workflows from 14 to 16
---

**Pull Request Type**

- [x] Feature Implementation

**Description**
Bump the node version used by the workflows from 14 to 16. I was also going to change them to all use yarn instead of npm, however yarn doesn't have the `--if-present` flag and they seem to be refusing to implement it https://github.com/yarnpkg/yarn/issues/6894.

**Desktop (please complete the following information):**
n/a. This pull request only contains workflow changes.