### PR TITLE
Fix scrolling through the download dropdown

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -300,6 +300,18 @@ export default Vue.extend({
           }
         ]
       })
+
+      this.$watch('$refs.downloadButton.dropdownShown', (dropdownShown) => {
+        this.$parent.infoAreaSticky = !dropdownShown
+
+        if (dropdownShown && window.innerWidth >= 901) {
+          // adds a slight delay so we know that the dropdown has shown up
+          // and won't mess up our scrolling
+          Promise.resolve().then(() => {
+            this.$parent.$refs.infoArea.scrollIntoView()
+          })
+        }
+      })
     }
   },
   methods: {

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -96,6 +96,7 @@
         />
         <ft-icon-button
           v-if="!isUpcoming && downloadLinks.length > 0"
+          ref="downloadButton"
           :title="$t('Video.Download Video')"
           class="option"
           theme="secondary"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -79,7 +79,8 @@ export default Vue.extend({
       timestamp: null,
       playNextTimeout: null,
       playNextCountDownIntervalId: null,
-      pictureInPictureButtonInverval: null
+      pictureInPictureButtonInverval: null,
+      infoAreaSticky: true
     }
   },
   computed: {

--- a/src/renderer/views/Watch/Watch.sass
+++ b/src/renderer/views/Watch/Watch.sass
@@ -74,7 +74,11 @@
     grid-area: info
     position: relative
 
-    @media only screen and (min-width: 901px)
+  @media only screen and (min-width: 901px)
+    .infoArea
+      scroll-margin-top: 76px
+
+    .infoAreaSticky
       position: sticky
       top: 76px
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -75,6 +75,8 @@
     <div
       v-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
       class="infoArea"
+      ref="infoArea"
+      :class="{ infoAreaSticky }"
     >
       <watch-video-info
         v-if="!isLoading"

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -74,8 +74,8 @@
     />
     <div
       v-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
-      class="infoArea"
       ref="infoArea"
+      class="infoArea"
       :class="{ infoAreaSticky }"
     >
       <watch-video-info


### PR DESCRIPTION
---
Fix scrolling through the download dropdown (development branch)
---

**Pull Request Type**

- [x] Bugfix

**Related issue**
works around issues introduced in #2284

**Description**
This pull request fixes the issue with not being able to scroll through the download dropdown. It toggles the sticky css position on the video info section when the downloads menu is open. It also includes some extra code to make the toggling feel seemless.

**Testing (for code that is not small enough to be easily understandable)**
I tested this PR both on wide and narrow screens and was able to scroll though the download dropdown without an issues.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0 RC/development (9fa4a5a36eb46cb7c2fb6d3d6a17749df5efbc97)