### PR TITLE
Fix empty description box showing for the Invidious API

### DIFF
--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -2,7 +2,6 @@ import Vue from 'vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtTimestampCatcher from '../ft-timestamp-catcher/ft-timestamp-catcher.vue'
 import autolinker from 'autolinker'
-import $ from 'jquery'
 
 export default Vue.extend({
   name: 'WatchVideoDescription',
@@ -31,13 +30,21 @@ export default Vue.extend({
   },
   mounted: function () {
     if (this.descriptionHtml !== '') {
-      this.shownDescription = this.parseDescriptionHtml(this.descriptionHtml)
-    } else {
-      this.shownDescription = autolinker.link(this.description)
-    }
+      const parsed = this.parseDescriptionHtml(this.descriptionHtml)
 
-    if (/^\s*$/.test(this.shownDescription)) {
-      $('.videoDescription')[0].style.display = 'none'
+      // the invidious API returns emtpy html elements when the description is empty
+      // so we need to check for that here
+
+      const testDiv = document.createElement('div')
+      testDiv.innerHTML = parsed
+
+      if (!/^\s*$/.test(testDiv.innerText)) {
+        this.shownDescription = parsed
+      }
+    } else {
+      if (!/^\s*$/.test(this.description)) {
+        this.shownDescription = autolinker.link(this.description)
+      }
     }
   },
   methods: {

--- a/src/renderer/components/watch-video-description/watch-video-description.js
+++ b/src/renderer/components/watch-video-description/watch-video-description.js
@@ -33,7 +33,8 @@ export default Vue.extend({
       const parsed = this.parseDescriptionHtml(this.descriptionHtml)
 
       // the invidious API returns emtpy html elements when the description is empty
-      // so we need to check for that here
+      // so we need to parse it to see if there is any meaningful text in the html
+      // or if it's just empty html elements e.g. `<p></p>`
 
       const testDiv = document.createElement('div')
       testDiv.innerHTML = parsed

--- a/src/renderer/components/watch-video-description/watch-video-description.vue
+++ b/src/renderer/components/watch-video-description/watch-video-description.vue
@@ -1,5 +1,8 @@
 <template>
-  <ft-card class="videoDescription">
+  <ft-card
+    v-if="shownDescription.length > 0"
+    class="videoDescription"
+  >
     <ft-timestamp-catcher
       class="description"
       :input-html="shownDescription"


### PR DESCRIPTION
---
Fix empty description box showing for the Invidious API
---

**Pull Request Type**
Please select what type of pull request this is:
- [x] Bugfix
- [x] Feature Implementation

**Description**
This pull request fixes an empty description box showing for videos that don't have a description when the Invidious API is selected. I noticed this problem while removing jquery from the description component so I've killed (fixed) two birds (issues) with one stone (PR).

**Screenshots (if appropriate)**
before:
![before](https://user-images.githubusercontent.com/48293849/192107742-60f37bf6-47f4-4003-9329-01985d39f745.jpg)

after:
![after](https://user-images.githubusercontent.com/48293849/192107743-17541644-670c-4bed-b277-72b3c45a3d0c.jpg)

**Testing (for code that is not small enough to be easily understandable)**
https://youtu.be/Dmu-Yt4Nzzs (from #2530)

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1

**Additional context**
jquery is used in a lot of places