### PR TITLE
Fix scrolling through the download dropdown

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -292,6 +292,18 @@ export default Vue.extend({
           }
         ]
       })
+
+      this.$watch('$refs.downloadButton.dropdownShown', (dropdownShown) => {
+        this.$parent.infoAreaSticky = !dropdownShown
+
+        if (dropdownShown && window.innerWidth >= 901) {
+          // adds a slight delay so we know that the dropdown has shown up
+          // and won't mess up our scrolling
+          Promise.resolve().then(() => {
+            this.$parent.$refs.infoArea.scrollIntoView()
+          })
+        }
+      })
     }
   },
   methods: {

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -95,6 +95,7 @@
         />
         <ft-icon-button
           v-if="!isUpcoming && downloadLinks.length > 0"
+          ref="downloadButton"
           :title="$t('Video.Download Video')"
           class="option"
           theme="secondary"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -76,7 +76,8 @@ export default Vue.extend({
       timestamp: null,
       playNextTimeout: null,
       playNextCountDownIntervalId: null,
-      pictureInPictureButtonInverval: null
+      pictureInPictureButtonInverval: null,
+      infoAreaSticky: true
     }
   },
   computed: {

--- a/src/renderer/views/Watch/Watch.sass
+++ b/src/renderer/views/Watch/Watch.sass
@@ -68,7 +68,11 @@
     grid-area: info
     position: relative
 
-    @media only screen and (min-width: 901px)
+  @media only screen and (min-width: 901px)
+    .infoArea
+      scroll-margin-top: 76px
+
+    .infoAreaSticky
       position: sticky
       top: 76px
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -65,8 +65,8 @@
       </div>
     </div>
     <div
-      class="infoArea"
       ref="infoArea"
+      class="infoArea"
       :class="{ infoAreaSticky }"
     >
       <watch-video-info

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -64,7 +64,11 @@
         </div>
       </div>
     </div>
-    <div class="infoArea">
+    <div
+      class="infoArea"
+      ref="infoArea"
+      :class="{ infoAreaSticky }"
+    >
       <watch-video-info
         v-if="!isLoading"
         :id="videoId"


### PR DESCRIPTION
---
Fix scrolling through the download dropdown (RC branch)
---

**Pull Request Type**

- [x] Bugfix

**Related issue**
works around issues introduced in #2284

**Description**
This pull request fixes the issue with not being able to scroll through the download dropdown. It toggles the sticky css position on the video info section when the downloads menu is open. It also includes some extra code to make the toggling feel seemless.

**Testing (for code that is not small enough to be easily understandable)**
I tested this PR both on wide and narrow screens and was able to scroll though the download dropdown without an issues.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0 RC (7ec1c1eb05738d9d45b1e2e5d3321cc086c0176f)