### PR TITLE
Implementing showOpenDialog's web callback

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -966,63 +966,65 @@ export default Vue.extend({
       if (response.canceled || response.filePaths.length === 0) {
         return
       }
+      let textDecode
       try {
-        let textDecode = await this.readFileFromDialog({ response })
-        textDecode = textDecode.split('\n')
-        textDecode.pop()
-
-        textDecode.forEach((history) => {
-          const historyData = JSON.parse(history)
-          // We would technically already be done by the time the data is parsed,
-          // however we want to limit the possibility of malicious data being sent
-          // to the app, so we'll only grab the data we need here.
-          const requiredKeys = [
-            '_id',
-            'author',
-            'authorId',
-            'description',
-            'isLive',
-            'lengthSeconds',
-            'paid',
-            'published',
-            'timeWatched',
-            'title',
-            'type',
-            'videoId',
-            'viewCount',
-            'watchProgress'
-          ]
-
-          const historyObject = {}
-
-          Object.keys(historyData).forEach((key) => {
-            if (!requiredKeys.includes(key)) {
-              this.showToast({
-                message: `Unknown data key: ${key}`
-              })
-            } else {
-              historyObject[key] = historyData[key]
-            }
-          })
-
-          if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
-            this.showToast({
-              message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
-            })
-          } else {
-            this.updateHistory(historyObject)
-          }
-        })
-
-        this.showToast({
-          message: this.$t('Settings.Data Settings.All watched history has been successfully imported')
-        })
+        textDecode = await this.readFileFromDialog({ response })
       } catch (exception) {
         console.error(exception)
         this.showToast({
           message: exception
         })
+        return
       }
+      textDecode = textDecode.split('\n')
+      textDecode.pop()
+
+      textDecode.forEach((history) => {
+        const historyData = JSON.parse(history)
+        // We would technically already be done by the time the data is parsed,
+        // however we want to limit the possibility of malicious data being sent
+        // to the app, so we'll only grab the data we need here.
+        const requiredKeys = [
+          '_id',
+          'author',
+          'authorId',
+          'description',
+          'isLive',
+          'lengthSeconds',
+          'paid',
+          'published',
+          'timeWatched',
+          'title',
+          'type',
+          'videoId',
+          'viewCount',
+          'watchProgress'
+        ]
+
+        const historyObject = {}
+
+        Object.keys(historyData).forEach((key) => {
+          if (!requiredKeys.includes(key)) {
+            this.showToast({
+              message: `Unknown data key: ${key}`
+            })
+          } else {
+            historyObject[key] = historyData[key]
+          }
+        })
+
+        if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
+          this.showToast({
+            message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
+          })
+        } else {
+          this.updateHistory(historyObject)
+        }
+      })
+
+      this.showToast({
+        message: this.$t('Settings.Data Settings.All watched history has been successfully imported')
+      })
     },
 
     exportHistory: async function () {

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -966,57 +966,63 @@ export default Vue.extend({
       if (response.canceled || response.filePaths.length === 0) {
         return
       }
+      try {
+        let textDecode = await this.readFileFromDialog({ response })
+        textDecode = textDecode.split('\n')
+        textDecode.pop()
 
-      let textDecode = await this.readFileFromDialog({ response })
-      textDecode = textDecode.split('\n')
-      textDecode.pop()
+        textDecode.forEach((history) => {
+          const historyData = JSON.parse(history)
+          // We would technically already be done by the time the data is parsed,
+          // however we want to limit the possibility of malicious data being sent
+          // to the app, so we'll only grab the data we need here.
+          const requiredKeys = [
+            '_id',
+            'author',
+            'authorId',
+            'description',
+            'isLive',
+            'lengthSeconds',
+            'paid',
+            'published',
+            'timeWatched',
+            'title',
+            'type',
+            'videoId',
+            'viewCount',
+            'watchProgress'
+          ]
 
-      textDecode.forEach((history) => {
-        const historyData = JSON.parse(history)
-        // We would technically already be done by the time the data is parsed,
-        // however we want to limit the possibility of malicious data being sent
-        // to the app, so we'll only grab the data we need here.
-        const requiredKeys = [
-          '_id',
-          'author',
-          'authorId',
-          'description',
-          'isLive',
-          'lengthSeconds',
-          'paid',
-          'published',
-          'timeWatched',
-          'title',
-          'type',
-          'videoId',
-          'viewCount',
-          'watchProgress'
-        ]
+          const historyObject = {}
 
-        const historyObject = {}
+          Object.keys(historyData).forEach((key) => {
+            if (!requiredKeys.includes(key)) {
+              this.showToast({
+                message: `Unknown data key: ${key}`
+              })
+            } else {
+              historyObject[key] = historyData[key]
+            }
+          })
 
-        Object.keys(historyData).forEach((key) => {
-          if (!requiredKeys.includes(key)) {
+          if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
             this.showToast({
-              message: `Unknown data key: ${key}`
+              message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
             })
           } else {
-            historyObject[key] = historyData[key]
+            this.updateHistory(historyObject)
           }
         })
 
-        if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
-          this.showToast({
-            message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
-          })
-        } else {
-          this.updateHistory(historyObject)
-        }
-      })
-
-      this.showToast({
-        message: this.$t('Settings.Data Settings.All watched history has been successfully imported')
-      })
+        this.showToast({
+          message: this.$t('Settings.Data Settings.All watched history has been successfully imported')
+        })
+      } catch (exception) {
+        console.error(exception)
+        this.showToast({
+          message: exception
+        })
+      }
     },
 
     exportHistory: async function () {

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -80,6 +80,9 @@ export default Vue.extend({
         `${exportYouTube} (.opml)`,
         `${exportNewPipe} (.json)`
       ]
+    },
+    usingElectron: function () {
+      return process.env.IS_ELECTRON
     }
   },
   methods: {
@@ -940,7 +943,7 @@ export default Vue.extend({
     checkForLegacySubscriptions: async function () {
       let dbLocation = await this.getUserDataPath()
       dbLocation = dbLocation + '/subscriptions.db'
-      this.handleFreetubeImportFile(dbLocation)
+      this.handleFreetubeImportFile({ canceled: false, filePaths: [dbLocation] })
       fs.unlink(dbLocation, (err) => {
         if (err) {
           console.log(err)

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -967,67 +967,55 @@ export default Vue.extend({
         return
       }
 
-      const filePath = response.filePaths[0]
+      let textDecode = await this.readFileFromDialog({ response })
+      textDecode = textDecode.split('\n')
+      textDecode.pop()
 
-      fs.readFile(filePath, async (err, data) => {
-        if (err) {
-          const message = this.$t('Settings.Data Settings.Unable to read file')
-          this.showToast({
-            message: `${message}: ${err}`
-          })
-          return
-        }
+      textDecode.forEach((history) => {
+        const historyData = JSON.parse(history)
+        // We would technically already be done by the time the data is parsed,
+        // however we want to limit the possibility of malicious data being sent
+        // to the app, so we'll only grab the data we need here.
+        const requiredKeys = [
+          '_id',
+          'author',
+          'authorId',
+          'description',
+          'isLive',
+          'lengthSeconds',
+          'paid',
+          'published',
+          'timeWatched',
+          'title',
+          'type',
+          'videoId',
+          'viewCount',
+          'watchProgress'
+        ]
 
-        let textDecode = new TextDecoder('utf-8').decode(data)
-        textDecode = textDecode.split('\n')
-        textDecode.pop()
+        const historyObject = {}
 
-        textDecode.forEach((history) => {
-          const historyData = JSON.parse(history)
-          // We would technically already be done by the time the data is parsed,
-          // however we want to limit the possibility of malicious data being sent
-          // to the app, so we'll only grab the data we need here.
-          const requiredKeys = [
-            '_id',
-            'author',
-            'authorId',
-            'description',
-            'isLive',
-            'lengthSeconds',
-            'paid',
-            'published',
-            'timeWatched',
-            'title',
-            'type',
-            'videoId',
-            'viewCount',
-            'watchProgress'
-          ]
-
-          const historyObject = {}
-
-          Object.keys(historyData).forEach((key) => {
-            if (!requiredKeys.includes(key)) {
-              this.showToast({
-                message: `Unknown data key: ${key}`
-              })
-            } else {
-              historyObject[key] = historyData[key]
-            }
-          })
-
-          if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
+        Object.keys(historyData).forEach((key) => {
+          if (!requiredKeys.includes(key)) {
             this.showToast({
-              message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
+              message: `Unknown data key: ${key}`
             })
           } else {
-            this.updateHistory(historyObject)
+            historyObject[key] = historyData[key]
           }
         })
 
-        this.showToast({
-          message: this.$t('Settings.Data Settings.All watched history has been successfully imported')
-        })
+        if (Object.keys(historyObject).length < (requiredKeys.length - 2)) {
+          this.showToast({
+            message: this.$t('Settings.Data Settings.History object has insufficient data, skipping item')
+          })
+        } else {
+          this.updateHistory(historyObject)
+        }
+      })
+
+      this.showToast({
+        message: this.$t('Settings.Data Settings.All watched history has been successfully imported')
       })
     },
 
@@ -1345,6 +1333,7 @@ export default Vue.extend({
       'getRandomColor',
       'calculateColorLuminance',
       'showOpenDialog',
+      'readFileFromDialog',
       'showSaveDialog',
       'getUserDataPath',
       'addPlaylist',

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -963,7 +963,7 @@ export default Vue.extend({
       }
 
       const response = await this.showOpenDialog(options)
-      if (response.canceled || response.filePaths.length === 0) {
+      if (response.canceled || response.filePaths?.length === 0) {
         return
       }
       let textDecode

--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -12,7 +12,7 @@
         @click="showImportSubscriptionsPrompt = true"
       />
       <ft-button
-        :v-if="usingElectron"
+        v-if="usingElectron"
         :label="$t('Settings.Data Settings.Check for Legacy Subscriptions')"
         @click="checkForLegacySubscriptions"
       />

--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -12,6 +12,7 @@
         @click="showImportSubscriptionsPrompt = true"
       />
       <ft-button
+        :v-if="usingElectron"
         :label="$t('Settings.Data Settings.Check for Legacy Subscriptions')"
         @click="checkForLegacySubscriptions"
       />

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -424,7 +424,7 @@ const actions = {
       return new Promise((resolve) => {
         const fileInput = document.createElement('input')
         fileInput.setAttribute('type', 'file')
-        fileInput.onchange = function() {
+        fileInput.onchange = () => {
           const files = Array.from(fileInput.files)
           resolve({ canceled: false, files })
         }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -426,7 +426,7 @@ const actions = {
         fileInput.setAttribute('type', 'file')
         fileInput.onchange = function() {
           const files = Array.from(fileInput.files)
-          resolve({ cancelled: files.length > 0, files })
+          resolve({ canceled: false, files })
         }
         fileInput.click()
       })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -430,9 +430,9 @@ const actions = {
           delete fileInput.onchange
         }
         const listenForEnd = () => {
+          window.removeEventListener('focus', listenForEnd)
           // 1 second timeout on the response from the file picker to prevent awaiting forever
           setTimeout(() => {
-            window.removeEventListener('focus', listenForEnd)
             if (fileInput.files.length === 0 && typeof fileInput.onchange === 'function') {
               // if there are no files and the onchange has not been triggered, the file-picker was canceled
               resolve({ canceled: true })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -424,6 +424,10 @@ const actions = {
       return new Promise((resolve) => {
         const fileInput = document.createElement('input')
         fileInput.setAttribute('type', 'file')
+        if (options?.filters[0]?.extensions !== undefined) {
+          // this will map the given extensions from the options to the accept attribute of the input
+          fileInput.setAttribute('accept', options.filters[0].extensions.map((extension) => { return `.${extension}` }).join(', '))
+        }
         fileInput.onchange = () => {
           const files = Array.from(fileInput.files)
           resolve({ canceled: false, files })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -432,7 +432,7 @@ const actions = {
           setTimeout(() => {
             window.removeEventListener('focus', listenForEnd)
             if (fileInput.files.length === 0) {
-              // if the file picker is closed, and there are no files, so it was canceled
+              // if the file picker is closed and there are no files, it was canceled
               resolve({ canceled: true })
             }
           }, 100)

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -395,9 +395,15 @@ const actions = {
     return (await invokeIRC(context, IpcChannels.GET_SYSTEM_LOCALE, webCbk)) || 'en-US'
   },
 
+  /**
+   * @param {Object} response the response from `showOpenDialog`
+   * @param {Number} index which file to read (defaults to the first in the response)
+   * @returns the text contents of the selected file
+   */
   async readFileFromDialog(context, { response, index = 0 }) {
     return await new Promise((resolve, reject) => {
       if (process.env.IS_ELECTRON) {
+        // if this is Electron, use fs
         fs.readFile(response.filePaths[index], (err, data) => {
           if (err) {
             reject(err)
@@ -406,6 +412,7 @@ const actions = {
           resolve(new TextDecoder('utf-8').decode(data))
         })
       } else {
+        // if this is web, use FileReader
         try {
           const reader = new FileReader()
           reader.onload = function (file) {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -428,6 +428,16 @@ const actions = {
           const files = Array.from(fileInput.files)
           resolve({ canceled: false, files })
         }
+        const listenForEnd = () => {
+          setTimeout(() => {
+            window.removeEventListener('focus', listenForEnd)
+            if (fileInput.files.length === 0) {
+              // if the file picker is closed, and there are no files, so it was canceled
+              resolve({ canceled: true })
+            }
+          }, 100)
+        }
+        window.addEventListener('focus', listenForEnd)
         fileInput.click()
       })
     }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -427,15 +427,18 @@ const actions = {
         fileInput.onchange = () => {
           const files = Array.from(fileInput.files)
           resolve({ canceled: false, files })
+          delete fileInput.onchange
         }
         const listenForEnd = () => {
+          // 1 second timeout on the response from the file picker to prevent awaiting forever
           setTimeout(() => {
             window.removeEventListener('focus', listenForEnd)
-            if (fileInput.files.length === 0) {
-              // if the file picker is closed and there are no files, it was canceled
+            if (fileInput.files.length === 0 && typeof fileInput.onchange === 'function') {
+              // if there are no files and the onchange has not been triggered, the file-picker was canceled
               resolve({ canceled: true })
+              delete fileInput.onchange
             }
-          }, 100)
+          }, 1000)
         }
         window.addEventListener('focus', listenForEnd)
         fileInput.click()


### PR DESCRIPTION
---
Implementing `showOpenDialog`'s web callback
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

**Description**
This PR implements `showOpenDialog`'s web callback, and in order to do that meaningfully, it also refactors the `import` functions in `data-settings` (`importHistory`, `importPlaylists`, `importSubscriptions`, etc) to use a new utility function called `readFileFromDialog` instead of `fs.readFile`.
```javascript
/**
 * @param {Object} response the response from `showOpenDialog`
 * @param {Number} index which file to read (defaults to the first in the response)
 * @returns the text contents of the selected file
 */
async readFileFromDialog(context, { response, index = 0 }) {
  return await new Promise((resolve, reject) => {
    if (process.env.IS_ELECTRON) {
      // if this is Electron, use fs
      fs.readFile(response.filePaths[index], (err, data) => {
        if (err) {
          reject(err)
          return
        }
        resolve(new TextDecoder('utf-8').decode(data))
      })
    } else {
      // if this is web, use FileReader
      try {
        const reader = new FileReader()
        reader.onload = function (file) {
          resolve(file.currentTarget.result)
        }
        reader.readAsText(response.files[index])
      } catch (exception) {
        reject(exception)
      }
    }
  })
}
```
 `readFileFromDialog` normalizes the reading of files from a file picker between Electron and web builds. In Electron, the underlying behavior should be exactly the same, but in web builds, this change makes the import buttons in `data-settings` work. 

It is worth noting that this change also hides the `Check for legacy subscriptions` button when `IS_ELECTRON` is `false`. I figured this made sense because there is no way to check for that in a web browser without something like the native file API which has limited browser support at this time.

**Screenshots (if appropriate)**
These screenshots are from a version of my web build with this PR applied to it.
*Before:*
<img src="https://user-images.githubusercontent.com/106682128/191824392-3f749dd1-7825-418c-a616-5fb56721d8e1.gif"  width="300" />


*After:*
<img src="https://user-images.githubusercontent.com/106682128/191829946-7da6619f-e773-439f-941c-0bb7fa1b75da.gif" width="500" />
<img src="https://user-images.githubusercontent.com/106682128/191830525-2e160679-fcaa-4c78-b8f5-218b39497c0c.gif" width="500" />
<img src="https://user-images.githubusercontent.com/106682128/191830682-f43a3a4f-1bb5-4c3b-b96c-87559cbfb0be.gif" width="500" />

**Testing (for code that is not small enough to be easily understandable)**
This change effects all of the import buttons under `data-settings`. I have tested this with Electron and web builds on every type of subscription import, the playlist import, and the history import. 

The easiest way to test the subscriptions is to populate them *( either through using the app or from an existing data export )* and export them to all of the different types (db,csv,json,opml). Then, you can remove all of your subscriptions in the privacy settings and check each of the subscription export types with the exact same subscriptions.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

**Additional context**
In my opinion, the diff for `data-settings` is really hard to read, but I didn't remove much of any existing code. I moved all of the code inside the `fs.readFile` callbacks to after the call for `readFileFromDialog`. 

I took code that looked like this:
```javascript
const response = await this.showOpenDialog(options)
if (response.canceled || response.filePaths.length === 0) {
  return
}

const filePath = response.filePaths[0]

fs.readFile(filePath, async (err, data) => {
  if (err) {
    const message = this.$t('Settings.Data Settings.Unable to read file')
    this.showToast({
      message: `${message}: ${err}`
    })
    return
  }
  // more specific function code
})
```
And, I made it look like this:
```javascript
const response = await this.showOpenDialog(options)
if (response.canceled || response.filePaths?.length === 0) {
  return
}
// this variable is also sometimes called `data`
let textDecode
try {
  textDecode = await this.readFileFromDialog({ response })
} catch (err) {
  const message = this.$t('Settings.Data Settings.Unable to read file')
  this.showToast({
    message: `${message}: ${err}`
  })
  return
}
// more specific function code
````

I would be willing to refactor everything back to using a callback with `.then` if that would reduce the amount of additions/deletions in this PR. The reason I used `await` over `.then` was because I noticed that `this.showOpenDialog` was being awaited, so I figured it made sense to also use `await` for `this.readFileFromDialog`. 

This change would take one step closer towards making an in-memory filesystem unnecessary for running FreeTube in web environments.