### PR TITLE
Fix channel page ID handling

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -174,10 +174,11 @@ export default Vue.extend({
           }
 
           case 'channel': {
-            const { channelId, subPath } = result
+            const { channelId, idType, subPath } = result
 
             this.$router.push({
-              path: `/channel/${channelId}/${subPath}`
+              path: `/channel/${channelId}/${subPath}`,
+              query: { idType }
             })
             break
           }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -621,7 +621,7 @@ const actions = {
     let urlType = 'unknown'
 
     const channelPattern =
-      /^\/(?:(c|channel|user)\/)?(?<channelId>[^/]+)(?:\/(join|featured|videos|playlists|about|community|channels))?\/?$/
+      /^\/(?:(?<type>channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(join|featured|videos|playlists|about|community|channels))?\/?$/
 
     const typePatterns = new Map([
       ['playlist', /^\/playlist\/?$/],
@@ -719,7 +719,9 @@ const actions = {
 
       */
       case 'channel': {
-        const channelId = url.pathname.match(channelPattern).groups.channelId
+        const match = url.pathname.match(channelPattern)
+        const channelId = match.groups.channelId
+        const idType = ['channel', 'user', 'c'].indexOf(match.groups.type) + 1
         if (!channelId) {
           throw new Error('Channel: could not extract id')
         }
@@ -741,6 +743,7 @@ const actions = {
         return {
           urlType: 'channel',
           channelId,
+          idType,
           subPath
         }
       }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -170,6 +170,7 @@ export default Vue.extend({
   watch: {
     $route() {
       // react to route changes...
+      this.originalId = this.$route.params.id
       this.id = this.$route.params.id
       this.currentTab = this.$route.params.currentTab ?? 'videos'
       this.latestVideosPage = 2
@@ -232,6 +233,7 @@ export default Vue.extend({
     }
   },
   mounted: function () {
+    this.originalId = this.$route.params.id
     this.id = this.$route.params.id
     this.currentTab = this.$route.params.currentTab ?? 'videos'
     this.isLoading = true
@@ -259,14 +261,14 @@ export default Vue.extend({
 
     getChannelInfoLocal: function () {
       this.apiUsed = 'local'
-      const expectedId = this.id
-      ytch.getChannelInfo({ channelId: expectedId }).then((response) => {
+      const expectedId = this.originalId
+      ytch.getChannelInfo({ channelId: this.id }).then((response) => {
         if (response.alertMessage) {
           this.setErrorMessage(response.alertMessage)
           return
         }
         this.errorMessage = ''
-        if (expectedId !== this.id) {
+        if (expectedId !== this.originalId) {
           return
         }
 
@@ -332,9 +334,9 @@ export default Vue.extend({
 
     getChannelVideosLocal: function () {
       this.isElementListLoading = true
-      const expectedId = this.id
-      ytch.getChannelVideos({ channelId: expectedId, sortBy: this.videoSortBy }).then((response) => {
-        if (expectedId !== this.id) {
+      const expectedId = this.originalId
+      ytch.getChannelVideos({ channelId: this.id, sortBy: this.videoSortBy }).then((response) => {
+        if (expectedId !== this.originalId) {
           return
         }
 
@@ -383,9 +385,9 @@ export default Vue.extend({
       this.isLoading = true
       this.apiUsed = 'invidious'
 
-      const expectedId = this.id
-      this.invidiousGetChannelInfo(expectedId).then((response) => {
-        if (expectedId !== this.id) {
+      const expectedId = this.originalId
+      this.invidiousGetChannelInfo(this.id).then((response) => {
+        if (expectedId !== this.originalId) {
           return
         }
 
@@ -463,9 +465,9 @@ export default Vue.extend({
     },
 
     getPlaylistsLocal: function () {
-      const expectedId = this.id
-      ytch.getChannelPlaylistInfo({ channelId: expectedId, sortBy: this.playlistSortBy }).then((response) => {
-        if (expectedId !== this.id) {
+      const expectedId = this.originalId
+      ytch.getChannelPlaylistInfo({ channelId: this.id, sortBy: this.playlistSortBy }).then((response) => {
+        if (expectedId !== this.originalId) {
           return
         }
 

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -33,6 +33,7 @@ export default Vue.extend({
       isElementListLoading: false,
       currentTab: 'videos',
       id: '',
+      idType: 0,
       channelName: '',
       bannerUrl: '',
       thumbnailUrl: '',
@@ -172,6 +173,7 @@ export default Vue.extend({
       // react to route changes...
       this.originalId = this.$route.params.id
       this.id = this.$route.params.id
+      this.idType = this.$route.query.idType ? Number(this.$route.query.idType) : 0
       this.currentTab = this.$route.params.currentTab ?? 'videos'
       this.latestVideosPage = 2
       this.searchPage = 2
@@ -235,6 +237,7 @@ export default Vue.extend({
   mounted: function () {
     this.originalId = this.$route.params.id
     this.id = this.$route.params.id
+    this.idType = this.$route.query.idType ? Number(this.$route.query.idType) : 0
     this.currentTab = this.$route.params.currentTab ?? 'videos'
     this.isLoading = true
 
@@ -262,7 +265,7 @@ export default Vue.extend({
     getChannelInfoLocal: function () {
       this.apiUsed = 'local'
       const expectedId = this.originalId
-      ytch.getChannelInfo({ channelId: this.id }).then((response) => {
+      ytch.getChannelInfo({ channelId: this.id, channelIdType: this.idType }).then((response) => {
         if (response.alertMessage) {
           this.setErrorMessage(response.alertMessage)
           return
@@ -276,6 +279,8 @@ export default Vue.extend({
         const channelName = response.author
         const channelThumbnailUrl = response.authorThumbnails[2].url
         this.id = channelId
+        // set the id type to 1 so that searching and sorting work
+        this.idType = 1
         this.channelName = channelName
         this.isFamilyFriendly = response.isFamilyFriendly
         document.title = `${this.channelName} - ${process.env.PRODUCT_NAME}`
@@ -335,7 +340,7 @@ export default Vue.extend({
     getChannelVideosLocal: function () {
       this.isElementListLoading = true
       const expectedId = this.originalId
-      ytch.getChannelVideos({ channelId: this.id, sortBy: this.videoSortBy }).then((response) => {
+      ytch.getChannelVideos({ channelId: this.id, channelIdType: this.idType, sortBy: this.videoSortBy }).then((response) => {
         if (expectedId !== this.originalId) {
           return
         }
@@ -466,7 +471,7 @@ export default Vue.extend({
 
     getPlaylistsLocal: function () {
       const expectedId = this.originalId
-      ytch.getChannelPlaylistInfo({ channelId: this.id, sortBy: this.playlistSortBy }).then((response) => {
+      ytch.getChannelPlaylistInfo({ channelId: this.id, channelIdType: this.idType, sortBy: this.playlistSortBy }).then((response) => {
         if (expectedId !== this.originalId) {
           return
         }
@@ -734,7 +739,7 @@ export default Vue.extend({
 
     searchChannelLocal: function () {
       if (this.searchContinuationString === '') {
-        ytch.searchChannel({ channelId: this.id, query: this.lastSearchQuery }).then((response) => {
+        ytch.searchChannel({ channelId: this.id, channelIdType: this.idType, query: this.lastSearchQuery }).then((response) => {
           console.log(response)
           this.searchResults = response.items
           this.isElementListLoading = false


### PR DESCRIPTION
---
Fix channel page ID handling
---

**Pull Request Type**
- [x] Bugfix

**Related issue**
closes #2420
fixes a race condition introduced by #2259

**Description**
This pull request resolves two issues relating to the handling of channel IDs on the channel page.

1. Treat `/channel/`, `/user/` and `/c/` channel URLs differently, as a `/user/` and `/c/` URLs with the same id might point to different channels.
2. Fixes the race condition introduced by #2259, that happens if fetching the info is faster than the video or playlist fetching. The issue is that after the info is fetched it overwrites the `id` property with the actual channel ID, so if you entered this URL `https://www.youtube.com/c/linustechtips`, the `id` property is set to `linustechtips` and when the info request returns it overwrites it with the channel ID `UCXuqSBlHAE6Xw-yeJA0Tunw`, as the videos and playlists functions still expect the `id` to be `linustechtips` they abort.

The fix for this was to introduce an `originalId` property that is only updated when the actual channel changes, which is then used for the abort checks.

**Testing (for code that is not small enough to be easily understandable)**
I tested the following URLs:
- https://www.youtube.com/c/linustechtips
- https://www.youtube.com/c/RealEngineering
- https://www.youtube.com/user/realengineering

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0