### PR TITLE
Disable http disk cache and implempent in-memory image cache

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -53,10 +53,12 @@ async function restartElectron() {
 
   electronProcess = spawn(electron, [
     path.join(__dirname, '../dist/main.js'),
-    // '--enable-logging', Enable to show logs from all electron processes
+    // '--enable-logging', // Enable to show logs from all electron processes
     remoteDebugging ? '--inspect=9222' : '',
     remoteDebugging ? '--remote-debugging-port=9223' : '',
-  ])
+  ],
+    // { stdio: 'inherit' } // required for logs to actually appear in the stdout
+  )
 
   electronProcess.on('exit', (code, _) => {
     if (code === relaunchExitCode) {

--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -55,8 +55,7 @@ async function restartElectron() {
     path.join(__dirname, '../dist/main.js'),
     // '--enable-logging', // Enable to show logs from all electron processes
     remoteDebugging ? '--inspect=9222' : '',
-    remoteDebugging ? '--remote-debugging-port=9223' : '',
-    // '--experiments-disable-disk-cache'
+    remoteDebugging ? '--remote-debugging-port=9223' : ''
   ],
     // { stdio: 'inherit' } // required for logs to actually appear in the stdout
   )

--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -56,6 +56,7 @@ async function restartElectron() {
     // '--enable-logging', // Enable to show logs from all electron processes
     remoteDebugging ? '--inspect=9222' : '',
     remoteDebugging ? '--remote-debugging-port=9223' : '',
+    // '--experiments-disable-disk-cache'
   ],
     // { stdio: 'inherit' } // required for logs to actually appear in the stdout
   )

--- a/src/main/ImageCache.js
+++ b/src/main/ImageCache.js
@@ -1,13 +1,17 @@
+// cleanup expired images once every 5 mins
+const CLEANUP_INTERVAL = 300_000
+
+// images expire after 2 hours if no expiry information is found in the http headers
+const FALLBACK_MAX_AGE = 7200
+
 export class ImageCache {
   constructor() {
     this._cache = new Map()
 
-    // cleanup expired images once every 5 mins
-    setInterval(this._cleanup.bind(this), 300_000)
+    setInterval(this._cleanup.bind(this), CLEANUP_INTERVAL)
   }
 
-  add(url, mimeType, data, expires) {
-    const expiry = Math.trunc(Date.now() / 1000) + expires
+  add(url, mimeType, data, expiry) {
     this._cache.set(url, { mimeType: mimeType, data, expiry })
   }
 
@@ -30,12 +34,40 @@ export class ImageCache {
   }
 
   _cleanup() {
-    const now = Date.now()
+    // seconds since 1970-01-01 00:00:00
+    const now = Math.trunc(Date.now() / 1000)
 
     for (const [key, entry] of this._cache.entries()) {
-      if (entry.expiry * 1000 <= now) {
+      if (entry.expiry <= now) {
         this._cache.delete(key)
       }
     }
+  }
+}
+
+/**
+ * Extracts the cache expiry timestamp of image from HTTP headers
+ * @param {Record<string, string>} headers
+ * @returns a timestamp in seconds
+ */
+export function extractExpiryTimestamp(headers) {
+  const maxAgeRegex = /max-age=([0-9]+)/
+
+  const cacheControl = headers['cache-control']
+  if (cacheControl && maxAgeRegex.test(cacheControl)) {
+    let maxAge = parseInt(cacheControl.match(maxAgeRegex)[1])
+
+    if (headers.age) {
+      maxAge -= parseInt(headers.age)
+    }
+
+    // we don't need millisecond precision, so we can store it as seconds to use less memory
+    return Math.trunc(Date.now() / 1000) + maxAge
+  } else if (headers.expires) {
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires
+
+    return Math.trunc(Date.parse(headers.expires) / 1000)
+  } else {
+    return Math.trunc(Date.now() / 1000) + FALLBACK_MAX_AGE
   }
 }

--- a/src/main/ImageCache.js
+++ b/src/main/ImageCache.js
@@ -12,7 +12,7 @@ export class ImageCache {
   }
 
   add(url, mimeType, data, expiry) {
-    this._cache.set(url, { mimeType: mimeType, data, expiry })
+    this._cache.set(url, { mimeType, data, expiry })
   }
 
   has(url) {

--- a/src/main/ImageCache.js
+++ b/src/main/ImageCache.js
@@ -1,0 +1,41 @@
+export class ImageCache {
+  constructor() {
+    this._cache = new Map()
+
+    // cleanup expired images once every 5 mins
+    setInterval(this._cleanup.bind(this), 300_000)
+  }
+
+  add(url, mimeType, data, expires) {
+    const expiry = Math.trunc(Date.now() / 1000) + expires
+    this._cache.set(url, { mimeType: mimeType, data, expiry })
+  }
+
+  has(url) {
+    return this._cache.has(url)
+  }
+
+  get(url) {
+    const entry = this._cache.get(url)
+
+    if (!entry) {
+      // this should never happen as the `has` method should be used to check for the existence first
+      throw new Error(`No image cache entry for ${url}`)
+    }
+
+    return {
+      data: entry.data,
+      mimeType: entry.mimeType
+    }
+  }
+
+  _cleanup() {
+    const now = Date.now()
+
+    for (const [key, entry] of this._cache.entries()) {
+      if (entry.expiry * 1000 <= now) {
+        this._cache.delete(key)
+      }
+    }
+  }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -7,7 +7,7 @@ import cp from 'child_process'
 
 import { IpcChannels, DBActions, SyncEvents } from '../constants'
 import baseHandlers from '../datastores/handlers/base'
-import { ImageCache } from './ImageCache'
+import { extractExpiryTimestamp, ImageCache } from './ImageCache'
 
 if (process.argv.includes('--version')) {
   app.exit()
@@ -194,12 +194,10 @@ function runApp() {
         response.on('end', () => {
           const data = Buffer.concat(chunks)
 
-          const age = parseInt(response.headers.age ?? 0)
-          const maxAge = parseInt(response.headers['cache-control'].match(/max-age=([0-9]+)/)[1])
-
+          const expiryTimestamp = extractExpiryTimestamp(response.headers)
           const mimeType = response.headers['content-type']
 
-          imageCache.add(url, mimeType, data, maxAge - age)
+          imageCache.add(url, mimeType, data, expiryTimestamp)
 
           // eslint-disable-next-line node/no-callback-literal
           callback({

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -219,12 +219,32 @@ function runApp() {
           })
 
           response.on('error', (error) => {
-            console.log('error', error)
+            console.error('image cache error', error)
+
+            // error objects don't get serialised properly
+            // https://stackoverflow.com/a/53624454
+
+            const errorJson = JSON.stringify(error, (key, value) => {
+              if (value instanceof Error) {
+                return {
+                  // Pull all enumerable properties, supporting properties on custom Errors
+                  ...value,
+                  // Explicitly pull Error's non-enumerable properties
+                  name: value.name,
+                  message: value.message,
+                  stack: value.stack
+                }
+              }
+
+              return value
+            })
+
             // eslint-disable-next-line node/no-callback-literal
             callback({
-              statusCode: response.statusCode ?? 400
+              statusCode: response.statusCode ?? 400,
+              mimeType: 'application/json',
+              data: Buffer.from(errorJson)
             })
-            throw error
           })
         })
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -156,6 +156,7 @@ function runApp() {
     })
 
     protocol.registerBufferProtocol('imagecache', (request, callback) => {
+      // Remove `imagecache://` prefix
       const url = decodeURIComponent(request.url.substring(13))
       if (imageCache.has(url)) {
         const cached = imageCache.get(url)

--- a/src/renderer/components/experimental-settings/experimental-settings.css
+++ b/src/renderer/components/experimental-settings/experimental-settings.css
@@ -1,0 +1,6 @@
+.experimental-warning {
+  text-align: center;
+  font-weight: bold;
+  padding-left: 4%;
+  padding-right: 4%
+}

--- a/src/renderer/components/experimental-settings/experimental-settings.js
+++ b/src/renderer/components/experimental-settings/experimental-settings.js
@@ -1,6 +1,7 @@
 import { closeSync, existsSync, openSync, rmSync } from 'fs'
 import Vue from 'vue'
 import { mapActions } from 'vuex'
+import FtSettingsSection from '../ft-settings-section/ft-settings-section.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtPrompt from '../ft-prompt/ft-prompt.vue'
@@ -8,6 +9,7 @@ import FtPrompt from '../ft-prompt/ft-prompt.vue'
 export default Vue.extend({
   name: 'ExperimentalSettings',
   components: {
+    'ft-settings-section': FtSettingsSection,
     'ft-flex-box': FtFlexBox,
     'ft-toggle-switch': FtToggleSwitch,
     'ft-prompt': FtPrompt

--- a/src/renderer/components/experimental-settings/experimental-settings.js
+++ b/src/renderer/components/experimental-settings/experimental-settings.js
@@ -1,0 +1,87 @@
+import { closeSync, existsSync, openSync, rmSync } from 'fs'
+import Vue from 'vue'
+import { mapActions } from 'vuex'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
+import FtPrompt from '../ft-prompt/ft-prompt.vue'
+
+export default Vue.extend({
+  name: 'ExperimentalSettings',
+  components: {
+    'ft-flex-box': FtFlexBox,
+    'ft-toggle-switch': FtToggleSwitch,
+    'ft-prompt': FtPrompt
+  },
+  data: function () {
+    return {
+      replaceHttpCacheLoading: true,
+      replaceHttpCache: false,
+      replaceHttpCachePath: '',
+      showRestartPrompt: false,
+      restartPromptValues: [
+        'yes',
+        'no'
+      ]
+    }
+  },
+  computed: {
+    restartPromptMessage: function () {
+      return this.$t('Settings["The app needs to restart for changes to take effect. Restart and apply change?"]')
+    },
+
+    restartPromptNames: function () {
+      return [
+        this.$t('Yes'),
+        this.$t('No')
+      ]
+    }
+  },
+  mounted: function () {
+    this.getUserDataPath().then((userData) => {
+      this.replaceHttpCachePath = `${userData}/experiment-replace-http-cache`
+
+      this.replaceHttpCache = existsSync(this.replaceHttpCachePath)
+      this.replaceHttpCacheLoading = false
+    })
+  },
+  methods: {
+    updateReplaceHttpCache: function () {
+      this.replaceHttpCache = !this.replaceHttpCache
+
+      if (this.replaceHttpCache) {
+        // create an empty file
+        closeSync(openSync(this.replaceHttpCachePath, 'w'))
+      } else {
+        rmSync(this.replaceHttpCachePath)
+      }
+    },
+
+    handleRestartPrompt: function (value) {
+      this.replaceHttpCache = value
+      this.showRestartPrompt = true
+    },
+
+    handleReplaceHttpCache: function (value) {
+      this.showRestartPrompt = false
+
+      if (value === null || value === 'no') {
+        this.replaceHttpCache = !this.replaceHttpCache
+        return
+      }
+
+      if (this.replaceHttpCache) {
+        // create an empty file
+        closeSync(openSync(this.replaceHttpCachePath, 'w'))
+      } else {
+        rmSync(this.replaceHttpCachePath)
+      }
+
+      const { ipcRenderer } = require('electron')
+      ipcRenderer.send('relaunchRequest')
+    },
+
+    ...mapActions([
+      'getUserDataPath'
+    ])
+  }
+})

--- a/src/renderer/components/experimental-settings/experimental-settings.js
+++ b/src/renderer/components/experimental-settings/experimental-settings.js
@@ -19,23 +19,7 @@ export default Vue.extend({
       replaceHttpCacheLoading: true,
       replaceHttpCache: false,
       replaceHttpCachePath: '',
-      showRestartPrompt: false,
-      restartPromptValues: [
-        'yes',
-        'no'
-      ]
-    }
-  },
-  computed: {
-    restartPromptMessage: function () {
-      return this.$t('Settings["The app needs to restart for changes to take effect. Restart and apply change?"]')
-    },
-
-    restartPromptNames: function () {
-      return [
-        this.$t('Yes'),
-        this.$t('No')
-      ]
+      showRestartPrompt: false
     }
   },
   mounted: function () {

--- a/src/renderer/components/experimental-settings/experimental-settings.sass
+++ b/src/renderer/components/experimental-settings/experimental-settings.sass
@@ -1,5 +1,3 @@
-@use "../../sass-partials/settings"
-
 .experimental-warning
   text-align: center
   font-weight: bold

--- a/src/renderer/components/experimental-settings/experimental-settings.sass
+++ b/src/renderer/components/experimental-settings/experimental-settings.sass
@@ -1,6 +1,0 @@
-.experimental-warning
-  text-align: center
-  font-weight: bold
-  padding:
-    left: 4%
-    right: 4%

--- a/src/renderer/components/experimental-settings/experimental-settings.sass
+++ b/src/renderer/components/experimental-settings/experimental-settings.sass
@@ -1,6 +1,7 @@
 @use "../../sass-partials/settings"
 
 .experimental-warning
+  text-align: center
   font-weight: bold
   padding:
     left: 4%

--- a/src/renderer/components/experimental-settings/experimental-settings.sass
+++ b/src/renderer/components/experimental-settings/experimental-settings.sass
@@ -1,0 +1,7 @@
+@use "../../sass-partials/settings"
+
+.experimental-warning
+  font-weight: bold
+  padding:
+    left: 4%
+    right: 4%

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -1,11 +1,7 @@
 <template>
-  <details>
-    <summary>
-      <h3>
-        {{ $t('Settings.Experimental Settings.Experimental Settings') }}
-      </h3>
-    </summary>
-    <hr>
+  <ft-settings-section
+    :title="$t('Settings.Experimental Settings.Experimental Settings')"
+  >
     <p class="experimental-warning">
       {{ $t('Settings.Experimental Settings.Warning') }}
     </p>
@@ -27,7 +23,7 @@
       :option-values="restartPromptValues"
       @click="handleReplaceHttpCache"
     />
-  </details>
+  </ft-settings-section>
 </template>
 
 <script src="./experimental-settings.js" />

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -1,0 +1,34 @@
+<template>
+  <details>
+    <summary>
+      <h3>
+        {{ $t('Settings.Experimental Settings.Experimental Settings') }}
+      </h3>
+    </summary>
+    <hr>
+    <ft-flex-box>
+      <p class="experimental-warning">
+        {{ $t('Settings.Experimental Settings.Warning') }}
+      </p>
+      <ft-toggle-switch
+        tooltip-position="top"
+        :label="$t('Settings.Experimental Settings.Replace HTTP Cache')"
+        :compact="true"
+        :default-value="replaceHttpCache"
+        :disabled="replaceHttpCacheLoading"
+        :tooltip="$t('Tooltips.Experimental Settings.Replace HTTP Cache')"
+        @change="handleRestartPrompt"
+      />
+    </ft-flex-box>
+    <ft-prompt
+      v-if="showRestartPrompt"
+      :label="restartPromptMessage"
+      :option-names="restartPromptNames"
+      :option-values="restartPromptValues"
+      @click="handleReplaceHttpCache"
+    />
+  </details>
+</template>
+
+<script src="./experimental-settings.js" />
+<style scoped lang="sass" src="./experimental-settings.sass" />

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -27,4 +27,4 @@
 </template>
 
 <script src="./experimental-settings.js" />
-<style scoped lang="sass" src="./experimental-settings.sass" />
+<style scoped src="./experimental-settings.css" />

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -6,10 +6,10 @@
       </h3>
     </summary>
     <hr>
+    <p class="experimental-warning">
+      {{ $t('Settings.Experimental Settings.Warning') }}
+    </p>
     <ft-flex-box>
-      <p class="experimental-warning">
-        {{ $t('Settings.Experimental Settings.Warning') }}
-      </p>
       <ft-toggle-switch
         tooltip-position="top"
         :label="$t('Settings.Experimental Settings.Replace HTTP Cache')"

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -18,9 +18,9 @@
     </ft-flex-box>
     <ft-prompt
       v-if="showRestartPrompt"
-      :label="restartPromptMessage"
-      :option-names="restartPromptNames"
-      :option-values="restartPromptValues"
+      :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
+      :option-names="[$t('Yes'), $t('No')]"
+      :option-values="['yes', 'no']"
       @click="handleReplaceHttpCache"
     />
   </ft-settings-section>

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.js
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.js
@@ -26,6 +26,10 @@ export default Vue.extend({
     tooltip: {
       type: String,
       default: ''
+    },
+    tooltipPosition: {
+      type: String,
+      default: 'bottom-left'
     }
   },
   data: function () {

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.vue
@@ -27,7 +27,7 @@
       <ft-tooltip
         v-if="tooltip !== ''"
         class="selectTooltip"
-        position="bottom-left"
+        :position="tooltipPosition"
         :tooltip="tooltip"
       />
     </label>

--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -13,6 +13,7 @@ import DistractionSettings from '../../components/distraction-settings/distracti
 import ProxySettings from '../../components/proxy-settings/proxy-settings.vue'
 import SponsorBlockSettings from '../../components/sponsor-block-settings/sponsor-block-settings.vue'
 import ParentControlSettings from '../../components/parental-control-settings/parental-control-settings.vue'
+import ExperimentalSettings from '../../components/experimental-settings/experimental-settings.vue'
 
 export default Vue.extend({
   name: 'Settings',
@@ -30,7 +31,8 @@ export default Vue.extend({
     'proxy-settings': ProxySettings,
     'sponsor-block-settings': SponsorBlockSettings,
     'download-settings': DownloadSettings,
-    'parental-control-settings': ParentControlSettings
+    'parental-control-settings': ParentControlSettings,
+    'experimental-settings': ExperimentalSettings
   },
   computed: {
     usingElectron: function () {

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -23,6 +23,8 @@
     <parental-control-settings />
     <hr>
     <sponsor-block-settings />
+    <hr v-if="usingElectron">
+    <experimental-settings v-if="usingElectron" />
   </div>
 </template>
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -408,7 +408,7 @@ Settings:
     Open in web browser: Open in web browser
   Experimental Settings:
     Experimental Settings: Experimental Settings
-    Warning: These settings are experimental, enabling them may result in a worse FreeTube experience. Use at your own risk!
+    Warning: These settings are experimental, they make cause crashes while enabled. Making backups is highly recommended. Use at your own risk!
     Replace HTTP Cache: Replace HTTP Cache
 About:
   #On About page

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -406,6 +406,10 @@ Settings:
     Download Behavior: Download Behavior
     Download in app: Download in app
     Open in web browser: Open in web browser
+  Experimental Settings:
+    Experimental Settings: Experimental Settings
+    Warning: These settings are experimental, enabling them may result in a worse FreeTube experience. Use at your own risk!
+    Replace HTTP Cache: Replace HTTP Cache
 About:
   #On About page
   About: About
@@ -774,6 +778,8 @@ Tooltips:
   Privacy Settings:
     Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files created during video playback,
       when the watch page is closed.
+  Experimental Settings:
+    Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
 
 # Toast Messages
 Local API Error (Click to copy): Local API Error (Click to copy)


### PR DESCRIPTION
---
Disable http disk cache and implempent in-memory image cache
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**

- [x] Bugfix
- [x] Feature Implementation

**Related issue**
#1837 could be related but I'm not sure

**Description**
Thank you to the Matrix user for bringing this issue to our attention.

To reduce RAM usage electron stores the http cache on disk. While that might be alright for other applications, in FreeTube that means that while you are watching a video, all of the buffered video data is actually being constantly streamed to and from your disk. In the long term this will likely have an inpact on disk health.

This pull request is made up of two parts:
1. Disabling the http cache, unfortunately there doesn't seem to be a way to get rid of the disk one without also getting rid of the in-memory one
2. To compensate for the now missing in-memory http cache, this pull request also implements an in-memory image cache.

_How the cache works:_
When FreeTube tries to load an image over HTTP(S), the request gets redirected to the `imagecache://` custom protocol handler. The protocol handler checks the cache for the image, if it finds it, the image data is returned. Otherwise it fetches the image, stores it to the cache and then returns the image data.

The amount of time an image stays in the cache is based on the `Cache-Control: max-age=<seconds>` and `Age: <seconds>` headers that are returned by the server when the image is fetched. The cache checks for and removes expired images every 5 minutes, this interval can altered in the future if needed.

_Performance:_
In my testing disabling the http cache reduced the disk usage while playing a 1080p DASH video from 1.4 - 2.2MB/s to 0MB/s, when you first start the video it will sit at about 0.1MB/s as the DASH manifest and storyboards are written to the disk and subsequently used.

I tried profiling the memory usage of the image cache using the `--inspect-brk` flag and connecting to the main process using the devtools in an external chromium browser. Unfortunately I'm not quite sure what the actual memory usage is, as the heap snapshot said it was using about 28.4MB for 1053 images, however the entire heap was only 19.1MB at the time of the snapshot, so something isn't adding up.

**Screenshots (if appropriate)**
Please add before and after screenshots if there is a visible change.

**Testing (for code that is not small enough to be easily understandable)**
Please test this PR with production/release builds as dev and debug builds use extra RAM because of the devtools.

To check the disk usage I used the Task Manager in Windows to monitor the disk usage during video playback (e.g. https://youtu.be/bafzQBSktwk)

RAM usage can be monitored using the Task Manager or by hooking up the devtools in an external chromium installation up to the main process:
1. Start FreeTube with the `--inspect-brk` (allows remote debugging of the main process and wait until you are ready before executing any javascript code).
2. Open an external chromium installation and open `chrome://inspect`
3. Depending on your browser their might be a link to open the dedicated node devtools
4. Connect to FreeTube using the connection details that FreeTube spat out in your terminal
5. In the Sources tab in the devtools, start code execution by pressing the play button in the top right corner
6. You can take heap snapshots in the Memory tab
7. As we are using a production build the `ImageCache` won't be called `ImageCache`, instead it will have a single letter name, in my case it was `q`. You can find the name by searching for `No image cache entry for` in the Sources tab, going back a bit until you find the `constructor` and then looking at the class name.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1

**Additional context**
If the uptick in RAM usage is too significant we can always consider caching the images on disk instead of in-memory. This will be slower but will have the advantage of lower RAM usage. It will also allow us to use the cached images, that haven't expired yet, the next time you open FreeTube.