### PR TITLE
Update top nav search input to open new window on shift click/enter

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -95,13 +95,13 @@ export default Vue.extend({
     setTimeout(this.addListener, 200)
   },
   methods: {
-    handleClick: function () {
+    handleClick: function (e) {
       // No action if no input text
       if (!this.inputDataPresent) { return }
 
       this.searchState.showOptions = false
       this.$emit('input', this.inputData)
-      this.$emit('click', this.inputData)
+      this.$emit('click', this.inputData, { event: e })
     },
 
     handleInput: function (val) {
@@ -185,7 +185,7 @@ export default Vue.extend({
       if (inputElement !== null) {
         inputElement.addEventListener('keydown', (event) => {
           if (event.key === 'Enter') {
-            this.handleClick()
+            this.handleClick(event)
           }
         })
       }

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -7,7 +7,6 @@ import $ from 'jquery'
 import debounce from 'lodash.debounce'
 import ytSuggest from 'youtube-suggest'
 
-import { ipcRenderer } from 'electron'
 import { IpcChannels } from '../../../constants'
 
 export default Vue.extend({

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -7,6 +7,7 @@ import $ from 'jquery'
 import debounce from 'lodash.debounce'
 import ytSuggest from 'youtube-suggest'
 
+import { ipcRenderer } from 'electron'
 import { IpcChannels } from '../../../constants'
 
 export default Vue.extend({
@@ -109,8 +110,9 @@ export default Vue.extend({
     this.debounceSearchResults = debounce(this.getSearchSuggestions, 200)
   },
   methods: {
-    goToSearch: async function (query) {
+    goToSearch: async function (query, { event }) {
       const appWidth = $(window).width()
+      const doCreateNewWindow = event && event.shiftKey
 
       if (appWidth <= 680) {
         const searchContainer = $('.searchContainer').get(0)
@@ -133,9 +135,10 @@ export default Vue.extend({
             if (playlistId && playlistId.length > 0) {
               query.playlistId = playlistId
             }
-            this.$router.push({
+            this.openInternalPath({
               path: `/watch/${videoId}`,
-              query: query
+              query,
+              doCreateNewWindow
             })
             break
           }
@@ -153,9 +156,10 @@ export default Vue.extend({
           case 'search': {
             const { searchQuery, query } = result
 
-            this.$router.push({
+            this.openInternalPath({
               path: `/search/${encodeURIComponent(searchQuery)}`,
-              query
+              query,
+              doCreateNewWindow
             })
             break
           }
@@ -176,23 +180,25 @@ export default Vue.extend({
           case 'channel': {
             const { channelId, idType, subPath } = result
 
-            this.$router.push({
+            this.openInternalPath({
               path: `/channel/${channelId}/${subPath}`,
-              query: { idType }
+              query: { idType },
+              doCreateNewWindow
             })
             break
           }
 
           case 'invalid_url':
           default: {
-            this.$router.push({
+            this.openInternalPath({
               path: `/search/${encodeURIComponent(query)}`,
               query: {
                 sortBy: this.searchSettings.sortBy,
                 time: this.searchSettings.time,
                 type: this.searchSettings.type,
                 duration: this.searchSettings.duration
-              }
+              },
+              doCreateNewWindow
             })
           }
         }
@@ -316,6 +322,27 @@ export default Vue.extend({
 
     toggleSideNav: function () {
       this.$store.commit('toggleSideNav')
+    },
+
+    openInternalPath: function({ path, doCreateNewWindow, query = {} }) {
+      if (this.usingElectron && doCreateNewWindow) {
+        const { ipcRenderer } = require('electron')
+
+        // Combine current document path and new "hash" as new window startup URL
+        const newWindowStartupURL = [
+          window.location.href.split('#')[0],
+          `#${path}?${(new URLSearchParams(query)).toString()}`
+        ].join('')
+        ipcRenderer.send(IpcChannels.CREATE_NEW_WINDOW, {
+          windowStartupUrl: newWindowStartupURL
+        })
+      } else {
+        // Web
+        this.$router.push({
+          path,
+          query
+        })
+      }
     },
 
     createNewWindow: function () {


### PR DESCRIPTION

**Pull Request Type**
Please select what type of pull request this is:
- [x] Feature Implementation

**Related issue**
N/A

**Description**
Opening a new window, loading channel and start searching seems wasting time
Browsers have search bar to open search in new tab/window already

Top nav search bar updated to open new window on shift click (on search/go button) or shift enter (on input bar)

Clicking search suggestion with shift still won't open a new window (Can be changed if needed)

**Screenshots (if appropriate)**

https://user-images.githubusercontent.com/1018543/182007959-447e2b09-d365-4c73-803d-a17b1b7c3f34.mov


**Testing (for code that is not small enough to be easily understandable)**
Enter 
- Random search string
- Channel/playlist/video URL

And perform
- Shift click on search/go button
- Shift + Enter

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 9fa4a5a36eb46cb7c2fb6d3d6a17749df5efbc97

**Additional context**
Add any other context about the problem here.
