### PR TITLE
Replace jquery in ft-icon-button with vue functionality

### DIFF
--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -54,7 +54,8 @@ export default Vue.extend({
   },
   data: function () {
     return {
-      dropdownShown: false
+      dropdownShown: false,
+      mouseDownOnIcon: false
     }
   },
   methods: {
@@ -76,6 +77,20 @@ export default Vue.extend({
         }
       } else {
         this.$emit('click')
+      }
+    },
+
+    handleIconMouseDown: function () {
+      if (this.dropdownShown) {
+        this.mouseDownOnIcon = true
+      }
+    },
+
+    handleDropdownFocusOut: function () {
+      if (this.mouseDownOnIcon) {
+        this.mouseDownOnIcon = false
+      } else {
+        this.dropdownShown = false
       }
     },
 

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -59,7 +59,7 @@ export default Vue.extend({
   },
   methods: {
     // used by the share menu
-    hide: function () {
+    hideDropdown: function () {
       this.dropdownShown = false
     },
 

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -69,7 +69,7 @@ export default Vue.extend({
 
         if (this.dropdownShown) {
           // wait until the dropdown is visible
-          // then focus it so we can hide it automatically when it looses focus
+          // then focus it so we can hide it automatically when it loses focus
           setTimeout(() => {
             this.$refs.dropdown.focus()
           }, 0)

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -1,5 +1,4 @@
 import Vue from 'vue'
-import $ from 'jquery'
 
 export default Vue.extend({
   name: 'FtIconButton',
@@ -55,60 +54,26 @@ export default Vue.extend({
   },
   data: function () {
     return {
-      dropdownShown: false,
-      id: ''
+      dropdownShown: false
     }
   },
-  mounted: function () {
-    this.id = `iconButton${this._uid}`
-  },
   methods: {
-    toggleDropdown: function () {
-      const dropdownBox = $(`#${this.id}`)
-
-      if (this.dropdownShown) {
-        dropdownBox.get(0).style.display = 'none'
-        this.dropdownShown = false
-      } else {
-        dropdownBox.get(0).style.display = 'inline'
-        dropdownBox.get(0).focus()
-        this.dropdownShown = true
-
-        dropdownBox.focusout(() => {
-          const shareLinks = dropdownBox.find('.shareLinks')
-
-          if (shareLinks.length > 0) {
-            if (!shareLinks[0].parentNode.matches(':hover')) {
-              dropdownBox.get(0).style.display = 'none'
-              // When pressing the profile button
-              // It will make the menu reappear if we set `dropdownShown` immediately
-              setTimeout(() => {
-                this.dropdownShown = false
-              }, 100)
-            }
-          } else {
-            dropdownBox.get(0).style.display = 'none'
-            // When pressing the profile button
-            // It will make the menu reappear if we set `dropdownShown` immediately
-            setTimeout(() => {
-              this.dropdownShown = false
-            }, 100)
-          }
-        })
-      }
-    },
-
-    focusOut: function () {
-      const dropdownBox = $(`#${this.id}`)
-
-      dropdownBox.focusout()
-      dropdownBox.get(0).style.display = 'none'
+    // used by the share menu
+    hide: function () {
       this.dropdownShown = false
     },
 
     handleIconClick: function () {
       if (this.forceDropdown || (this.dropdownOptions.length > 0)) {
-        this.toggleDropdown()
+        this.dropdownShown = !this.dropdownShown
+
+        if (this.dropdownShown) {
+          // wait until the dropdown is visible
+          // then focus it so we can hide it automatically when it looses focus
+          setTimeout(() => {
+            this.$refs.dropdown.focus()
+          }, 0)
+        }
       } else {
         this.$emit('click')
       }
@@ -121,7 +86,7 @@ export default Vue.extend({
         this.$emit('click', url)
       }
 
-      this.focusOut()
+      this.dropdownShown = false
     }
   }
 })

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -89,7 +89,7 @@ export default Vue.extend({
     handleDropdownFocusOut: function () {
       if (this.mouseDownOnIcon) {
         this.mouseDownOnIcon = false
-      } else {
+      } else if (!this.$refs.dropdown.matches(':focus-within')) {
         this.dropdownShown = false
       }
     },

--- a/src/renderer/components/ft-icon-button/ft-icon-button.sass
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.sass
@@ -56,7 +56,7 @@
     color: var(--favorite-icon-color)
 
 .iconDropdown
-  display: none
+  display: inline
   position: absolute
   text-align: center
   list-style-type: none
@@ -67,9 +67,6 @@
   background-color: var(--side-nav-color)
   color: var(--secondary-text-color)
   user-select: none
-
-  &:focus
-    display: inline
 
   &.left
     right: calc(50% - 10px)

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -13,6 +13,7 @@
         fontSize: size + 'px'
       }"
       @click="handleIconClick"
+      @mousedown="handleIconMouseDown"
     />
     <div
       v-show="dropdownShown"
@@ -26,7 +27,7 @@
         bottom: dropdownPositionY === 'bottom',
         top: dropdownPositionY === 'top'
       }"
-      @focusout="dropdownShown = false"
+      @focusout="handleDropdownFocusOut"
     >
       <slot>
         <ul

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -15,7 +15,8 @@
       @click="handleIconClick"
     />
     <div
-      :id="id"
+      v-show="dropdownShown"
+      ref="dropdown"
       tabindex="-1"
       class="iconDropdown"
       :class="{
@@ -25,6 +26,7 @@
         bottom: dropdownPositionY === 'bottom',
         top: dropdownPositionY === 'top'
       }"
+      @focusout="dropdownShown = false"
     >
       <slot>
         <ul

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -79,42 +79,42 @@ export default Vue.extend({
 
     openInvidious() {
       this.openExternalLink(this.getFinalUrl(this.invidiousURL))
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     copyInvidious() {
       this.copyToClipboard({ content: this.getFinalUrl(this.invidiousURL), messageOnSuccess: this.$t('Share.Invidious URL copied to clipboard') })
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     openYoutube() {
       this.openExternalLink(this.getFinalUrl(this.youtubeURL))
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     copyYoutube() {
       this.copyToClipboard({ content: this.getFinalUrl(this.youtubeShareURL), messageOnSuccess: this.$t('Share.YouTube URL copied to clipboard') })
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     openYoutubeEmbed() {
       this.openExternalLink(this.getFinalUrl(this.youtubeEmbedURL))
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     copyYoutubeEmbed() {
       this.copyToClipboard({ content: this.getFinalUrl(this.youtubeEmbedURL), messageOnSuccess: this.$t('Share.YouTube Embed URL copied to clipboard') })
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     openInvidiousEmbed() {
       this.openExternalLink(this.getFinalUrl(this.invidiousEmbedURL))
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     copyInvidiousEmbed() {
       this.copyToClipboard({ content: this.getFinalUrl(this.invidiousEmbedURL), messageOnSuccess: this.$t('Share.Invidious Embed URL copied to clipboard') })
-      this.$refs.iconButton.hide()
+      this.$refs.iconButton.hideDropdown()
     },
 
     updateIncludeTimestamp() {

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -79,42 +79,42 @@ export default Vue.extend({
 
     openInvidious() {
       this.openExternalLink(this.getFinalUrl(this.invidiousURL))
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     copyInvidious() {
       this.copyToClipboard({ content: this.getFinalUrl(this.invidiousURL), messageOnSuccess: this.$t('Share.Invidious URL copied to clipboard') })
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     openYoutube() {
       this.openExternalLink(this.getFinalUrl(this.youtubeURL))
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     copyYoutube() {
       this.copyToClipboard({ content: this.getFinalUrl(this.youtubeShareURL), messageOnSuccess: this.$t('Share.YouTube URL copied to clipboard') })
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     openYoutubeEmbed() {
       this.openExternalLink(this.getFinalUrl(this.youtubeEmbedURL))
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     copyYoutubeEmbed() {
       this.copyToClipboard({ content: this.getFinalUrl(this.youtubeEmbedURL), messageOnSuccess: this.$t('Share.YouTube Embed URL copied to clipboard') })
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     openInvidiousEmbed() {
       this.openExternalLink(this.getFinalUrl(this.invidiousEmbedURL))
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     copyInvidiousEmbed() {
       this.copyToClipboard({ content: this.getFinalUrl(this.invidiousEmbedURL), messageOnSuccess: this.$t('Share.Invidious Embed URL copied to clipboard') })
-      this.$refs.iconButton.focusOut()
+      this.$refs.iconButton.hide()
     },
 
     updateIncludeTimestamp() {


### PR DESCRIPTION
---
Replace jquery in ft-icon-button with vue functionality
---

**Pull Request Type**

- [x] Feature Implementation

**Description**
This pull request replaces the use of jquery for the `ft-icon-button` component with vue's `v-show` and refs. Also managed to clean the code up a bit while I was at it.

**Testing**
The `ft-icon-button` component is used in all of these places:
- Reload button on the trending, subscriptions and popular tabs
- Three dots button dropdown in video lists
- Settings button in the profile selector dropdown
- Share and download button etc on the watch page

**Desktop (please complete the following information):**
 - OS: Windows
 - OS Version: 10
 - FreeTube version: 0.17.1

**Additional context**
jquery who?