### PR TITLE
Replace jquery $.param with native URLSearchParams

### DIFF
--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -1,4 +1,3 @@
-import $ from 'jquery'
 import fs from 'fs'
 
 const state = {
@@ -71,7 +70,7 @@ const actions = {
 
   invidiousAPICall({ state }, payload) {
     return new Promise((resolve, reject) => {
-      const requestUrl = state.currentInvidiousInstance + '/api/v1/' + payload.resource + '/' + payload.id + '?' + $.param(payload.params)
+      const requestUrl = state.currentInvidiousInstance + '/api/v1/' + payload.resource + '/' + payload.id + '?' + new URLSearchParams(payload.params).toString()
 
       fetch(requestUrl)
         .then((response) => response.json())


### PR DESCRIPTION
---
Replace jquery $.param with native URLSearchParams
---

**Pull Request Type**

- [x] Feature Implementation

**Description**
This pull request replaces jquery's param function with the native URLSearchParams class.

**Testing (for code that is not small enough to be easily understandable)**
Try a few things with the Invidious API selected e.g. searching

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1

**Additional context**
This is another PR in your favourite series: replacing jquery with absidue