### PR TITLE
Fix long links in the video description breaking the layout

### DIFF
--- a/src/renderer/components/watch-video-description/watch-video-description.css
+++ b/src/renderer/components/watch-video-description/watch-video-description.css
@@ -7,4 +7,5 @@
   font-family: 'Roboto', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-size: 17px;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
---
Fix long video links in the video description breaking the layout (dev branch)
---

**Pull Request Type**

- [x] Bugfix

**Related issue**
closes #2380

**Description**
This pull request fixes long links in the video description breaking the layout of the watch page because they weren't getting wrapped correctly.

**Screenshots (if appropriate)**
Before:
![before](https://user-images.githubusercontent.com/48293849/177768621-999a66e2-e6e6-4219-b5e9-0bdf324a1b4e.jpg)

After:
![after](https://user-images.githubusercontent.com/48293849/177768629-7b57490e-74d4-4c54-ae69-f04ea60c5cdd.jpg)

**Testing (for code that is not small enough to be easily understandable)**
I tested it with the URL provided in the issue https://youtu.be/7pfxHoAnCkE.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: c501e0d301050da3e6205741f6cffb9a728845bb