### PR TITLE
Add MPR to Unofficial Downloads

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -85,6 +85,7 @@ body:
         - .dmg
         - .exe
         - Flathub
+        - MPR
         - .pacman
         - Portable
         - PortableApps

--- a/.github/workflows/autoLabelIssue.yaml
+++ b/.github/workflows/autoLabelIssue.yaml
@@ -17,7 +17,7 @@ jobs:
                 "labels": ["B: visual"]
               },
               {
-                "keywords": ["AUR", "Chocolatey", "PortableApps", "winget", "Scoop"],
+                "keywords": ["AUR", "Chocolatey", "PortableApps", "winget", "Scoop", "MPR"],
                 "labels": ["B: Unofficial Download"]
               },
               {

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ These builds are maintained by the community.  While they should be safe, downlo
 
 * Chocolatey: [Download](https://chocolatey.org/packages/freetube/)
 
+* makedeb Package Repository (MPR): [Download](https://mpr.makedeb.org/packages/freetube-bin)
+
 * PortableApps (Windows Only): [Download](https://github.com/rddim/FreeTubePortable/releases) [Source](https://github.com/rddim/FreeTubePortable)
 
 * Scoop (Windows Only): [Usage](https://github.com/ScoopInstaller/Scoop)


### PR DESCRIPTION
---
Add MPR to Unofficial Downloads
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [X] Feature Implementation (as original issue was filed as feature request)
- [X] Documentation
- [ ] Other

**Related issue**
Closes #2130

**Description**
Add MPR link to Unofficial Downloads section in README

**Screenshots (if appropriate)**
N/A (screenshot of MPR package page isn't too interesting)

**Testing (for code that is not small enough to be easily understandable)**
Yes (Markdown preview was used)

**Desktop (please complete the following information):**
 - OS: Debian- and Ubuntu-based distros
 - OS Version: Debian 11.5 (Bullseye) or newer, Ubuntu 22.04 (Jammy Jellyfish) or newer
 - FreeTube version: 0.17.1+

**Additional context**
N/A