### PR TITLE
Fix download filename problems

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -181,8 +181,8 @@ const actions = {
     }
   },
 
-  replaceDownloadFilename(_, titleOriginal) {
-    let titleNew = titleOriginal
+  replaceFilenameForbiddenChars(_, filenameOriginal) {
+    let filenameNew = filenameOriginal
     let forbiddenChars = {}
     switch (process.platform) {
       case 'win32':
@@ -209,13 +209,13 @@ const actions = {
     }
 
     for (const forbiddenChar in forbiddenChars) {
-      titleNew = titleNew.replaceAll(forbiddenChar, forbiddenChars[forbiddenChar])
+      filenameNew = filenameNew.replaceAll(forbiddenChar, forbiddenChars[forbiddenChar])
     }
-    return titleNew
+    return filenameNew
   },
 
   async downloadMedia({ rootState, dispatch }, { url, title, extension, fallingBackPath }) {
-    const fileName = `${await dispatch('replaceDownloadFilename', title)}.${extension}`
+    const fileName = `${await dispatch('replaceFilenameForbiddenChars', title)}.${extension}`
     const usingElectron = rootState.settings.usingElectron
     const locale = i18n._vm.locale
     const translations = i18n._vm.messages[locale]
@@ -248,6 +248,17 @@ const actions = {
 
       folderPath = response.filePath
     } else {
+      if (!fs.existsSync(folderPath)) {
+        try {
+          fs.mkdirSync(folderPath, { recursive: true })
+        } catch (err) {
+          console.error(err)
+          this.showToast({
+            message: err
+          })
+          return
+        }
+      }
       folderPath = path.join(folderPath, fileName)
     }
 


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix

**Related issue**
None
[addressed here](https://github.com/FreeTubeApp/FreeTube/discussions/2309#discussioncomment-2934372)

**Description**
1. Replace forbidden chars
2. EISDIR when `downloadFolderPath` is not empty

**Screenshots (if appropriate)**
![z21](https://user-images.githubusercontent.com/80553357/173263221-0d83d123-41a8-41dd-b57a-288e3a72af5f.PNG)
![z22](https://user-images.githubusercontent.com/80553357/173264833-2c81369a-45fe-4602-9be8-97dd831509aa.PNG)

**Testing (for code that is not small enough to be easily understandable)**
1. Tested with these videos. could not find < and >
- [xcRxwi0x5ig](https://youtu.be/xcRxwi0x5ig) Prehistoric Planet — Uncovered: Did Velociraptor Have Feathers? | Apple TV+
- [e5NLW_c8i7g](https://youtu.be/e5NLW_c8i7g) \*MUSIKVIDEOS Som BEVIS\* RAPPARE & GÄNGMEDLEMMAR DÖMDA TILL FÄNGELSE
- [pwAMJG1BMB0](https://youtu.be/pwAMJG1BMB0) Blaze & Monster Machines "Let's Blaze!" Compilation!
- [Kx_eAKYnn-g](https://youtu.be/Kx_eAKYnn-g) How to find backward slash (\\) or forward slash (/) or € on keyboard

2. set download folder and download some videos

**Desktop (please complete the following information):**
 - OS: Windows10 21H1
 - FreeTube version: ae654a1581a47b6056fd321dc7b3fa865d3624b0

**Additional context**
[What characters are forbidden in Windows and Linux directory names?](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names)
[What characters are forbidden in OS X filenames?](https://superuser.com/questions/204287/what-characters-are-forbidden-in-os-x-filenames)