### PR TITLE
Fix package.json getting embedded in the release builds

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -12,6 +12,7 @@ import FtProgressBar from './components/ft-progress-bar/ft-progress-bar.vue'
 import { marked } from 'marked'
 import Parser from 'rss-parser'
 import { IpcChannels } from '../constants'
+import packageDetails from '../../package.json'
 
 let ipcRenderer = null
 
@@ -195,7 +196,6 @@ export default Vue.extend({
 
     checkForNewUpdates: function () {
       if (this.checkForUpdates) {
-        const { version } = require('../../package.json')
         const requestUrl = 'https://api.github.com/repos/freetubeapp/freetube/releases?per_page=1'
 
         fetch(requestUrl)
@@ -209,7 +209,7 @@ export default Vue.extend({
             const message = this.$t('Version $ is now available!  Click for more details')
             this.updateBannerMessage = message.replace('$', versionNumber)
 
-            const appVersion = version.split('.')
+            const appVersion = packageDetails.version.split('.')
             const latestVersion = versionNumber.split('.')
 
             if (parseInt(appVersion[0]) < parseInt(latestVersion[0])) {

--- a/src/renderer/views/About/About.js
+++ b/src/renderer/views/About/About.js
@@ -2,8 +2,7 @@ import Vue from 'vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
-
-const { version } = require('../../../../package.json')
+import packageDetails from '../../../../package.json'
 
 export default Vue.extend({
   name: 'About',
@@ -14,7 +13,7 @@ export default Vue.extend({
   },
   data: function () {
     return {
-      versionNumber: `v${version}`,
+      versionNumber: `v${packageDetails.version}`,
       chunks: [
         {
           icon: ['fab', 'github'],


### PR DESCRIPTION
# Fix package.json getting embedded in the release builds

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This pull request fixes webpack embedding the entire package.json file in the renderer.js file for release builds. My guess is that when we import it with `require()` webpack treats it at a commonjs file and doesn't treeshake it. When it's imported with an es6 import, webpack properly treeshakes it and gets rid of the rest of the JSON. It only makes about a 1KB difference to the size of the renderer.js file but it was a small easy fix so it seems worth it anyway.

I didn't use the named import for the `version` property, as webpack complained that using named imports for JSON is being deprecated. When I looked it up apparently it's because the web standards people decided that JSON should be treated as a single thing. https://github.com/tc39/proposal-json-modules#why-dont-json-modules-support-named-exports

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

before:
![before](https://user-images.githubusercontent.com/48293849/192866672-003613de-f43f-4eac-84d9-c67fbcda01e5.jpg)

after:
![after](https://user-images.githubusercontent.com/48293849/192866681-1cb444aa-b92f-45f6-9525-cbdbab5d575c.jpg)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

`yarn dev` and `yarn build`

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1