### PR TITLE
Update marked to 4.0.14 and ytsr to 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.uniqwith": "^4.5.0",
-    "marked": "^4.0.13",
+    "marked": "^4.0.14",
     "material-design-icons": "^3.0.1",
     "nedb-promises": "^5.0.1",
     "node-forge": "^1.3.1",
@@ -94,7 +94,7 @@
     "yt-trending-scraper": "^2.0.1",
     "ytdl-core": "^4.11.0",
     "ytpl": "^2.3.0",
-    "ytsr": "^3.6.0"
+    "ytsr": "^3.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.uniqwith": "^4.5.0",
-    "marked": "^4.0.14",
+    "marked": "^4.0.15",
     "material-design-icons": "^3.0.1",
     "nedb-promises": "^5.0.1",
     "node-forge": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6032,10 +6032,10 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-marked@^4.0.14:
-  version "4.0.14"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.14.tgz#7a3a5fa5c80580bac78c1ed2e3b84d7bd6fc3870"
-  integrity sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==
+marked@^4.0.15:
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.15.tgz#0216b7c9d5fcf6ac5042343c41d81a8b1b5e1b4a"
+  integrity sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==
 
 matcher@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6032,10 +6032,10 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-marked@^4.0.13:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.13.tgz#4fd46ca93da46448f3d83f054d938c4f905a258d"
-  integrity sha512-lS/ZCa4X0gsRcfWs1eoh6dLnHr9kVH3K1t2X4M/tTtNouhZ7anS1Csb6464VGLQHv8b2Tw1cLeZQs58Jav8Rzw==
+marked@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.14.tgz#7a3a5fa5c80580bac78c1ed2e3b84d7bd6fc3870"
+  integrity sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==
 
 matcher@^3.0.0:
   version "3.0.0"
@@ -6161,11 +6161,6 @@ miniget@^2.0.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/miniget/-/miniget-2.1.0.tgz"
   integrity sha512-fy9x3d/0oOIhkwAms6kgxTYkHwdELhMfgj+9a/aYZpJdTWIIWGta9aXHUtnzUn+LjBmRoTdPRQSi2hkmEvXk3A==
-
-miniget@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/miniget/-/miniget-4.2.1.tgz"
-  integrity sha512-O/DduzDR6f+oDtVype9S/Qu5hhnx73EDYGyZKwU/qN82lehFZdfhoa4DT51SpsO+8epYrB3gcRmws56ROfTIoQ==
 
 miniget@^4.2.2:
   version "4.2.2"
@@ -9097,12 +9092,12 @@ ytpl@^2.3.0:
   dependencies:
     miniget "^4.2.2"
 
-ytsr@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.npmjs.org/ytsr/-/ytsr-3.6.0.tgz"
-  integrity sha512-3fN8lxL+JHtp2xEZoAK3AeTjNm5WB4MH6n2OxHNxP06xQtuO5khbLwh6IJGiZRNi/v3de+jYYbctp2pUqNT/Qw==
+ytsr@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/ytsr/-/ytsr-3.8.0.tgz#49a8e5dc413f41515fc3d79d93ee3e073d10e772"
+  integrity sha512-R+RfYXvBBMAr2e4OxrQ5SBv5x/Mdhmcj1Q8TH0f2HK5d2jbhHOtK4BdzPvLriA6MDoMwqqX04GD8Rpf9UNtSTg==
   dependencies:
-    miniget "^4.2.1"
+    miniget "^4.2.2"
 
 zip-stream@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
**Pull Request Type**

- [x] Bugfix

**Description**

Update marked to [4.0.15](https://github.com/markedjs/marked/releases/tag/v4.0.15)
Changelog 4.0.15:

> Bug Fixes
>
> *    list item bullet without whitespace

Changelog [4.0.14](https://github.com/markedjs/marked/releases/tag/v4.0.14):

> Bug Fixes
> 
> *    only convert leading tabs to spaces

Update ytsr to [3.8.0](https://github.com/TimeForANinja/node-ytsr/releases/tag/v3.8.0)
Changelog 3.8.0:

> Features
> 
> *    add support for chipCloudRenderer

Changelog [3.7.0](https://github.com/TimeForANinja/node-ytsr/releases/tag/v3.7.0):

> Features
> 
> *    add support for reelShelfRenderer

**Testing**
* `ytsr`: I checked that searching still worked and no errors appeared
* `marked`: I changed the version in the package.json file to "0.15.0" to force the changelog to show up and checked that it looked they way it did before upgrading marked.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: e29d041a91fe78e96b62ac8cd61d8d8a78797ab7