### PR TITLE
Upgrade electron from 16 > 18

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "chrome": "98",
+          "chrome": "100",
           "node": 16
         }
       }

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "chrome": "96",
+          "chrome": "98",
           "node": 16
         }
       }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^16.2.7",
+    "electron": "^17.4.8",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^17.4.8",
+    "electron": "^18.3.5",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^18.3.5",
+    "electron": "^18.3.7",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^18.3.8",
+    "electron": "^18.3.9",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^18.3.7",
+    "electron": "^18.3.8",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,10 +3103,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^18.3.7:
-  version "18.3.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.7.tgz#a22a23d63811d067c8e33abc5674122408319265"
-  integrity sha512-SDvX0VYejR1xw9PrJyvnyiDcuIhdzFVaA1NaRN2LEWXr5R6mEFl8NVTM+i5dtxMm2SHP/FPnkvmsWZs6MHijqg==
+electron@^18.3.8:
+  version "18.3.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.8.tgz#394ae5f8c6133db4c5c5c166ef9167bb65249e56"
+  integrity sha512-x67LztfMFMR/oQ788PTHLl871tQ/As78+/esjXCv/MhbumgVbd+dWYHf1YU4FaZK7GnUHNK7W8b2BamOyIP5AA==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,10 +3103,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^18.3.8:
-  version "18.3.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.8.tgz#394ae5f8c6133db4c5c5c166ef9167bb65249e56"
-  integrity sha512-x67LztfMFMR/oQ788PTHLl871tQ/As78+/esjXCv/MhbumgVbd+dWYHf1YU4FaZK7GnUHNK7W8b2BamOyIP5AA==
+electron@^18.3.9:
+  version "18.3.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.9.tgz#a2e8301f0bdf5a7a867793bd64441ae49f42499e"
+  integrity sha512-59m2yyHNeFxMjbMyYoRxyNWhdEwK0UOzbhGXGbAoYx/f95cVd9AduWL1G2TSUNgpwugm5Ia7hRs6GlZSPbbJtQ==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,10 +1307,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.33.tgz#3c1879b276dc63e73030bb91165e62a4509cd506"
   integrity sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==
 
-"@types/node@^14.6.2":
-  version "14.18.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
-  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
+"@types/node@^16.11.26":
+  version "16.11.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.41.tgz#88eb485b1bfdb4c224d878b7832239536aa2f813"
+  integrity sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==
 
 "@types/plist@^3.0.1":
   version "3.0.2"
@@ -3103,13 +3103,13 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^17.4.8:
-  version "17.4.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.8.tgz#a7940d125c120d51aa0c737c10d17851dada295d"
-  integrity sha512-JUHTFcBCXols+REajy9YQNypcgRGu35u/8oDmLIvjvrfIL4/Z3YAiq8HN4mhclWfuSmznrLeZ8uMktZWmvPOAg==
+electron@^18.3.5:
+  version "18.3.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.5.tgz#a589c2bfa3fe807914a055f54f665999329b739b"
+  integrity sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==
   dependencies:
     "@electron/get" "^1.13.0"
-    "@types/node" "^14.6.2"
+    "@types/node" "^16.11.26"
     extract-zip "^1.0.3"
 
 emoji-regex@^8.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,10 +3103,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^18.3.5:
-  version "18.3.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.5.tgz#a589c2bfa3fe807914a055f54f665999329b739b"
-  integrity sha512-/GJ39X3ijpyZiOtYQ1ha5Ly0hWiIzF19CGEapM9euaM2AZrmt79x+MckQDXqJxOaVA9YHXju5Ho6b9pB9a/2pQ==
+electron@^18.3.7:
+  version "18.3.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-18.3.7.tgz#a22a23d63811d067c8e33abc5674122408319265"
+  integrity sha512-SDvX0VYejR1xw9PrJyvnyiDcuIhdzFVaA1NaRN2LEWXr5R6mEFl8NVTM+i5dtxMm2SHP/FPnkvmsWZs6MHijqg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3103,10 +3103,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^16.2.7:
-  version "16.2.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.2.7.tgz#945e35ad1625e604f10c124fb912d1e2b3018317"
-  integrity sha512-aZKF3b00+rqW/HGs8lJM5DhPNj+mOfCuhLSiFXV6J9dQCIRhctJTmToOrwXfbCxvXK8as8eQTNl5uSfnHmH6tA==
+electron@^17.4.8:
+  version "17.4.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-17.4.8.tgz#a7940d125c120d51aa0c737c10d17851dada295d"
+  integrity sha512-JUHTFcBCXols+REajy9YQNypcgRGu35u/8oDmLIvjvrfIL4/Z3YAiq8HN4mhclWfuSmznrLeZ8uMktZWmvPOAg==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
Might or might not fix issue in #2113

Closes #2358

**Description**
16.x is not supported anymore
From https://www.electronjs.org/blog/electron-17-0
<img width="257" alt="image" src="https://user-images.githubusercontent.com/1018543/175764286-3e7f829b-6814-4bbf-88a0-8dd61774a9cf.png">

[Breaking change in 17.x](https://www.electronjs.org/blog/electron-17-0#breaking-changes) = 
- [`desktopCapturer.getSources`](https://www.electronjs.org/blog/electron-17-0#desktopcapturergetsources-in-the-renderer)
- The end

[Breaking change in 18.x](https://www.electronjs.org/blog/electron-18-0#breaking-changes) = 
- [Removed `nativeWindowOpen`](https://www.electronjs.org/blog/electron-18-0#removed-nativewindowopen)
- The end

Should be safe to upgrade if true

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
Open app, open new window via
- Keyboard shortcut
- New window button
- Middle click on links

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.4
 - FreeTube version: 63442282a9a824ba77ed1c0d551213ff3e6abf99

**Additional context**
Add any other context about the problem here.
