### PR TITLE
Build and release 7zip artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,19 +114,40 @@ jobs:
         name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_x64
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.zip
 
+    - name: Upload Linux .7z x64 Artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
+      with:
+        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_x64.7z
+        path: build/freetube-${{ steps.versionNumber.outputs.result }}.7z
+
     - name: Upload Linux .zip ARMv7l Artifact
       uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       with:
         name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_armv7l
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.zip
-    
+
+    - name: Upload Linux .7z ARMv7l Artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
+      with:
+        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_armv7l.7z
+        path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.7z
+
     - name: Upload Linux .zip ARM64 Artifact
       uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
         name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_arm64
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.zip
+
+    - name: Upload Linux .7z ARM64 Artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
+      with:
+        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_arm64.7z
+        path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.7z
 
     - name: Upload .deb x64 Artifact
       uses: actions/upload-artifact@v2
@@ -242,12 +263,26 @@ jobs:
         name: freetube-${{ steps.versionNumber.outputs.result }}-win-x64-portable
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-win.zip
 
+    - name: Upload Windows x64 .7z Artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
+      with:
+        name: freetube-${{ steps.versionNumber.outputs.result }}-win-x64-portable.7z
+        path: build/freetube-${{ steps.versionNumber.outputs.result }}-win.7z
+
     - name: Upload Windows arm64 .zip Artifact
       uses: actions/upload-artifact@v2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-win-arm64-portable
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64-win.zip
+
+    - name: Upload Windows arm64 .7z Artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
+      with:
+        name: freetube-${{ steps.versionNumber.outputs.result }}-win-arm64-portable.7z
+        path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64-win.7z
         
     - name: Upload Windows x64 Portable Artifact
       uses: actions/upload-artifact@v2
@@ -283,6 +318,13 @@ jobs:
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-mac-x64.zip
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-mac.zip
+
+    - name: Upload Mac x64 .7z Artifact
+      uses: actions/upload-artifact@v2
+      if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
+      with:
+        name: freetube-${{ steps.versionNumber.outputs.result }}-mac-x64.7z
+        path: build/freetube-${{ steps.versionNumber.outputs.result }}-mac.7z
 
 #    - name: Upload Mac arm64 .zip Artifact
 #      uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,17 @@ jobs:
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}.zip
         asset_content_type: application/zip
 
+    - name: Upload Linux .7z x64 Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ env.PACKAGE_VERSION }}-linux-portable-x64.7z
+        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}.7z
+        asset_content_type: application/x-7z-compressed
+
     - name: Upload Linux .zip ARMv7l Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
@@ -108,6 +119,17 @@ jobs:
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-armv7l.zip
         asset_content_type: application/zip
 
+    - name: Upload Linux .7z ARMv7l Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ env.PACKAGE_VERSION }}-linux-portable-armv7l.7z
+        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-armv7l.7z
+        asset_content_type: application/x-7z-compressed
+
     - name: Upload Linux .zip ARM64 Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
@@ -118,6 +140,17 @@ jobs:
         asset_name: freetube-${{ env.PACKAGE_VERSION }}-linux-portable-arm64.zip
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64.zip
         asset_content_type: application/zip
+
+    - name: Upload Linux .7z ARM64 Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ env.PACKAGE_VERSION }}-linux-portable-arm64.7z
+        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64.7z
+        asset_content_type: application/x-7z-compressed
 
     - name: Upload Linux .deb x64 Release
       uses: actions/upload-release-asset@v1
@@ -209,6 +242,17 @@ jobs:
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-win.zip
         asset_content_type: application/zip
 
+    - name: Upload Windows x64 .7z Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ env.PACKAGE_VERSION }}-win-x64-portable.7z
+        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-win.7z
+        asset_content_type: application/x-7z-compressed
+
     - name: Upload Windows arm64 .zip Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
@@ -219,6 +263,17 @@ jobs:
         asset_name: freetube-${{ env.PACKAGE_VERSION }}-win-arm64-portable.zip
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64-win.zip
         asset_content_type: application/zip
