### PR TITLE
Implement last window's fullscreen state

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -255,7 +255,8 @@ function runApp() {
 
     const boundsDoc = await baseHandlers.settings._findBounds()
     if (typeof boundsDoc?.value === 'object') {
-      const { maximized, ...bounds } = boundsDoc.value
+      console.log({ boundsDoc })
+      const { maximized, fullScreen, ...bounds } = boundsDoc.value
       const allDisplaysSummaryWidth = screen
         .getAllDisplays()
         .reduce((accumulator, { size: { width } }) => accumulator + width, 0)
@@ -271,6 +272,10 @@ function runApp() {
 
       if (maximized) {
         newWindow.maximize()
+      }
+
+      if (fullScreen) {
+        newWindow.setFullScreen(true)
       }
     }
 
@@ -316,7 +321,8 @@ function runApp() {
 
       const value = {
         ...newWindow.getNormalBounds(),
-        maximized: newWindow.isMaximized()
+        maximized: newWindow.isMaximized(),
+        fullScreen: newWindow.isFullScreen()
       }
 
       await baseHandlers.settings._updateBounds(value)


### PR DESCRIPTION

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
closes #1535

**Description**
Implement last window's fullscreen state

**Screenshots (if appropriate)**
Lazy to take video

**Testing (for code that is not small enough to be easily understandable)**
- open app
- switch to full screen
- quit app
- open app, confirm window is in full screen
- switch from full screen
- quit app
- open app, confirm window is not in full screen

**Desktop (please complete the following information):**
 - OS: MacOS
 - OS Version: 12.1
 - FreeTube version: 70481b4880a71bed4dc28c6a6321fc7cf849f0cd

**Additional context**
Add any other context about the problem here.
