### PR TITLE
Fix blank space in the subscription settings

### DIFF
--- a/src/renderer/components/subscription-settings/subscription-settings.js
+++ b/src/renderer/components/subscription-settings/subscription-settings.js
@@ -1,31 +1,17 @@
 import Vue from 'vue'
 import { mapActions } from 'vuex'
-import FtCard from '../ft-card/ft-card.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
-import FtButton from '../ft-button/ft-button.vue'
-import FtSelect from '../ft-select/ft-select.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 
 export default Vue.extend({
   name: 'SubscriptionSettings',
   components: {
-    'ft-card': FtCard,
     'ft-toggle-switch': FtToggleSwitch,
-    'ft-button': FtButton,
-    'ft-select': FtSelect,
     'ft-flex-box': FtFlexBox
   },
   data: function () {
     return {
-      title: 'Subscription Settings',
-      viewNames: [
-        'Basic',
-        'Modern'
-      ],
-      viewValues: [
-        'basic',
-        'modern'
-      ]
+      title: 'Subscription Settings'
     }
   },
   computed: {

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -19,23 +19,6 @@
         @change="updateUseRssFeeds"
       />
     </ft-flex-box>
-    <br v-if="false">
-    <ft-flex-box>
-      <ft-select
-        v-if="false"
-        placeholder="Subscription View Type"
-        :value="viewValues[0]"
-        :select-names="viewNames"
-        :select-values="viewValues"
-      />
-    </ft-flex-box>
-    <br v-if="false">
-    <ft-flex-box>
-      <ft-button
-        v-if="false"
-        label="Manage My Subscriptions"
-      />
-    </ft-flex-box>
   </details>
 </template>
 

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -19,7 +19,7 @@
         @change="updateUseRssFeeds"
       />
     </ft-flex-box>
-    <br>
+    <br v-if="false">
     <ft-flex-box>
       <ft-select
         v-if="false"
@@ -29,7 +29,7 @@
         :select-values="viewValues"
       />
     </ft-flex-box>
-    <br>
+    <br v-if="false">
     <ft-flex-box>
       <ft-button
         v-if="false"


### PR DESCRIPTION
---
Title
---

**Pull Request Type**

- [x] Bugfix

**Description**
Fixes the blank space in the subscription settings.

**Screenshots (if appropriate)**
before:
![before](https://user-images.githubusercontent.com/48293849/176979611-f8b17911-06b3-4dce-808a-d917a3625340.jpg)

after:
![after](https://user-images.githubusercontent.com/48293849/176979614-2964415a-3b56-4ac3-b7a8-d6dd50514548.jpg)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 3ccdf566998fc88350d55797c936b6014d65551c