### PR TITLE
Upgrade electron from 16 > 17

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "chrome": "96",
+          "chrome": "98",
           "node": 16
         }
       }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^16.2.7",
+    "electron": "^17.4.8",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^17.4.9",
+    "electron": "^17.4.10",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^17.4.8",
+    "electron": "^17.4.9",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^16.2.7:
-  version "16.2.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.2.7.tgz#945e35ad1625e604f10c124fb912d1e2b3018317"
-  integrity sha512-aZKF3b00+rqW/HGs8lJM5DhPNj+mOfCuhLSiFXV6J9dQCIRhctJTmToOrwXfbCxvXK8as8eQTNl5uSfnHmH6tA==
+electron@^17.4.8:
+  version "17.4.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.8.tgz#a7940d125c120d51aa0c737c10d17851dada295d"
+  integrity sha512-JUHTFcBCXols+REajy9YQNypcgRGu35u/8oDmLIvjvrfIL4/Z3YAiq8HN4mhclWfuSmznrLeZ8uMktZWmvPOAg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^17.4.9:
-  version "17.4.9"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.9.tgz#d323dac4151e24f7345250414c3bc540c6576811"
-  integrity sha512-DuoCyjTo29TNAaI2eEurN78zvzKQBBZGKjmsy0qEyUaJmgAFzPHDGwVsX9BqativzkboNvXEKXnseHe5CbLiyg==
+electron@^17.4.10:
+  version "17.4.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.10.tgz#904247a9eed0b09825f4d9f221f2442c7679f9e6"
+  integrity sha512-4v5Xwa4rZjWf0LmpYOaBXG8ZQ1rpPEpww+MCe4uuwenFsx3QSLSXmek720EY7drQa/O1YyvcZ1pr2sDBMIq0mA==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^17.4.8:
-  version "17.4.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.8.tgz#a7940d125c120d51aa0c737c10d17851dada295d"
-  integrity sha512-JUHTFcBCXols+REajy9YQNypcgRGu35u/8oDmLIvjvrfIL4/Z3YAiq8HN4mhclWfuSmznrLeZ8uMktZWmvPOAg==
+electron@^17.4.9:
+  version "17.4.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.9.tgz#d323dac4151e24f7345250414c3bc540c6576811"
+  integrity sha512-DuoCyjTo29TNAaI2eEurN78zvzKQBBZGKjmsy0qEyUaJmgAFzPHDGwVsX9BqativzkboNvXEKXnseHe5CbLiyg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
Might or might not fix issue in #2113

**Description**
16.x is not supported anymore
From https://www.electronjs.org/blog/electron-17-0
<img width="257" alt="image" src="https://user-images.githubusercontent.com/1018543/175764286-3e7f829b-6814-4bbf-88a0-8dd61774a9cf.png">

[Breaking change in 17.x](https://www.electronjs.org/blog/electron-17-0#breaking-changes) = 
- [`desktopCapturer.getSources`](https://www.electronjs.org/blog/electron-17-0#desktopcapturergetsources-in-the-renderer)
- The end

Should be safe to upgrade if true

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
Open app, open new window via
- Keyboard shortcut
- New window button
- Middle click on links

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.4
 - FreeTube version: 63442282a9a824ba77ed1c0d551213ff3e6abf99

**Additional context**
Will submit PR for electron 18 upgrade after/in parallel to this PR (depends on its breaking changes)
