### PR TITLE
* Update app menu to add item for new window

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -769,7 +769,21 @@ function runApp() {
     const template = [
       {
         label: 'File',
-        submenu: [{ role: 'quit' }]
+        submenu: [
+          {
+            label: 'New Window',
+            accelerator: 'CmdOrCtrl+N',
+            click: (_menuItem, _browserWindow, _event) => {
+              createWindow({
+                replaceMainWindow: false,
+                showWindowNow: true
+              })
+            },
+            type: 'normal'
+          },
+          { type: 'separator' },
+          { role: 'quit' }
+        ]
       },
       {
         label: 'Edit',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -7,6 +7,7 @@ FreeTube: FreeTube
 
 # Webkit Menu Bar
 File: File
+New Window: New Window
 Quit: Quit
 Edit: Edit
 Undo: Undo


### PR DESCRIPTION


**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
#1869 Partially

**Description**
Update app menu to add item for new window
with keyboard shortcut

**Screenshots (if appropriate)**

https://user-images.githubusercontent.com/1018543/173169981-cdab77a2-b298-4d56-ae33-25da4f46b006.mov

**Testing (for code that is not small enough to be easily understandable)**
- Use new menu item to create new window
- Use new keyboard shortcut (Ctrl/Cmd + N) to create new window

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.4
 - FreeTube version: e861e70b3374b10430a3f657b626c7f14fc22bea

**Additional context**
Add any other context about the problem here.
