### PR TITLE
Don't log any errors if there are no SponsorBlock segments

### DIFF
--- a/src/renderer/store/modules/sponsorblock.js
+++ b/src/renderer/store/modules/sponsorblock.js
@@ -24,10 +24,16 @@ const actions = {
             .flatMap((result) => result.segments)
           resolve(segments)
         }).fail((xhr, textStatus, error) => {
+          // 404 means that there are no segments registered for the video
+          if (xhr.status === 404) {
+            resolve([])
+            return
+          }
+
           console.log(xhr)
           console.log(textStatus)
           console.log(requestUrl)
-          console.log(error)
+          console.error(error)
           reject(xhr)
         })
       })


### PR DESCRIPTION
---
Don't log any errors if there are no SponsorBlock segments
---

**Pull Request Type**

- [x] Bugfix

**Description**
The SponsorBlock API returns 404 if it doesn't have any segments for a video, currently this logs 4 messages to the console. As segments not being available is expected behaviour, we don't need to log anything.

**Testing (for code that is not small enough to be easily understandable)**
No SponsorBlock segments: https://youtu.be/qim2Y6v_4EI
Has SponsorBlock segments: https://youtu.be/zy2a47e-Qao

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1