### PR TITLE
Clear filter when clicked "Clear input" [0.17RC]

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -126,6 +126,8 @@ export default Vue.extend({
 
       // Focus on input element after text is clear for better UX
       inputElement.focus()
+
+      this.$emit('clear')
     },
 
     handleActionIconChange: function() {

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -16,6 +16,7 @@
         :show-clear-text-button="true"
         :show-action-button="false"
         @input="(input) => query = input"
+        @clear="query = ''"
       />
       <ft-flex-box
         v-show="fullData.length === 0"

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -23,6 +23,7 @@
         :show-clear-text-button="true"
         :show-action-button="false"
         @input="(input) => query = input"
+        @clear="query = ''"
       />
       <ft-flex-box
         v-show="fullData.length === 0"


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix

**Related issue**
#2346

**Description**
>1. Add items to userplaylists and history
>2. Filter to show fewer results
>3. Click "Clear input"
>4. Filter state persists, not showing all items

**Screenshots (if appropriate)**
Before
<video src="https://user-images.githubusercontent.com/80553357/174777700-f4107b9b-5a10-4425-bfae-4894a27a4ac7.mp4">

After
<video src="https://user-images.githubusercontent.com/80553357/174777514-28d4f9ef-6caf-460c-951e-6f6efd26cec8.mp4">

**Desktop (please complete the following information):**
 - OS: Windows10 21H1
 - FreeTube version: d1a7bc301103f3680ae06882449703d7828c0fed
