### PR TITLE
Respect autoplay playlists setting

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -129,6 +129,9 @@ export default Vue.extend({
     playNextVideo: function () {
       return this.$store.getters.getPlayNextVideo
     },
+    autoplayPlaylists: function () {
+      return this.$store.getters.getAutoplayPlaylists
+    },
     hideRecommendedVideos: function () {
       return this.$store.getters.getHideRecommendedVideos
     },
@@ -915,7 +918,7 @@ export default Vue.extend({
     },
 
     handleVideoEnded: function () {
-      if (!this.watchingPlaylist && !this.playNextVideo) {
+      if ((!this.watchingPlaylist || !this.autoplayPlaylists) && !this.playNextVideo) {
         return
       }
 


### PR DESCRIPTION
---
Respect autoplay playlists setting
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes #2362

**Description**
Fixes the issue where the "Autoplay Playlists" setting wasn't being respected by the app.

**Testing (for code that is not small enough to be easily understandable)**
Attempted watching a playlist with the setting disabled and letting a video end. Attempted watching a playlist with the setting enabled and letting a video end. Both scenarios act as expected.

**Desktop (please complete the following information):**
 - OS: Fedora
 - OS Version: 35
 - FreeTube version: Version v0.17.0 RC
