### PR TITLE
Hide Picture in Picture button and disable keyboard shortcut for audio formats

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1578,7 +1578,7 @@ export default Vue.extend({
             // I Key
             event.preventDefault()
             // Toggle Picture in Picture Mode
-            if (!this.player.isInPictureInPicture()) {
+            if (this.format !== 'audio' && !this.player.isInPictureInPicture()) {
               this.player.requestPictureInPicture()
             } else if (this.player.isInPictureInPicture()) {
               this.player.exitPictureInPicture()

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -75,7 +75,8 @@ export default Vue.extend({
       playlistId: '',
       timestamp: null,
       playNextTimeout: null,
-      playNextCountDownIntervalId: null
+      playNextCountDownIntervalId: null,
+      pictureInPictureButtonInverval: null
     }
   },
   computed: {
@@ -174,6 +175,21 @@ export default Vue.extend({
           }
           break
       }
+    },
+    activeFormat: function (format) {
+      clearInterval(this.pictureInPictureButtonInverval)
+
+      // only hide/show the button once the player is available
+      this.pictureInPictureButtonInverval = setInterval(() => {
+        if (!this.hidePlayer) {
+          if (format === 'audio') {
+            document.querySelector('.vjs-picture-in-picture-control').classList.add('vjs-hidden')
+          } else {
+            document.querySelector('.vjs-picture-in-picture-control').classList.remove('vjs-hidden')
+          }
+          clearInterval(this.pictureInPictureButtonInverval)
+        }
+      }, 100)
     }
   },
   mounted: function () {


### PR DESCRIPTION
---
Hide Picture in Picture button and disable keyboard shortcut for audio formats
---

**Pull Request Type**

- [x] Feature Implementation

**Description**
Please write a clear and concise description of what the pull request does.

**Screenshots**

<details><summary>Before</summary>

![before_audio](https://user-images.githubusercontent.com/48293849/166103305-7dbd4640-e5cd-4324-878f-7d9efade2d35.png)

![errors](https://user-images.githubusercontent.com/48293849/166103302-415a8c6b-afed-4d95-bd19-fe01cd670b7b.png)

</details>

<details><summary>After</summary>

![after_video](https://user-images.githubusercontent.com/48293849/166103341-91be19ea-ccb1-4732-a362-949a60e5da93.png)

![after_audio](https://user-images.githubusercontent.com/48293849/166103344-ed477f4a-7779-4196-a5e6-da90a01aa6cd.png)

</details>

**Testing**
I tested various videos and checked that it works regardless of which formats are set as default and that it works when the formats are changed on the video page. The video used for the screenshots is this one: [https://youtu.be/lIxAPW0YAEU](https://youtu.be/lIxAPW0YAEU)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: e29d041a91fe78e96b62ac8cd61d8d8a78797ab7