### PR TITLE
Fix the YouTube GDPR cookie not being sent along with requests

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -147,7 +147,8 @@ function runApp() {
       session.defaultSession.cookies.set({
         url: url,
         name: 'CONSENT',
-        value: 'YES+'
+        value: 'YES+',
+        sameSite: 'no_restriction'
       })
     })
 


### PR DESCRIPTION
---
Fix the YouTube GDPR cookie not being sent along with requests
---

**Pull Request Type**
- [x] Bugfix

**Description**

Fixes the empty GDPR consent cookie not being sent along with requests to YouTube. This fixes the trending tab and the channel community page (#1568) in Europe.

**Testing (for code that is not small enough to be easily understandable)**
Yes, this change successfully fixed trending and the channel community page in Europe.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version:  v0.17.0-RC