### PR TITLE
Fix Cmd+M unable to minimize window when viewing video

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1807,8 +1807,10 @@ export default Vue.extend({
           case 77:
             // M Key
             // Toggle Mute
-            event.preventDefault()
-            this.toggleMute()
+            if (!event.metaKey) {
+              event.preventDefault()
+              this.toggleMute()
+            }
             break
           case 67:
             // C Key


### PR DESCRIPTION

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
#2485

**Description**
Fix `Cmd+M` to be able to minimize a window when viewing a video
Tested on MacOS only

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

**Testing (for code that is not small enough to be easily understandable)**
- View random video
- Test both `M` & `Ctrl/Cmd+M`

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 33cf88ce31c02b485951b6fdcdaf33969db78cdc

**Additional context**
Documented keyboard shortcuts: https://docs.freetubeapp.io/usage/keyboard-shortcuts/
