### PR TITLE
Fix the theming of the share menu logos for the system, black and dracula themes

### DIFF
--- a/src/renderer/components/ft-share-button/ft-share-button.sass
+++ b/src/renderer/components/ft-share-button/ft-share-button.sass
@@ -29,10 +29,15 @@
 		width: auto
 
 		@at-root
-			.dark &
+			.dark &, .system[data-system-theme*='dark'] &
 				filter: brightness(0.868)
 
-			.light &
+			.black &
+				filter: brightness(0.933)
+
+			/* no changes for the dracula theme */
+
+			.light &, .system[data-system-theme*='light'] &
 				filter: invert(0.87)
 
 	.invidious
@@ -48,8 +53,11 @@
 			margin-right: 2px
 
 			@at-root
-				.dark &
+				.dark &,
+				.black &,
+				.dracula &,
+				.system[data-system-theme*='dark'] &
 					background-image: url(~../../assets/img/invidious-logo-dark.svg)
 
-				.light &
+				.light &, .system[data-system-theme*='light'] &
 					background-image: url(~../../assets/img/invidious-logo-light.svg)


### PR DESCRIPTION
---
Fix the theming of the share menu logos for the system, black and dracula themes (RC branch)
---

**Pull Request Type**
- [x] Bugfix

**Description**
This pull request fixes the YouTube and Invidious logos being invisible in the share menu when the system, black or dracula themes are active.

**Screenshots (if appropriate)**

<details><summary>System</summary>

![before](https://user-images.githubusercontent.com/48293849/174288114-5134b984-460d-445e-8d69-ed8e8d070826.jpg)

![after](https://user-images.githubusercontent.com/48293849/174288126-044a18cc-4b27-49fa-a2b5-fd89796070ce.jpg)

</details>

<details><summary>Black</summary>

![before](https://user-images.githubusercontent.com/48293849/174290226-4e223d17-0f3b-4a5f-ac59-4e6857bea3a3.jpg)

![after](https://user-images.githubusercontent.com/48293849/174292049-1d1f226e-0c01-4374-a7b1-2683c86b283f.jpg)

</details>

<details><summary>Dracula</summary>

![before](https://user-images.githubusercontent.com/48293849/174290167-65ed8c1b-fcd9-4841-a7df-1901a1dfbb7c.jpg)

![after](https://user-images.githubusercontent.com/48293849/174292097-54ffa181-b2a1-4482-824d-0e8f4eb8bc28.jpg)

</details>

**Testing (for code that is not small enough to be easily understandable)**
I tested this pull request by changing the theme and checking that the logos are visible regardless of the selected theme.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: c12d64c389a7bb1ecde6b4727859852701cb8baf