### PR TITLE
Implementing download media when IS_ELECTRON is false

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -209,7 +209,7 @@ const actions = {
       const ipcRenderer = require('electron').ipcRenderer
       ipcRenderer.send(IpcChannels.OPEN_EXTERNAL_LINK, url)
     } else {
-      // Web placeholder
+      window.open(url, '_blank')
     }
   },
 
@@ -256,7 +256,7 @@ const actions = {
     let folderPath = rootState.settings.downloadFolderPath
 
     if (!process.env.IS_ELECTRON) {
-      // Add logic here in the future
+      dispatch('openExternalLink', url)
       return
     }
 


### PR DESCRIPTION
---
Implementing downloadMedia when IS_ELECTRON is false
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

**Description**
This PR adds two lines to `utils` to implement `openExternalLink` and `downloadMedia` in builds where `IS_ELECTRON` is set to `false`.

**Screenshots**
These screenshots are from a web build produced by my fork before and after these changes were applied to it.
*Before:*
![before-change](https://user-images.githubusercontent.com/106682128/191354491-39d1402b-d05e-49cf-9ed7-d3489f2a2ab0.gif)
*After:*
<img src="https://user-images.githubusercontent.com/106682128/191353118-df5eaa37-d4fe-452e-bcf8-674a60c9c922.gif" width="300" />

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1
