### PR TITLE
Properly localize numbers

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'FtListChannel',
@@ -32,6 +33,9 @@ export default Vue.extend({
     },
     hideChannelSubscriptions: function () {
       return this.$store.getters.getHideChannelSubscriptions
+    },
+    currentLocale: function () {
+      return i18n.locale.replace('_', '-')
     }
   },
   mounted: function () {
@@ -59,7 +63,7 @@ export default Vue.extend({
       if (this.data.videos === null) {
         this.videoCount = 0
       } else {
-        this.videoCount = this.data.videos.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+        this.videoCount = Intl.NumberFormat(this.currentLocale).format(this.data.videos)
       }
 
       this.description = this.data.descriptionShort
@@ -81,9 +85,9 @@ export default Vue.extend({
       if (this.hideChannelSubscriptions) {
         this.subscriberCount = null
       } else {
-        this.subscriberCount = this.data.subCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+        this.subscriberCount = Intl.NumberFormat(this.currentLocale).format(this.data.subCount)
       }
-      this.videoCount = this.data.videoCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+      this.videoCount = Intl.NumberFormat(this.currentLocale).format(this.data.videoCount)
       this.description = this.data.description
     }
   }

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
 import { mapActions } from 'vuex'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'FtListVideo',
@@ -249,6 +250,10 @@ export default Vue.extend({
 
     saveWatchedProgress: function () {
       return this.$store.getters.getSaveWatchedProgress
+    },
+
+    currentLocale: function () {
+      return i18n.locale.replace('_', '-')
     }
   },
   mounted: function () {
@@ -424,7 +429,7 @@ export default Vue.extend({
       if (this.hideVideoViews) {
         this.hideViews = true
       } else if (typeof (this.data.viewCount) !== 'undefined' && this.data.viewCount !== null) {
-        this.parsedViewCount = this.data.viewCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+        this.parsedViewCount = Intl.NumberFormat(this.currentLocale).format(this.data.viewCount)
       } else if (typeof (this.data.viewCountText) !== 'undefined') {
         this.parsedViewCount = this.data.viewCountText.replace(' views', '')
       } else {

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import { mapActions } from 'vuex'
 import FtListDropdown from '../ft-list-dropdown/ft-list-dropdown.vue'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'PlaylistInfo',
@@ -75,6 +76,9 @@ export default Vue.extend({
         default:
           return `https://i.ytimg.com/vi/${this.firstVideoId}/mqdefault.jpg`
       }
+    },
+    currentLocale: function () {
+      return i18n.locale.replace('_', '-')
     }
   },
   mounted: function () {
@@ -91,11 +95,11 @@ export default Vue.extend({
 
     // Causes errors if not put inside of a check
     if (typeof (this.data.viewCount) !== 'undefined') {
-      this.viewCount = this.hideViews ? null : this.data.viewCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+      this.viewCount = this.hideViews ? null : Intl.NumberFormat(this.currentLocale).format(this.data.viewCount)
     }
 
     if (typeof (this.data.videoCount) !== 'undefined') {
-      this.videoCount = this.data.videoCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+      this.videoCount = Intl.NumberFormat(this.currentLocale).format(this.data.videoCount)
     }
 
     this.lastUpdated = this.data.lastUpdated

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -7,6 +7,7 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
 import FtShareButton from '../ft-share-button/ft-share-button.vue'
 import { MAIN_PROFILE_ID } from '../../../constants'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'WatchVideoInfo',
@@ -135,7 +136,7 @@ export default Vue.extend({
     },
 
     currentLocale: function () {
-      return this.$store.getters.getCurrentLocale
+      return i18n.locale.replace('_', '-')
     },
 
     profileList: function () {
@@ -238,7 +239,7 @@ export default Vue.extend({
       if (this.hideVideoViews) {
         return null
       }
-      return this.viewCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') + ` ${this.$t('Video.Views').toLowerCase()}`
+      return Intl.NumberFormat(this.currentLocale).format(this.viewCount.toString) + ` ${this.$t('Video.Views').toLowerCase()}`
     },
 
     isSubscribed: function () {

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -239,7 +239,7 @@ export default Vue.extend({
       if (this.hideVideoViews) {
         return null
       }
-      return Intl.NumberFormat(this.currentLocale).format(this.viewCount.toString) + ` ${this.$t('Video.Views').toLowerCase()}`
+      return Intl.NumberFormat(this.currentLocale).format(this.viewCount) + ` ${this.$t('Video.Views').toLowerCase()}`
     },
 
     isSubscribed: function () {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -13,6 +13,7 @@ import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricte
 import ytch from 'yt-channel-info'
 import autolinker from 'autolinker'
 import { MAIN_PROFILE_ID } from '../../../constants'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'Search',
@@ -136,11 +137,15 @@ export default Vue.extend({
       ]
     },
 
+    currentLocale: function () {
+      return i18n.locale.replace('_', '-')
+    },
+
     formattedSubCount: function () {
       if (this.hideChannelSubscriptions) {
         return null
       }
-      return this.subCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+      return Intl.NumberFormat(this.currentLocale).format(this.subCount)
     },
 
     showFetchMoreButton: function () {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -14,6 +14,7 @@ import WatchVideoLiveChat from '../../components/watch-video-live-chat/watch-vid
 import WatchVideoPlaylist from '../../components/watch-video-playlist/watch-video-playlist.vue'
 import WatchVideoRecommendations from '../../components/watch-video-recommendations/watch-video-recommendations.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'Watch',
@@ -163,6 +164,9 @@ export default Vue.extend({
     },
     theatrePossible: function () {
       return !this.hideRecommendedVideos || (!this.hideLiveChat && this.isLive) || this.watchingPlaylist
+    },
+    currentLocale: function () {
+      return i18n.locale.replace('_', '-')
     }
   },
   watch: {
@@ -350,7 +354,7 @@ export default Vue.extend({
             } else if (subCount >= 10000) {
               this.channelSubscriptionCountText = `${subCount / 1000}K`
             } else {
-              this.channelSubscriptionCountText = subCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+              this.channelSubscriptionCountText = Intl.NumberFormat(this.currentLocale).format(subCount)
             }
           }
 


### PR DESCRIPTION
---
Properly localize numbers
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix


**Related issue**
closes #2547

**Description**
Number seperators (",", "." and " ") were not chosen based on locale and were always shown as ","

**Screenshots (if appropriate)**
<img width="513" alt="image" src="https://user-images.githubusercontent.com/78101139/189428368-db387634-59f4-4899-850a-87539d7753c6.png">

**Testing (for code that is not small enough to be easily understandable)**
Used search with different locales (had to clear search to test)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 11
 - FreeTube version: 0.17.1
