### PR TITLE
Replace sketchy lodash import for tooltip ids with own implementation

### DIFF
--- a/src/renderer/components/ft-tooltip/ft-tooltip.js
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
-import { uniqueId } from 'lodash'
+
+let idCounter = 0
 
 export default Vue.extend({
   name: 'FtTooltip',
@@ -15,7 +16,7 @@ export default Vue.extend({
     }
   },
   data() {
-    const id = uniqueId('ft-tooltip-')
+    const id = `ft-tooltip-${++idCounter}`
 
     return {
       id


### PR DESCRIPTION
---
Replace sketchy lodash import for tooltip ids with own implementation
---

**Pull Request Type**

- [x] Bugfix

**Description**
Currently `lodash` is being imported and included in FreeTube despite FreeTube not declaring it as a dependency.

Why did it still work?

Some of FreeTube's development dependencies depend on lodash, so lodash is in the node_modules folder. Webpack doesn't care if you've declared it as a dependency in the `package.json` file, as long as it can find it it will successfully import it. As we haven't declared it as a dependency, the build script wasn't picking lodash up as an external dependency, so webpack just inlined lodash into the renderer.js file. Due to us using commonjs imports webpack wasn't able to treeshake lodash so it included all of lodash, not just the `uniqueId` function.

The solution

Originally I was just going to add a dependency for `lodash.uniqueid` and leave it at that. Instead I wondered how complicated that function could really be, turns out it's quite simple [uniqueId source code](https://github.com/lodash/lodash/blob/master/uniqueId.js) and we can replicate it in even less code. So I decided to write my own two line version of it. You can see the before and after size difference in the screenshots below.

Why fix it if it was working fine?

The current code relies on the development dependencies never removing their dependency on lodash. If they did ever remove it we would face weird webpack errors about it not being able to find lodash.
While a 69KB reduction in size won't make a noticable difference in the electron build, the potential future web version of FreeTube will benefit from better loading times by not having to download what is essentially dead code, as most of lodash never gets used by FreeTube.

**Screenshots (if appropriate)**
Size of the renderer.js file before the change:
![before](https://user-images.githubusercontent.com/48293849/177195209-0347e50d-c846-4d44-b0bd-941c0537bd71.jpg)

and after the change:
![after](https://user-images.githubusercontent.com/48293849/177195216-e86aa081-a6e4-4bf5-b562-420d88422e2f.jpg)

**Testing (for code that is not small enough to be easily understandable)**
I tested this PR by checking that tooltips still worked as expected and also by adding a ```console.log(`tooltip id: ${id}`)``` to line 20, just to make sure that all IDs were still unique.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 3ccdf566998fc88350d55797c936b6014d65551c