### PR TITLE
Update yt-comment-scraper to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/vue-fontawesome": "^2.0.2",
     "@freetube/youtube-chat": "^1.1.2",
-    "@freetube/yt-comment-scraper": "^6.1.0",
+    "@freetube/yt-comment-scraper": "^6.2.0",
     "@freetube/yt-trending-scraper": "^3.1.0",
     "@silvermine/videojs-quality-selector": "^1.2.5",
     "autolinker": "^3.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,12 +1017,12 @@
     axios "^0.21.1"
     tslib "^1.11.1"
 
-"@freetube/yt-comment-scraper@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@freetube/yt-comment-scraper/-/yt-comment-scraper-6.1.0.tgz#13583dedf5cf0cff6d42d155ef5f2474c64fd4ee"
-  integrity sha512-Cj6Of7DPkTH1ax1AcaOn0xul179YsnfaNNoH11lQ4xUxUrmtf70Qj04+FDI+7/O/qsOR3RMq1mreCvM6BQI6Aw==
+"@freetube/yt-comment-scraper@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@freetube/yt-comment-scraper/-/yt-comment-scraper-6.2.0.tgz#ed11d65111d03076ff842eb9c3eb25413f8632ab"
+  integrity sha512-69mBsvQ50rUBTUDfR6s1OaiH2sEmmx9T0uV2Qpp0ckMhL0sxxMZtxujraHV2FHDtOm5jG7uygi3Gseb54C9DGw==
   dependencies:
-    axios "^0.21.1"
+    axios "^0.27.2"
 
 "@freetube/yt-trending-scraper@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
---
Update yt-comment-scraper to 6.2.0
---

**Pull Request Type**

- [x] Dependency Update

**Description**
This pull request updates the yt-comment-scraper dependency to the latest release, 6.2.0.

**Testing (for code that is not small enough to be easily understandable)**
I tested the comments under a few videos and didn't notice any new issues (for some reason YouTube 403's for some profile pictures).
I also checked that bold, italics and strikethrough showed up in comments under this video: https://www.youtube.com/watch?v=OqiXFXlYFi8 (same one as in #2475)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1