### PR TITLE
Fix banner width

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -16,8 +16,12 @@
 }
 
 .banner {
-  width: 80%;
+  width: 85%;
   margin: 20px auto 0;
+}
+
+.banner-wrapper {
+  margin: 0 10px;
 }
 
 .flexBox {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -14,6 +14,7 @@
     >
       <div
         v-if="showUpdatesBanner || showBlogBanner"
+        class="banner-wrapper"
       >
         <ft-notification-banner
           v-if="showUpdatesBanner"


### PR DESCRIPTION
---
Fix banner width (development branch)
---

**Pull Request Type**

- [x] Bugfix

**Description**
Makes the banners the same width as the cards below them.

**Screenshots (if appropriate)**
![before](https://user-images.githubusercontent.com/48293849/182041917-da1f41b6-d69d-432f-8871-d11053e94805.jpg)
![fixed](https://user-images.githubusercontent.com/48293849/182041918-cbc2b890-5635-4e9d-8e9a-76a5a31884af.jpg)

**Testing (for code that is not small enough to be easily understandable)**
I tested both the new blog and update banners.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0 RC