### PR TITLE
Remove node-loader as we don't have any binary/native node modules

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -25,10 +25,6 @@ const config = {
         use: 'babel-loader',
         exclude: /node_modules/,
       },
-      {
-        test: /\.node$/,
-        loader: 'node-loader',
-      },
     ],
   },
   // webpack defaults to only optimising the production builds, so having this here is fine

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -39,10 +39,6 @@ const config = {
         exclude: /node_modules/,
       },
       {
-        test: /\.node$/,
-        loader: 'node-loader',
-      },
-      {
         test: /\.vue$/,
         loader: 'vue-loader',
       },

--- a/_scripts/webpack.workers.config.js
+++ b/_scripts/webpack.workers.config.js
@@ -30,10 +30,6 @@ const config = {
         use: 'babel-loader',
         exclude: /node_modules/,
       },
-      {
-        test: /\.node$/,
-        loader: 'node-loader',
-      },
     ],
   },
   node: {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "html-webpack-plugin": "^5.3.2",
     "json-minimizer-webpack-plugin": "^4.0.0",
     "mini-css-extract-plugin": "^2.2.2",
-    "node-loader": "^2.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5378,13 +5378,6 @@ node-forge@^1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
-node-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/node-loader/-/node-loader-2.0.0.tgz#9109a6d828703fd3e0aa03c1baec12a798071562"
-  integrity sha512-I5VN34NO4/5UYJaUBtkrODPWxbobrE4hgDqPrjB25yPkonFhCmZ146vTH+Zg417E9Iwoh1l/MbRs1apc5J295Q==
-  dependencies:
-    loader-utils "^2.0.0"
-
 node-releases@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.4.tgz#f38252370c43854dc48aa431c766c6c398f40476"


### PR DESCRIPTION
---
Remove node-loader as we don't have any binary/native node modules
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**

- [x] Build config change

**Description**
Neither FreeTube or any of it's dependencies use binary/native node modules (`.node` file extension), so we don't need to use `node-loader`.

**Testing (for code that is not small enough to be easily understandable)**
`yarn dev` and `yarn build` (you can also test just the webpack build with `yarn run pack`)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1