### PR TITLE
Prevent packaging unneeded dependency files

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -57,13 +57,22 @@ const config = {
     '_icons/iconColor.*',
     'icon.svg',
     './dist/**/*',
-    '!./dist/web/**/*',
+    '!dist/web/*',
+    '!**/node_modules/**/.*',
     '!**/{.github,Jenkinsfile}',
-    '!**/{CHANGES.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,DEVELOPMENT.md,docs,docs.md,examples,History.md,HISTORY.md,README.md,TODO.md,UPGRADE_GUIDE.md,UPGRADING.md}',
-    '!**/{commitlint.config.js,.editorconfig,.eslintignore,.eslintrc.{js,yml},.nvmrc,.nycrc{,.json},.prettierrc{,.yaml},tslint.json}',
-    '!**/{.babelrc,bower.json,Gruntfile.js,Makefile,rollup.config.js,tsconfig.json}',
+    '!**/{CHANGES.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,CONTRIBUTION.md,DEVELOPMENT.md,docs,docs.md,docs.mli,examples,History.md,HISTORY.md,index.html,README.md,TODO.md,UPGRADE_GUIDE.md,UPGRADING.md}',
+    '!**/{commitlint.config.js,.editorconfig,.eslintignore,.eslintrc.{js,yml},.gitmodules,.huskyrc,.lintstagedrc,.nvmrc,.nycrc{,.json},.prettierrc{,.yaml},tslint.json}',
+    '!**/{.babelrc,bower.json,Gruntfile.js,Makefile,.npmrc.proregistry,rollup.config.js,.tm_properties,.tool-versions,tsconfig.json,webpack.config.js}',
     '!**/*.{{,c,m}js,min,ts}.map',
-    '!**/*.d.ts'
+    '!**/*.d.ts',
+
+    // only exclude the src directory for specific packages
+    // as some of them have their dist code in there and we don't want to exclude those
+    '!**/node_modules/{@fortawesome/vue-fontawesome,agent-base,jquery,localforage,m3u8-parser,marked,mpd-parser,performance-now,video.js,vue,vue-i18n,vue-router}/src/*',
+    '!**/node_modules/**/{bin,man,scripts}/*',
+    '!**/node_modules/jquery/dist/jquery.slim*.js',
+    '!**/node_modules/video.js/dist/{alt/*,video.js}',
+    '!**/node_modules/@videojs/*/src'
   ],
   dmg: {
     contents: [

--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -53,7 +53,18 @@ const config = {
       ]
     }
   ],
