### PR TITLE
Mapping the Invidious API field to the view

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -414,7 +414,7 @@ export default Vue.extend({
         this.channelDescription = autolinker.link(response.description)
         this.relatedChannels = response.relatedChannels.map((channel) => {
           channel.authorThumbnails[channel.authorThumbnails.length - 1].url = channel.authorThumbnails[channel.authorThumbnails.length - 1].url.replace('https://yt3.ggpht.com', `${this.currentInvidiousInstance}/ggpht/`)
-
+          channel.channelId = channel.authorId
           return channel
         })
         this.latestVideos = response.latestVideos


### PR DESCRIPTION

---
Mapping the Invidious API field "authorId" to the expected field "channelId"
---


**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
closes FreeTubeApp#2481

**Description**
Added a line to map the field "authorId" to "channelId"
on the featured channels that come from the Invidious API
because the Channel view expects related channels to have
the property "channelId". 
```vue
<!-- line 130 of src/renderer/views/Channel/Channel.vue -->
<ft-channel-bubble
  v-for="(channel, index) in relatedChannels"
  :key="index"
  :channel-name="channel.author || channel.channelName"
  :channel-id="channel.channelId"
  :channel-thumbnail="channel.authorThumbnails[channel.authorThumbnails.length - 1].url"
  @click="goToChannel(channel.channelId)"
/>
```

**Desktop (please complete the following information):**
 - OS: Windows 10 
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

