### PR TITLE
Fix playlist page sizing and layout

### DIFF
--- a/src/renderer/views/Playlist/Playlist.css
+++ b/src/renderer/views/Playlist/Playlist.css
@@ -5,17 +5,18 @@
 .playlistInfo {
   background-color: var(--card-bg-color);
   box-sizing: border-box;
-  height: calc(100vh - 96px);
+  height: calc(100vh - 132px);
   margin-right: 1em;
   overflow-y: auto;
   padding: 10px;
   position: sticky;
-  top: 78px;
+  top: 96px;
   width: 30%;
 }
 
 .playlistItems {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   grid-gap: 10px;
   margin: 0;
   padding: 10px;


### PR DESCRIPTION
---
Fix playlist page sizing and layout
---

**Pull Request Type**

- [x] Bugfix

**Related issue**
closes #2444

**Description**
This PR fixes 3 styling issues with the playlist page:
1. The playlist page was styled with the `grid` display, making it space the videos out to fill the space if the playlist had less videos than space on the page. Changing this to `display: flex` and `flex-direction: column` fixes that behaviour.
2. The height of the info box currently overflows past the bottom of the window, I fixed this by changing the height calculation so that it has equally sized gaps at the top and the bottom of the info box.
3. The last issue was that the info box would scroll slightly when scrolling in playlists even though it's meant to stay in it's place. I fixed this by increasing the `top` property so it's the same as the distance from the top of the window if you have scrolled right to the top.

**Screenshots (if appropriate)**
<details><summary>before:</summary>

![before1](https://user-images.githubusercontent.com/48293849/184707458-b64b50aa-b58c-4ad4-b8a4-3330b0bb29e2.jpg)
![before2](https://user-images.githubusercontent.com/48293849/184707463-1cf370e0-d087-4cac-9519-c360147be15b.jpg)
![before3](https://user-images.githubusercontent.com/48293849/184707475-a1b849e6-94f1-4918-abeb-a9864f9022ac.jpg)

</details>

<details><summary>after:</summary>

![after1](https://user-images.githubusercontent.com/48293849/184707575-dc5cf59b-6b9d-447f-9ed2-c271d19e63b8.jpg)
![after2](https://user-images.githubusercontent.com/48293849/184707584-142b3088-b504-4933-9bfc-66c1a00c285b.jpg)
![after3](https://user-images.githubusercontent.com/48293849/184707593-9af6416f-867c-4a91-ba4e-6653eea8ebb7.jpg)

</details>

**Testing (for code that is not small enough to be easily understandable)**
1. Playlist with only two videos: https://www.youtube.com/playlist?list=PLQMVnqe4Xbid6EkHJPPxwlhePJ-5iUxro
2. Any playlist works, check that there is the right size gap below the info box.
3. Any playlist that's has enough videos so you can scroll e.g. https://www.youtube.com/playlist?list=PLTC7VQ12-9raqhLCx1S1E_ic35t94dj28

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: [e.g. 0.8]

**Additional context**
The info box is actually the right size and in the correct position when you scroll down, but because of the many banner style fixes we actually increased the gap at the top of the cards throughout the app. Ideally we would go back to the old size of the gap but I don't want to have to deal with that all over again so this PR will have to do. Fixing the gap globally would only fix 2 and 3, number 1 would still be an issue so this PR is still necessary.