### PR TITLE
Differentiate header and body content in black theme

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -70,6 +70,14 @@
     --logo-text: url("../../_icons/textColorSmall.png");
 }
 
+.black .topNav,.black .sideNav {
+  box-shadow: 0 0 0 2px #ddddddc7 !important;
+}
+
+.black .ft-card {
+  box-shadow: inset 0 0 0 2px #ddddddc7 !important;
+}
+
 .gray {
   --primary-text-color: #EEEEEE;
   --secondary-text-color: #E0E0E0;


### PR DESCRIPTION
---
Differentiate header and body content in black theme
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [x] Other

**Related issue**
closes #2043 

**Description**
Added few lines of css to differentiate header and body content in black theme.

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/102938585/190923281-f0b60a6f-e539-487a-a4a9-670d41e4f7ed.png)

**Testing (for code that is not small enough to be easily understandable)**
Has this pull request been tested?
yes with inspect tool (thanks to electron)

**Desktop (please complete the following information):**
 - OS: Fedora
 - OS Version: 37 Pre release
 - FreeTube version: latest nightly

