### PR TITLE
Fix confusing zoomin shortcut

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -801,9 +801,12 @@ function runApp() {
           { role: 'toggledevtools' },
           { type: 'separator' },
           { role: 'resetzoom' },
+          { role: 'resetzoom', accelerator: 'CmdOrCtrl+num0', visible: false },
           { role: 'zoomin', accelerator: 'CmdOrCtrl+Plus' },
           { role: 'zoomin', accelerator: 'CmdOrCtrl+=', visible: false },
+          { role: 'zoomin', accelerator: 'CmdOrCtrl+numadd', visible: false },
           { role: 'zoomout' },
+          { role: 'zoomout', accelerator: 'CmdOrCtrl+numsub', visible: false },
           { type: 'separator' },
           { role: 'togglefullscreen' }
         ]

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -801,7 +801,8 @@ function runApp() {
           { role: 'toggledevtools' },
           { type: 'separator' },
           { role: 'resetzoom' },
-          { role: 'zoomin' },
+          { role: 'zoomin', accelerator: 'CmdOrCtrl+Plus' },
+          { role: 'zoomin', accelerator: 'CmdOrCtrl+=', visible: false },
           { role: 'zoomout' },
           { type: 'separator' },
           { role: 'togglefullscreen' }


### PR DESCRIPTION
---
Fix confusing zoomin shortcut
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Closes #1247 

**Description**
Adds a "hidden" global shortcut for zooming in (ctrl + equals) that should fix some of the confusion over the zoomin shortcuts, also adds zoom shortcuts using numpad (numpad +, -, and 0) to mirror browser behaviour.

**Testing (for code that is not small enough to be easily understandable)**
Zoom in and out a bunch with keyboard shortcuts :)

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] 10
 - OS Version: [e.g. 22] Debian
 - FreeTube version: [e.g. 0.8] upstream/development

**Additional context**
I tried to do some digging into how we could sync UI scale with the zoom properly, sadly I didn't come to any clear conclusions. Electron only sends an event on changing zoom via mouse wheel. Annoying!