### PR TITLE
update yt-channel-info

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "vue-router": "^3.5.2",
     "vuex": "^3.6.2",
     "youtube-suggest": "^1.1.2",
-    "yt-channel-info": "^3.0.3",
+    "yt-channel-info": "^3.0.4",
     "yt-dash-manifest-generator": "1.1.0",
     "yt-trending-scraper": "^2.0.1",
     "ytdl-core": "^4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9003,10 +9003,10 @@ youtube-suggest@^1.1.2:
     node-fetch "^2.6.0"
     smol-jsonp "^1.0.0"
 
-yt-channel-info@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/yt-channel-info/-/yt-channel-info-3.0.3.tgz#3113aa505ca7511d52c02c4a7fbd16dc7c248a5d"
-  integrity sha512-M7JTFLWE+bA1t+s+H3sZ+FFV8VTaslhRFVB49I+ilBsemqAKa19EH+70uWdJrYgJQWSM5/hCSU26yBhsA8/evQ==
+yt-channel-info@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/yt-channel-info/-/yt-channel-info-3.0.4.tgz#16004068376f443df1806daf0cd6d22c69ef0301"
+  integrity sha512-MdW3upNBfcws4uth8HFL0XymxlgmuTcCu3sleXSDJml8jLOKl0iiYJe//vT00F1OXGFzSVGfQrXqf29RzkMPKw==
   dependencies:
     axios "^0.26.1"
 


### PR DESCRIPTION
---
update yt-channel-info
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
closes #2248
#2243

**Description**
This PR updates the yt-channel-info dependency

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
- Subscribe to https://youtube.com/channel/UCjr2bPAyPV7t35MvcgT3W8Q and https://youtube.com/channel/UCueOZEvMffxjJyVO1fGiJNQ so u have them listed in the sidebar for convenience.
- Click in the sidebar on the channel icon from 'the hated one' and u'll see that everything works fine.
- Go to the other channel u subscribed to and see no error

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.16.0
