### PR TITLE
Clean up ft-input for top-nav

### DIFF
--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -9,14 +9,12 @@
 
 .clearInputTextButton {
   position: absolute;
-  /* horizontal intentionally reduced to keep "I-beam pointer" visible */
-  padding: 10px 8px;
+  margin: 0 3px;
+  padding: 10px;
   top: 5px;
   left: 0;
-  cursor: pointer;
-  border-radius: 200px 200px 200px 200px;
+  border-radius: 100%;
   color: var(--primary-text-color);
-
   opacity: 0;
 
   -moz-transition: background 0.2s ease-in, opacity 0.2s ease-in;
@@ -24,10 +22,12 @@
   transition: background 0.2s ease-in, opacity 0.2s ease-in;
 }
 
-.clearInputTextButton:hover {
+.clearInputTextButton.visible:hover {
   background-color: var(--side-nav-hover-color);
 }
+
 .clearInputTextButton.visible {
+  cursor: pointer;
   opacity: 1;
 }
 
@@ -35,7 +35,7 @@
   background-color: var(--primary-color-hover);
 }
 
-.clearInputTextButton:active {
+.clearInputTextButton.visible:active {
   background-color: var(--tertiary-text-color);
   -moz-transition: background 0.2s ease-in;
   -o-transition: background 0.2s ease-in;
@@ -55,20 +55,22 @@
 }
 
 .ft-input {
-    box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    outline: none;
-    width: 100%;
-    padding: 1rem;
-    border: none;
-    background: transparent;
-    margin-bottom: 10px;
-    font-size: 16px;
-    height: 45px;
-    color: var(--secondary-text-color);
-    border-radius: 5px;
-    background-color: var(--search-bar-color);
+  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  outline: none;
+  width: 100%;
+  padding: 1rem;
+  border: none;
+  background: transparent;
+  margin-bottom: 10px;
+  font-size: 16px;
+  height: 45px;
+  color: var(--secondary-text-color);
+  border-radius: 5px;
+  background-color: var(--search-bar-color);
+
+  transition: padding 0.3s;
 }
 
 .ft-input-component ::-webkit-input-placeholder {
@@ -93,10 +95,11 @@
 
 .inputAction {
   position: absolute;
-  padding: 10px 8px;
+  margin: 0 3px;
+  padding: 10px;
   top: 5px;
   right: 0;
-  border-radius: 200px 200px 200px 200px;
+  border-radius: 100%;
   color: var(--primary-text-color);
   /* this should look disabled by default */
   opacity: 50%;
@@ -174,6 +177,8 @@
 /*   color: white; */
 }
 
-.showClearTextButton .ft-input {
-  padding-left: 2em;
+.clearInputTextButton.visible ~ .ft-input {
+  /* 36px width of clearInputTextButton plus 6px of margin */
+  padding-left: calc(36px + 6px);
+  transition: padding 0.1s;
 }

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -6,12 +6,12 @@
   padding-left: 30px;
 }
 
-.ft-input-component.clearTextButtonVibisle,
+.ft-input-component.clearTextButtonVisible,
 .ft-input-component.showClearTextButton:focus-within {
   padding-left: 0;
 }
 
-.clearTextButtonVibisle .ft-input,
+.clearTextButtonVisible .ft-input,
 .ft-input-component.showClearTextButton:focus-within .ft-input {
   padding-left: 46px;
 }
@@ -20,7 +20,7 @@
   opacity: 0.5;
 }
 
-.clearTextButtonVibisle .clearInputTextButton.visible,
+.clearTextButtonVisible .clearInputTextButton.visible,
 .ft-input-component:focus-within .clearInputTextButton.visible {
   cursor: pointer;
   opacity: 1;

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -6,22 +6,21 @@
   padding-left: 30px;
 }
 
-.ft-input-component.showClearTextButton:focus,
+.ft-input-component.clearTextButtonVibisle,
 .ft-input-component.showClearTextButton:focus-within {
   padding-left: 0;
 }
 
-.ft-input-component.showClearTextButton:focus .ft-input,
+.clearTextButtonVibisle .ft-input,
 .ft-input-component.showClearTextButton:focus-within .ft-input {
   padding-left: 46px;
 }
 
-.ft-input-component:focus .clearInputTextButton,
 .ft-input-component:focus-within .clearInputTextButton {
   opacity: 0.5;
 }
 
-.ft-input-component:focus .clearInputTextButton.visible,
+.clearTextButtonVibisle .clearInputTextButton.visible,
 .ft-input-component:focus-within .clearInputTextButton.visible {
   cursor: pointer;
   opacity: 1;

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -70,6 +70,8 @@
   border-radius: 5px;
   background-color: var(--search-bar-color);
 
+  -moz-transition: padding 0.3s;
+  -o-transition: padding 0.3s;
   transition: padding 0.3s;
 }
 
@@ -180,5 +182,4 @@
 .clearInputTextButton.visible ~ .ft-input {
   /* 36px width of clearInputTextButton plus 6px of margin */
   padding-left: calc(36px + 6px);
-  transition: padding 0.1s;
 }

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -128,7 +128,7 @@
   With arrow present means
   the text might get under the arrow with normal padding
    */
-  padding-right: 2em;
+  padding-right: calc(36px + 6px);
 }
 
 .inputAction.enabled:hover {

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -2,6 +2,31 @@
   position: relative;
 }
 
