### PR TITLE
Localization inconsistency fix for Local API

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -309,7 +309,8 @@ export default Vue.extend({
             // workaround for description localization
             const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
             this.videoDescription = descriptionLines?.join('\n') ?? ''
-          } catch {
+          } catch (err) {
+            console.error('Failed to extract localised video description, falling back to the standard one.', err)
             // if the workaround for localization fails, this sets the description to the potentially non-localized value
             this.videoDescription = result.player_response.videoDetails.shortDescription
           }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -308,7 +308,7 @@ export default Vue.extend({
           try {
             // workaround for description localization
             const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
-            this.videoDescription = descriptionLines?.join('\n') ?? ''
+            this.videoDescription = descriptionLines?.map(line => line.text).join('\n') ?? ''
           } catch (err) {
             console.error('Failed to extract localised video description, falling back to the standard one.', err)
             // if the workaround for localization fails, this sets the description to the potentially non-localized value

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -307,7 +307,7 @@ export default Vue.extend({
           this.videoPublished = new Date(result.videoDetails.publishDate.replace('-', '/')).getTime()
           try {
             // workaround for description localization
-            const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
+            const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description?.runs
             this.videoDescription = descriptionLines?.map(line => line.text).join('\n') ?? ''
           } catch (err) {
             console.error('Failed to extract localised video description, falling back to the standard one.', err)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -277,7 +277,8 @@ export default Vue.extend({
           try {
             // workaround for title localization
             this.videoTitle = result.response.contents.twoColumnWatchNextResults.results.results.contents[0].videoPrimaryInfoRenderer.title.runs[0].text
-          } catch {
+          } catch (err) {
+            console.error('Failed to extract localised video title, falling back to the standard one.', err)
             // if the workaround for localization fails, this sets the title to the potentially non-localized value
             this.videoTitle = result.videoDetails.title
           }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -308,7 +308,7 @@ export default Vue.extend({
           try {
             // workaround for description localization
             const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description?.runs
-            this.videoDescription = descriptionLines?.map(line => line.text).join('\n') ?? ''
+            this.videoDescription = descriptionLines?.map(line => line.text).join('') ?? ''
           } catch (err) {
             console.error('Failed to extract localised video description, falling back to the standard one.', err)
             // if the workaround for localization fails, this sets the description to the potentially non-localized value

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -275,7 +275,7 @@ export default Vue.extend({
             throw new Error(`${reason}: ${subReason}`)
           }
 
-          this.videoTitle = result.videoDetails.title
+          this.videoTitle = result.response.contents.twoColumnWatchNextResults.results.results.contents[0].videoPrimaryInfoRenderer.title.runs[0].text
           this.videoViewCount = parseInt(
             result.player_response.videoDetails.viewCount,
             10

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -274,8 +274,13 @@ export default Vue.extend({
 
             throw new Error(`${reason}: ${subReason}`)
           }
-
-          this.videoTitle = result.response.contents.twoColumnWatchNextResults.results.results.contents[0].videoPrimaryInfoRenderer.title.runs[0].text
+          try {
+            // workaround for title localization
+            this.videoTitle = result.response.contents.twoColumnWatchNextResults.results.results.contents[0].videoPrimaryInfoRenderer.title.runs[0].text
+          } catch {
+            // if the workaround for localization fails, this sets the title to the potentially non-localized value
+            this.videoTitle = result.videoDetails.title
+          }
           this.videoViewCount = parseInt(
             result.player_response.videoDetails.viewCount,
             10
@@ -299,10 +304,16 @@ export default Vue.extend({
           })
 
           this.videoPublished = new Date(result.videoDetails.publishDate.replace('-', '/')).getTime()
-          const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
-          this.videoDescription = ''
-          for (let i = 0; i < descriptionLines.length; i++) {
-            this.videoDescription += `${descriptionLines[i].text}\n`
+          try {
+            // workaround for description localization
+            const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
+            this.videoDescription = ''
+            for (let i = 0; i < descriptionLines.length; i++) {
+              this.videoDescription += `${descriptionLines[i].text}\n`
+            }
+          } catch {
+            // if the workaround for localization fails, this sets the description to the potentially non-localized value
+            this.videoDescription = result.player_response.videoDetails.shortDescription
           }
 
           switch (this.thumbnailPreference) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -299,7 +299,11 @@ export default Vue.extend({
           })
 
           this.videoPublished = new Date(result.videoDetails.publishDate.replace('-', '/')).getTime()
-          this.videoDescription = result.player_response.videoDetails.shortDescription
+          const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
+          this.videoDescription = ''
+          for (let i = 0; i < descriptionLines.length; i++) {
+            this.videoDescription += `${descriptionLines[i].text}\n`
+          }
 
           switch (this.thumbnailPreference) {
             case 'start':

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -308,10 +308,7 @@ export default Vue.extend({
           try {
             // workaround for description localization
             const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description.runs
-            this.videoDescription = ''
-            for (let i = 0; i < descriptionLines.length; i++) {
-              this.videoDescription += `${descriptionLines[i].text}\n`
-            }
+            this.videoDescription = descriptionLines?.join('\n') ?? ''
           } catch {
             // if the workaround for localization fails, this sets the description to the potentially non-localized value
             this.videoDescription = result.player_response.videoDetails.shortDescription


### PR DESCRIPTION
---
Localization inconsistency fix for Local API
---

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
closes FreeTubeApp#2530

**Description**
This applies a workaround for the inconsistency in the responses from `ytdl` and `ytpl`. The result of this change is that the video title and description are localized to `en-US` by `ytdl` (as it was expected to be based on the following code snippet).
```js
// line 353 of src\renderer\store\modules\ytdl.js
ytdl.getInfo(videoId, {
        lang: 'en-US',// this locale was not being honored before this change
        requestOptions: { agent }
      }).then((result) => {
        resolve(result)
      }).catch((err) => {
        reject(err)
      })
```

**Screenshots (if appropriate)**
Before this change:
![image](https://user-images.githubusercontent.com/106682128/188283285-ef45480f-91bc-435a-892f-d13e6229b58a.png)
![image](https://user-images.githubusercontent.com/106682128/188283396-d02347f1-cc76-4c43-a90c-5a4e5fca972a.png)
![image](https://user-images.githubusercontent.com/106682128/188283439-51e863b7-23ad-4d46-a979-5f19800117cd.png)

After this change:
![image](https://user-images.githubusercontent.com/106682128/188283268-c0299704-b801-451c-9f6d-11e59d92589a.png)
![image](https://user-images.githubusercontent.com/106682128/188283331-7108dc31-6432-449f-96cc-21ee611c6e51.png)
![image](https://user-images.githubusercontent.com/106682128/188283458-a82f118c-128e-4ef1-bc71-2378e014487f.png)


**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1


**Additional context**
The inconsistency described in FreeTubeApp#2530 still occurs when using the Invidious API; however, as far as I can tell, this is an issue with invidious. Even if we aren't sending a locale, it should give back titles and descriptions that reflect a consistent locale, but I don't believe there is a way to fix that inconsistency without digging into the invidious source, and at that point, it isn't an issue with FreeTube.
