### PR TITLE
Fix some development code not getting optimised out

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -18,15 +18,16 @@
 
   <body>
     <div id="app"></div>
+    <% if (process.env.NODE_ENV !== 'development') { %>
     <!-- Set `__static` path to static files in production -->
     <script>
     try {
-      if ('<%= process.env.NODE_ENV %>' !== 'development')
         window.__static = require('path')
           .join(__dirname, '/static')
           .replace(/\\/g, '\\\\')
       } catch {}
     </script>
+    <% } %>
 
     <script>
     // This is the service worker with the Advanced caching

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -51,9 +51,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    isDev: function () {
-      return process.env.NODE_ENV === 'development'
-    },
     isOpen: function () {
       return this.$store.getters.getIsSideNavOpen
     },
@@ -149,7 +146,7 @@ export default Vue.extend({
     this.grabUserSettings().then(async () => {
       this.checkThemeSettings()
 
-      await this.fetchInvidiousInstances({ isDev: this.isDev })
+      await this.fetchInvidiousInstances()
       if (this.defaultInvidiousInstance === '') {
         await this.setRandomCurrentInvidiousInstance()
       }
@@ -262,7 +259,6 @@ export default Vue.extend({
 
     checkExternalPlayer: async function () {
       const payload = {
-        isDev: this.isDev,
         externalPlayer: this.externalPlayer
       }
       this.getExternalPlayerCmdArgumentsData(payload)

--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -19,10 +19,6 @@ export default Vue.extend({
     return {}
   },
   computed: {
-    isDev: function () {
-      return process.env.NODE_ENV === 'development'
-    },
-
     externalPlayerNames: function () {
       const fallbackNames = this.$store.getters.getExternalPlayerNames
       const nameTranslationKeys = this.$store.getters.getExternalPlayerNameTranslationKeys

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -59,9 +59,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    isDev: function () {
-      return process.env.NODE_ENV === 'development'
-    },
     currentInvidiousInstance: function () {
       return this.$store.getters.getCurrentInvidiousInstance
     },

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -42,10 +42,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    isDev: function () {
-      return process.env.NODE_ENV === 'development'
-    },
-
     backendPreference: function () {
       return this.$store.getters.getBackendPreference
     },

--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -22,7 +22,7 @@ const getters = {
 }
 
 const actions = {
-  async fetchInvidiousInstances({ commit }, payload) {
+  async fetchInvidiousInstances({ commit }) {
     const requestUrl = 'https://api.invidious.io/instances.json'
 
     let instances = []
@@ -44,7 +44,7 @@ const actions = {
       // And fallback to hardcoded entry(s) if static file absent
       const fileName = 'invidious-instances.json'
       /* eslint-disable-next-line */
-      const fileLocation = payload.isDev ? './static/' : `${__dirname}/static/`
+      const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
       if (fs.existsSync(`${fileLocation}${fileName}`)) {
         console.log('reading static file for invidious instances')
         const fileData = fs.readFileSync(`${fileLocation}${fileName}`)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -319,7 +319,6 @@ const stateWithSideEffects = {
 
       i18n.locale = targetLocale
       dispatch('getRegionData', {
-        isDev: process.env.NODE_ENV === 'development',
         locale: targetLocale
       })
     }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -490,7 +490,7 @@ const actions = {
   getRegionData ({ commit }, payload) {
     let fileData
     /* eslint-disable-next-line */
-    const fileLocation = payload.isDev ? './static/geolocations/' : `${__dirname}/static/geolocations/`
+    const fileLocation = process.env.NODE_ENV === 'development' ? './static/geolocations/' : `${__dirname}/static/geolocations/`
     if (fs.existsSync(`${fileLocation}${payload.locale}`)) {
       fileData = fs.readFileSync(`${fileLocation}${payload.locale}/countries.json`)
     } else {
@@ -971,7 +971,7 @@ const actions = {
     const fileName = 'external-player-map.json'
     let fileData
     /* eslint-disable-next-line */
-    const fileLocation = payload.isDev ? './static/' : `${__dirname}/static/`
+    const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
 
     if (fs.existsSync(`${fileLocation}${fileName}`)) {
       fileData = fs.readFileSync(`${fileLocation}${fileName}`)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -16,6 +16,8 @@ import WatchVideoRecommendations from '../../components/watch-video-recommendati
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
 import i18n from '../../i18n/index'
 
+const isDev = process.env.NODE_ENV === 'development'
+
 export default Vue.extend({
   name: 'Watch',
   components: {
@@ -86,9 +88,6 @@ export default Vue.extend({
     }
   },
   computed: {
-    isDev: function () {
-      return process.env.NODE_ENV === 'development'
-    },
     historyCache: function () {
       return this.$store.getters.getHistoryCache
     },
@@ -1126,7 +1125,7 @@ export default Vue.extend({
 
       if (this.removeVideoMetaFiles) {
         const userData = await this.getUserDataPath()
-        if (this.isDev) {
+        if (isDev) {
           const dashFileLocation = `static/dashFiles/${videoId}.xml`
           const vttFileLocation = `static/storyboards/${videoId}.vtt`
           // only delete the file it actually exists
@@ -1173,7 +1172,7 @@ export default Vue.extend({
       const userData = await this.getUserDataPath()
       let fileLocation
       let uriSchema
-      if (this.isDev) {
+      if (isDev) {
         fileLocation = `static/dashFiles/${this.videoId}.xml`
         uriSchema = `dashFiles/${this.videoId}.xml`
         // if the location does not exist, writeFileSync will not create the directory, so we have to do that manually
@@ -1254,7 +1253,7 @@ export default Vue.extend({
 
         // Dev mode doesn't have access to the file:// schema, so we access
         // storyboards differently when run in dev
-        if (this.isDev) {
+        if (isDev) {
           fileLocation = `static/storyboards/${this.videoId}.vtt`
           uriSchema = `storyboards/${this.videoId}.vtt`
           // if the location does not exist, writeFileSync will not create the directory, so we have to do that manually


### PR DESCRIPTION
---
Fix some development code not getting optimised out
---

**Important note**
We may remove your pull request if you do not use this provided PR template correctly.

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix

**Description**
Webpack doesn't know about vue's computed properties or vuex stores, so it doesn't know how to optimise them out. This PR fixes that by marking development only code in a way that webpack understands, so it can remove the dead code properly while optimising the release builds. This PR also gets rid of some unnecessary `isDev` computed properties. This change doesn't make a big size or speed difference but even a 849 byte decrease in size and an unmeasurably small performance improvement are better than including dead code in a release build.

**Screenshots (if appropriate)**
![before](https://user-images.githubusercontent.com/48293849/191614823-35af9105-094a-4d3f-a9b1-64edd1b67253.jpg)

![after](https://user-images.githubusercontent.com/48293849/191614833-83940f22-d1d0-4a03-ae51-b9ec86366224.jpg)

**Testing (for code that is not small enough to be easily understandable)**
`yarn dev` and `yarn build`

Opening the settings will test both the geolocation names for trending the fetching of the invidious instances.

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1