### PR TITLE
Drastically improve loading speed of the settings page

### DIFF
--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -122,8 +122,8 @@ export default Vue.extend({
         this.$t('Settings.General Settings.System Default')
       ]
 
-      Object.keys(this.$i18n.messages).forEach((locale) => {
-        const localeName = this.$i18n.messages[locale]['Locale Name']
+      Object.entries(this.$i18n.messages).forEach(([locale, localeData]) => {
+        const localeName = localeData['Locale Name']
         if (typeof localeName !== 'undefined') {
           names.push(localeName)
         } else {


### PR DESCRIPTION
---
Drastically improve loading speed of the settings page
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Description**
This pull request fixes the slow loading of the settings page by only loading the language list once, instead of the 45 times it does it at the moment (once outside of the loop and once for each language inside the loop). As the list of language names is also regenerated when you choose a different language, this change also speeds up that as well.

<details><summary>Illustration of what it feels like to open the settings page now:</summary>

![speed](https://user-images.githubusercontent.com/48293849/182957732-26122abd-22a7-43c5-961e-91130fa10a43.jpg)

</details>


**Screenshots (if appropriate)**
Here is how long it takes to generate the list of language names with and without this change. The numbers are in milliseconds.

![settings_locale_list_performance](https://user-images.githubusercontent.com/48293849/182957435-8bbf05b8-ec39-4b32-8d2d-782bc5ab2d1f.jpg)

**Testing (for code that is not small enough to be easily understandable)**
Open the settings page and change language. You will definitely notice the difference, if you don't then your computer is too fast (I would definitely like to borrow it at some point).

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0