### PR TITLE
Allow Unsubscribing from Deleted Channels

### DIFF
--- a/src/renderer/store/modules/subscriptions.js
+++ b/src/renderer/store/modules/subscriptions.js
@@ -4,7 +4,8 @@ const state = {
   allSubscriptionsList: [],
   profileSubscriptions: {
     activeProfile: MAIN_PROFILE_ID,
-    videoList: []
+    videoList: [],
+    errorChannels: []
   }
 }
 

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -92,14 +92,9 @@ export default Vue.extend({
     },
 
     subscriptionInfo: function () {
-      const subIndex = this.activeProfile.subscriptions.findIndex((channel) => {
+      return this.activeProfile.subscriptions.find((channel) => {
         return channel.id === this.id
-      })
-      if (subIndex !== -1) {
-        return this.activeProfile.subscriptions[subIndex]
-      } else {
-        return null
-      }
+      }) ?? null
     },
 
     isSubscribed: function () {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -403,6 +403,7 @@ export default Vue.extend({
           this.bannerUrl = null
         }
 
+        this.errorMessage = ''
         this.isLoading = false
       }).catch((err) => {
         this.setErrorMessage(err.responseJSON.error)

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -650,6 +650,7 @@ export default Vue.extend({
     },
 
     setErrorMessage: function (errorMessage) {
+      this.isLoading = false
       this.errorMessage = errorMessage
       this.id = this.subscriptionInfo.id
       this.channelName = this.subscriptionInfo.name

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -3,7 +3,7 @@
     ref="search"
   >
     <ft-loader
-      v-if="isLoading"
+      v-if="isLoading && !isErrorMessage"
       :fullscreen="true"
     />
     <ft-card

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -3,7 +3,7 @@
     ref="search"
   >
     <ft-loader
-      v-if="isLoading && !isErrorMessage"
+      v-if="isLoading && !errorMessage"
       :fullscreen="true"
     />
     <ft-card

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -61,6 +61,7 @@
         </div>
 
         <ft-flex-box
+          v-if="!errorMessage"
           class="channelInfoTabs"
         >
           <div
@@ -112,7 +113,7 @@
       </div>
     </ft-card>
     <ft-card
-      v-if="!isLoading"
+      v-if="!isLoading && !errorMessage"
       class="card"
     >
       <div
@@ -193,6 +194,14 @@
           <font-awesome-icon icon="search" /> {{ $t("Search Filters.Fetch more results") }}
         </div>
       </div>
+    </ft-card>
+    <ft-card
+      v-if="errorMessage"
+      class="card"
+    >
+      <p>
+        {{ errorMessage }}
+      </p>
     </ft-card>
   </div>
 </template>

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -14,6 +14,10 @@
   right: 10px;
 }
 
+.channelBubble {
+  display: inline-block;
+}
+
 @media only screen and (max-width: 350px) {
   .floatingTopButton {
     position: absolute

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -113,6 +113,7 @@ export default Vue.extend({
           }))
         } else {
           this.videoList = subscriptionList.videoList
+          this.errorChannels = subscriptionList.errorChannels
         }
       } else {
         this.getProfileSubscriptions()

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -6,6 +6,7 @@ import FtButton from '../../components/ft-button/ft-button.vue'
 import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
+import FtChannelBubble from '../../components/ft-channel-bubble/ft-channel-bubble.vue'
 
 import ytch from 'yt-channel-info'
 import Parser from 'rss-parser'
@@ -19,13 +20,15 @@ export default Vue.extend({
     'ft-button': FtButton,
     'ft-icon-button': FtIconButton,
     'ft-flex-box': FtFlexBox,
-    'ft-element-list': FtElementList
+    'ft-element-list': FtElementList,
+    'ft-channel-bubble': FtChannelBubble
   },
   data: function () {
     return {
       isLoading: false,
       dataLimit: 100,
-      videoList: []
+      videoList: [],
+      errorChannels: []
     }
   },
   computed: {
@@ -123,6 +126,10 @@ export default Vue.extend({
     }
   },
   methods: {
+    goToChannel: function (id) {
+      this.$router.push({ path: `/channel/${id}` })
+    },
+
     getSubscriptions: function () {
       if (this.activeSubscriptionList.length === 0) {
         this.isLoading = false
@@ -144,10 +151,9 @@ export default Vue.extend({
 
       let videoList = []
       let channelCount = 0
-
+      this.errorChannels = []
       this.activeSubscriptionList.forEach(async (channel) => {
         let videos = []
-
         if (!this.usingElectron || this.backendPreference === 'invidious') {
           if (useRss) {
             videos = await this.getChannelVideosInvidiousRSS(channel)
@@ -174,7 +180,8 @@ export default Vue.extend({
 
           const profileSubscriptions = {
             activeProfile: this.activeProfile._id,
-            videoList: videoList
+            videoList: videoList,
+            errorChannels: this.errorChannels
           }
 
           this.videoList = await Promise.all(videoList.filter((video) => {
@@ -226,6 +233,11 @@ export default Vue.extend({
     getChannelVideosLocalScraper: function (channel, failedAttempts = 0) {
       return new Promise((resolve, reject) => {
         ytch.getChannelVideos({ channelId: channel.id, sortBy: 'latest' }).then(async (response) => {
+          if (response.alertMessage) {
+            this.errorChannels.push(channel)
+            resolve([])
+            return
+          }
           const videos = await Promise.all(response.items.map(async (video) => {
             if (video.liveNow) {
               video.publishedDate = new Date().getTime()
@@ -297,33 +309,38 @@ export default Vue.extend({
           resolve(items)
         }).catch((err) => {
           console.log(err)
-          const errorMessage = this.$t('Local API Error (Click to copy)')
-          this.showToast({
-            message: `${errorMessage}: ${err}`,
-            time: 10000,
-            action: () => {
-              navigator.clipboard.writeText(err)
-            }
-          })
-          switch (failedAttempts) {
-            case 0:
-              resolve(this.getChannelVideosLocalScraper(channel, failedAttempts + 1))
-              break
-            case 1:
-              if (this.backendFallback) {
-                this.showToast({
-                  message: this.$t('Falling back to Invidious API')
-                })
-                resolve(this.getChannelVideosInvidiousRSS(channel, failedAttempts + 1))
-              } else {
-                resolve([])
+          if (err.toString().match(/404/)) {
+            this.errorChannels.push(channel)
+            resolve([])
+          } else {
+            const errorMessage = this.$t('Local API Error (Click to copy)')
+            this.showToast({
+              message: `${errorMessage}: ${err}`,
+              time: 10000,
+              action: () => {
+                navigator.clipboard.writeText(err)
               }
-              break
-            case 2:
-              resolve(this.getChannelVideosLocalScraper(channel, failedAttempts + 1))
-              break
-            default:
-              resolve([])
+            })
+            switch (failedAttempts) {
+              case 0:
+                resolve(this.getChannelVideosLocalScraper(channel, failedAttempts + 1))
+                break
+              case 1:
+                if (this.backendFallback) {
+                  this.showToast({
+                    message: this.$t('Falling back to Invidious API')
+                  })
+                  resolve(this.getChannelVideosInvidiousRSS(channel, failedAttempts + 1))
+                } else {
+                  resolve([])
+                }
+                break
+              case 2:
+                resolve(this.getChannelVideosLocalScraper(channel, failedAttempts + 1))
+                break
+              default:
+                resolve([])
+            }
           }
         })
       })
@@ -403,25 +420,30 @@ export default Vue.extend({
               navigator.clipboard.writeText(err)
             }
           })
-          switch (failedAttempts) {
-            case 0:
-              resolve(this.getChannelVideosInvidiousScraper(channel, failedAttempts + 1))
-              break
-            case 1:
-              if (this.backendFallback) {
-                this.showToast({
-                  message: this.$t('Falling back to the local API')
-                })
-                resolve(this.getChannelVideosLocalRSS(channel, failedAttempts + 1))
-              } else {
+          if (err.toString().match(/500/)) {
+            this.errorChannels.push(channel)
+            resolve([])
+          } else {
+            switch (failedAttempts) {
+              case 0:
+                resolve(this.getChannelVideosInvidiousScraper(channel, failedAttempts + 1))
+                break
+              case 1:
+                if (this.backendFallback) {
+                  this.showToast({
+                    message: this.$t('Falling back to the local API')
+                  })
+                  resolve(this.getChannelVideosLocalRSS(channel, failedAttempts + 1))
+                } else {
+                  resolve([])
+                }
+                break
+              case 2:
+                resolve(this.getChannelVideosInvidiousScraper(channel, failedAttempts + 1))
+                break
+              default:
                 resolve([])
-              }
-              break
-            case 2:
-              resolve(this.getChannelVideosInvidiousScraper(channel, failedAttempts + 1))
-              break
-            default:
-              resolve([])
+            }
           }
         })
       })

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -8,6 +8,22 @@
       v-else
       class="card"
     >
+      <div
+        v-if="errorChannels.length !== 0"
+      >
+        <h3> {{ $t("Subscriptions.Error Channels") }}</h3>
+        <div>
+          <ft-channel-bubble
+            v-for="(channel, index) in errorChannels"
+            :key="index"
+            :channel-name="channel.name"
+            :channel-id="channel.id"
+            :channel-thumbnail="channel.thumbnail"
+            class="channelBubble"
+            @click="goToChannel(channel.id)"
+          />
+        </div>
+      </div>
       <h3>{{ $t("Subscriptions.Subscriptions") }}</h3>
       <ft-flex-box
         v-if="activeVideoList.length === 0"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -79,7 +79,7 @@ Subscriptions:
     # On Subscriptions Page
   Subscriptions: Subscriptions
   # channels that were likely deleted
-  Error Channels: Error Channels
+  Error Channels: Channels with Errors
   Latest Subscriptions: Latest Subscriptions
   This profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting: This
     profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -78,6 +78,8 @@ Search Filters:
 Subscriptions:
     # On Subscriptions Page
   Subscriptions: Subscriptions
+  # channels that were likely deleted
+  Error Channels: Error Channels
   Latest Subscriptions: Latest Subscriptions
   This profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting: This
     profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting


### PR DESCRIPTION
---
Allow Unsubscribing from Deleted Channels
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [x] Feature Implementation

**Related issue**
closes #2133 
closes #1231 
closes #1590
closes #555

**Description**
This PR will try to find channels that may have been deleted when your subscriptions get loaded (except when using Invidious that's not in RSS) and it allows you to load the subscription information that is saved when viewing a channel page

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/78101139/171316615-2ea1926f-d4d1-4eeb-b2d1-817037262bf1.png)

![image](https://user-images.githubusercontent.com/78101139/171316552-6b8ec986-d97a-4e9e-9269-0293995e4877.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been testedZ

I was able to get the links of two channels that were deleted for different reasons and I tested:
**refreshing the Subscription page** with 
  - Local API + RSS
  - Local API + RSS Disabled
  - Invidious + RSS
  - Invidious + RSS Disabled (not currently useful)
 
I also tested **navigating to the channels** with invidious and local api and was able to unsubscribe

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.16.0

**Additional context**
Test Subscription File (change extension from txt to db):
[Test Subscriptions.txt](https://github.com/FreeTubeApp/FreeTube/files/8810688/Test.Subscriptions.txt)
 