### PR TITLE
Set height of watch page grid with auto in dual-column-template

### DIFF
--- a/src/renderer/views/Watch/Watch.sass
+++ b/src/renderer/views/Watch/Watch.sass
@@ -1,5 +1,5 @@
 =dual-column-template
-  grid-template: "video video sidebar" 0fr "info info sidebar" 1fr "info info sidebar" 1fr / 1fr 1fr 1fr
+  grid-template: "video video sidebar" 0fr "info info sidebar" auto "info info sidebar" 1fr / 1fr 1fr 1fr
 
 =theatre-mode-template
   grid-template: "video video video" auto "info info sidebar" auto "info info sidebar" auto / 1fr 1fr 1fr


### PR DESCRIPTION


---
Set height of watch page grid with auto in dual-column-template
---

**Pull Request Type**
- [x] Bugfix

**Related issue**
closes #2587

**Description**
Sets the height of the grid-template with auto instead of 1fr.
This ensures the page doesn't keep scrolling for longer than necessary if live chat is enabled and recommended videos is disabled

**Screenshots**
look at the scroll bar on the right.
Zoom in might be required to
before:
![2022-09-17_T16:19:13](https://user-images.githubusercontent.com/66974576/190863057-2e1c3278-9b89-4e51-a4c2-94f7a2ff5195.png)

after:
![2022-09-17_T16:51:13](https://user-images.githubusercontent.com/66974576/190863008-21500553-1876-4cda-bd6b-d251e6f28e50.png)

**Testing**
I've tested all combinations of live chat and recommend videos being enabled and disabled.
There should be no difference except for when only live chat is enabled with dual column template

**Desktop:**
 - OS: Linux
 - OS Version: 5.19.7-arch1-1
 - FreeTube version: 
