### PR TITLE
Update ytdl-core to 4.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "youtube-suggest": "^1.1.2",
     "yt-channel-info": "^3.1.0",
     "yt-dash-manifest-generator": "1.1.0",
-    "ytdl-core": "^4.11.1",
+    "ytdl-core": "^4.11.2",
     "ytpl": "^2.3.0",
     "ytsr": "^3.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7692,10 +7692,10 @@ ytdl-core@^3.2.2:
     miniget "^2.0.1"
     sax "^1.1.3"
 
-ytdl-core@^4.11.1:
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.11.1.tgz#f29c688f1217957118790d49599569d1fc26d6db"
-  integrity sha512-0H2hl8kv9JA50qEUewPVpDCloyEVkXZfKJ6o2RNmkngfiY99pGVqE7jQbMT6Rs1QwZpF8GiMB50VWXqivpzlgQ==
+ytdl-core@^4.11.2:
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/ytdl-core/-/ytdl-core-4.11.2.tgz#c2341916b9757171741a2fa118b6ffbb4ffd92f7"
+  integrity sha512-D939t9b4ZzP3v0zDvehR2q+KgG97UTgrTKju3pOPGQcXtl4W6W5z0EpznzcJFu+OOpl7S7Ge8hv8zU65QnxYug==
   dependencies:
     m3u8stream "^0.8.6"
     miniget "^4.2.2"


### PR DESCRIPTION
---
Update ytdl-core to 4.11.2
---

**Pull Request Type**

- [x] Other - dependency update

**Description**
This pull request updates ytdl-core to the latest version, which supposedly fixes the regex issue we had for a few hours a couple of days ago, it doesn't seem to have broken anything so that's good.

**Testing (for code that is not small enough to be easily understandable)**
I tested both `yarn dev` and `yarn build` and video playback still worked.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1