### PR TITLE
Fix right clicking on links being treated as link clicks

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -334,14 +334,17 @@ export default Vue.extend({
       })
 
       $(document).on('auxclick', 'a[href^="http"]', (event) => {
-        this.handleLinkClick(event)
+        // auxclick fires for all clicks not performed with the primary button
+        // only handle the link click if it was the middle button,
+        // otherwise the context menu breaks
+        if (event.button === 1) {
+          this.handleLinkClick(event)
+        }
       })
     },
 
     handleLinkClick: function (event) {
       const el = event.currentTarget
-      console.log(this.usingElectron)
-      console.log(el)
       event.preventDefault()
 
       // Check if it's a YouTube link


### PR DESCRIPTION
---
Fix right clicking on links being treated as link clicks (development branch)
---

**Pull Request Type**

- [x] Bugfix

**Related issue**
closes #2343

**Description**
This PR fixes right clicking on links opening them instead of the context menu showing up.

**Testing (for code that is not small enough to be easily understandable)**
Right click on a bunch of links, with this PR only the context menu should show up.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 4f4f727ae1af304ce3131f03b29383ce4fdbb724