### PR TITLE
Add setting to disable automatic fetching of subscription feed

### DIFF
--- a/src/renderer/components/subscription-settings/subscription-settings.js
+++ b/src/renderer/components/subscription-settings/subscription-settings.js
@@ -22,12 +22,16 @@ export default Vue.extend({
     },
     useRssFeeds: function () {
       return this.$store.getters.getUseRssFeeds
+    },
+    loadSubscriptionsAutomatically: function () {
+      return this.$store.getters.getLoadSubscriptionsAutomatically
     }
   },
   methods: {
     ...mapActions([
       'updateHideWatchedSubs',
-      'updateUseRssFeeds'
+      'updateUseRssFeeds',
+      'updateLoadSubscriptionsAutomatically'
     ])
   }
 })

--- a/src/renderer/components/subscription-settings/subscription-settings.js
+++ b/src/renderer/components/subscription-settings/subscription-settings.js
@@ -23,15 +23,15 @@ export default Vue.extend({
     useRssFeeds: function () {
       return this.$store.getters.getUseRssFeeds
     },
-    loadSubscriptionsAutomatically: function () {
-      return this.$store.getters.getLoadSubscriptionsAutomatically
+    fetchSubscriptionsAutomatically: function () {
+      return this.$store.getters.getFetchSubscriptionsAutomatically
     }
   },
   methods: {
     ...mapActions([
       'updateHideWatchedSubs',
       'updateUseRssFeeds',
-      'updateLoadSubscriptionsAutomatically'
+      'updateFetchSubscriptionsAutomatically'
     ])
   }
 })

--- a/src/renderer/components/subscription-settings/subscription-settings.js
+++ b/src/renderer/components/subscription-settings/subscription-settings.js
@@ -2,14 +2,12 @@ import Vue from 'vue'
 import { mapActions } from 'vuex'
 import FtSettingsSection from '../ft-settings-section/ft-settings-section.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
