### PR TITLE
Format playlist dates with the selected locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@silvermine/videojs-quality-selector": "^1.2.5",
     "autolinker": "^3.15.0",
     "bulma-pro": "^0.2.0",
-    "dateformat": "^4.5.1",
     "electron-context-menu": "^3.1.2",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",

--- a/src/renderer/store/modules/ytdl.js
+++ b/src/renderer/store/modules/ytdl.js
@@ -288,10 +288,10 @@ const actions = {
             break
         }
       }
-      const locale = settings.currentLocale.replace('-', '_')
+      const locale = settings.currentLocale.replace('_', '-')
       ytpl(playlistId, {
         hl: locale,
-        limit: 'Infinity',
+        limit: Infinity,
         requestOptions: { agent }
       }).then((result) => {
         resolve(result)

--- a/src/renderer/store/modules/ytdl.js
+++ b/src/renderer/store/modules/ytdl.js
@@ -288,7 +288,12 @@ const actions = {
             break
         }
       }
-      const locale = settings.currentLocale.replace('_', '-')
+      let locale = settings.currentLocale.replace('_', '-')
+
+      if (locale === 'nn') {
+        locale = 'no'
+      }
+
       ytpl(playlistId, {
         hl: locale,
         limit: Infinity,

--- a/src/renderer/store/modules/ytdl.js
+++ b/src/renderer/store/modules/ytdl.js
@@ -7,6 +7,8 @@ import { SocksProxyAgent } from 'socks-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { HttpProxyAgent } from 'http-proxy-agent'
 
+import i18n from '../../i18n/index'
+
 const state = {
   isYtSearchRunning: false
 }
@@ -288,7 +290,7 @@ const actions = {
             break
         }
       }
-      let locale = settings.currentLocale.replace('_', '-')
+      let locale = i18n.locale.replace('_', '-')
 
       if (locale === 'nn') {
         locale = 'no'

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -5,6 +5,7 @@ import FtCard from '../../components/ft-card/ft-card.vue'
 import PlaylistInfo from '../../components/playlist-info/playlist-info.vue'
 import FtListVideo from '../../components/ft-list-video/ft-list-video.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'Playlist',
@@ -37,7 +38,7 @@ export default Vue.extend({
       return this.$store.getters.getCurrentInvidiousInstance
     },
     currentLocale: function () {
-      return this.$store.getters.getCurrentLocale.replace('_', '-')
+      return i18n.locale.replace('_', '-')
     }
   },
   watch: {

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import { mapActions } from 'vuex'
-import dateFormat from 'dateformat'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import PlaylistInfo from '../../components/playlist-info/playlist-info.vue'
@@ -36,6 +35,9 @@ export default Vue.extend({
     },
     currentInvidiousInstance: function () {
       return this.$store.getters.getCurrentInvidiousInstance
+    },
+    currentLocale: function () {
+      return this.$store.getters.getCurrentLocale.replace('_', '-')
     }
   },
   watch: {
@@ -134,8 +136,7 @@ export default Vue.extend({
         }
 
         const dateString = new Date(result.updated * 1000)
-        dateString.setDate(dateString.getDate() + 1)
-        this.infoData.lastUpdated = dateFormat(dateString, 'mmm dS, yyyy')
+        this.infoData.lastUpdated = dateString.toLocaleDateString(this.currentLocale, { year: 'numeric', month: 'short', day: 'numeric' })
 
         this.playlistItems = this.playlistItems.concat(result.videos)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,11 +3177,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dateformat@^4.5.1:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
-  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
-
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
---
Format playlist dates with the selected locale
---

**Pull Request Type**

- [x] Feature Implementation

**Description**

Currently FreeTube uses the dateFormat function provided by the [dateformat](https://github.com/felixge/node-dateformat) dependency to format the date for playlists when the Invidious API is selected as a backend. It does a good job of formatting the date however it doesn't respect the users selected locale, to fix this we can use the `Date.prototype.toLocaleDateString()` function that is built into JavaScript. The only downside is that we loose the ordinals (e.g. `9th` -> `9`).

This also fixes the date having 1 day added on to it (not sure why that was there in the first place).

**Screenshots (if appropriate)**

I used German for the screenshots as the difference is clearly visible on the screenshots, it works with the other locales as well, I just didn't screenshot them.

before with the locale set to German:

![before_german](https://user-images.githubusercontent.com/48293849/168660594-01df0e1c-8048-4be9-9568-ae7b8caf749a.jpg)

after with the locale set to German:

![after_german](https://user-images.githubusercontent.com/48293849/168660611-8d477a00-2e49-4d99-945c-271c246a6ad2.jpg)

after with the locale set to English US:

![after_en_us](https://user-images.githubusercontent.com/48293849/168660620-36ddd056-b446-4109-bb34-dd642afe2b2b.jpg)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 85bbffaf6c25b89f666df4cefee81bb456f03dc1