### PR TITLE
Workflow: Use slim instead of full super linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,53 +1,24 @@
-#################################
-#################################
-## Super Linter GitHub Actions ##
-#################################
-#################################
 name: Lint Code Base
-
-#
 # Documentation:
 # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
-#
-
-#############################
-# Start the job on all push #
-#############################
 on:
   push:
     branches-ignore: [master, development]
-    # Remove the line above to run when pushing to master
   pull_request:
     branches: [master, development]
 
-###############
-# Set the Job #
-###############
 jobs:
   build:
-    # Name the Job
     name: Lint Code Base
-    # Set the agent to run on
     runs-on: ubuntu-latest
-
-    ##################
-    # Load all steps #
-    ##################
     steps:
-      ##########################
-      # Checkout the code base #
-      ##########################
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
-
-      ################################
-      # Run Linter against code base #
-      ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JAVASCRIPT_ES: false


### PR DESCRIPTION
---
Use slim linter option for super linter
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Other

**Related issue**
Speeds up Super Linter workflow

**Description**
The slim github/super-linter:slim-v4 comes with all supported linters but removes the following:
- rust linters
- dotenv linters
- armttk linters
- pwsh linters
- c# linters

"By removing these linters, we were able to bring the image size down by 2gb and drastically speed up the build and download time. The behavior will be the same for non-supported languages, and will skip languages at run time."

I also removed some comments that were not needed

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 11
 - FreeTube version: 0.17.1
