### PR TITLE
fix unsubscribe from "All Channels" profile

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -606,7 +606,7 @@ export default Vue.extend({
           message: this.$t('Channel.Channel has been removed from your subscriptions')
         })
 
-        if (this.activeProfile === MAIN_PROFILE_ID) {
+        if (this.activeProfile._id === MAIN_PROFILE_ID) {
           // Check if a subscription exists in a different profile.
           // Remove from there as well.
           let duplicateSubscriptions = 0
@@ -651,7 +651,7 @@ export default Vue.extend({
           message: this.$t('Channel.Added channel to your subscriptions')
         })
 
-        if (this.activeProfile !== MAIN_PROFILE_ID) {
+        if (this.activeProfile._id !== MAIN_PROFILE_ID) {
           const index = primaryProfile.subscriptions.findIndex((channel) => {
             return channel.id === this.id
           })


### PR DESCRIPTION
---
Fix unsubscribe from "All Channels" profile
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation

**Related issue**
None.

**Description**
When on the "All Channels" profile, it should unsubscribe all channels from that channel. (It does this if you unsubscribe while on a channel's video but not from their Channel page)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
Subscribe to a channel on a few profiles, unsubscribe to the channel from the "Channel" page on the "All Channels" profile

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 11
 - FreeTube version: 0.17.0

**Additional context**
I fixed this issue here https://github.com/FreeTubeApp/FreeTube/pull/1934 as well but I don't have the time to fix up that PR