### PR TITLE
PR label automation conflicts

### DIFF
--- a/conflicts.yml
+++ b/conflicts.yml
@@ -1,0 +1,25 @@
+name: "Conflicts"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+  workflow_run:
+    workflows: ['Dummy workflow for conflicts']
+    types: [requested]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "PR: merge conflicts / rebase needed"
+          removeOnDirtyLabel: "PR: waiting for review"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."

--- a/dummy-conflicts.yml
+++ b/dummy-conflicts.yml
@@ -1,0 +1,9 @@
+name: Dummy workflow for conflicts
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "this is a dummy workflow that triggers a workflow_run; it's necessary because otherwise the repo secrets will not be in scope for externally forked pull requests"


### PR DESCRIPTION
---
PR label automation conflicts
---

**Pull Request Type**
- [x] Feature Implementation

**Related issue**
https://github.com/FreeTubeApp/FreeTube/issues/1720

**Description**

- [x] Added workflow for conflicts
- [ ] Added workflow for requested changes
- [ ] Added workflow for waiting for review

Other workflows will hopefully get added soon. All workflows i tested do not work at the moment when opened from forks. I have created issues for them but most of them seem to be abandoned because of this reason :(

**Testing (for code that is not small enough to be easily understandable)**
All workflows have been extensively tested in https://github.com/FreeTubeApp/Test-Repo

1. Fork https://github.com/FreeTubeApp/Test-Repo
2. create a PR from the fork
3. add the waiting for review label
4. create conflict
5. conflict label and comment gets added to notify author of PR
6. resolve conflict
7. conflict label will be removed and waiting for review label gets added

**Additional context**
GitHub doesn't allow workflows to trigger from a fork. To workaround this i created a dummy workflow that calls the real workflow. 

Tested this like 1000 times and if u dont want to just take a look at https://github.com/FreeTubeApp/Test-Repo/pull/76