### PR TITLE
channel fix (banner, playlist)

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -373,8 +373,10 @@ export default Vue.extend({
         })
         this.latestVideos = response.latestVideos
 
-        if (typeof (response.authorBanners) !== 'undefined') {
+        if (response.authorBanners instanceof Array && response.authorBanners.length > 0) {
           this.bannerUrl = response.authorBanners[0].url.replace('https://yt3.ggpht.com', `${this.currentInvidiousInstance}/ggpht/`)
+        } else {
+          this.bannerUrl = null
         }
 
         this.isLoading = false
@@ -468,6 +470,41 @@ export default Vue.extend({
     },
 
     getPlaylistsInvidious: function () {
+      const payload = {
+        resource: 'channels/playlists',
+        id: this.id,
+        params: {
+          sort_by: this.playlistSortBy
+        }
+      }
+
+      this.invidiousAPICall(payload).then((response) => {
+        console.log(response)
+        this.playlistContinuationString = response.continuation
+        this.latestPlaylists = response.playlists
+        this.isElementListLoading = false
+      }).catch((err) => {
+        console.log(err)
+        const errorMessage = this.$t('Invidious API Error (Click to copy)')
+        this.showToast({
+          message: `${errorMessage}: ${err.responseJSON.error}`,
+          time: 10000,
+          action: () => {
+            navigator.clipboard.writeText(err.responseJSON.error)
+          }
+        })
+        if (this.backendPreference === 'invidious' && this.backendFallback) {
+          this.showToast({
+            message: this.$t('Falling back to Local API')
+          })
+          this.getPlaylistsLocal()
+        } else {
+          this.isLoading = false
+        }
+      })
+    },
+
+    getPlaylistsInvidiousMore: function () {
       if (this.playlistContinuationString === null) {
         console.log('There are no more playlists available for this channel')
         return
@@ -486,6 +523,7 @@ export default Vue.extend({
       }
 
       this.invidiousAPICall(payload).then((response) => {
+        console.log(response)
         this.playlistContinuationString = response.continuation
         this.latestPlaylists = this.latestPlaylists.concat(response.playlists)
         this.isElementListLoading = false
@@ -600,7 +638,7 @@ export default Vue.extend({
               this.getPlaylistsLocalMore()
               break
             case 'invidious':
-              this.getPlaylistsInvidious()
+              this.getPlaylistsInvidiousMore()
               break
           }
           break

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -479,7 +479,6 @@ export default Vue.extend({
       }
 
       this.invidiousAPICall(payload).then((response) => {
-        console.log(response)
         this.playlistContinuationString = response.continuation
         this.latestPlaylists = response.playlists
         this.isElementListLoading = false
@@ -523,7 +522,6 @@ export default Vue.extend({
       }
 
       this.invidiousAPICall(payload).then((response) => {
-        console.log(response)
         this.playlistContinuationString = response.continuation
         this.latestPlaylists = this.latestPlaylists.concat(response.playlists)
         this.isElementListLoading = false


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Closes #2214

**Description**
Banner: Invidious returns "authorBanners": [ ] for channels without banners, results in "TypeError: Cannot read properties of undefined (reading 'url')"
example: UC3VHfy8e1jbDnT5TG2pjP1w (Nyan cat)

Playlist:
> Subscribe to a few channels with playlists (to access them from sidebar)
> Reload (Ctrl R)
> View "Playlists" tab of one of the channels
> View another channel's playlists (without visiting other pages in between)
> It will display either "This channel does not currently have any playlists" or wrong playlists

**Screenshots (if appropriate)**
Shows defaultBanner.png
<img src="https://user-images.githubusercontent.com/80553357/164645084-8cc31a57-cb0e-4057-9480-6045537bba45.PNG" width=300>

**Testing (for code that is not small enough to be easily understandable)**
Visit a channel without banner

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: 21H1
 - FreeTube version: v0.16, 2c131ae31110dd8b2fd0063c97a421c571630735
