### PR TITLE
[rc] Allow more locales to be used by FreeTube

### DIFF
--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -8,7 +8,7 @@ const isDev = process.env.NODE_ENV === 'development'
 Vue.use(VueI18n)
 
 // List of locales approved for use
-const activeLocales = ['en-US', 'en_GB', 'ar', 'bg', 'cs', 'da', 'de-DE', 'el', 'es', 'es-MX', 'et', 'fi', 'fr-FR', 'gl', 'he', 'hu', 'hr', 'id', 'is', 'it', 'ja', 'nb_NO', 'nl', 'nn', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ru', 'sk', 'sl', 'sr', 'sv', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
+const activeLocales = ['en-US', 'en_GB', 'ar', 'bg', 'ca', 'cs', 'da', 'de-DE', 'el', 'es', 'es_AR', 'es-MX', 'et', 'eu', 'fi', 'fr-FR', 'gl', 'he', 'hu', 'hr', 'id', 'is', 'it', 'ja', 'ko', 'lt', 'nb_NO', 'nl', 'nn', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
 const messages = {}
 /* eslint-disable-next-line */
 const fileLocation = isDev ? 'static/locales/' : `${__dirname}/static/locales/`


### PR DESCRIPTION
---
[rc] Allow more locales to be used by FreeTube
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation

**Related issue**
I noticed a lot of changes recently for languages that are not currently displayed in the FreeTube app

**Description**
This PR allows the following locales to be selected:
ca (català/catalan), es_AR, et (Eesti/Estonian), eu (euskera/basque), ko (한국인/ korean), lt (lietuvių/lithuanian)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 
I tested by changing my locale to the languages that were added.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0 RC

**Additional context**
Tested on dev branch with latest locale changes (Basque in particular got a lot of updates not in the RC branch so it won't appear to be translated as much on that branch)
