### PR TITLE
Allow the lint workflow to run on the v0.17.0-RC branch

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,7 +6,7 @@ name: Linter
 # events but only for the master branch
 on:
   pull_request:
-    branches: [ master, development ]
+    branches: [ master, development, '**-RC' ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
---
Allow the lint workflow to run on all RC branches
---

**Pull Request Type**

- [x] Bugfix

**Description**
Allows the lint workflow to run on all RC branches, as it is required for PRs to be merged.