### PR TITLE
Temporarily switch over to my fork of ytdl-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "yt-channel-info": "^3.0.4",
     "yt-dash-manifest-generator": "1.1.0",
     "yt-trending-scraper": "^2.0.1",
-    "ytdl-core": "^4.11.0",
+    "ytdl-core": "git+https://github.com/absidue/node-ytdl-core#temp-fix-11-08-2022",
     "ytpl": "^2.3.0",
     "ytsr": "^3.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7517,10 +7517,9 @@ ytdl-core@^3.2.2:
     miniget "^2.0.1"
     sax "^1.1.3"
 
-ytdl-core@^4.11.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.11.0.tgz#79a3ea94d9d662b4b3acecdb1372ed3f1a9ea9db"
-  integrity sha512-Q3hCLiUA9AOGQXzPvno14GN+HgF9wsO1ZBHlj0COTcyxjIyFpWvMfii0UC4/cAbVaIjEdbWB71GdcGuc4J1Lmw==
+"ytdl-core@git+https://github.com/absidue/node-ytdl-core#temp-fix-11-08-2022":
+  version "0.0.0-development"
+  resolved "git+https://github.com/absidue/node-ytdl-core#22f6c2cbffa0bb242af799ce143e9e2f260019c4"
   dependencies:
     m3u8stream "^0.8.6"
     miniget "^4.2.2"


### PR DESCRIPTION
---
Temporarily switch over to my fork of ytdl-core
---

**Pull Request Type**

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
closes #2467
closes #2468

**Description**
YouTube made a change a couple of hours ago that broke ytdl-core's info extraction. This PR changes the ytdl-core dependency to use the branch on my fork that has the fix, while we wait for upstream ytdl-core to be updated.

The fix was found by @WaqasIbrahim in https://github.com/fent/node-ytdl-core/issues/1108#issuecomment-1212500413.

**Testing (for code that is not small enough to be easily understandable)**
Yes. `yarn install` and then open any video with the Local API selected.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.0

**Additional context**
This doesn't address any other issues we are having with ytdl-core, it purely addresses YouTube's current breaking change. Hopefully we won't have to wait too long for an upstream ytdl-core update.