+
+    - name: Upload Windows arm64 .7z Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ env.PACKAGE_VERSION }}-win-arm64-portable.7z
+        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64-win.7z
+        asset_content_type: application/x-7z-compressed
         
     - name: Upload Windows x64 portable Release
       uses: actions/upload-release-asset@v1
@@ -273,7 +328,18 @@ jobs:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
         asset_name: freetube-${{ env.PACKAGE_VERSION }}-mac-x64.zip
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-mac.zip
-        asset_content_type: application/x-apple-diskimage
+        asset_content_type: application/zip
+
+    - name: Upload Mac x64 .7z Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ env.PACKAGE_VERSION }}-mac-x64.7z
+        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-mac.7z
+        asset_content_type: application/x-7z-compressed
 
 #    - name: Upload Mac arm64 .zip Release
 #      uses: actions/upload-release-asset@v1

--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -17,7 +17,7 @@ if (platform === 'darwin') {
     arch = Arch.arm64
   }
   
-  targets = Platform.MAC.createTarget(['DMG','zip'], arch)
+  targets = Platform.MAC.createTarget(['DMG','zip', '7z'], arch)
 } else if (platform === 'win32') {
   let arch = Arch.x64
 
@@ -25,7 +25,7 @@ if (platform === 'darwin') {
     arch = Arch.arm64
   }
   
-  targets = Platform.WINDOWS.createTarget(['nsis', 'zip', 'portable'], arch)
+  targets = Platform.WINDOWS.createTarget(['nsis', 'zip', '7z', 'portable'], arch)
 } else if (platform === 'linux') {
   let arch = Arch.x64
 
@@ -37,7 +37,7 @@ if (platform === 'darwin') {
     arch = Arch.armv7l
   }
 
-  targets = Platform.LINUX.createTarget(['deb', 'zip', 'apk', 'rpm', 'AppImage', 'pacman'], arch)
+  targets = Platform.LINUX.createTarget(['deb', 'zip', '7z', 'apk', 'rpm', 'AppImage', 'pacman'], arch)
 }
 
 const config = {
@@ -93,7 +93,7 @@ const config = {
   linux: {
     category: 'Network',
     icon: '_icons/icon.svg',
-    target: ['deb', 'zip', 'apk', 'rpm', 'AppImage', 'pacman'],
+    target: ['deb', 'zip', '7z', 'apk', 'rpm', 'AppImage', 'pacman'],
   },
   // See the following issues for more information
   // https://github.com/jordansissel/fpm/issues/1503
@@ -117,7 +117,7 @@ const config = {
   mac: {
     category: 'public.app-category.utilities',
     icon: '_icons/iconMac.icns',
-    target: ['dmg', 'zip'],
+    target: ['dmg', 'zip', '7z'],
     type: 'distribution',
     extendInfo: {
       CFBundleURLTypes: [
@@ -130,7 +130,7 @@ const config = {
   },
   win: {
     icon: '_icons/icon.ico',
-    target: ['nsis', 'zip', 'portable'],
+    target: ['nsis', 'zip', '7z', 'portable'],
   },
   nsis: {
     allowToChangeInstallationDirectory: true,


### PR DESCRIPTION
---
Build and release 7zip artifacts
---

**Pull Request Type**

- [x] Feature Implementation

**Related issue**
closes #2009

**Description**
This pull request makes electron-builder build 7-zip archives in addition to the current zip ones. 7-zip has better compression the archives are smaller resulting in faster downloads. The Windows x64 7-zip archive is 29.8MB smaller than the zip archive.

**Screenshots (if appropriate)**
![size-difference](https://user-images.githubusercontent.com/48293849/189412794-6b00eab0-2f94-4375-aa71-e2c61847c647.jpg)

**Testing (for code that is not small enough to be easily understandable)**
I tested local builds with `yarn build` and triggered this workflow run on my fork: https://github.com/absidue/FreeTube/actions/runs/3024373522

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1