### PR TITLE
Clear watch progress from view cache when removing video form history

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -439,6 +439,7 @@ export default Vue.extend({
       })
 
       this.watched = false
+      this.watchProgress = 0
     },
 
     addToPlaylist: function () {


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix
- [ ] Feature Implementation

**Description**
On the channel view (and pretty much anywhere with a `ft-list-video` component), after removing a seen video from history through the context menu, the page would still remember the watch progress and delegate it to the external player afterwards, which was very annoying since most of those videos' previous watch progress is basically at the end of the video.
This PR clears that view's cached watch progress value after removing the video from history.

**Additional notes**
I personally don't care, but I'll leave it here as a note in case someone wants to look into it.
I noticed that the watch progress bar value doesn't always seem to be accurate.
It's possible that the calculation for this value is badly done or the values provided to the calculation itself are a bit off, I don't know ¯\\\_(ツ)\_/¯
