### PR TITLE
Fix: loop button

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1167,8 +1167,8 @@ export default Vue.extend({
 
     toggleVideoLoop: async function () {
       if (!this.player.loop()) {
-        const currentTheme = localStorage.getItem('mainColor')
-        const colorNames = this.$store.state.utils.colorClasses
+        const currentTheme = this.$store.state.settings.mainColor
+        const colorNames = this.$store.state.utils.colorNames
         const colorValues = this.$store.state.utils.colorValues
 
         const nameIndex = colorNames.findIndex((color) => {


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix

**Related issue**
Closes #2312

**Description**
>1. Clear Local Storage (Developer tools -> Application)
>2. Play a video
>3. Click "Toggle loop" button
>4. Doesn't work

**Screenshots (if appropriate)**
![z21](https://user-images.githubusercontent.com/80553357/173301149-b933a86c-ac0c-4bd8-a2d0-d890a364d633.PNG)

**Desktop (please complete the following information):**
 - OS: Windows10 21H1
 - FreeTube version: ae654a1581a47b6056fd321dc7b3fa865d3624b0
