### PR TITLE
Fix webpack deprecation warnings in the dev-runner

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -115,7 +115,7 @@ function startRenderer(callback) {
     console.log(`\nWatching file changes for ${name} script...`)
   })
 
-  const server = new WebpackDevServer(compiler, {
+  const server = new WebpackDevServer({
     static: {
       directory: path.join(process.cwd(), 'static'),
       watch: {
@@ -126,9 +126,9 @@ function startRenderer(callback) {
       }
     },
     port
-  })
+  }, compiler)
 
-  server.listen(port, '', err => {
+  server.startCallback(err => {
     if (err) console.error(err)
 
     callback()


### PR DESCRIPTION
---
Fix webpack deprecation warnings in the dev-runner
---

**Pull Request Type**

- [x] Bugfix

**Description**
This pull request fixes the two deprecation warnings output by webpack when the using the dev-runner script (`yarn dev`)
The deprecation warnings in question:
```
(node:5376) [DEP_WEBPACK_DEV_SERVER_CONSTRUCTOR] DeprecationWarning: Using 'compiler' as the first argument is deprecated. Please use 'options' as the first argument and 'compiler' as the second argument.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:5376) [DEP_WEBPACK_DEV_SERVER_LISTEN] DeprecationWarning: 'listen' is deprecated. Please use the async 'start' or 'startCallback' method.
```

**Testing (for code that is not small enough to be easily understandable)**
Starting FreeTube in with the dev-runner script by running `yarn dev` works as expected.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 331f65ec264aeb77f66a7b8544fbbf8c2194ceea