### PR TITLE
Removing an empty toast

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -570,10 +570,6 @@ export default Vue.extend({
             })
           })
         })
-      }).catch((error) => {
-        this.showToast({
-          message: error.message
-        })
       })
     },
 


### PR DESCRIPTION


---
Removing an empty toast which was unintentionally introduced by my last pull request
---

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
related to FreeTubeApp#2493

**Description**
This removes a toast which does not actually display any information and which was introduced by my last pull request.

**Screenshots (if appropriate)**
![example of empty toast](https://user-images.githubusercontent.com/48293849/185754213-3988e0ea-1b68-449c-8a2e-d40e20311879.jpg)

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1
