### PR TITLE
Fix caption baseurl

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1157,6 +1157,13 @@ export default Vue.extend({
           label = `${this.$t('Locale Name')} (translated from English)`
         }
 
+        const indexTranslated = captionTracks.findIndex((item) => {
+          return item.name.simpleText === label
+        })
+        if (indexTranslated !== -1) {
+          return
+        }
+
         if (enCaptionExists) {
           url = new URL(captionTracks[enCaptionIdx].baseUrl)
         } else {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -422,8 +422,9 @@ export default Vue.extend({
                   )
 
                   if (!standardLocale.startsWith('en') && noLocaleCaption) {
-                    const baseUrl = result.player_response.captions.playerCaptionsRenderer.baseUrl
-                    this.tryAddingTranslatedLocaleCaption(captionTracks, standardLocale, baseUrl)
+                    captionTracks.forEach((caption) => {
+                      this.tryAddingTranslatedLocaleCaption(captionTracks, standardLocale, caption.baseUrl)
+                    })
                   }
                 }
 


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix

**Related issue**
closes #2265

**Description**
1. Set API to Local
2. Set Language to anything but English (US, UK or System)
3. Watch any video with caption and receive error.

Also remove duplicate translations in `tryAddingTranslatedLocaleCaption`

**Screenshots (if appropriate)**
Before: API Error
<img src="https://user-images.githubusercontent.com/80553357/170221485-d1899967-a4d2-479a-b045-412e0d0b8779.PNG">

After:
<img src="https://user-images.githubusercontent.com/80553357/170221495-51bfd596-c58e-42ca-8490-64a7e6c9351a.PNG">

**Desktop (please complete the following information):**
 - OS: Windows 10 21H1
 - FreeTube version: 2332aafd68834e421bec8c75977b3dd12691f62f
