### PR TITLE
Cleaning up calls to the Clipboard API

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1291,7 +1291,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err.responseJSON.error}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err.responseJSON.error })
             }
           })
 
@@ -1318,7 +1318,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err.responseJSON.error })
             }
           })
 

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1291,7 +1291,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err.responseJSON.error}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err.responseJSON.error)
+              this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
             }
           })
 
@@ -1318,7 +1318,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
 
@@ -1348,7 +1348,8 @@ export default Vue.extend({
       'showSaveDialog',
       'getUserDataPath',
       'addPlaylist',
-      'addVideo'
+      'addVideo',
+      'copyToClipboard'
     ]),
 
     ...mapMutations([

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1318,7 +1318,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err.responseJSON.error })
+              this.copyToClipboard({ content: err })
             }
           })
 

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -298,46 +298,31 @@ export default Vue.extend({
           }
           break
         case 'copyYoutube':
-          navigator.clipboard.writeText(this.youtubeShareUrl)
-          this.showToast({
-            message: this.$t('Share.YouTube URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: this.youtubeShareUrl, name: 'Share.YouTube URL', t: this.$t.bind(this) })
           break
         case 'openYoutube':
           this.openExternalLink(this.youtubeUrl)
           break
         case 'copyYoutubeEmbed':
-          navigator.clipboard.writeText(this.youtubeEmbedUrl)
-          this.showToast({
-            message: this.$t('Share.YouTube Embed URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: this.youtubeEmbedUrl, name: 'Share.YouTube Embed URL', t: this.$t.bind(this) })
           break
         case 'openYoutubeEmbed':
           this.openExternalLink(this.youtubeEmbedUrl)
           break
         case 'copyInvidious':
-          navigator.clipboard.writeText(this.invidiousUrl)
-          this.showToast({
-            message: this.$t('Share.Invidious URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: this.invidiousUrl, name: 'Share.Invidious URL', t: this.$t.bind(this) })
           break
         case 'openInvidious':
           this.openExternalLink(this.invidiousUrl)
           break
         case 'copyYoutubeChannel':
-          navigator.clipboard.writeText(this.youtubeChannelUrl)
-          this.showToast({
-            message: this.$t('Share.YouTube Channel URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: this.youtubeChannelUrl, name: 'Share.YouTube Channel URL', t: this.$t.bind(this) })
           break
         case 'openYoutubeChannel':
           this.openExternalLink(this.youtubeChannelUrl)
           break
         case 'copyInvidiousChannel':
-          navigator.clipboard.writeText(this.invidiousChannelUrl)
-          this.showToast({
-            message: this.$t('Share.Invidious Channel URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: this.invidiousChannelUrl, name: 'Share.Invidious Channel URL', t: this.$t.bind(this) })
           break
         case 'openInvidiousChannel':
           this.openExternalLink(this.invidiousChannelUrl)

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -298,31 +298,31 @@ export default Vue.extend({
           }
           break
         case 'copyYoutube':
-          this.copyToClipboard({ content: this.youtubeShareUrl, name: 'Share.YouTube URL', t: this.$t.bind(this) })
+          this.copyToClipboard({ content: this.youtubeShareUrl, messageOnSuccess: this.$t('Share.YouTube URL copied to clipboard') })
           break
         case 'openYoutube':
           this.openExternalLink(this.youtubeUrl)
           break
         case 'copyYoutubeEmbed':
-          this.copyToClipboard({ content: this.youtubeEmbedUrl, name: 'Share.YouTube Embed URL', t: this.$t.bind(this) })
+          this.copyToClipboard({ content: this.youtubeEmbedUrl, messageOnSuccess: this.$t('Share.YouTube Embed URL copied to clipboard') })
           break
         case 'openYoutubeEmbed':
           this.openExternalLink(this.youtubeEmbedUrl)
           break
         case 'copyInvidious':
-          this.copyToClipboard({ content: this.invidiousUrl, name: 'Share.Invidious URL', t: this.$t.bind(this) })
+          this.copyToClipboard({ content: this.invidiousUrl, messageOnSuccess: this.$t('Share.Invidious URL copied to clipboard') })
           break
         case 'openInvidious':
           this.openExternalLink(this.invidiousUrl)
           break
         case 'copyYoutubeChannel':
-          this.copyToClipboard({ content: this.youtubeChannelUrl, name: 'Share.YouTube Channel URL', t: this.$t.bind(this) })
+          this.copyToClipboard({ content: this.youtubeChannelUrl, messageOnSuccess: this.$t('Share.YouTube Channel URL copied to clipboard') })
           break
         case 'openYoutubeChannel':
           this.openExternalLink(this.youtubeChannelUrl)
           break
         case 'copyInvidiousChannel':
-          this.copyToClipboard({ content: this.invidiousChannelUrl, name: 'Share.Invidious Channel URL', t: this.$t.bind(this) })
+          this.copyToClipboard({ content: this.invidiousChannelUrl, messageOnSuccess: this.$t('Share.YouTube Channel URL copied to clipboard') })
           break
         case 'openInvidiousChannel':
           this.openExternalLink(this.invidiousChannelUrl)

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -520,7 +520,8 @@ export default Vue.extend({
       'removeFromHistory',
       'addVideo',
       'removeVideo',
-      'openExternalLink'
+      'openExternalLink',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -322,7 +322,7 @@ export default Vue.extend({
           this.openExternalLink(this.youtubeChannelUrl)
           break
         case 'copyInvidiousChannel':
-          this.copyToClipboard({ content: this.invidiousChannelUrl, messageOnSuccess: this.$t('Share.YouTube Channel URL copied to clipboard') })
+          this.copyToClipboard({ content: this.invidiousChannelUrl, messageOnSuccess: this.$t('Share.Invidious Channel URL copied to clipboard') })
           break
         case 'openInvidiousChannel':
           this.openExternalLink(this.invidiousChannelUrl)

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -83,7 +83,7 @@ export default Vue.extend({
     },
 
     copyInvidious() {
-      this.copyToClipboard({ content: this.getFinalUrl(this.invidiousURL), name: 'Share.Invidious URL', t: this.$t.bind(this) })
+      this.copyToClipboard({ content: this.getFinalUrl(this.invidiousURL), messageOnSuccess: this.$t('Share.Invidious URL copied to clipboard') })
       this.$refs.iconButton.focusOut()
     },
 
@@ -93,7 +93,7 @@ export default Vue.extend({
     },
 
     copyYoutube() {
-      this.copyToClipboard({ content: this.getFinalUrl(this.youtubeShareURL), name: 'Share.YouTube URL', t: this.$t.bind(this) })
+      this.copyToClipboard({ content: this.getFinalUrl(this.youtubeShareURL), messageOnSuccess: this.$t('Share.YouTube URL copied to clipboard') })
       this.$refs.iconButton.focusOut()
     },
 
@@ -103,7 +103,7 @@ export default Vue.extend({
     },
 
     copyYoutubeEmbed() {
-      this.copyToClipboard({ content: this.getFinalUrl(this.youtubeEmbedURL), name: 'Share.YouTube Embed URL', t: this.$t.bind(this) })
+      this.copyToClipboard({ content: this.getFinalUrl(this.youtubeEmbedURL), messageOnSuccess: this.$t('Share.YouTube Embed URL copied to clipboard') })
       this.$refs.iconButton.focusOut()
     },
 
@@ -113,7 +113,7 @@ export default Vue.extend({
     },
 
     copyInvidiousEmbed() {
-      this.copyToClipboard({ content: this.getFinalUrl(this.invidiousEmbedURL), name: 'Share.Invidious Embed URL', t: this.$t.bind(this) })
+      this.copyToClipboard({ content: this.getFinalUrl(this.invidiousEmbedURL), messageOnSuccess: this.$t('Share.Invidious Embed URL copied to clipboard') })
       this.$refs.iconButton.focusOut()
     },
 

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -76,9 +76,6 @@ export default Vue.extend({
     }
   },
   methods: {
-    copy(text) {
-      navigator.clipboard.writeText(text)
-    },
 
     openInvidious() {
       this.openExternalLink(this.getFinalUrl(this.invidiousURL))
@@ -86,10 +83,7 @@ export default Vue.extend({
     },
 
     copyInvidious() {
-      this.showToast({
-        message: this.$t('Share.Invidious URL copied to clipboard')
-      })
-      this.copy(this.getFinalUrl(this.invidiousURL))
+      this.copyToClipboard({ content: this.getFinalUrl(this.invidiousURL), name: 'Share.Invidious URL', t: this.$t.bind(this) })
       this.$refs.iconButton.focusOut()
     },
 
@@ -99,10 +93,7 @@ export default Vue.extend({
     },
 
     copyYoutube() {
-      this.showToast({
-        message: this.$t('Share.YouTube URL copied to clipboard')
-      })
-      this.copy(this.getFinalUrl(this.youtubeShareURL))
+      this.copyToClipboard({ content: this.getFinalUrl(this.youtubeShareURL), name: 'Share.YouTube URL', t: this.$t.bind(this) })
       this.$refs.iconButton.focusOut()
     },
 
@@ -112,10 +103,7 @@ export default Vue.extend({
     },
 
     copyYoutubeEmbed() {
-      this.showToast({
-        message: this.$t('Share.YouTube Embed URL copied to clipboard')
-      })
-      this.copy(this.getFinalUrl(this.youtubeEmbedURL))
+      this.copyToClipboard({ content: this.getFinalUrl(this.youtubeEmbedURL), name: 'Share.YouTube Embed URL', t: this.$t.bind(this) })
       this.$refs.iconButton.focusOut()
     },
 
@@ -125,10 +113,7 @@ export default Vue.extend({
     },
 
     copyInvidiousEmbed() {
-      this.showToast({
-        message: this.$t('Share.Invidious Embed URL copied to clipboard')
-      })
-      this.copy(this.getFinalUrl(this.invidiousEmbedURL))
+      this.copyToClipboard({ content: this.getFinalUrl(this.invidiousEmbedURL), name: 'Share.Invidious Embed URL', t: this.$t.bind(this) })
       this.$refs.iconButton.focusOut()
     },
 
@@ -145,7 +130,8 @@ export default Vue.extend({
 
     ...mapActions([
       'showToast',
-      'openExternalLink'
+      'openExternalLink',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -107,19 +107,13 @@ export default Vue.extend({
 
       switch (method) {
         case 'copyYoutube':
-          navigator.clipboard.writeText(youtubeUrl)
-          this.showToast({
-            message: this.$t('Share.YouTube URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: youtubeUrl, name: 'Share.YouTube URL', t: this.$t })
           break
         case 'openYoutube':
           this.openExternalLink(youtubeUrl)
           break
         case 'copyInvidious':
-          navigator.clipboard.writeText(invidiousUrl)
-          this.showToast({
-            message: this.$t('Share.Invidious URL copied to clipboard')
-          })
+          this.copyToClipboard({ content: invidiousUrl, name: 'Share.Invidious URL', t: this.$t })
           break
         case 'openInvidious':
           this.openExternalLink(invidiousUrl)
@@ -146,7 +140,8 @@ export default Vue.extend({
 
     ...mapActions([
       'showToast',
-      'openExternalLink'
+      'openExternalLink',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -107,13 +107,13 @@ export default Vue.extend({
 
       switch (method) {
         case 'copyYoutube':
-          this.copyToClipboard({ content: youtubeUrl, name: 'Share.YouTube URL', t: this.$t })
+          this.copyToClipboard({ content: youtubeUrl, messageOnSuccess: this.$t('Share.YouTube URL copied to clipboard') })
           break
         case 'openYoutube':
           this.openExternalLink(youtubeUrl)
           break
         case 'copyInvidious':
-          this.copyToClipboard({ content: invidiousUrl, name: 'Share.Invidious URL', t: this.$t })
+          this.copyToClipboard({ content: invidiousUrl, messageOnSuccess: this.$t('Share.Invidious URL copied to clipboard') })
           break
         case 'openInvidious':
           this.openExternalLink(invidiousUrl)

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -188,7 +188,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendFallback && this.backendPreference === 'local') {
@@ -223,7 +223,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendFallback && this.backendPreference === 'local') {
@@ -339,7 +339,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${xhr.responseText}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(xhr.responseText)
+            this.copyToClipboard({ content: xhr.responseText, t: this.$t.bind(this) })
           }
         })
         if (this.backendFallback && this.backendPreference === 'invidious') {
@@ -396,7 +396,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${xhr.responseText}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(xhr.responseText)
+            this.copyToClipboard({ content: xhr.responseText, t: this.$t.bind(this) })
           }
         })
         this.isLoading = false
@@ -410,7 +410,8 @@ export default Vue.extend({
     ...mapActions([
       'showToast',
       'toLocalePublicationString',
-      'invidiousAPICall'
+      'invidiousAPICall',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -188,7 +188,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendFallback && this.backendPreference === 'local') {
@@ -223,7 +223,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendFallback && this.backendPreference === 'local') {
@@ -339,7 +339,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${xhr.responseText}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: xhr.responseText, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: xhr.responseText })
           }
         })
         if (this.backendFallback && this.backendPreference === 'invidious') {
@@ -396,7 +396,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${xhr.responseText}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: xhr.responseText, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: xhr.responseText })
           }
         })
         this.isLoading = false

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -313,7 +313,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -354,7 +354,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -313,7 +313,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -354,7 +354,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -392,7 +392,8 @@ export default Vue.extend({
     ...mapActions([
       'showToast',
       'ytGetPlaylistInfo',
-      'invidiousGetPlaylistInfo'
+      'invidiousGetPlaylistInfo',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -257,7 +257,7 @@ const actions = {
   async copyToClipboard ({ dispatch }, { content, messageOnSuccess, messageOnError }) {
     const locale = i18n._vm.locale
     const translations = i18n._vm.messages[locale]
-    if (navigator.clipboard !== undefined) {
+    if (navigator.clipboard !== undefined && window.isSecureContext) {
       try {
         await navigator.clipboard.writeText(content)
         if (messageOnSuccess !== undefined) {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -246,6 +246,36 @@ const actions = {
     return filenameNew
   },
 
+  async copyToClipboard ({ dispatch }, { content, name, t = (content) => { return content } }) {
+    if (navigator.clipboard !== undefined) {
+      try {
+        await navigator.clipboard.writeText(content)
+        if (name !== undefined) {
+          dispatch('showToast', {
+            message: t(`${name} copied to clipboard`)
+          })
+        }
+      } catch (error) {
+        if (name !== undefined) {
+          dispatch('showToast', {
+            message: `${t(`${name} copy to clipboard failed`)}: ${error}`,
+            time: 5000
+          })
+        } else {
+          dispatch('showToast', {
+            message: `${t('Clipboard.Copy failed')}: ${error}`,
+            time: 5000
+          })
+        }
+      }
+    } else {
+      dispatch('showToast', {
+        message: t('Clipboard.Can not access without a secure connection'),
+        time: 5000
+      })
+    }
+  },
+
   async downloadMedia({ rootState, dispatch }, { url, title, extension, fallingBackPath }) {
     const fileName = `${await dispatch('replaceFilenameForbiddenChars', title)}.${extension}`
     const locale = i18n._vm.locale

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -266,6 +266,7 @@ const actions = {
           })
         }
       } catch (error) {
+          console.error(`Failed to copy ${content} to clipboard`, error)
         if (messageOnError !== undefined) {
           dispatch('showToast', {
             message: `${messageOnError}: ${error}`,

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -246,6 +246,14 @@ const actions = {
     return filenameNew
   },
 
+  /**
+   * This writes to the clipboard. If an error occurs during the copy,
+   * a toast with the error is shown. If the copy is successful and
+   * there is a success message, a toast with that message is shown.
+   * @param {string} content the content to be copied to the clipboard
+   * @param {string} messageOnSuccess the message to be displayed as a toast when the copy succeeds (optional)
+   * @param {string} messageOnError the message to be displayed as a toast when the copy fails (optional)
+   */
   async copyToClipboard ({ dispatch }, { content, messageOnSuccess, messageOnError }) {
     const locale = i18n._vm.locale
     const translations = i18n._vm.messages[locale]

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -255,8 +255,6 @@ const actions = {
    * @param {string} messageOnError the message to be displayed as a toast when the copy fails (optional)
    */
   async copyToClipboard ({ dispatch }, { content, messageOnSuccess, messageOnError }) {
-    const locale = i18n._vm.locale
-    const translations = i18n._vm.messages[locale]
     if (navigator.clipboard !== undefined && window.isSecureContext) {
       try {
         await navigator.clipboard.writeText(content)
@@ -266,7 +264,7 @@ const actions = {
           })
         }
       } catch (error) {
-          console.error(`Failed to copy ${content} to clipboard`, error)
+        console.error(`Failed to copy ${content} to clipboard`, error)
         if (messageOnError !== undefined) {
           dispatch('showToast', {
             message: `${messageOnError}: ${error}`,
@@ -274,14 +272,14 @@ const actions = {
           })
         } else {
           dispatch('showToast', {
-            message: `${translations.Clipboard['Copy failed']}: ${error}`,
+            message: `${i18n.t('Clipboard.Copy failed')}: ${error}`,
             time: 5000
           })
         }
       }
     } else {
       dispatch('showToast', {
-        message: translations.Clipboard['Can not access without a secure connection'],
+        message: i18n.t('Clipboard.Cannot access clipboard without a secure connection'),
         time: 5000
       })
     }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -246,31 +246,33 @@ const actions = {
     return filenameNew
   },
 
-  async copyToClipboard ({ dispatch }, { content, name, t = (content) => { return content } }) {
+  async copyToClipboard ({ dispatch }, { content, messageOnSuccess, messageOnError }) {
+    const locale = i18n._vm.locale
+    const translations = i18n._vm.messages[locale]
     if (navigator.clipboard !== undefined) {
       try {
         await navigator.clipboard.writeText(content)
-        if (name !== undefined) {
+        if (messageOnSuccess !== undefined) {
           dispatch('showToast', {
-            message: t(`${name} copied to clipboard`)
+            message: messageOnSuccess
           })
         }
       } catch (error) {
-        if (name !== undefined) {
+        if (messageOnError !== undefined) {
           dispatch('showToast', {
-            message: `${t(`${name} copy to clipboard failed`)}: ${error}`,
+            message: `${messageOnError}: ${error}`,
             time: 5000
           })
         } else {
           dispatch('showToast', {
-            message: `${t('Clipboard.Copy failed')}: ${error}`,
+            message: `${translations.Clipboard['Copy failed']}: ${error}`,
             time: 5000
           })
         }
       }
     } else {
       dispatch('showToast', {
-        message: t('Clipboard.Can not access without a secure connection'),
+        message: translations.Clipboard['Can not access without a secure connection'],
         time: 5000
       })
     }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -305,7 +305,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -337,7 +337,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -362,7 +362,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
       })
@@ -417,7 +417,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseJSON.error}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err.responseJSON.error })
           }
         })
         this.isLoading = false
@@ -445,7 +445,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
       })
@@ -472,7 +472,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -498,7 +498,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
       })
@@ -524,7 +524,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseJSON.error}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err.responseJSON.error })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -567,7 +567,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseJSON.error}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err.responseJSON.error })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -733,7 +733,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err })
             }
           })
           if (this.backendPreference === 'local' && this.backendFallback) {
@@ -758,7 +758,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err })
             }
           })
         })
@@ -786,7 +786,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -305,7 +305,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -337,7 +337,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -362,7 +362,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
       })
@@ -417,7 +417,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseJSON.error}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
           }
         })
         this.isLoading = false
@@ -445,7 +445,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
       })
@@ -472,7 +472,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -498,7 +498,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
       })
@@ -524,7 +524,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseJSON.error}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err.responseJSON.error)
+            this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -567,7 +567,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseJSON.error}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err.responseJSON.error)
+            this.copyToClipboard({ content: err.responseJSON.error, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -733,7 +733,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
           if (this.backendPreference === 'local' && this.backendFallback) {
@@ -758,7 +758,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
         })
@@ -786,7 +786,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -805,7 +805,8 @@ export default Vue.extend({
       'updateProfile',
       'invidiousGetChannelInfo',
       'invidiousAPICall',
-      'updateSubscriptionDetails'
+      'updateSubscriptionDetails',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -207,7 +207,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -279,7 +279,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {
@@ -345,7 +345,8 @@ export default Vue.extend({
     ...mapActions([
       'showToast',
       'ytSearch',
-      'invidiousAPICall'
+      'invidiousAPICall',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -207,7 +207,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -279,7 +279,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'invidious' && this.backendFallback) {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -260,7 +260,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
           switch (failedAttempts) {
@@ -323,7 +323,7 @@ export default Vue.extend({
               message: `${errorMessage}: ${err}`,
               time: 10000,
               action: () => {
-                navigator.clipboard.writeText(err)
+                this.copyToClipboard({ content: err, t: this.$t.bind(this) })
               }
             })
             switch (failedAttempts) {
@@ -371,7 +371,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err.responseText}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err.responseText, t: this.$t.bind(this) })
             }
           })
           switch (failedAttempts) {
@@ -422,7 +422,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
           if (err.toString().match(/500/)) {
@@ -465,7 +465,8 @@ export default Vue.extend({
       'updateShowProgressBar',
       'updateProfileSubscriptions',
       'updateAllSubscriptionsList',
-      'calculatePublishedDate'
+      'calculatePublishedDate',
+      'copyToClipboard'
     ]),
 
     ...mapMutations([

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -260,7 +260,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err })
             }
           })
           switch (failedAttempts) {
@@ -323,7 +323,7 @@ export default Vue.extend({
               message: `${errorMessage}: ${err}`,
               time: 10000,
               action: () => {
-                this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+                this.copyToClipboard({ content: err })
               }
             })
             switch (failedAttempts) {
@@ -371,7 +371,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err.responseText}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err.responseText, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err.responseText })
             }
           })
           switch (failedAttempts) {
@@ -422,7 +422,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err })
             }
           })
           if (err.toString().match(/500/)) {

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -132,7 +132,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -191,7 +191,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseText}`,
           time: 10000,
           action: () => {
-            navigator.clipboard.writeText(err)
+            this.copyToClipboard({ content: err.responseText, t: this.$t.bind(this) })
           }
         })
 

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -208,7 +208,8 @@ export default Vue.extend({
 
     ...mapActions([
       'showToast',
-      'invidiousAPICall'
+      'invidiousAPICall',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -132,7 +132,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err })
           }
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
@@ -191,7 +191,7 @@ export default Vue.extend({
           message: `${errorMessage}: ${err.responseText}`,
           time: 10000,
           action: () => {
-            this.copyToClipboard({ content: err.responseText, t: this.$t.bind(this) })
+            this.copyToClipboard({ content: err.responseText })
           }
         })
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -577,7 +577,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
           console.log(err)
@@ -762,7 +762,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err.responseText}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err.responseText)
+              this.copyToClipboard({ content: err.responseText, t: this.$t.bind(this) })
             }
           })
           console.log(err)
@@ -883,7 +883,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              navigator.clipboard.writeText(err)
+              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
             }
           })
           console.log(err)
@@ -1343,7 +1343,8 @@ export default Vue.extend({
       'getUserDataPath',
       'ytGetVideoInformation',
       'invidiousGetVideoInformation',
-      'updateSubscriptionDetails'
+      'updateSubscriptionDetails',
+      'copyToClipboard'
     ])
   }
 })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -577,7 +577,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err })
             }
           })
           console.log(err)
@@ -762,7 +762,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err.responseText}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err.responseText, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err.responseText })
             }
           })
           console.log(err)
@@ -883,7 +883,7 @@ export default Vue.extend({
             message: `${errorMessage}: ${err}`,
             time: 10000,
             action: () => {
-              this.copyToClipboard({ content: err, t: this.$t.bind(this) })
+              this.copyToClipboard({ content: err })
             }
           })
           console.log(err)

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -683,11 +683,20 @@ Share:
   Open Embed: Open Embed
   # On Click
   Invidious URL copied to clipboard: Invidious URL copied to clipboard
+  Invidious URL copy to clipboard failed: Failed to copy Invidious URL to clipboard
   Invidious Embed URL copied to clipboard: Invidious Embed URL copied to clipboard
+  Invidious Embed URL copy to clipboard failed: Failed to copy Invidious URL to clipboard
   Invidious Channel URL copied to clipboard: Invidious Channel URL copied to clipboard
+  Invidious Channel URL copy to clipboard failed: Failed to copy Invidious Channel to clipboard
   YouTube URL copied to clipboard: YouTube URL copied to clipboard
+  YouTube URL copy to clipboard failed: Failed to copy YouTube URL to clipboard
   YouTube Embed URL copied to clipboard: YouTube Embed URL copied to clipboard
+  YouTube Embed URL copy to clipboard failed: Failed to copy YouTube Embed URL to clipboard
   YouTube Channel URL copied to clipboard: YouTube Channel URL copied to clipboard
+  YouTube Channel URL copy to clipboard failed: Failed to copy YouTube Channel URL to clipboard
+Clipboard:
+  Copy failed: Copy to clipboard failed
+  Can not access without a secure connection: Can not access clipboard without a secure connection
 
 Mini Player: Mini Player
 Comments:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -690,7 +690,7 @@ Share:
   YouTube Channel URL copied to clipboard: YouTube Channel URL copied to clipboard
 Clipboard:
   Copy failed: Copy to clipboard failed
-  Can not access without a secure connection: Can not access clipboard without a secure connection
+  Cannot access clipboard without a secure connection: Cannot access clipboard without a secure connection
 
 Mini Player: Mini Player
 Comments:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -683,17 +683,11 @@ Share:
   Open Embed: Open Embed
   # On Click
   Invidious URL copied to clipboard: Invidious URL copied to clipboard
-  Invidious URL copy to clipboard failed: Failed to copy Invidious URL to clipboard
   Invidious Embed URL copied to clipboard: Invidious Embed URL copied to clipboard
-  Invidious Embed URL copy to clipboard failed: Failed to copy Invidious URL to clipboard
   Invidious Channel URL copied to clipboard: Invidious Channel URL copied to clipboard
-  Invidious Channel URL copy to clipboard failed: Failed to copy Invidious Channel to clipboard
   YouTube URL copied to clipboard: YouTube URL copied to clipboard
-  YouTube URL copy to clipboard failed: Failed to copy YouTube URL to clipboard
   YouTube Embed URL copied to clipboard: YouTube Embed URL copied to clipboard
-  YouTube Embed URL copy to clipboard failed: Failed to copy YouTube Embed URL to clipboard
   YouTube Channel URL copied to clipboard: YouTube Channel URL copied to clipboard
-  YouTube Channel URL copy to clipboard failed: Failed to copy YouTube Channel URL to clipboard
 Clipboard:
   Copy failed: Copy to clipboard failed
   Can not access without a secure connection: Can not access clipboard without a secure connection


### PR DESCRIPTION
---
Cleaning up calls to the Clipboard API
---

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Description**
I have found some issues with the current usage of the clipboard API in FreeTube. `navigator.clipboard.writeText` returns a promise, but most of the code that uses it in FreeTube doesn't seem to acknowledge that; this can lead to unexpected behavior.
```javascript
// line 337 of src/renderer/components/ft-list-video/ft-list-video.js
navigator.clipboard.writeText(this.invidiousChannelUrl)
this.showToast({// we don't necessarily know if writeText is successful when this executes
  message: this.$t('Share.Invidious Channel URL copied to clipboard')
})
```
```javascript
// line 115 of src/renderer/components/ft-share-button/ft-share-button.js
this.showToast({
  message: this.$t('Share.Invidious URL copied to clipboard')
})
this.copy(this.getFinalUrl(this.invidiousURL))// even if this is a synchronous function, it won't prevent the success message from being displayed
```
There are also some instances where the content being copied to the clipboard is not ideal.
```javascript
// line 171 of src/renderer/views/Subscriptions/Subscriptions.js
message: `${errorMessage}: ${err.responseText}`,
time: 10000,
action: () => {
  navigator.clipboard.writeText(err)// err is an object, so this is copying `[object Object]` to the clipboard
}
```
This PR aims to clean-up and centralize these calls to the clipboard API into a utility function called `copyToClipboard`.
```javascript
/**
 * This writes to the clipboard. If an error occurs during the copy,
 * a toast with the error is shown. If the copy is successful and
 * there is a success message, a toast with that message is shown.
 * @param {string} content - the content to be copied to the clipboard
 * @param {string} messageOnSuccess - the message to be displayed as a toast when the copy succeeds (optional)
 * @param {string} messageOnError - the message to be displayed as a toast when the copy fails (optional)
 */
async copyToClipboard ({ dispatch }, { content, messageOnSuccess, messageOnError }) {
  const locale = i18n._vm.locale
  const translations = i18n._vm.messages[locale]
  if (navigator.clipboard !== undefined && window.isSecureContext) {
    try {
      await navigator.clipboard.writeText(content)
      if (messageOnSuccess !== undefined) {
        dispatch('showToast', {
          message: messageOnSuccess
        })
      }
    } catch (error) {
      if (messageOnError !== undefined) {
        dispatch('showToast', {
          message: `${messageOnError}: ${error}`,
          time: 5000
        })
      } else {
        dispatch('showToast', {
          message: `${translations.Clipboard['Copy failed']}: ${error}`,
          time: 5000
        })
      }
    }
  } else {
    dispatch('showToast', {
      message: translations.Clipboard['Can not access without a secure connection'],
      time: 5000
    })
  }
}
```

**Testing (for code that is not small enough to be easily understandable)**
This change effects all views and components that copy to the clipboard. The easiest ones to test would be the `ft-share-button` or the `ft-list-video` components. The easiest way to test the copy to clipboard events which happen as a result of clicking on toast messages is to set your invidious server to something ridiculous like `abasdcassadas` or some other fake domain.

I have tested these components and views with the clipboard API both failing and succeeding, but the only way I know to reliably cause the clipboard API to fail in electron is to pause on a break point during the function that triggers the `copyToClipboard` function and continue with the electron window unfocused. This is the error it should display:
![image](https://user-images.githubusercontent.com/106682128/191092022-2e152b2b-2b3a-455b-aed6-2303795d3161.png)


**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

**Additional context**
Errors do not usually occur with the clipboard API in electron, but they are much more likely in a web browser. My main motivation for making this PR is to make it easier to extend the 'copy to clipboard' functionality in non-electron environments.