### PR TITLE
Update yt-trending-scraper to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@freetube/youtube-chat": "^1.1.2",
     "@freetube/yt-comment-scraper": "^6.1.0",
+    "@freetube/yt-trending-scraper": "^3.1.0",
     "@silvermine/videojs-quality-selector": "^1.2.5",
     "autolinker": "^3.15.0",
     "electron-context-menu": "^3.1.2",
@@ -78,7 +79,6 @@
     "youtube-suggest": "^1.1.2",
     "yt-channel-info": "^3.0.4",
     "yt-dash-manifest-generator": "1.1.0",
-    "yt-trending-scraper": "^2.0.1",
     "ytdl-core": "^4.11.1",
     "ytpl": "^2.3.0",
     "ytsr": "^3.8.0"

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -4,7 +4,7 @@ import IsEqual from 'lodash.isequal'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
-import ytTrendScraper from 'yt-trending-scraper'
+import { calculateLengthInSeconds } from '@freetube/yt-trending-scraper/src/HtmlParser'
 
 export default Vue.extend({
   name: 'Search',
@@ -154,7 +154,7 @@ export default Vue.extend({
             let videoDuration = video.duration
             const videoId = video.id
             if (videoDuration !== null && videoDuration !== '' && videoDuration !== 'LIVE') {
-              videoDuration = ytTrendScraper.calculate_length_in_seconds(video.duration)
+              videoDuration = calculateLengthInSeconds(video.duration)
             }
             dataToShow.push(
               {

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -7,7 +7,7 @@ import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 
 import $ from 'jquery'
-import ytrend from 'yt-trending-scraper'
+import { scrapeTrendingPage } from '@freetube/yt-trending-scraper'
 
 export default Vue.extend({
   name: 'Trending',
@@ -124,7 +124,7 @@ export default Vue.extend({
         geoLocation: this.region
       }
 
-      ytrend.scrape_trending_page(param).then((result) => {
+      scrapeTrendingPage(param).then((result) => {
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,6 +1024,13 @@
   dependencies:
     axios "^0.21.1"
 
+"@freetube/yt-trending-scraper@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@freetube/yt-trending-scraper/-/yt-trending-scraper-3.1.0.tgz#51e20931b0d8a8d32216ecead320bbbcbb7ca959"
+  integrity sha512-qPyQaxU7Bv3e6HXn/ULH2h6iy1Egh3l7NKUgzuqPFHA7dAxbmMN7Ozr4QFnwXVnNYzfEdTsR+GFs9v71ChVJkQ==
+  dependencies:
+    axios "^0.27.2"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1964,6 +1971,14 @@ axios@^0.26.1:
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-eslint@^10.1.0:
   version "10.1.0"
@@ -3716,6 +3731,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.8:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
+
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -7490,13 +7510,6 @@ yt-dash-manifest-generator@1.1.0:
   dependencies:
     xml-js "^1.6.11"
     ytdl-core "^3.2.2"
-
-yt-trending-scraper@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/yt-trending-scraper/-/yt-trending-scraper-2.0.1.tgz#830ab96faaccca22001043ca72147f83fb099ffd"
-  integrity sha512-VTgIfVbRTMWUFn6Ir/XtEF2MBaYUU2JeaZxCtshfiyPI9yrOutp4A/0L755nl7Ip3Cigp8EW159/JH+z7Is7Jg==
-  dependencies:
-    axios "^0.21.1"
 
 ytdl-core@^3.2.2:
   version "3.4.2"


### PR DESCRIPTION
---
Update yt-trending-scraper to 3.1.0
---

**Pull Request Type**

- [x] Dependency Update

**Description**
This pull request updates the yt-trending-scraper dependency to the latest release, 3.1.0.

**Testing (for code that is not small enough to be easily understandable)**
I tested both the trending tab and the search results pages.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1