### PR TITLE
Switch back to upstream ytdl-core now that it has been updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,15 +79,15 @@
     "yt-channel-info": "^3.0.4",
     "yt-dash-manifest-generator": "1.1.0",
     "yt-trending-scraper": "^2.0.1",
-    "ytdl-core": "git+https://github.com/absidue/node-ytdl-core#temp-fix-11-08-2022",
+    "ytdl-core": "^4.11.1",
     "ytpl": "^2.3.0",
     "ytsr": "^3.8.0"
   },
   "devDependencies": {
-    "@evilmartians/lefthook": "^1.0.5",
     "@babel/core": "^7.17.10",
     "@babel/plugin-proposal-class-properties": "^7.16.7",
     "@babel/preset-env": "^7.17.10",
+    "@evilmartians/lefthook": "^1.0.5",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7508,9 +7508,10 @@ ytdl-core@^3.2.2:
     miniget "^2.0.1"
     sax "^1.1.3"
 
-"ytdl-core@git+https://github.com/absidue/node-ytdl-core#temp-fix-11-08-2022":
-  version "0.0.0-development"
-  resolved "git+https://github.com/absidue/node-ytdl-core#22f6c2cbffa0bb242af799ce143e9e2f260019c4"
+ytdl-core@^4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.11.1.tgz#f29c688f1217957118790d49599569d1fc26d6db"
+  integrity sha512-0H2hl8kv9JA50qEUewPVpDCloyEVkXZfKJ6o2RNmkngfiY99pGVqE7jQbMT6Rs1QwZpF8GiMB50VWXqivpzlgQ==
   dependencies:
     m3u8stream "^0.8.6"
     miniget "^4.2.2"


### PR DESCRIPTION
---
Switch back to upstream ytdl-core now that it has been updated
---

**Pull Request Type**

- [x] Bugfix

**Description**
Upstream ytdl-core, has received an update (4.11.1) that resolves the issues properly, which means we can stop using my fork that had the quick fix in it. The changelog for the 4.11.1 is missing the most important part, that it includes this PR https://github.com/fent/node-ytdl-core/pull/1126 that updates the parsing logic.

**Testing (for code that is not small enough to be easily understandable)**
Seems to work just as well, maybe even better than the quick fix on my fork.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1

**Additional context**
I'll delete the branch on my fork when this is merged.