### PR TITLE
Fix the stats for nerds modal hogging all the keyboard events

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1439,6 +1439,13 @@ export default Vue.extend({
         temporary: false,
         pauseOnOpen: false
       })
+      this.statsModal.handleKeyDown_ = (event) => {
+        // the default handler prevents keyboard events propagating beyond the modal
+        // the modal should only handle the escape and tab key, all others should be handled by the player
+        if (event.key === 'Escape' || event.key === 'Tab') {
+          this.statsModal.handleKeyDown(event)
+        }
+      }
       this.player.addChild(this.statsModal)
       this.statsModal.el_.classList.add('statsModal')
       this.statsModal.on('modalclose', () => {


### PR DESCRIPTION
---
Title
---

**Pull Request Type**
- [x] Bugfix

**Description**
By default the video.js modal component calls [`.stopPropagation()` on all `keydown` events](https://github.com/videojs/video.js/blob/main/src/js/modal-dialog.js#L450-L453), even though it only uses the tab and escape key events. To fix this issue this pull request replaces the handler and only calls the original one if the event is caused by the escape or tab keys, otherwise it ignores it which allows the event to progate unhindered to the event handler on the document.

**Testing (for code that is not small enough to be easily understandable)**
I tested that the tab and escape key events are still passed on to the modal and that other keyboard shortcuts are captured by the event handler on the document and work correctly.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 6b3874e8c908e142699db6c2b5a20d345dd667e0