-  files: ['_icons/iconColor.*', 'icon.svg', './dist/**/*', '!./dist/web/**/*'],
+  files: [
+    '_icons/iconColor.*',
+    'icon.svg',
+    './dist/**/*',
+    '!./dist/web/**/*',
+    '!**/{.github,Jenkinsfile}',
+    '!**/{CHANGES.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,DEVELOPMENT.md,docs,docs.md,examples,History.md,HISTORY.md,README.md,TODO.md,UPGRADE_GUIDE.md,UPGRADING.md}',
+    '!**/{commitlint.config.js,.editorconfig,.eslintignore,.eslintrc.{js,yml},.nvmrc,.nycrc{,.json},.prettierrc{,.yaml},tslint.json}',
+    '!**/{.babelrc,bower.json,Gruntfile.js,Makefile,rollup.config.js,tsconfig.json}',
+    '!**/*.{{,c,m}js,min,ts}.map',
+    '!**/*.d.ts'
+  ],
   dmg: {
     contents: [
       {

--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -23,7 +23,7 @@ const config = {
   module: {
     rules: [
       {
-        test: /\.(j|t)s$/,
+        test: /\.js$/,
         use: 'babel-loader',
         exclude: /node_modules/,
       },
@@ -76,21 +76,24 @@ if (isDevMode) {
             from: path.join(__dirname, '../static'),
             to: path.join(__dirname, '../dist/web/static'),
             globOptions: {
-              ignore: ['.*', 'pwabuilder-sw.js'],
+              dot: true,
+              ignore: ['**/.*', '**/pwabuilder-sw.js', '**/dashFiles/**', '**/storyboards/**'],
             },
           },
           {
             from: path.join(__dirname, '../_icons'),
             to: path.join(__dirname, '../dist/_icons'),
             globOptions: {
-              ignore: ['.*'],
+              dot: true,
+              ignore: ['**/.*'],
             },
           },
           {
             from: path.join(__dirname, '../src/renderer/assets/img'),
             to: path.join(__dirname, '../dist/images'),
             globOptions: {
-              ignore: ['.*'],
+              dot: true,
+              ignore: ['**/.*'],
             },
           },
         ]

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -37,7 +37,7 @@ const config = {
   module: {
     rules: [
       {
-        test: /\.(j|t)s$/,
+        test: /\.js$/,
         use: 'babel-loader',
         exclude: /node_modules/,
       },
@@ -165,28 +165,32 @@ if (isDevMode) {
             from: path.join(__dirname, '../static'),
             to: path.join(__dirname, '../dist/web/static'),
             globOptions: {
-              ignore: ['.*', 'pwabuilder-sw.js'],
+              dot: true,
+              ignore: ['**/.*', '**/pwabuilder-sw.js', '**/dashFiles/**', '**/storyboards/**'],
             },
           },
           {
             from: path.join(__dirname, '../static'),
             to: path.join(__dirname, '../dist/static'),
             globOptions: {
-              ignore: ['.*', 'pwabuilder-sw.js'],
+              dot: true,
+              ignore: ['**/.*', '**/pwabuilder-sw.js', '**/dashFiles/**', '**/storyboards/**'],
             },
           },
           {
             from: path.join(__dirname, '../_icons'),
             to: path.join(__dirname, '../dist/web/_icons'),
             globOptions: {
-              ignore: ['.*'],
+              dot: true,
+              ignore: ['**/.*'],
             },
           },
           {
             from: path.join(__dirname, '../src/renderer/assets/img'),
             to: path.join(__dirname, '../dist/web/images'),
             globOptions: {
-              ignore: ['.*'],
+              dot: true,
+              ignore: ['**/.*'],
             },
           },
         ]

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -23,7 +23,7 @@ const config = {
   module: {
     rules: [
       {
-        test: /\.(j|t)s$/,
+        test: /\.js$/,
         use: 'babel-loader',
         exclude: /node_modules/,
       },
@@ -163,21 +163,24 @@ if (isDevMode) {
             from: path.join(__dirname, '../static'),
             to: path.join(__dirname, '../dist/web/static'),
             globOptions: {
-              ignore: ['.*', 'pwabuilder-sw.js'],
+              dot: true,
+              ignore: ['**/.*', '**/pwabuilder-sw.js', '**/dashFiles/**', '**/storyboards/**'],
             },
           },
           {
             from: path.join(__dirname, '../_icons'),
             to: path.join(__dirname, '../dist/web/_icons'),
             globOptions: {
-              ignore: ['.*'],
+              dot: true,
+              ignore: ['**/.*'],
             },
           },
           {
             from: path.join(__dirname, '../src/renderer/assets/img'),
             to: path.join(__dirname, '../dist/web/images'),
             globOptions: {
-              ignore: ['.*'],
+              dot: true,
+              ignore: ['**/.*'],
             },
           },
         ]

--- a/_scripts/webpack.workers.config.js
+++ b/_scripts/webpack.workers.config.js
@@ -26,7 +26,7 @@ const config = {
   module: {
     rules: [
       {
-        test: /\.(j|t)s$/,
+        test: /\.js$/,
         use: 'babel-loader',
         exclude: /node_modules/,
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build-release": "node _scripts/build.js",
     "build-release:arm64": "node _scripts/build.js arm64",
     "build-release:arm32": "node _scripts/build.js arm32",
-    "clean": "rimraf build/ dashFiles/ dist/ storyboards/",
+    "clean": "rimraf build/ static/dashFiles/ dist/ static/storyboards/",
     "debug": "run-s rebuild:electron debug-runner",
     "debug-runner": "node _scripts/dev-runner.js --remote-debug",
     "dev": "run-s rebuild:electron dev-runner",


### PR DESCRIPTION
---
Prevent packaging unneeded dependency files
---

**Pull Request Type**

- [x] Feature Implementation

**Description**
FreeTube's dependencies ship a lot of files that might be useful during development, these files aren't useful for users of FreeTube. As we don't have any control over the majority of the dependencies, we can exclude the files during the electron build and reduce the package size (`resources/app.asar`: 54.2MB -> ~49.5MB~ 35.2MB). This pull request also fixes the webpack builds no longer properly ignoring dotfiles.

**Testing (for code that is not small enough to be easily understandable)**
I tested this by running `yarn run build` and then checking the files produced by the webpack builds in the `dist/` directory and the files produced by the electron build in the `build/` directory. I also clicked around FreeTube just to make sure that no required files were accidentally blacklisted.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 26e4433c999d2c32d925e2b2dae5d1da4886e6e3