### PR TITLE
Make installation method and API method mandatory in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -75,19 +75,24 @@ body:
       required: true
   - type: dropdown
     attributes:
-      label: 'Installation Method (If applicable)'
+      label: Installation Method
       options:
+        - .apk
         - .AppImage
+        - AUR
+        - Chocolatey
         - .deb
         - .dmg
         - .exe
         - Flathub
+        - .pacman
         - Portable
         - .rpm
+        - winget
         - .zip
         - other
     validations:
-      required: false
+      required: true
   - type: input
     attributes:
       label: 'Last Known Working FreeTube Version (If Any)'
@@ -102,7 +107,7 @@ body:
         - Local API
         - Invidious API
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Additional Information

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -93,11 +93,6 @@ body:
         - other
     validations:
       required: true
-  - type: input
-    attributes:
-      label: 'Last Known Working FreeTube Version (If Any)'
-      description: What is the last version of FreeTube this worked in, if applicable?
-      placeholder: v0.14.0
   - type: dropdown
     attributes: 
       label: Primary API used
@@ -108,6 +103,11 @@ body:
         - Invidious API
     validations:
       required: true
+  - type: input
+    attributes:
+      label: 'Last Known Working FreeTube Version (If Any)'
+      description: What is the last version of FreeTube this worked in, if applicable?
+      placeholder: v0.14.0
   - type: textarea
     attributes:
       label: Additional Information


### PR DESCRIPTION
---
Make installation method and API method mandatory in bug issue template
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [ ] Feature Implementation
- [x] IRC discussion? :)

**Description**
In the past people neglected to mention in an API related issue, what API they were using or installation method they were using in a installation they used that broke FT.

This was because the fields were not mandatory.

**Additional context**
I need some help on deciding what to do with the position of the API field. I would like to see all the mandatory fields first but i dont know what position sounds logical to move the API field to. Also im feeling a bit conflicted about changing the position because of the already logical order of all the fields.
