### PR TITLE
Fixing an undefined function reference

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -284,7 +284,7 @@ const actions = {
           fs.mkdirSync(folderPath, { recursive: true })
         } catch (err) {
           console.error(err)
-          this.showToast({
+          dispatch('showToast', {
             message: err
           })
           return


### PR DESCRIPTION
---
Fixing an undefined function reference
---

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Description**
This replaces a use of `this.showToast` with `dispatch("showToast",` inside of `src\renderer\store\modules\utils.js` because `this.showToast` is not defined.

**Screenshots (if appropriate)**
before:
![image](https://user-images.githubusercontent.com/106682128/190857766-51b57f82-9c87-41a8-bf72-79cb03886770.png)
![image](https://user-images.githubusercontent.com/106682128/190857853-ea563941-9349-4d3c-b0ee-6482faebb9b2.png)
after:
![image](https://user-images.githubusercontent.com/106682128/190859067-8a734664-4b39-4cfe-869f-38ab4e209a36.png)

**Testing (for code that is not small enough to be easily understandable)**
In order to reach this code, the download path must be a path which does not exist. Then, there needs to be an error during the creation of the directory. 

An easy way to test this would be to set the download path to a path the user would have access to read but not write like `C:/Program Files/test test test`. If you create that folder, select it as the download path, and then, delete that folder, this error should occur the next time you try to download a video.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

