### PR TITLE
Fixes search suggestion issues with arrow keys

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -198,7 +198,8 @@ export default Vue.extend({
       this.handleClick()
     },
 
-    handleKeyDown: function (keyCode) {
+    handleKeyDown: function (event) {
+      const keyCode = event.keyCode
       if (this.visibleDataList.length === 0) { return }
       // Update selectedOption based on arrow key pressed
       if (keyCode === 40) {
@@ -219,6 +220,7 @@ export default Vue.extend({
       }
       // Update Input box value if arrow keys were pressed
       if ((keyCode === 40 || keyCode === 38) && this.searchState.selectedOption !== -1) {
+        event.preventDefault()
         this.inputData = this.visibleDataList[this.searchState.selectedOption]
       } else {
         this.updateVisibleDataList()

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -184,7 +184,7 @@ export default Vue.extend({
 
       if (inputElement !== null) {
         inputElement.addEventListener('keydown', (event) => {
-          if (event.keyCode === 13) {
+          if (event.key === 'Enter') {
             this.handleClick()
           }
         })
@@ -199,12 +199,11 @@ export default Vue.extend({
     },
 
     handleKeyDown: function (event) {
-      const keyCode = event.keyCode
       if (this.visibleDataList.length === 0) { return }
       // Update selectedOption based on arrow key pressed
-      if (keyCode === 40) {
+      if (event.key === 'ArrowDown') {
         this.searchState.selectedOption = (this.searchState.selectedOption + 1) % this.visibleDataList.length
-      } else if (keyCode === 38) {
+      } else if (event.key === 'ArrowUp') {
         if (this.searchState.selectedOption < 1) {
           this.searchState.selectedOption = this.visibleDataList.length - 1
         } else {
@@ -215,11 +214,11 @@ export default Vue.extend({
       }
 
       // Key pressed isn't enter
-      if (keyCode !== 13) {
+      if (event.key !== 'Enter') {
         this.searchState.showOptions = true
       }
       // Update Input box value if arrow keys were pressed
-      if ((keyCode === 40 || keyCode === 38) && this.searchState.selectedOption !== -1) {
+      if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && this.searchState.selectedOption !== -1) {
         event.preventDefault()
         this.inputData = this.visibleDataList[this.searchState.selectedOption]
       }

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -222,8 +222,6 @@ export default Vue.extend({
       if ((keyCode === 40 || keyCode === 38) && this.searchState.selectedOption !== -1) {
         event.preventDefault()
         this.inputData = this.visibleDataList[this.searchState.selectedOption]
-      } else {
-        this.updateVisibleDataList()
       }
     },
 

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -49,7 +49,7 @@
       @input="e => handleInput(e.target.value)"
       @focus="handleFocus"
       @blur="handleInputBlur"
-      @keydown="e => handleKeyDown(e.keyCode)"
+      @keydown="handleKeyDown"
     >
     <font-awesome-icon
       v-if="showActionButton"


### PR DESCRIPTION
---
Fixes search suggestion issues with arrow keys (development branch)
---

**Pull Request Type**
- [x] Bugfix

**Related issue**
closes #1741

**Description**
This pull request fixes the cursor moving in the search bar when the up and down arrow keys are used to navigate through the search suggestions.
It also fixes the search suggestions being updated for all keyboard events even when the value of the search bar doesn't change (e.g. left and right arrow keys). Currently the search suggestions get updated for the `input` and `keydown` events, the `input` only gets fired if the value of the field changes, `keydown` is fired for all keyboard events.
It also replaces uses of the deprecated `event.keyCode` property with `event.key`, this improves code readability as you don't need to go and look up which key has which code.

**Testing (for code that is not small enough to be easily understandable)**
1. Cycle through the search suggestions with the up and down arrow keys, the cursor in the search field should stay where you left it.
2. Use the left and right arrow keys to move the cursor in the search field, if the initial value was typed in quickly, the search suggestions used to get updated for the left and right arrow keys.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 3ccdf566998fc88350d55797c936b6014d65551c