### PR TITLE
Use the built-in subtle crypto library instead of node-forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "marked": "^4.0.15",
     "material-design-icons": "^3.0.1",
     "nedb-promises": "^5.0.1",
-    "node-forge": "^1.3.1",
     "opml-to-json": "^1.0.1",
     "rss-parser": "^3.12.0",
     "socks-proxy-agent": "^6.0.0",

--- a/src/renderer/store/modules/sponsorblock.js
+++ b/src/renderer/store/modules/sponsorblock.js
@@ -1,5 +1,4 @@
 import $ from 'jquery'
-import forge from 'node-forge'
 
 const state = {}
 const getters = {}
@@ -7,22 +6,30 @@ const getters = {}
 const actions = {
   sponsorBlockSkipSegments ({ rootState }, { videoId, categories }) {
     return new Promise((resolve, reject) => {
-      const messageDigestSha256 = forge.md.sha256.create()
-      messageDigestSha256.update(videoId)
-      const videoIdHashPrefix = messageDigestSha256.digest().toHex().substring(0, 4)
-      const requestUrl = `${rootState.settings.sponsorBlockUrl}/api/skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
+      const videoIdBuffer = new TextEncoder().encode(videoId)
 
-      $.getJSON(requestUrl, (response) => {
-        const segments = response
-          .filter((result) => result.videoID === videoId)
-          .flatMap((result) => result.segments)
-        resolve(segments)
-      }).fail((xhr, textStatus, error) => {
-        console.log(xhr)
-        console.log(textStatus)
-        console.log(requestUrl)
-        console.log(error)
-        reject(xhr)
+      crypto.subtle.digest('SHA-256', videoIdBuffer).then((hashBuffer) => {
+        const hashArray = Array.from(new Uint8Array(hashBuffer))
+
+        const videoIdHashPrefix = hashArray
+          .map(byte => byte.toString(16).padStart(2, '0'))
+          .slice(0, 4)
+          .join('')
+
+        const requestUrl = `${rootState.settings.sponsorBlockUrl}/api/skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
+
+        $.getJSON(requestUrl, (response) => {
+          const segments = response
+            .filter((result) => result.videoID === videoId)
+            .flatMap((result) => result.segments)
+          resolve(segments)
+        }).fail((xhr, textStatus, error) => {
+          console.log(xhr)
+          console.log(textStatus)
+          console.log(requestUrl)
+          console.log(error)
+          reject(xhr)
+        })
       })
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6356,7 +6356,7 @@ node-fetch@^2.6.0:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^1, node-forge@^1.3.1:
+node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==


### PR DESCRIPTION
---
Use the subtle crypto library built-in to Electron instead of node-forge
---

**Pull Request Type**

- [x] Feature Implementation

**Description**

Currently FreeTube uses the [node-forge](https://www.npmjs.com/package/node-forge) library to generate the hash prefix of the video id that it sends to the SponsorBlock API. This pull request removes the need for that dependency by using the [digest](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest) function provided by the SubtleCrypto library which is built into all modern webrowsers (added to Chrome in v37, FreeTube uses Electron 16 -> Chrome 96).

**Testing (for code that is not small enough to be easily understandable)**
I tested various different videos and it worked the same as it did before this pull request.

Example videos: https://youtu.be/qjw8ohwZ4nY and https://youtu.be/2ehSCWoaOqQ

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0ca42129341af43697418b6510e18207adb91f2c