### PR TITLE
fix: open external link only primary button clicked [rc]

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -364,7 +364,7 @@ export default Vue.extend({
         // there is no other way to pass the URL to click callback
         this.lastExternalLinkToBeOpened = el.href
         this.showExternalLinkOpeningPrompt = true
-      } else {
+      } else if (event.type === 'click') {
         // Open links externally
         this.openExternalLink(el.href)
       }


### PR DESCRIPTION
**Pull Request Type**
- [x] Bugfix

**Related issue**
Closes #2343

**Description**
>1.Go to any video
>2.right click on urls in the description or comment section
>3.url opens

**Desktop (please complete the following information):**
 - OS: Windows10 21H1
 - FreeTube version: 0.17rc
