### PR TITLE
Add support for bold, italics and strikethrough formatting in comments

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -268,7 +268,8 @@ export default Vue.extend({
         if (this.hideCommentLikes) {
           comment.likes = null
         }
-        comment.text = autolinker.link(comment.text.replace(/(<(?!br>)([^>]+)>)/ig, ''))
+        // strip html tags but keep <br>, <b>, </b> <s>, </s>, <i>, </i>
+        comment.text = autolinker.link(comment.text.replace(/(<(?!br|\/?(?:b|s|i)>)([^>]+)>)/ig, ''))
         if (comment.customEmojis.length > 0) {
           comment.customEmojis.forEach(emoji => {
             comment.text = comment.text.replace(emoji.text, `<img width="14" height="14" class="commentCustomEmoji" alt="${emoji.text.substring(2, emoji.text.length - 1)}" src="${emoji.emojiThumbnails[0].url}">`)


### PR DESCRIPTION
---
Add support for bold, italics and strikethrough formatting in comments
---

**Pull Request Type**

- [x] Feature Implementation

**Related issue**
closes #2404
yt-comment-scraper PR: https://github.com/FreeTubeApp/yt-comment-scraper/pull/41

**Description**
_The majority of the changes are in yt-comment-scraper, this PR purely adds support for the yt-comment-scraper changes._

This pull request adds support for bold, italics and strikethrough formatting in comments.

**Screenshots (if appropriate)**
before:
![before](https://user-images.githubusercontent.com/48293849/184450009-c232f18e-6a6e-4e45-93a3-0ce645acbda0.jpg)

after:
![after](https://user-images.githubusercontent.com/48293849/184450016-9019a4fc-bac5-40bd-8a98-64bba6549373.jpg)

**Testing (for code that is not small enough to be easily understandable)**
1. Install the yt-comment-scraper PR: `yarn add "@freetube/yt-comment-scraper@git+https://github.com/absidue/yt-comment-scraper#parse-formatting"`
2. The comments under this video are a good place to test this PR (taken from this [article](https://www.simplehelp.net/2021/08/19/how-to-format-text-in-youtube-comments-bold-italicized-or-crossed-out/))

https://www.youtube.com/watch?v=OqiXFXlYFi8

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1