### PR TITLE
Eliminating a race condition with SponsorBlock markers

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -73,6 +73,10 @@ export default Vue.extend({
     videoId: {
       type: String,
       required: true
+    },
+    lengthSeconds: {
+      type: Number,
+      required: true
     }
   },
   data: function () {
@@ -566,6 +570,10 @@ export default Vue.extend({
             })
           })
         })
+      }).catch((error) => {
+        this.showToast({
+          message: error.message
+        })
       })
     },
 
@@ -627,8 +635,8 @@ export default Vue.extend({
       markerDiv.style.position = 'absolute'
       markerDiv.style.opacity = '0.6'
       markerDiv.style['background-color'] = marker.color
-      markerDiv.style.width = (marker.duration / this.player.duration()) * 100 + '%'
-      markerDiv.style.marginLeft = (marker.time / this.player.duration()) * 100 + '%'
+      markerDiv.style.width = (marker.duration / this.lengthSeconds) * 100 + '%'
+      markerDiv.style.marginLeft = (marker.time / this.lengthSeconds) * 100 + '%'
       markerDiv.title = this.sponsorBlockTranslatedCategory(marker.category)
 
       this.player.el().querySelector('.vjs-progress-holder').appendChild(markerDiv)

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -27,6 +27,7 @@
           :format="activeFormat"
           :thumbnail="thumbnail"
           :video-id="videoId"
+          :length-seconds="videoLengthSeconds"
           class="videoPlayer"
           :class="{ theatrePlayer: useTheatreMode }"
           @ready="checkIfWatched"


### PR DESCRIPTION

---
Eliminating a race condition with SponsorBlock markers
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
closes FreeTubeApp#2492

**Description**
This modifies the SponsorBlock markers to use the `lengthSeconds` already provided by the API to calculate their size and position instead of using `this.player.duration()`. `this.player.duration()` is 0 when the view loads and only obtains a value some time after. `lengthSeconds` should never be 0 unless the API is giving a strange response. Because of this, changing `this.player.duration()` to `lengthSeconds` should eliminate the race condition where `this.player.duration()` is 0 at the time when `addSponsorBlockMarker` is called.

**Screenshots**
(These are with Invidious API selected as primary)
Before:
![image](https://user-images.githubusercontent.com/106682128/185232177-7b871922-a518-483f-aa1f-d82412ff2aaf.png)
After:
![image](https://user-images.githubusercontent.com/106682128/185231882-a07b4b90-e705-4d0f-9d55-527e10c5790a.png)

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

