### PR TITLE
Stop electron-builder trying to create GitHub releases in CI workflow

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -146,6 +146,7 @@ builder
   .build({
     targets,
     config,
+    publish: 'never'
   })
   .then(m => {
     console.log(m)


### PR DESCRIPTION
---
Stop electron-builder trying to create GitHub releases in CI workflow
---

**Pull Request Type**

- [x] Bugfix

**Description**

By default electron-builder will try to publish the built artifacts to GitHub releases, as we don't publish CI builds to GitHub releases and we handle the publishing ourselves, we don't need electron-builder to do that for us. Personally I think this should be an opt-in setting instead of an opt-out one but I guess the electron-builder developers see it differently.

**Screenshots (if appropriate)**
The error message in the GitHub actions log:
```
InvalidConfigurationError: GitHub Personal Access Token is not set, neither programmatically, nor using env "GH_TOKEN"
    at new GitHubPublisher (/home/runner/work/FreeTube/FreeTube/node_modules/electron-publish/src/gitHubPublisher.ts:47:15)
    at createPublisher (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/PublishManager.ts:298:14)
    at PublishManager.getOrCreatePublisher (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/PublishManager.ts:217:19)
    at PublishManager.scheduleUpload (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/PublishManager.ts:151:28)
    at EventEmitter.<anonymous> (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/PublishManager.ts:131:14)
    at EventEmitter.emit (node:events:539:35)
    at Packager.dispatchArtifactCreated (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/packager.ts:270:23)
    at bluebird_lst_1.default.map.concurrency (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/updateInfoBuilder.ts:232:16)
From previous event:
    at processImmediate (node:internal/timers:466:21)
From previous event:
    at Object.writeUpdateInfoFiles (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/updateInfoBuilder.ts:211:25)
    at PublishManager.awaitTasks (/home/runner/work/FreeTube/FreeTube/node_modules/app-builder-lib/src/publish/PublishManager.ts:238:11)
    at Object.executeFinally (/home/runner/work/FreeTube/FreeTube/node_modules/builder-util/src/promise.ts:23:3) {
  code: 'ERR_ELECTRON_BUILDER_INVALID_CONFIGURATION'
```

**Testing (for code that is not small enough to be easily understandable)**
Locally: `yarn build` (build worked the same as before)
GitHub actions: [before](https://github.com/absidue/FreeTube/runs/7425211127?check_suite_focus=true#step:10:107) |  [after](https://github.com/absidue/FreeTube/runs/7426983248?check_suite_focus=true#step:10:92)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 5d4048571f9dcb9f57c4f215ae59b00ebe0d20d1