### PR TITLE
Fix the localised description containing broken URLs

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -277,7 +277,7 @@ export default Vue.extend({
           }
           try {
             // workaround for title localization
-            this.videoTitle = result.response.contents.twoColumnWatchNextResults.results.results.contents[0].videoPrimaryInfoRenderer.title.runs[0].text
+            this.videoTitle = result.response.contents.twoColumnWatchNextResults.results.results.contents[0].videoPrimaryInfoRenderer.title.runs.map(run => run.text).join('')
           } catch (err) {
             console.error('Failed to extract localised video title, falling back to the standard one.', err)
             // if the workaround for localization fails, this sets the title to the potentially non-localized value
@@ -802,7 +802,7 @@ export default Vue.extend({
     processDescriptionPart(part, fallbackDescription) {
       const timestampRegex = /^([0-9]+:)?[0-9]+:[0-9]+$/
 
-      if (typeof part.navigationEndpoint === 'undefined' || part.navigationEndpoint === null) {
+      if (typeof part.navigationEndpoint === 'undefined' || part.navigationEndpoint === null || part.text.startsWith('#')) {
         return part.text
       }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -308,8 +308,20 @@ export default Vue.extend({
           this.videoPublished = new Date(result.videoDetails.publishDate.replace('-', '/')).getTime()
           try {
             // workaround for description localization
-            const descriptionLines = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description?.runs
-            this.videoDescription = descriptionLines?.map(line => line.text).join('') ?? ''
+            const descriptionRuns = result.response.contents.twoColumnWatchNextResults.results.results.contents[1].videoSecondaryInfoRenderer.description?.runs
+
+            if (!Array.isArray(descriptionRuns)) {
+              // eslint-disable-next-line no-throw-literal
+              throw ['not an array', descriptionRuns]
+            }
+
+            const fallbackDescription = result.player_response.videoDetails.shortDescription
+
+            // YouTube truncates links in the localised description
+            // so we need to fix them here, so that autolinker can do it's job properly later on
+            this.videoDescription = descriptionRuns
+              .map(run => this.processDescriptionPart(run, fallbackDescription))
+              .join('')
           } catch (err) {
             console.error('Failed to extract localised video description, falling back to the standard one.', err)
             // if the workaround for localization fails, this sets the description to the potentially non-localized value
@@ -785,6 +797,56 @@ export default Vue.extend({
             this.isLoading = false
           }
         })
+    },
+
+    processDescriptionPart(part, fallbackDescription) {
+      const timestampRegex = /^([0-9]+:)?[0-9]+:[0-9]+$/
+
+      if (typeof part.navigationEndpoint === 'undefined' || part.navigationEndpoint === null) {
+        return part.text
+      }
+
+      if (part.navigationEndpoint.urlEndpoint) {
+        const urlWithTracking = part.navigationEndpoint.urlEndpoint.url
+        const url = new URL(urlWithTracking)
+
+        if (url.hostname === 'www.youtube.com' && url.pathname === '/redirect' && url.searchParams.has('q')) {
+          // remove utm tracking parameters
+          const realURL = new URL(url.searchParams.get('q'))
+
+          realURL.searchParams.delete('utm_source')
+          realURL.searchParams.delete('utm_medium')
+          realURL.searchParams.delete('utm_campaign')
+          realURL.searchParams.delete('utm_term')
+          realURL.searchParams.delete('utm_content')
+
+          return realURL.toString()
+        } else if (fallbackDescription.includes(urlWithTracking)) {
+          // this is probably a special YouTube URL like http://www.youtube.com/approachingnirvana
+          // only use it if it exists in the fallback description
+          // otherwise assume YouTube has changed it's tracking URLs and throw an error
+          return urlWithTracking
+        }
+
+        // eslint-disable-next-line no-throw-literal
+        throw `Failed to extract real URL from tracking URL: ${urlWithTracking}`
+      } else if (part.navigationEndpoint.watchEndpoint) {
+        if (timestampRegex.test(part.text)) {
+          return part.text
+        }
+        const watchEndpoint = part.navigationEndpoint.watchEndpoint
+
+        let videoURL = `https://www.youtube.com/watch?v=${watchEndpoint.videoId}`
+        if (watchEndpoint.startTimeSeconds !== 0) {
+          videoURL += `&t=${watchEndpoint.startTimeSeconds}s`
+        }
+        return videoURL
+      } else {
+        // Some YouTube URLs don't have the urlEndpoint so we handle them here
+
+        const path = part.navigationEndpoint.commandMetadata.webCommandMetadata.url
+        return `https://www.youtube.com${path}`
+      }
     },
 
     addToHistory: function (watchProgress) {


### PR DESCRIPTION
---
Fix the localised description containing broken URLs
---

**Pull Request Type**

- [x] Bugfix

**Related issue**
Follow up to #2535
Closes #2578

**Description**
This pull request fixes the truncated links in the localised video description, making them valid URLs so that `autolinker` can properly link them.

**Screenshots**
Before:
![before](https://user-images.githubusercontent.com/48293849/189708914-1f804b75-9aff-4e9e-8ff4-b2d7e76b6fec.jpg)

After:
![after](https://user-images.githubusercontent.com/48293849/189708925-ffdcf937-4592-44e8-8505-980d17220790.jpg)

**Testing**
https://www.youtube.com/watch?v=zcchDu7KoYs

This video's description has a bunch of tricky things like timestamps, links to other videos, the special URL `http://www.youtube.com/approachingnirvana` and the lttstore link has utm tracking parameters.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1