### PR TITLE
Fix channel names being cut off

### DIFF
--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
@@ -1,9 +1,14 @@
 .bubblePadding {
   position: relative;
   width: 100px;
-  height: 115px;
+  height: 100px;
   padding: 10px;
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  overflow: hidden;
   -webkit-transition: background 0.2s ease-out;
   -moz-transition: background 0.2s ease-out;
   -o-transition: background 0.2s ease-out;
@@ -20,10 +25,8 @@
 .bubble {
   width: 50px;
   height: 50px;
-  margin-bottom: 5px;
-  margin-left: 25px;
-  border-radius: 200px 200px 200px 200px;
-  -webkit-border-radius: 200px 200px 200px 200px;
+  border-radius: 100%;
+  -webkit-border-radius: 100%;
 }
 
 .selected {
@@ -41,8 +44,10 @@
 }
 
 .channelName {
+  display: block;
   font-size: 13px;
-  height: 60px;
   overflow: hidden;
   text-align: center;
+  text-overflow: ellipsis;
+  width: 100%;
 }


### PR DESCRIPTION
---
Fix channel names being cut off
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Closes #2291 

**Description**
Adds ellipsis overflow to featured channel names

**Testing**
1. Go to channel: https://www.youtube.com/c/Whitelight
2. Go to "About" tab
3. Compare Feature Channel "MandaloreGaming" between upstream and PR.

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/18506096/172044462-50e53eb4-f37b-450f-bf3f-1a51cb69e1ad.png)

After:
![image](https://user-images.githubusercontent.com/18506096/172044454-ec3ed769-a9fd-4b74-8f12-bd0804e37fda.png)

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] 10
 - OS Version: [e.g. 22] Debian
 - FreeTube version: [e.g. 0.8] upstream/development
