### PR TITLE
Fix style issue introduced in #2398

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -17,11 +17,10 @@
 
 .banner {
   width: 80%;
-  margin: 0 auto;
+  margin: 20px auto 0;
 }
 
 .flexBox {
-  margin-top: 60px;
   display: block;
 }
 
@@ -45,7 +44,7 @@
 
   .banner {
     width: 80%;
-    margin-top: 60px;
+    margin-top: 20px;
   }
 
   .flexBox {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Fix style issue introduced in #2398

**Description**
`margin-top` with 60px seems way too much even for narrow windows not to mention wide windows

**Screenshots (if appropriate)**
There are 2 window size variants tested (according to affected stylesheet's media queires)

<details>
<summary>> 680px</summary>

![mt_680px_1](https://user-images.githubusercontent.com/1018543/179914792-9f018046-65fe-455e-8289-22524cacd09c.png)
![mt_680px_2](https://user-images.githubusercontent.com/1018543/179914836-3cb9c7c3-7790-463e-95d0-73f0ef65aa72.png)
![mt_680px_3](https://user-images.githubusercontent.com/1018543/179914838-493034a8-744d-4a01-b4d1-518cceaa0f25.png)
![mt_680px_4](https://user-images.githubusercontent.com/1018543/179914840-426c189c-a4bc-45b9-b956-a65b16ac1a06.png)

</details>

<details>
<summary><= 680px</summary>

![lt_680px_1](https://user-images.githubusercontent.com/1018543/179914900-f6ecb7fe-8163-4290-bba1-aa3081051703.png)
![lt_680px_2](https://user-images.githubusercontent.com/1018543/179914914-61318dbc-ed79-48ec-9fd9-f34b114481d8.png)
![lt_680px_3](https://user-images.githubusercontent.com/1018543/179914917-0feb96bf-49fc-4e37-85a5-3d4e32f02ff9.png)
![lt_680px_4](https://user-images.githubusercontent.com/1018543/179914925-642788c9-8496-40c6-8d67-01bf08dcb93b.png)

</details>

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Please describe shortly how you tested it and whether there are any ramifications remaining. 

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: e6fdfa5f7ddfccf4cd840b781f7d15a66555929b

**Additional context**
PR for `development` to be created once this is reviewed (too lazy to make changes on 2 branches for every request change)
