### PR TITLE
Fixing issue with instance list not falling back

### DIFF
--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -39,6 +39,9 @@ const actions = {
       })
     } catch (err) {
       console.error(err)
+    }
+    // If the invidious instance fetch isn't returning anything interpretable
+    if (instances.length === 0) {
       // Starts fallback strategy: read from static file
       // And fallback to hardcoded entry(s) if static file absent
       const fileName = 'invidious-instances.json'
@@ -58,7 +61,6 @@ const actions = {
         ]
       }
     }
-
     commit('setInvidiousInstancesList', instances)
   },
 


### PR DESCRIPTION

Fixing issue instance list not falling back to the local instance list or the hardcoded list


## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
This PR expands the fall-back condition for the fetch to the invidious instances list to catch all cases where the instances list returns an empty response. I don't know if this is a super regular thing, but right now as I type this, the URL [https://api.invidious.io/instances.json](https://api.invidious.io/instances.json) isn't throwing an error, but it isn't giving back any useful information either. Instead, it is handing back an empty array `[]` with a status code of `200`. 
![image](https://user-images.githubusercontent.com/106682128/192430635-14addb80-61fa-405d-98b6-bf4b2a19bcb2.png)
![image](https://user-images.githubusercontent.com/106682128/192430640-5f5cc671-66bf-4dc6-b76a-77343627b2f8.png)
This won't throw an error when retrieved via `await fetch`, and thus, it won't trigger the fall-back to use the local `json` list of invidious instances or even the hardcoded list. Since it does not trigger the fall-back, the instance list in settings does not populate, and if no default instance is set, the value will be undefined.

## Screenshots <!-- If appropriate -->
*Before (in 0.17.1 right at this moment)*
![before-change-0 17 1](https://user-images.githubusercontent.com/106682128/192429851-a2c2a3d3-d4ee-4211-afe5-8fd7ec1c8b27.gif)
*After*
![after-change](https://user-images.githubusercontent.com/106682128/192430193-9abecb8a-9107-45f5-b3d3-a4cef13d7b38.gif)

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

