### PR TITLE
Fix Proxy Test URL

### DIFF
--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -31,8 +31,7 @@ export default Vue.extend({
     return {
       isLoading: false,
       dataAvailable: false,
-      proxyTestUrl: 'https://api.ipify.org?format=json',
-      proxyTestUrl1: 'https://freegeoip.app/json/',
+      proxyTestUrl: 'https://ipwho.is/',
       proxyId: '',
       proxyCountry: '',
       proxyRegion: '',
@@ -125,11 +124,11 @@ export default Vue.extend({
       if (!this.useProxy) {
         this.enableProxy()
       }
-      $.getJSON(this.proxyTestUrl1, (response) => {
+      $.getJSON(this.proxyTestUrl, (response) => {
         console.log(response)
         this.proxyIp = response.ip
-        this.proxyCountry = response.country_name
-        this.proxyRegion = response.region_name
+        this.proxyCountry = response.country
+        this.proxyRegion = response.region
         this.proxyCity = response.city
         this.dataAvailable = true
       }).fail((xhr, textStatus, error) => {

--- a/src/renderer/components/proxy-settings/proxy-settings.vue
+++ b/src/renderer/components/proxy-settings/proxy-settings.vue
@@ -45,7 +45,7 @@
         class="center"
         :style="{opacity: useProxy ? 1 : 0.4}"
       >
-        {{ $t('Settings.Proxy Settings.Clicking on Test Proxy will send a request to') }} https://freegeoip.app/json/
+        {{ $t('Settings.Proxy Settings.Clicking on Test Proxy will send a request to') }} {{ proxyTestUrl }}
       </p>
       <ft-flex-box>
         <ft-button


### PR DESCRIPTION
---
Fix Proxy Test URL
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
Closes #2389

**Description**
Our previous site for testing the built in proxy stopped working. The URL has been updated to use https://ipwho.is/ instead of the existing one.

**Testing (for code that is not small enough to be easily understandable)**
Enable Tor Proxy. Click on the "Test Proxy" button. Results are shown as expected.

**Desktop (please complete the following information):**
 - OS: Fedora
 - OS Version: 35
 - FreeTube version: v0.17.0 Nightly
