### PR TITLE
Fully replace electron-debug with our own implementation

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -14,10 +14,6 @@ const config = {
   entry: {
     main: path.join(__dirname, '../src/main/index.js'),
   },
-  // webpack spits out errors while inlining electron-debug as
-  // it tries to dynamically load dependencies
-  // the error: "Critical dependency: the request of a dependency is an expression"
-  externals: ['electron-debug'],
   module: {
     rules: [
       {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "css-minimizer-webpack-plugin": "^4.1.0",
     "electron": "^20.1.4",
     "electron-builder": "^23.3.3",
-    "electron-debug": "^3.2.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3159,14 +3159,6 @@ electron-context-menu@^3.1.2:
     electron-dl "^3.2.1"
     electron-is-dev "^2.0.0"
 
-electron-debug@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/electron-debug/-/electron-debug-3.2.0.tgz#46a15b555c3b11872218c65ea01d058aa0814920"
-  integrity sha512-7xZh+LfUvJ52M9rn6N+tPuDw6oRAjxUj9SoxAZfJ0hVCXhZCsdkrSt7TgXOiWiEOBgEV8qwUIO/ScxllsPS7ow==
-  dependencies:
-    electron-is-dev "^1.1.0"
-    electron-localshortcut "^3.1.0"
-
 electron-dl@^3.2.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/electron-dl/-/electron-dl-3.3.1.tgz#14164595bebcc636c671eb791b2a3265003f76c4"
@@ -3176,30 +3168,10 @@ electron-dl@^3.2.1:
     pupa "^2.0.1"
     unused-filename "^2.1.0"
 
-electron-is-accelerator@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
-  integrity sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns=
-
-electron-is-dev@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.2.0.tgz#2e5cea0a1b3ccf1c86f577cee77363ef55deb05e"
-  integrity sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw==
-
 electron-is-dev@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-2.0.0.tgz#833487a069b8dad21425c67a19847d9064ab19bd"
   integrity sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA==
-
-electron-localshortcut@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-3.2.1.tgz#cfc83a3eff5e28faf98ddcc87f80a2ce4f623cd3"
-  integrity sha512-DWvhKv36GsdXKnaFFhEiK8kZZA+24/yFLgtTwJJHc7AFgDjNRIBJZ/jq62Y/dWv9E4ypYwrVWN2bVrCYw1uv7Q==
-  dependencies:
-    debug "^4.0.1"
-    electron-is-accelerator "^0.1.0"
-    keyboardevent-from-electron-accelerator "^2.0.0"
-    keyboardevents-areequal "^0.2.1"
 
 electron-osx-sign@^0.6.0:
   version "0.6.0"
@@ -4889,16 +4861,6 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.4.0"
     verror "1.10.0"
-
-keyboardevent-from-electron-accelerator@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/keyboardevent-from-electron-accelerator/-/keyboardevent-from-electron-accelerator-2.0.0.tgz#ace21b1aa4e47148815d160057f9edb66567c50c"
-  integrity sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA==
-
-keyboardevents-areequal@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
-  integrity sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==
 
 keycode@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
---
Fully replace electron-debug with our own implementation
---

**Pull Request Type**

- [x] Bugfix
- [x] Feature Implementation

**Description**
This pull removes the `electron-debug` dependency and adds our own implementation for the features that we didn't already have our own implementations for. There are various advantages to getting rid of that dependency and replacing it with our own implementations:
1. Our keyboard shortcuts will work on release builds, which is fine as this isn't a proprietary app, so being able to debug easily on release builds is quite useful.
2. electron-debug was causing issues with our release webpack builds, getting rid of the dependency, means we don't need to mark it as external in the webpack config.
3. this also gets rid of 6 development dependencies which is nice, also our implementation uses a lot less code than electron-debug and it's dependencies :).

**Screenshots**
The new visible menu item:
![new-menu-element](https://user-images.githubusercontent.com/48293849/190858477-a3f5504c-31dd-4cd8-9576-7ee2e7b579e4.jpg)

**Testing**
`yarn dev` and `yarn build`

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1