### PR TITLE
Update all GH workflow to used `ubuntu-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         runtime: [ linux-x64, linux-arm64, win-x64, osx-x64 ]
         include:
         - runtime: linux-x64
-          os: ubuntu-18.04
+          os: ubuntu-latest
 
         - runtime: linux-arm64
           os: ubuntu-latest

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "build"
   lint:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
**Pull Request Type**
Please select what type of pull request this is:
- [x] Other

**Related issue**
N/A

**Description**
Update a few remaining `runs-on` from "ubuntu with specific version" (e.g. `ubuntu-20.04`, `ubuntu-18.04`)
to `ubuntu-latest`

Especially with ubuntu-18.04 deprecated

https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/

**Screenshots (if appropriate)**
N/A

**Testing (for code that is not small enough to be easily understandable)**
Just let workflow run

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: a910e5f8041c0fa5c32243b8428bb4daf3b92617

**Additional context**
Add any other context about the problem here.
