### PR TITLE
Fixing issue with visibleDataList holding onto stale data

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -92,6 +92,11 @@ export default Vue.extend({
       if (val !== oldVal) {
         this.updateVisibleDataList()
       }
+    },
+    inputData(val, oldVal) {
+      if (val !== oldVal) {
+        this.updateVisibleDataList()
+      }
     }
   },
   mounted: function () {


### PR DESCRIPTION
---
Fixing issue with visibleDataList holding onto stale data
---

**Pull Request Type**
Please select what type of pull request this is:
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

**Description**
This PR intends to fix an unintentional bug introduced by FreeTubeApp#2567. 

When selecting an invidious instance in the settings, the dropdown which displays possible instances will only update when the view is mounted. The result is that you can not get the dropdown to populate with invidious instances other than the current instance at the time the view was mounted:
![before-change](https://user-images.githubusercontent.com/106682128/191320666-85b3f0c1-4d2e-4d9e-ae9f-61b535ab71e1.gif)

The core issue is that the call to `updateVisibleDataList` was moved out of `handleInput` and into the watch method for `dataList`; however, there was no watch method added `inputData`, This means that `visibleDataList` sometimes retains stale data when it should be updating. This PR aims to resolve this by adding `updateVisibleDataList` to a watch method for `inputData`.


**Screenshots**
![after-change](https://user-images.githubusercontent.com/106682128/191321967-452f3112-a6a4-43fa-85b1-9da1707bc563.gif)


**Testing (for code that is not small enough to be easily understandable)**
I have tested the search suggestions and the invidious instance selector, but there may be other relevant `ft-input`s to test.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

