### PR TITLE
! Fix style issue introduced in https://github.com/FreeTubeApp/FreeTube/pull/2399

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -17,11 +17,10 @@
 
 .banner {
   width: 80%;
-  margin: 0 auto;
+  margin: 20px auto 0;
 }
 
 .flexBox {
-  margin-top: 60px;
   display: block;
 }
 
@@ -45,7 +44,7 @@
 
   .banner {
     width: 80%;
-    margin-top: 60px;
+    margin-top: 20px;
   }
 
   .flexBox {


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Related issue**
Fix style issue introduced in #2399

**Description**
`margin-top` with 60px seems way too much even for narrow windows not to mention wide windows

**Screenshots (if appropriate)**
Please refer to #2405 

**Testing (for code that is not small enough to be easily understandable)**
Tested locally (same as #2405)

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 9a01030919003e4dfb5826240de21d564aaea805

**Additional context**
Add any other context about the problem here.
