### PR TITLE
Watch: Fix "Show More Replies" button visibility condition

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -175,7 +175,7 @@
             </p>
           </div>
           <div
-            v-if="comment.replies.length < comment.numReplies"
+            v-if="comment.replyToken !== null"
             class="showMoreReplies"
             @click="getCommentReplies(index)"
           >


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- Bugfix

**Related issue**
None

**Description**
YouTube's reply count is unreliable. If I had to wager a guess, it's probably because comments that have been flagged/removed by the system don't decrement the counter at all.
This PR changes the visibility condition of the "Show More Replies" to check if the continuation token is null or not, which is, as far as I can see, reliable without a fault.

**Testing / Screenshots**
Tested video: https://www.youtube.com/watch?v=cMIgU6YlsEw (pinned comment)
### BEFORE
![Screenshot from 2022-08-06 19-32-02](https://user-images.githubusercontent.com/41585298/183261743-0f57d9a4-9090-4af0-8239-93f5981fa449.png)

### AFTER
![Screenshot from 2022-08-06 19-32-12](https://user-images.githubusercontent.com/41585298/183261747-5bcb5bb4-1f4d-42ad-b7af-8057d3224d61.png)
