### PR TITLE
Allow DASH formats for livestream replays

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -310,7 +310,7 @@ export default Vue.extend({
             }
           }
 
-          if ((this.isLive || this.isLiveContent) && !this.isUpcoming) {
+          if ((this.isLive && this.isLiveContent) && !this.isUpcoming) {
             this.enableLegacyFormat()
 
             this.videoSourceList = result.formats.filter((format) => {


### PR DESCRIPTION
---
Allow DASH formats for livestream replays
---

**Pull Request Type**

- [x] Bugfix

**Description**

Currently FreeTube enforces the legacy formats for all livestreams regardless of whether they are live or replays. This pull requests allows DASH formats to be used for livestream replays.

**Screenshots (if appropriate)**
Before:
![before](https://user-images.githubusercontent.com/48293849/163716997-ed90222f-0966-4932-a6dc-a90199d1b73f.png)

After:
![after](https://user-images.githubusercontent.com/48293849/163717017-4c0163af-00c2-4249-9a0d-dc099c0910bf.png)

**Testing (for code that is not small enough to be easily understandable)**
I tested various videos to check that nothing broke. Here is an example of a livestream replay video that has DASH formats after this change: https://youtu.be/TEygSwHWhfA

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 7878e9e3a671830426bc0893a44c1baff5801cb9