### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,6 +17,8 @@ body:
           required: true  
         - label: I have searched the [issue tracker](https://github.com/FreeTubeApp/FreeTube/issues) for a bug report that matches the one I want to file, without success.
           required: true
+        - label: I have searched the [documentation](https://docs.freetubeapp.io/) for information that matches the description of the bug I want to file, without success.
+          required: true
   - type: textarea
     attributes:
       label: Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -15,6 +15,8 @@ body:
       options:
           - label: I have searched the [issue tracker](https://github.com/FreeTubeApp/FreeTube/issues) for a feature request that matches the one I want to file, without success.
             required: true
+          - label: I have searched the [documentation](https://docs.freetubeapp.io/) for information that matches the description of the feature request I want to file, without success.
+            required: true
   - type: textarea
     attributes:
       label: Problem Description


### PR DESCRIPTION
---
Update issue templates
---

**Description**
I got the feeling that nobody is searching our [documentation](docs.freetubeapp.io) before opening up an issue. That leads us to spending our time responding to people with answers they could have found in the docs.

**Additional context**
Not sure if I've worded it clear enough what people must do before opening up an issue