+.ft-input-component.showClearTextButton {
+  padding-left: 30px;
+}
+
+.ft-input-component.showClearTextButton:focus,
+.ft-input-component.showClearTextButton:focus-within {
+  padding-left: 0;
+}
+
+.ft-input-component.showClearTextButton:focus .ft-input,
+.ft-input-component.showClearTextButton:focus-within .ft-input {
+  padding-left: 46px;
+}
+
+.ft-input-component:focus .clearInputTextButton,
+.ft-input-component:focus-within .clearInputTextButton {
+  opacity: 0.5;
+}
+
+.ft-input-component:focus .clearInputTextButton.visible,
+.ft-input-component:focus-within .clearInputTextButton.visible {
+  cursor: pointer;
+  opacity: 1;
+}
+
 .disabled label, .disabled .ft-input{
   opacity: 0.4;
   cursor: not-allowed;
@@ -16,19 +41,13 @@
   border-radius: 100%;
   color: var(--primary-text-color);
   opacity: 0;
-
-  -moz-transition: background 0.2s ease-in, opacity 0.2s ease-in;
-  -o-transition: background 0.2s ease-in, opacity 0.2s ease-in;
-  transition: background 0.2s ease-in, opacity 0.2s ease-in;
+  -moz-transition: background 0.2s ease-in;
+  -o-transition: background 0.2s ease-in;
+  transition: background 0.2s ease-in;
 }
 
 .clearInputTextButton.visible:hover {
   background-color: var(--side-nav-hover-color);
-}
-
-.clearInputTextButton.visible {
-  cursor: pointer;
-  opacity: 1;
 }
 
 .forceTextColor .clearInputTextButton:hover {
@@ -69,10 +88,6 @@
   color: var(--secondary-text-color);
   border-radius: 5px;
   background-color: var(--search-bar-color);
-
-  -moz-transition: padding 0.3s;
-  -o-transition: padding 0.3s;
-  transition: padding 0.3s;
 }
 
 .ft-input-component ::-webkit-input-placeholder {
@@ -177,9 +192,4 @@
 .hover {
   background-color: var(--scrollbar-color-hover);
 /*   color: white; */
-}
-
-.clearInputTextButton.visible ~ .ft-input {
-  /* 36px width of clearInputTextButton plus 6px of margin */
-  padding-left: calc(36px + 6px);
 }

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -87,28 +87,6 @@ export default Vue.extend({
       return this.inputData.length > 0
     }
   },
-  watch: {
-    inputDataPresent: function (newVal, oldVal) {
-      if (newVal) {
-        // The button needs to be visible **immediately**
-        // To allow user to see the transition
-        this.clearTextButtonExisting = true
-        // The transition is not rendered if this property is set right after
-        // It's visible
-        setTimeout(() => {
-          this.clearTextButtonVisible = true
-        }, 0)
-      } else {
-        // Hide the button with transition
-        this.clearTextButtonVisible = false
-        // Remove the button after the transition
-        // 0.2s in CSS = 200ms in JS
-        setTimeout(() => {
-          this.clearTextButtonExisting = false
-        }, 200)
-      }
-    }
-  },
   mounted: function () {
     this.id = this._uid
     this.inputData = this.value
@@ -136,6 +114,9 @@ export default Vue.extend({
     },
 
     handleClearTextClick: function () {
+      // No action if no input text
+      if (!this.inputDataPresent) { return }
+
       this.inputData = ''
       this.handleActionIconChange()
       this.updateVisibleDataList()

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -6,6 +6,7 @@
       forceTextColor: forceTextColor,
       showActionButton: showActionButton,
       showClearTextButton: showClearTextButton,
+      clearTextButtonVibisle: inputDataPresent,
       disabled: disabled
     }"
   >

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -6,7 +6,7 @@
       forceTextColor: forceTextColor,
       showActionButton: showActionButton,
       showClearTextButton: showClearTextButton,
-      clearTextButtonVibisle: inputDataPresent,
+      clearTextButtonVisible: inputDataPresent,
       disabled: disabled
     }"
   >

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -22,11 +22,11 @@
       />
     </label>
     <font-awesome-icon
-      v-if="showClearTextButton && clearTextButtonExisting"
+      v-if="showClearTextButton"
       icon="times-circle"
       class="clearInputTextButton"
       :class="{
-        visible: clearTextButtonVisible
+        visible: inputDataPresent
       }"
       tabindex="0"
       role="button"


### PR DESCRIPTION
---
Clean up ft-input for top-nav
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
Fragmentation of #1793, slightly cleans up ft-input logic.

* Removed setTimeout for transition and opted for a CSS solution instead
* Made both clearInputTextButton and actionButton the same width/height for visual consistency

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/18506096/171151837-a5da0094-2814-49df-b8fb-f24c639ce04a.png)

After:
![image](https://user-images.githubusercontent.com/18506096/171151979-cd12a3bc-7b4f-4ed9-92e8-d0a2e20fcf68.png)

**Testing (for code that is not small enough to be easily understandable)**
Looked through the app and tried to input text anywhere I could to check for visual errors.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] Debian
 - OS Version: [e.g. 22] 10
 - FreeTube version: [e.g. 0.8] upstream/development

**Additional context**
Feels like we need an "improvement" PR type, this is really neither a bugfix or a feature :)

Removing the setTimeout for the transition actually fixed a slight bug where the clearInputTextButton would not show up if you deleted and started typing text fast enough.
