### PR TITLE
Add support for next/previous/pause/resume global hotkeys/actions

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -98,6 +98,17 @@ export default Vue.extend({
           break
       }
     }
+
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.setActionHandler('previoustrack', this.playPreviousVideo)
+      navigator.mediaSession.setActionHandler('nexttrack', this.playNextVideo)
+    }
+  },
+  beforeDestroy: function () {
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.setActionHandler('previoustrack', null)
+      navigator.mediaSession.setActionHandler('nexttrack', null)
+    }
   },
   methods: {
     goToPlaylist: function () {


### PR DESCRIPTION
---
Add support for next/previous/pause/resume global hotkeys/actions
---

**Pull Request Type**

- [x] Feature Implementation

**Related issue**

Related to https://github.com/FreeTubeApp/FreeTube/issues/2138
Closes #1931

**Description**

This pull request adds support for the global next and previous track hotkeys/actions inside of playlists. As I'm using the MediaSession API this also works with the next and previous track actions on my Bluetooth headphones.

As there have been issues with the play/pause hotkeys on non Windows operating systems in the past, I've also added explicit handlers for those. I also made it explicitly report the playback state (playing, paused, none) to the MediaSession API. I can remove these handlers and explicit reporting of the playback state if we are sure that those issues have been fully resolved.

If play/pause issues persist then we can be certain it's either Electron or more likely, an issue with something outside of FreeTube on the Linux side.

**Testing (for code that is not small enough to be easily understandable)**

I tested this with the next and previous keyboard buttons as well as the actions on my Bluetooth headphones. By adding log statements to the event handlers i was also able to confirm that they are removed properly when they are no longer required.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 2809d81e5c34580738c037dbbbcd2ee331c6da34