### PR TITLE
Auto label the PR when submitted

### DIFF
--- a/.github/workflows/autoLabelPR.yaml
+++ b/.github/workflows/autoLabelPR.yaml
@@ -1,0 +1,15 @@
+name: "Set PR Label"
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Naturalclar/issue-action@v2.0.2
+        with:
+          title-or-body: "both"
+          parameters: '[ {"keywords": ["Important note", "Pull Request Type", "Related issue", "Dependent PR/issue", "Description", "Screenshots", "Testing", "Desktop", "Additional context"], "labels": ["PR: waiting for review"]}]'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
---
Auto label the PR when submitted
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
Partially addresses https://github.com/FreeTubeApp/FreeTube/issues/1720

**Description**
When PR is submitted the waiting for review label will be added. Also if a PR is reopened the label will be added.

**Testing (for code that is not small enough to be easily understandable)**
1. go to https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/tree/autoLabelPR
2. submit a pr