### PR TITLE
Remove usage of fixed positioning for core UI elements

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -3,24 +3,15 @@
   src: url(assets/font/Roboto-Regular.ttf);
 }
 
-body {
-  min-height: 100vh;
-}
-
 #app {
+  display: flex;
+  flex-wrap: wrap;
   font-family: 'Roboto', sans-serif;
 }
 
 .routerView {
-  margin-left: 200px;
-  margin-top: 80px;
-  transition-property: margin;
-  transition-duration: 150ms;
-  transition-timing-function: ease-in-out;
-}
-
-.expand {
-  margin-left: 80px;
+  flex: 1 1 0%;
+  margin: 18px 10px;
 }
 
 .banner {
@@ -46,9 +37,8 @@ body {
 }
 
 @media only screen and (max-width: 680px) {
-  .expand, .routerView {
-    margin-left: 0px;
-    margin-bottom: 80px;
+  .routerView {
+    margin: 68px 8px 68px;
   }
 
   .banner {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -12,7 +12,6 @@
     <ft-flex-box
       v-if="showUpdatesBanner || showBlogBanner"
       class="flexBox routerView"
-      :class="{ expand: !isOpen }"
     >
       <ft-notification-banner
         v-if="showUpdatesBanner"
@@ -36,7 +35,6 @@
       <RouterView
         ref="router"
         class="routerView"
-        :class="{ expand: !isOpen }"
       />
       <!-- </keep-alive> -->
     </transition>

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -167,10 +167,11 @@
   }
 
   .sideNav {
-    bottom: 0;
-    display: flex;
-    left: 0;
     position: fixed;
+    left: 0;
+    bottom: 0;
+
+    display: flex;
   }
 
   .topNavOption {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -3,11 +3,10 @@
   height: calc(100vh - 60px);
   width: 200px;
   overflow-x: hidden;
-  position: fixed;
-  left: 0px;
-  top: 0px;
-  z-index: 4;
-  margin-top: 60px;
+  position: sticky;
+  left: 0;
+  top: 60px;
+  z-index: 3;
   box-shadow: 1px -1px 1px -1px var(--primary-shadow-color);
   background-color: var(--side-nav-color);
   transition-property: width;
@@ -168,7 +167,10 @@
   }
 
   .sideNav {
+    bottom: 0;
     display: flex;
+    left: 0;
+    position: fixed;
   }
 
   .topNavOption {

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -44,10 +44,6 @@ export default Vue.extend({
       return this.$store.getters.getSearchSettings
     },
 
-    isSideNavOpen: function () {
-      return this.$store.getters.getIsSideNavOpen
-    },
-
     barColor: function () {
       return this.$store.getters.getBarColor
     },

--- a/src/renderer/components/top-nav/top-nav.sass
+++ b/src/renderer/components/top-nav/top-nav.sass
@@ -24,7 +24,7 @@
 
   @include top-nav-is-colored
     background-color: var(--primary-color)
-  
+
   @media only screen and (max-width: 680px)
     position: fixed
 
@@ -164,7 +164,3 @@
       left: 0
       right: 0
       margin: 95px 10px 0px
-
-    @media only screen and (min-width: 681px)
-      &.expand
-        margin-left: 100px

--- a/src/renderer/components/top-nav/top-nav.sass
+++ b/src/renderer/components/top-nav/top-nav.sass
@@ -4,12 +4,13 @@
       @content
 
 .topNav
-  position: fixed
+  position: sticky
   z-index: 4
   left: 0
   right: 0
   top: 0
   height: 60px
+  width: 100%
   line-height: 60px
   background-color: var(--card-bg-color)
   -webkit-box-shadow: 0px 2px 1px 0px var(--primary-shadow-color)
@@ -23,6 +24,9 @@
 
   @include top-nav-is-colored
     background-color: var(--primary-color)
+  
+  @media only screen and (max-width: 680px)
+    position: fixed
 
 .menuIcon // the hamburger button
   @media only screen and (max-width: 680px)

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -90,7 +90,6 @@
       <ft-search-filters
         v-show="showFilters"
         class="searchFilters"
-        :class="{ expand: !isSideNavOpen }"
         @filterValueUpdated="handleSearchFilterValueChanged"
       />
     </div>

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -619,6 +619,8 @@
 }
 
 body {
+  margin: 0;
+  min-height: 100vh;
   color: var(--primary-text-color);
   background-color: var(--bg-color);
   --red-500: #f44336;

--- a/src/renderer/views/Watch/Watch.sass
+++ b/src/renderer/views/Watch/Watch.sass
@@ -1,5 +1,5 @@
 =dual-column-template
-  grid-template: "video video sidebar" 0fr "info info sidebar" auto "info info sidebar" auto / 1fr 1fr 1fr
+  grid-template: "video video sidebar" 0fr "info info sidebar" 1fr "info info sidebar" 1fr / 1fr 1fr 1fr
 
 =theatre-mode-template
   grid-template: "video video video" auto "info info sidebar" auto "info info sidebar" auto / 1fr 1fr 1fr
@@ -65,6 +65,8 @@
     grid-column: 1
 
   .infoArea
+    position: sticky
+    top: 76px
     grid-area: info
 
   .sidebarArea

--- a/src/renderer/views/Watch/Watch.sass
+++ b/src/renderer/views/Watch/Watch.sass
@@ -29,7 +29,7 @@
     grid-area: video
 
     .videoAreaMargin
-      margin: 0px 8px 16px
+      margin: 0 0 16px
 
     .videoPlayer
       grid-column: 1
@@ -61,13 +61,16 @@
           margin-top: 10px
 
   .watchVideo
-    margin: 0px 8px 16px
+    margin: 0 0 16px
     grid-column: 1
 
   .infoArea
-    position: sticky
-    top: 76px
     grid-area: info
+    position: relative
+
+    @media only screen and (min-width: 901px)
+      position: sticky
+      top: 76px
 
   .sidebarArea
     grid-area: sidebar
@@ -85,4 +88,7 @@
     height: 500px
 
   .watchVideoRecommendations, .theatreRecommendations
-    margin: 0 8px 16px
+    margin: 0 0 16px
+
+    @media only screen and (min-width: 901px)
+      margin: 0 8px 16px


### PR DESCRIPTION
---
Remove usage of fixed positioning for core UI elements
---
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
N/A

**Description**
This PR attempts to remove the usage of margins for positioning the UI elements (routerView, top-nav, side-nav, etc.) and replace it with a more modern approach using flexbox and sticky positioning.

* Remove position: fixed from top-nav and side-nav
* Reduce z-index position of side-nav to make it not overlap the box-shadow on the top-nav
* Make video infoArea sticky so it follows users scroll (in the case there are many suggested videos)

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/18506096/171427537-3c295eb2-70e6-4ee1-a729-ed64670d7eef.png)

After:
![image](https://user-images.githubusercontent.com/18506096/171427416-eee934a1-7c22-4bef-a6e6-efe6271af74c.png)

Before:
![image](https://user-images.githubusercontent.com/18506096/171427676-f34cb246-29af-4009-b90e-fa75b16f9140.png)

After:
![image](https://user-images.githubusercontent.com/18506096/171427803-650c434c-85bc-4499-bdae-0b33908b2647.png)

**Testing (for code that is not small enough to be easily understandable)**
I ran through most of the app, making sure that I checked as many views as I could.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] 10
 - OS Version: [e.g. 22] Debian
 - FreeTube version: [e.g. 0.8] upstream/development

**Additional context**
Very open to discuss about this PR and how it should work. For now I just wanted to get rid of some of the CSS-smell that we had with the margin positioning that I feel were causing me headaches when working on the rest of the app.
