### PR TITLE
Improve channel info bar

### DIFF
--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -127,6 +127,7 @@
 
 .channelSearch {
   margin-top: 10px;
+  max-width: 320px;
 }
 
 .elementListLoading {
@@ -171,5 +172,6 @@
 
   .channelSearch {
     width: 100%;
+    max-width: none;
   }
 }

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -6,7 +6,7 @@
 }
 
 .channelDetails {
-  padding: 0 0 16px;
+  padding: 0;
 }
 
 .channelBannerContainer {
@@ -65,38 +65,50 @@
 
 .channelSearch {
   width: 200px;
+  margin-left: auto;
   align-self: flex-end;
+  flex: 1 1 0%;
 }
 
 .sortSelect {
-  align-self: flex-end;
+  margin-left: auto;
 }
 
 .channelInfoTabs {
   position: relative;
   width: 100%;
-  margin-top: -16px;
-  margin-bottom: -13px;
+  height: 85px;
+  justify-content: unset;
+  gap: 32px;
+}
+
+.tabs {
+  display: flex;
+  flex: 0 1 33%;
 }
 
 .tab {
   padding: 15px;
   font-size: 15px;
   cursor: pointer;
+  flex: 1 1 0%;
   align-self: flex-end;
+  text-align: center;
   color: var(--tertiary-text-color);
-}
-
-.selectedTab {
-  color: var(--primary-text-color);
-  border-bottom: 3px solid var(--primary-color);
-  margin-bottom: -3px;
-  font-weight: bold;
-  box-sizing: border-box;
+  border-bottom: 3px solid transparent;
 }
 
 .tab:hover {
   font-weight: bold;
+  border-bottom: 3px solid var(--tertiary-text-color);
+}
+
+.selectedTab,
+.selectedTab:hover {
+  color: var(--primary-text-color);
+  border-bottom: 3px solid var(--primary-color);
+  font-weight: bold;
+  box-sizing: border-box;
 }
 
 .aboutTab {
@@ -115,10 +127,6 @@
 
 .channelSearch {
   margin-top: 10px;
-}
-
-.elementList {
-  margin-top: 15px;
 }
 
 .elementListLoading {
@@ -153,4 +161,15 @@
 .channelLineContainer h1,
 .channelLineContainer p {
   margin: 0;
+}
+
+@media only screen and (max-width: 800px) {
+  .channelInfoTabs {
+    height: auto;
+    flex-flow: column-reverse;
+  }
+
+  .channelSearch {
+    width: 100%;
+  }
 }

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -64,50 +64,35 @@
           v-if="!errorMessage"
           class="channelInfoTabs"
         >
-          <div
-            class="tab"
-            :class="(currentTab==='videos')?'selectedTab':''"
-            @click="changeTab('videos')"
-          >
-            {{ $t("Channel.Videos.Videos").toUpperCase() }}
+          <div class="tabs">
+            <div
+              class="tab"
+              :class="(currentTab==='videos')?'selectedTab':''"
+              @click="changeTab('videos')"
+            >
+              {{ $t("Channel.Videos.Videos").toUpperCase() }}
+            </div>
+            <div
+              class="tab"
+              :class="(currentTab==='playlists')?'selectedTab':''"
+              @click="changeTab('playlists')"
+            >
+              {{ $t("Channel.Playlists.Playlists").toUpperCase() }}
+            </div>
+            <div
+              class="tab"
+              :class="(currentTab==='about')?'selectedTab':''"
+              @click="changeTab('about')"
+            >
+              {{ $t("Channel.About.About").toUpperCase() }}
+            </div>
           </div>
-          <div
-            class="tab"
-            :class="(currentTab==='playlists')?'selectedTab':''"
-            @click="changeTab('playlists')"
-          >
-            {{ $t("Channel.Playlists.Playlists").toUpperCase() }}
-          </div>
-          <div
-            class="tab"
-            :class="(currentTab==='about')?'selectedTab':''"
-            @click="changeTab('about')"
-          >
-            {{ $t("Channel.About.About").toUpperCase() }}
-          </div>
+
           <ft-input
             :placeholder="$t('Channel.Search Channel')"
             :select-on-focus="true"
             class="channelSearch"
             @click="newSearch"
-          />
-          <ft-select
-            v-show="currentTab === 'videos'"
-            class="sortSelect"
-            :value="videoSelectValues[0]"
-            :select-names="videoSelectNames"
-            :select-values="videoSelectValues"
-            :placeholder="$t('Search Filters.Sort By.Sort By')"
-            @change="videoSortBy = $event"
-          />
-          <ft-select
-            v-show="currentTab === 'playlists'"
-            class="sortSelect"
-            :value="playlistSelectValues[0]"
-            :select-names="playlistSelectNames"
-            :select-values="playlistSelectValues"
-            :placeholder="$t('Search Filters.Sort By.Sort By')"
-            @change="playlistSortBy = $event"
           />
         </ft-flex-box>
       </div>
@@ -146,6 +131,24 @@
           />
         </ft-flex-box>
       </div>
+      <ft-select
+        v-show="currentTab === 'videos'"
+        class="sortSelect"
+        :value="videoSelectValues[0]"
+        :select-names="videoSelectNames"
+        :select-values="videoSelectValues"
+        :placeholder="$t('Search Filters.Sort By.Sort By')"
+        @change="videoSortBy = $event"
+      />
+      <ft-select
+        v-show="currentTab === 'playlists'"
+        class="sortSelect"
+        :value="playlistSelectValues[0]"
+        :select-names="playlistSelectNames"
+        :select-values="playlistSelectValues"
+        :placeholder="$t('Search Filters.Sort By.Sort By')"
+        @change="playlistSortBy = $event"
+      />
       <ft-loader
         v-if="isElementListLoading"
       />


### PR DESCRIPTION
---
Improve channel info bar
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
N/A

**Description**
Slight refactor to the way we render the channel info bar fixing some issues and improving on others:

* Fixes issue where tabs would "jump around" when you navigate over to the about tab
* Fixes cramped space on mobile and desktop view

**Screenshots (if appropriate)**
Before:
![image](https://user-images.githubusercontent.com/18506096/172045403-74fe8f1f-ba7f-4b08-82f5-8c672caa1dd7.png)

After:
![image](https://user-images.githubusercontent.com/18506096/172607594-2e30ba72-2455-4e4f-9923-ccec9bb8d6a2.png)

**Desktop (please complete the following information):**
 - OS: [e.g. iOS] 10
 - OS Version: [e.g. 22] Debian
 - FreeTube version: [e.g. 0.8] upstream/development