-import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 
 export default Vue.extend({
   name: 'SubscriptionSettings',
   components: {
     'ft-settings-section': FtSettingsSection,
-    'ft-toggle-switch': FtToggleSwitch,
-    'ft-flex-box': FtFlexBox
+    'ft-toggle-switch': FtToggleSwitch
   },
   data: function () {
     return {

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -14,6 +14,12 @@
         :tooltip="$t('Tooltips.Subscription Settings.Fetch Feeds from RSS')"
         @change="updateUseRssFeeds"
       />
+      <ft-toggle-switch
+        :label="$t('Settings.Subscription Settings.Load Subscriptions Automatically')"
+        :default-value="loadSubscriptionsAutomatically"
+        :tooltip="$t('Tooltips.Subscription Settings.Load Subscriptions Automatically')"
+        @change="updateLoadSubscriptionsAutomatically"
+      />
     </ft-flex-box>
   </ft-settings-section>
 </template>

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -8,12 +8,14 @@
           :label="$t('Settings.Subscription Settings.Fetch Automatically')"
           :default-value="fetchSubscriptionsAutomatically"
           :tooltip="$t('Tooltips.Subscription Settings.Fetch Automatically')"
+          :compact="true"
           @change="updateFetchSubscriptionsAutomatically"
         />
         <ft-toggle-switch
           :label="$t('Settings.Subscription Settings.Fetch Feeds from RSS')"
           :default-value="useRssFeeds"
           :tooltip="$t('Tooltips.Subscription Settings.Fetch Feeds from RSS')"
+          :compact="true"
           @change="updateUseRssFeeds"
         />
       </div>
@@ -21,6 +23,7 @@
         <ft-toggle-switch
           :label="$t('Settings.Subscription Settings.Hide Videos on Watch')"
           :default-value="hideWatchedSubs"
+          :compact="true"
           @change="updateHideWatchedSubs"
         />
       </div>

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -2,25 +2,29 @@
   <ft-settings-section
     :title="$t('Settings.Subscription Settings.Subscription Settings')"
   >
-    <ft-flex-box class="settingsFlexStart500px">
-      <ft-toggle-switch
-        :label="$t('Settings.Subscription Settings.Hide Videos on Watch')"
-        :default-value="hideWatchedSubs"
-        @change="updateHideWatchedSubs"
-      />
-      <ft-toggle-switch
-        :label="$t('Settings.Subscription Settings.Fetch Feeds from RSS')"
-        :default-value="useRssFeeds"
-        :tooltip="$t('Tooltips.Subscription Settings.Fetch Feeds from RSS')"
-        @change="updateUseRssFeeds"
-      />
-      <ft-toggle-switch
-        :label="$t('Settings.Subscription Settings.Fetch Automatically')"
-        :default-value="fetchSubscriptionsAutomatically"
-        :tooltip="$t('Tooltips.Subscription Settings.Fetch Automatically')"
-        @change="updateFetchSubscriptionsAutomatically"
-      />
-    </ft-flex-box>
+    <div class="switchColumnGrid">
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Subscription Settings.Fetch Automatically')"
+          :default-value="fetchSubscriptionsAutomatically"
+          :tooltip="$t('Tooltips.Subscription Settings.Fetch Automatically')"
+          @change="updateFetchSubscriptionsAutomatically"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Subscription Settings.Fetch Feeds from RSS')"
+          :default-value="useRssFeeds"
+          :tooltip="$t('Tooltips.Subscription Settings.Fetch Feeds from RSS')"
+          @change="updateUseRssFeeds"
+        />
+      </div>
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Subscription Settings.Hide Videos on Watch')"
+          :default-value="hideWatchedSubs"
+          @change="updateHideWatchedSubs"
+        />
+      </div>
+    </div>
   </ft-settings-section>
 </template>
 

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -15,10 +15,10 @@
         @change="updateUseRssFeeds"
       />
       <ft-toggle-switch
-        :label="$t('Settings.Subscription Settings.Load Subscriptions Automatically')"
-        :default-value="loadSubscriptionsAutomatically"
-        :tooltip="$t('Tooltips.Subscription Settings.Load Subscriptions Automatically')"
-        @change="updateLoadSubscriptionsAutomatically"
+        :label="$t('Settings.Subscription Settings.Fetch Automatically')"
+        :default-value="fetchSubscriptionsAutomatically"
+        :tooltip="$t('Tooltips.Subscription Settings.Fetch Automatically')"
+        @change="updateFetchSubscriptionsAutomatically"
       />
     </ft-flex-box>
   </ft-settings-section>

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -268,7 +268,8 @@ const state = {
   screenshotQuality: 95,
   screenshotAskPath: false,
   screenshotFolderPath: '',
-  screenshotFilenamePattern: '%Y%M%D-%H%N%S'
+  screenshotFilenamePattern: '%Y%M%D-%H%N%S',
+  loadSubscriptionsAutomatically: true
 }
 
 const stateWithSideEffects = {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -269,7 +269,7 @@ const state = {
   screenshotAskPath: false,
   screenshotFolderPath: '',
   screenshotFilenamePattern: '%Y%M%D-%H%N%S',
-  loadSubscriptionsAutomatically: true
+  fetchSubscriptionsAutomatically: true
 }
 
 const stateWithSideEffects = {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -87,8 +87,8 @@ export default Vue.extend({
     hideLiveStreams: function() {
       return this.$store.getters.getHideLiveStreams
     },
-    loadSubscriptionsAutomatically: function() {
-      return this.$store.getters.getLoadSubscriptionsAutomatically
+    fetchSubscriptionsAutomatically: function() {
+      return this.$store.getters.getFetchSubscriptionsAutomatically
     }
   },
   watch: {
@@ -119,13 +119,11 @@ export default Vue.extend({
           this.errorChannels = subscriptionList.errorChannels
         }
       } else {
-        if (this.loadSubscriptionsAutomatically) {
-          this.getProfileSubscriptions()
-        }
+        this.getProfileSubscriptions()
       }
 
       this.isLoading = false
-    } else if (this.loadSubscriptionsAutomatically) {
+    } else if (this.fetchSubscriptionsAutomatically) {
       setTimeout(async () => {
         this.getSubscriptions()
       }, 300)
@@ -237,8 +235,12 @@ export default Vue.extend({
           }
         }))
         this.isLoading = false
-      } else {
+      } else if (this.fetchSubscriptionsAutomatically) {
         this.getSubscriptions()
+      } else if (this.activeProfile._id === this.profileSubscriptions.activeProfile) {
+        this.videoList = this.profileSubscriptions.videoList
+      } else {
+        this.videoList = []
       }
     },
 

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -86,6 +86,9 @@ export default Vue.extend({
 
     hideLiveStreams: function() {
       return this.$store.getters.getHideLiveStreams
+    },
+    loadSubscriptionsAutomatically: function() {
+      return this.$store.getters.getLoadSubscriptionsAutomatically
     }
   },
   watch: {
@@ -116,14 +119,18 @@ export default Vue.extend({
           this.errorChannels = subscriptionList.errorChannels
         }
       } else {
-        this.getProfileSubscriptions()
+        if (this.loadSubscriptionsAutomatically) {
+          this.getProfileSubscriptions()
+        }
       }
 
       this.isLoading = false
-    } else {
+    } else if (this.loadSubscriptionsAutomatically) {
       setTimeout(async () => {
         this.getSubscriptions()
       }, 300)
+    } else {
+      this.isLoading = false
     }
   },
   methods: {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -28,7 +28,8 @@ export default Vue.extend({
       isLoading: false,
       dataLimit: 100,
       videoList: [],
-      errorChannels: []
+      errorChannels: [],
+      attemptedFetch: false
     }
   },
   computed: {
@@ -154,6 +155,7 @@ export default Vue.extend({
       this.isLoading = true
       this.updateShowProgressBar(true)
       this.setProgressBarPercentage(0)
+      this.attemptedFetch = true
 
       let videoList = []
       let channelCount = 0
@@ -241,6 +243,7 @@ export default Vue.extend({
         this.videoList = this.profileSubscriptions.videoList
       } else {
         this.videoList = []
+        this.attemptedFetch = false
       }
     },
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -35,7 +35,7 @@
           {{ $t("Subscriptions['Your Subscription list is currently empty. Start adding subscriptions to see them here.']") }}
         </p>
         <p
-          v-else-if="!fetchSubscriptionsAutomatically"
+          v-else-if="!fetchSubscriptionsAutomatically && !attemptedFetch"
           class="message"
         >
           {{ $t("Subscriptions.Disabled Automatic Fetching") }}

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -28,8 +28,23 @@
       <ft-flex-box
         v-if="activeVideoList.length === 0"
       >
-        <p class="message">
+        <p
+          v-if="activeSubscriptionList.length === 0"
+          class="message"
+        >
           {{ $t("Subscriptions['Your Subscription list is currently empty. Start adding subscriptions to see them here.']") }}
+        </p>
+        <p
+          v-else-if="!fetchSubscriptionsAutomatically"
+          class="message"
+        >
+          {{ $t("Subscriptions.Disabled Automatic Fetching") }}
+        </p>
+        <p
+          v-else
+          class="message"
+        >
+          {{ $t("Subscriptions.Empty Channels") }}
         </p>
       </ft-flex-box>
       <ft-element-list

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -84,8 +84,9 @@ Subscriptions:
   Latest Subscriptions: Latest Subscriptions
   This profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting: This
     profile has a large number of subscriptions.  Forcing RSS to avoid rate limiting
-  'Your Subscription list is currently empty. Start adding subscriptions to see them here.': Your
-    Subscription list is currently empty. Start adding subscriptions to see them here.
+  'Your Subscription list is currently empty. Start adding subscriptions to see them here.': Your Subscription list is currently empty. Start adding subscriptions to see them here.
+  Disabled Automatic Fetching: You have disabled automatic subscription fetching. Refresh subscriptions to see them here.
+  Empty Channels: Your subscribed channels currently does not have any videos.
   'Getting Subscriptions. Please wait.': Getting Subscriptions. Please wait.
   Refresh Subscriptions: Refresh Subscriptions
   Load More Videos: Load More Videos
@@ -304,6 +305,7 @@ Settings:
     Hide Videos on Watch: Hide Videos on Watch
     Fetch Feeds from RSS: Fetch Feeds from RSS
     Manage Subscriptions: Manage Subscriptions
+    Fetch Automatically: Fetch Feed Automatically
   Distraction Free Settings:
     Distraction Free Settings: Distraction Free Settings
     Hide Video Views: Hide Video Views
@@ -768,6 +770,8 @@ Tooltips:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
       but doesn't provide certain information like video duration or live status
+    Fetch Automatically: When enabled, FreeTube will automatically fetch
+      your subscription feed on start and when switching profile.
   Privacy Settings:
     Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files created during video playback,
       when the watch page is closed.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -771,7 +771,7 @@ Tooltips:
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
       but doesn't provide certain information like video duration or live status
     Fetch Automatically: When enabled, FreeTube will automatically fetch
-      your subscription feed on start and when switching profile.
+      your subscription feed when a new window is opened and when switching profile.
   Privacy Settings:
     Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files created during video playback,
       when the watch page is closed.


### PR DESCRIPTION
# Add setting to disable automatic fetching of subscription feed

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #2515
part of #539

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
### Main changes
Adds a new setting in subscription settings to disable automatic fetching of the subscription feed.
Prevents calls to the method `getSubscriptions()` in` Subscriptions.js` in to places.

1. When the subscriptions component is mounted
2. In `getProfileSubscriptions` method, when the users switches profile.

When the users switches profile and has disabled auto fetching 2 things can happen
1. the video list is emptied.
2. if the video list is saved in `profileSubscriptions` then it will be loaded instead.

### other stuff

In `Subscriptions.vue` I made some changes to the messages that show when the video list is empty
1. The regular "You have not subscribed to any channel" message will now only show when you have in fact not subscribed to any channel.
2. Added a new message that only shows if you have disabled automatic fetching.
3. Added a new message that will show when the user is subscribed to channels that have not uploaded any videos.

~~message 2 will block message 3 from being displayed even if they have attempted two fetch subscriptions.
This will probably not be a huge deal since I imagine it rarely happens.
The alternatives is to check if the user has attempted to refresh subscriptions.~~


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

This is the message that shows when the setting is disabled and the user starts the app or navigates to a new profile.
![2022-09-28_T02:27:41](https://user-images.githubusercontent.com/66974576/192660732-375e6143-efed-4956-ad56-dfa46a4be02b.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
I created 2 new profiles
one without any channels to test if message 1 is displayed
the second one included only a channel without any videos to test if message 3 is displayed.

with the new setting disabled
I tested to make sure subscriptions where not fetched when freetube is started.
I switched between profiles to make sure subscriptions where not fetched automatically
I fetched subscriptions from one profile switched to another and the switched back to see if the video list was kept.

chosen api or rss should not affect anything since this check is done before that part of the code.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** 5.19.8-arch1-1
- **FreeTube version:** 0.17.1

## Additional context
<!-- Add any other context about the pull request here. -->
It's likely that I've missed something or implemented this weirdly since I am unfamiliar with this part of the code.

I had to remove the newline for the `Your Subscription list is currently empty` string in the locale file to get the new strings to work.

If disabling fetching when switching profile is unwanted I could make a new setting for that or just remove it.