### PR TITLE
Upgrade electron from 16 > 19

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/env",
       {
         "targets": {
-          "chrome": "96",
+          "chrome": "102",
           "node": 16
         }
       }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^19.0.11",
+    "electron": "^19.0.12",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^19.0.12",
+    "electron": "^19.0.14",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^16.2.7",
+    "electron": "^19.0.8",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^19.0.10",
+    "electron": "^19.0.11",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "5.2.6",
-    "electron": "^19.0.8",
+    "electron": "^19.0.10",
     "electron-builder": "^23.0.3",
     "electron-builder-squirrel-windows": "^22.13.1",
     "electron-debug": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^19.0.12:
-  version "19.0.12"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.12.tgz#73d11cc2a3e4dbcd61fdc1c39561e7a7911046e9"
-  integrity sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==
+electron@^19.0.14:
+  version "19.0.14"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.14.tgz#f6eafeea65edb0cb6ac079c3167ad6d6907c539c"
+  integrity sha512-I+ptDJZXjwMTitjF4W1s/kkt5nMrzO+TeWP3oy/kmH3pilhNag2OQA7+/cGOHTTUubDMFA8Ni4AvlQ0VDRScwQ==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^19.0.10:
-  version "19.0.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.10.tgz#4d2f03f307fbb70a295ff419112130b75661eda9"
-  integrity sha512-EiWtPWdD7CzkRkp1cw7t0N9W2qhI5XZOudHX7daOh5wI076nsdV2dtlAf/XyTHhPNoKR5qhTWrSnYL9PY6D1vg==
+electron@^19.0.11:
+  version "19.0.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.11.tgz#0c0a52abc08694fd38916d9270baf45bb7752a27"
+  integrity sha512-GPM6C1Ze17/gR4koTE171MxrI5unYfFRgXQdkMdpWM2Cd55LMUrVa0QHCsfKpsaloufv9T65lsOn0uZuzCw5UA==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^19.0.11:
-  version "19.0.11"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.11.tgz#0c0a52abc08694fd38916d9270baf45bb7752a27"
-  integrity sha512-GPM6C1Ze17/gR4koTE171MxrI5unYfFRgXQdkMdpWM2Cd55LMUrVa0QHCsfKpsaloufv9T65lsOn0uZuzCw5UA==
+electron@^19.0.12:
+  version "19.0.12"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.12.tgz#73d11cc2a3e4dbcd61fdc1c39561e7a7911046e9"
+  integrity sha512-GOvG0t2NCeJYIfmC3g/dnEAQ71k3nQDbRVqQhpi2YbsYMury0asGJwqnVAv2uZQEwCwSx4XOwOQARTFEG/msWw==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,7 +913,7 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@electron/get@^1.13.0":
+"@electron/get@^1.14.1":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-1.14.1.tgz#16ba75f02dffb74c23965e72d617adc721d27f40"
   integrity sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==
@@ -1285,10 +1285,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.33.tgz#3c1879b276dc63e73030bb91165e62a4509cd506"
   integrity sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==
 
-"@types/node@^14.6.2":
-  version "14.18.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
-  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
+"@types/node@^16.11.26":
+  version "16.11.45"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.45.tgz#155b13a33c665ef2b136f7f245fa525da419e810"
+  integrity sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==
 
 "@types/plist@^3.0.1":
   version "3.0.2"
@@ -3081,13 +3081,13 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^16.2.7:
-  version "16.2.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.2.7.tgz#945e35ad1625e604f10c124fb912d1e2b3018317"
-  integrity sha512-aZKF3b00+rqW/HGs8lJM5DhPNj+mOfCuhLSiFXV6J9dQCIRhctJTmToOrwXfbCxvXK8as8eQTNl5uSfnHmH6tA==
+electron@^19.0.8:
+  version "19.0.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.8.tgz#c4d4ba915de554f2926261eb37d3527d2b092d4c"
+  integrity sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==
   dependencies:
-    "@electron/get" "^1.13.0"
-    "@types/node" "^14.6.2"
+    "@electron/get" "^1.14.1"
+    "@types/node" "^16.11.26"
     extract-zip "^1.0.3"
 
 emoji-regex@^8.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@ electron-to-chromium@^1.4.118:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
   integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
 
-electron@^19.0.8:
-  version "19.0.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.8.tgz#c4d4ba915de554f2926261eb37d3527d2b092d4c"
-  integrity sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==
+electron@^19.0.10:
+  version "19.0.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-19.0.10.tgz#4d2f03f307fbb70a295ff419112130b75661eda9"
+  integrity sha512-EiWtPWdD7CzkRkp1cw7t0N9W2qhI5XZOudHX7daOh5wI076nsdV2dtlAf/XyTHhPNoKR5qhTWrSnYL9PY6D1vg==
   dependencies:
     "@electron/get" "^1.14.1"
     "@types/node" "^16.11.26"


### PR DESCRIPTION

**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
Might or might not fix issue in #2113

Closes #2358

**Description**
16.x is not supported anymore
From https://www.electronjs.org/blog/electron-17-0
<img width="257" alt="image" src="https://user-images.githubusercontent.com/1018543/175764286-3e7f829b-6814-4bbf-88a0-8dd61774a9cf.png">

[Breaking change in 17.x](https://www.electronjs.org/blog/electron-17-0#breaking-changes) = 
- [`desktopCapturer.getSources`](https://www.electronjs.org/blog/electron-17-0#desktopcapturergetsources-in-the-renderer)
- The end

[Breaking change in 18.x](https://www.electronjs.org/blog/electron-18-0#breaking-changes) = 
- [Removed `nativeWindowOpen`](https://www.electronjs.org/blog/electron-18-0#removed-nativewindowopen)
- The end

[Breaking change in 19.x](https://www.electronjs.org/blog/electron-19-0#breaking-changes)

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
Use test build daily in different OS

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 5d4048571f9dcb9f57c4f215ae59b00ebe0d20d1

**Additional context**
Add any other context about the problem here.
