### PR TITLE
Fix ft-input bug padding

### DIFF
--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -11,7 +11,7 @@
   padding-left: 0;
 }
 
-.ft-input-component:not(.search) .ft-input {
+.ft-input-component.showClearTextButton:not(.search) .ft-input {
   padding-left: 46px;
 }
 

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -2,17 +2,22 @@
   position: relative;
 }
 
-.ft-input-component.showClearTextButton {
+.ft-input-component.search.showClearTextButton {
   padding-left: 30px;
 }
 
-.ft-input-component.clearTextButtonVisible,
-.ft-input-component.showClearTextButton:focus-within {
+.ft-input-component.search.clearTextButtonVisible,
+.ft-input-component.search.showClearTextButton:focus-within {
   padding-left: 0;
 }
 
-.clearTextButtonVisible .ft-input,
-.ft-input-component.showClearTextButton:focus-within .ft-input {
+.ft-input-component:not(.search) .ft-input {
+  padding-left: 46px;
+}
+
+/* Main search input */
+.clearTextButtonVisible.search .ft-input,
+.ft-input-component.search.showClearTextButton:focus-within .ft-input {
   padding-left: 46px;
 }
 


### PR DESCRIPTION
---
Fix ft-input bug padding
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
#2279

**Description**
Fixes bug found by @PikachuEXE https://github.com/FreeTubeApp/FreeTube/pull/2279#issuecomment-1144835903
I made the padding trick only happen on the main search input, this should fix it for the rest of the inputs across the app.

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] 10
 - OS Version: [e.g. 22] Debian
 - FreeTube version: [e.g. 0.8] upstream/development

**Additional context**
Thanks for catching it pika
