### PR TITLE
Remove explicitly disabling CORS. issue is fixed upstream

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -45,11 +45,6 @@ function runApp() {
   let mainWindow
   let startupUrl
 
-  // CORS somehow gets re-enabled in Electron v9.0.4
-  // This line disables it.
-  // This line can possible be removed if the issue is fixed upstream
-  app.commandLine.appendSwitch('disable-features', 'OutOfBlinkCors')
-
   app.commandLine.appendSwitch('enable-accelerated-video-decode')
   app.commandLine.appendSwitch('enable-file-cookies')
   app.commandLine.appendSwitch('ignore-gpu-blacklist')


### PR DESCRIPTION
---
Remove explicitly disabling CORS. issue is fixed upstream
---

**Pull Request Type**
Please select what type of pull request this is:
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other - remove unneeded code

**Related issue**
no related issue

**Description**
On electron `v9.0.4` CORS was not disabled by `webSecurity: false`

This was fixed in https://github.com/electron/electron/pull/25463
This line should no longer be needed.

**Testing (for code that is not small enough to be easily understandable)**
I've tested Local API and Invidious API.
tested some videos/live streams and made sure comments, description, etc were loaded.

**Desktop:**
  - OS: Arch Linux
  - OS Version: 5.19.8-arch1-1
  - FreeTube version: 0.17