### PR TITLE
Fix: screenshot forbidden chars on Windows

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -326,7 +326,7 @@ const actions = {
       if (platform === 'win32') {
         // https://www.boost.org/doc/libs/1_78_0/libs/filesystem/doc/portability_guide.htm
         // https://stackoverflow.com/questions/1976007/
-        const noForbiddenChars = ['<', '>', ':', '"', '/', '|'].every(char => {
+        const noForbiddenChars = ['<', '>', ':', '"', '/', '|', '?', '*'].every(char => {
           return parsedString.indexOf(char) === -1
         })
         if (!noForbiddenChars) {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
None

**Description**
I forgot to add '?'  and '*' to #2221 for win32

**Desktop (please complete the following information):**
 - OS: Windows 10 21H1
 - FreeTube version: 0.16
