### PR TITLE
Switch cookie value from YES+ to PENDING+

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -147,7 +147,7 @@ function runApp() {
       session.defaultSession.cookies.set({
         url: url,
         name: 'CONSENT',
-        value: 'YES+',
+        value: 'PENDING+',
         sameSite: 'no_restriction'
       })
     })


### PR DESCRIPTION
---
switch consent cookie value from YES+ to PENDING+
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Sending the YES+ value will consent to google tracking you so this PR should help with privacy (at least for European users?)

**Description**
Changes the consent cookie from YES+ to PENDING+ (This is what NewPipe does, the only thing that this does not work for seems to be MIX playlists which aren't supported in FreeTube at the moment anyway)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 
- Use a VPN from a European server, go to pages that use consent verification (youtube comments)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 11
 - FreeTube version: 0.16.0

