### PR TITLE
Increase width of quality selector so that 1080p60 doesn't overflow into the full screen button

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1498,6 +1498,8 @@ export default Vue.extend({
               <span class="vjs-control-text" aria-live="polite"></span>
             </li>` */
           })
+          // the default width is 3em which is too narrow for qualitly labels with fps e.g. 1080p60
+          button.style.width = '4em'
           return $(button).html(
             $(beginningHtml + qualityHtml + endingHtml).attr(
               'title',


### PR DESCRIPTION
---
Increase width of quality selector so that 1080p60 doesn't overflow into the full screen button
---

**Pull Request Type**

- [x] Bugfix

**Description**
Fix the quality selector button overflowing into the full screen button when it has wide values like 1080p60 in it.

**Screenshots**
before:
![before](https://user-images.githubusercontent.com/48293849/189407798-631ab918-8310-45d2-bb98-cadbec970a0f.jpg)
after:
![after](https://user-images.githubusercontent.com/48293849/189407866-eae3c49a-762a-466d-b112-0831cc0b4096.jpg)

**Testing (for code that is not small enough to be easily understandable)**
https://www.youtube.com/watch?v=zCLOJ9j1k2Y (select 1080p60)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1