### PR TITLE
Improve premiere timestamp to be easier to read

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -419,6 +419,11 @@ export default Vue.extend({
                 hour: 'numeric',
                 minute: '2-digit'
               }
+              if (new Date().getFullYear() < upcomingTimestamp.getFullYear()) {
+                Object.defineProperty(timestampOptions, 'year', {
+                  value: 'numeric'
+                })
+              }
               this.upcomingTimestamp = Intl.DateTimeFormat(this.currentLocale, timestampOptions).format(upcomingTimestamp)
 
               let upcomingTimeLeft = upcomingTimestamp - new Date()

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -419,7 +419,7 @@ export default Vue.extend({
                 hour: 'numeric',
                 minute: '2-digit'
               }
-              this.upcomingTimestamp = upcomingTimestamp.toLocaleString(this.currentLocale, timestampOptions)
+              this.upcomingTimestamp = Intl.DateTimeFormat(this.currentLocale, timestampOptions).format(upcomingTimestamp)
 
               let upcomingTimeLeft = upcomingTimestamp - new Date()
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -419,7 +419,7 @@ export default Vue.extend({
                 hour: 'numeric',
                 minute: '2-digit'
               }
-              this.upcomingTimestamp = upcomingTimestamp.toLocaleString([locale, 'en'], timestampOptions)
+              this.upcomingTimestamp = upcomingTimestamp.toLocaleString([locale, 'default'], timestampOptions)
 
               let upcomingTimeLeft = upcomingTimestamp - new Date()
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -410,10 +410,10 @@ export default Vue.extend({
             if (typeof startTimestamp !== 'undefined') {
               const upcomingTimestamp = new Date(result.videoDetails.liveBroadcastDetails.startTimestamp)
               const timestampOptions = {
-                  month: 'long',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  minute: '2-digit'
+                month: 'long',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit'
               }
               this.upcomingTimestamp = upcomingTimestamp.toLocaleString('default', timestampOptions)
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -14,6 +14,7 @@ import WatchVideoLiveChat from '../../components/watch-video-live-chat/watch-vid
 import WatchVideoPlaylist from '../../components/watch-video-playlist/watch-video-playlist.vue'
 import WatchVideoRecommendations from '../../components/watch-video-recommendations/watch-video-recommendations.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
+import i18n from '../../i18n/index'
 
 export default Vue.extend({
   name: 'Watch',
@@ -165,7 +166,7 @@ export default Vue.extend({
       return !this.hideRecommendedVideos || (!this.hideLiveChat && this.isLive) || this.watchingPlaylist
     },
     currentLocale: function () {
-      return this.$store.getters.getCurrentLocale
+      return i18n.locale.replace('_', '-')
     }
   },
   watch: {
@@ -412,14 +413,13 @@ export default Vue.extend({
 
             if (typeof startTimestamp !== 'undefined') {
               const upcomingTimestamp = new Date(result.videoDetails.liveBroadcastDetails.startTimestamp)
-              const locale = this.currentLocale.replace('_', '-')
               const timestampOptions = {
                 month: 'long',
                 day: 'numeric',
                 hour: 'numeric',
                 minute: '2-digit'
               }
-              this.upcomingTimestamp = upcomingTimestamp.toLocaleString([locale, 'default'], timestampOptions)
+              this.upcomingTimestamp = upcomingTimestamp.toLocaleString(this.currentLocale, timestampOptions)
 
               let upcomingTimeLeft = upcomingTimestamp - new Date()
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -409,7 +409,13 @@ export default Vue.extend({
 
             if (typeof startTimestamp !== 'undefined') {
               const upcomingTimestamp = new Date(result.videoDetails.liveBroadcastDetails.startTimestamp)
-              this.upcomingTimestamp = upcomingTimestamp.toLocaleString()
+              const timestampOptions = {
+                  month: 'long',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit'
+              }
+              this.upcomingTimestamp = upcomingTimestamp.toLocaleString('default', timestampOptions)
 
               let upcomingTimeLeft = upcomingTimestamp - new Date()
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -163,6 +163,9 @@ export default Vue.extend({
     },
     theatrePossible: function () {
       return !this.hideRecommendedVideos || (!this.hideLiveChat && this.isLive) || this.watchingPlaylist
+    },
+    currentLocale: function () {
+      return this.$store.getters.getCurrentLocale
     }
   },
   watch: {
@@ -409,13 +412,14 @@ export default Vue.extend({
 
             if (typeof startTimestamp !== 'undefined') {
               const upcomingTimestamp = new Date(result.videoDetails.liveBroadcastDetails.startTimestamp)
+              const locale = this.currentLocale.replace('_', '-')
               const timestampOptions = {
                 month: 'long',
                 day: 'numeric',
                 hour: 'numeric',
                 minute: '2-digit'
               }
-              this.upcomingTimestamp = upcomingTimestamp.toLocaleString('default', timestampOptions)
+              this.upcomingTimestamp = upcomingTimestamp.toLocaleString([locale, 'en'], timestampOptions)
 
               let upcomingTimeLeft = upcomingTimestamp - new Date()
 


### PR DESCRIPTION
---
Improve premiere timestamp to be easier to read
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

**Related issue**
no related issue that i know of

**Description**
Changes the premiere timestamp to be easier to read.
Removes year and seconds from string because they are not important.
Displays month as it's "long name" (eg., March)

also displays timestamp in the same locale set in freetube.

**Screenshots (if appropriate)**
before:
my locale
![2022-09-10_T00:28:02](https://user-images.githubusercontent.com/66974576/189454079-5ef45e9e-76ed-4c9b-a157-01721a030c6d.png)

after:
my locale / system default
![2022-09-10_T00:10:35](https://user-images.githubusercontent.com/66974576/189453728-3d0a8db1-1f0a-47a2-ba24-ac638c88a8b9.png)
english locale
![2022-09-10_T00:10:55](https://user-images.githubusercontent.com/66974576/189453732-d4a307da-acaa-43a7-bffc-37ff6839c34c.png)
french locale
![2022-09-10_T01:11:38](https://user-images.githubusercontent.com/66974576/189457339-c4ab9aed-233f-4bc6-b799-e3127ca0b874.png)



**Testing (for code that is not small enough to be easily understandable)**
I have tested some different locales in freetube.
Open this in browser and you should be able to find some upcoming live streams.
https://www.youtube.com/live

**Desktop (please complete the following information):**
 - OS: [e.g. iOS]
 - OS Version: [e.g. 22]
 - FreeTube version: [e.g. 0.8]

**Additional context**
~~I noticed that the locale set in freetube was not used when using `date.toLocaleString()`.
So I searched, found, and copied the code from `watch-video-info.js` to solve this problem.
This obviously however caused 'en' to be used when i would have preferred my system locale.
I changed 'en' to 'default' to solve that.
Should the same be done to the other functions that do this?~~

