### PR TITLE
Fix: wrong info displayed when quickly navigate from a channel to another

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -354,7 +354,12 @@ export default Vue.extend({
       this.isLoading = true
       this.apiUsed = 'invidious'
 
-      this.invidiousGetChannelInfo(this.id).then((response) => {
+      const id = this.id
+      this.invidiousGetChannelInfo(id).then((response) => {
+        if (id !== this.id) {
+          return
+        }
+
         console.log(response)
         this.channelName = response.author
         document.title = `${this.channelName} - ${process.env.PRODUCT_NAME}`

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -249,9 +249,9 @@ export default Vue.extend({
 
     getChannelInfoLocal: function () {
       this.apiUsed = 'local'
-      const id = this.id
-      ytch.getChannelInfo({ channelId: this.id }).then((response) => {
-        if (id !== this.id) {
+      const expectedId = this.id
+      ytch.getChannelInfo({ channelId: expectedId }).then((response) => {
+        if (expectedId !== this.id) {
           return
         }
 
@@ -313,9 +313,9 @@ export default Vue.extend({
 
     getChannelVideosLocal: function () {
       this.isElementListLoading = true
-      const id = this.id
-      ytch.getChannelVideos({ channelId: this.id, sortBy: this.videoSortBy }).then((response) => {
-        if (id !== this.id) {
+      const expectedId = this.id
+      ytch.getChannelVideos({ channelId: expectedId, sortBy: this.videoSortBy }).then((response) => {
+        if (expectedId !== this.id) {
           return
         }
 
@@ -364,9 +364,9 @@ export default Vue.extend({
       this.isLoading = true
       this.apiUsed = 'invidious'
 
-      const id = this.id
-      this.invidiousGetChannelInfo(id).then((response) => {
-        if (id !== this.id) {
+      const expectedId = this.id
+      this.invidiousGetChannelInfo(expectedId).then((response) => {
+        if (expectedId !== this.id) {
           return
         }
 
@@ -437,9 +437,9 @@ export default Vue.extend({
     },
 
     getPlaylistsLocal: function () {
-      const id = this.id
-      ytch.getChannelPlaylistInfo({ channelId: this.id, sortBy: this.playlistSortBy }).then((response) => {
-        if (id !== this.id) {
+      const expectedId = this.id
+      ytch.getChannelPlaylistInfo({ channelId: expectedId, sortBy: this.playlistSortBy }).then((response) => {
+        if (expectedId !== this.id) {
           return
         }
 

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -249,7 +249,12 @@ export default Vue.extend({
 
     getChannelInfoLocal: function () {
       this.apiUsed = 'local'
+      const id = this.id
       ytch.getChannelInfo({ channelId: this.id }).then((response) => {
+        if (id !== this.id) {
+          return
+        }
+
         this.id = response.authorId
         this.channelName = response.author
         document.title = `${this.channelName} - ${process.env.PRODUCT_NAME}`
@@ -308,7 +313,12 @@ export default Vue.extend({
 
     getChannelVideosLocal: function () {
       this.isElementListLoading = true
+      const id = this.id
       ytch.getChannelVideos({ channelId: this.id, sortBy: this.videoSortBy }).then((response) => {
+        if (id !== this.id) {
+          return
+        }
+
         this.latestVideos = response.items
         this.videoContinuationString = response.continuation
         this.isElementListLoading = false
@@ -427,7 +437,12 @@ export default Vue.extend({
     },
 
     getPlaylistsLocal: function () {
+      const id = this.id
       ytch.getChannelPlaylistInfo({ channelId: this.id, sortBy: this.playlistSortBy }).then((response) => {
+        if (id !== this.id) {
+          return
+        }
+
         console.log(response)
         this.latestPlaylists = response.items.map((item) => {
           item.proxyThumbnail = false


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix

**Related issue**
closes #1545

**Description**
Holds id in `getChannelInfoInvidious` etc. and compares to this.id, if they are different (route changed), do nothing.

**Screenshots (if appropriate)**
Before:
<video src="https://user-images.githubusercontent.com/80553357/169692829-4ff6cc7e-bb4a-4d21-9c9c-64141c790d00.mp4">

After:
<video src="https://user-images.githubusercontent.com/80553357/169692835-16c137be-daa9-4c17-b92f-bea410e2ae74.mp4">

**Desktop (please complete the following information):**
 - OS: Windows10
 - OS Version: 21H1
 - FreeTube version: 75d59a54990280c08488cb39ba136d2b38c9d0fe
