### PR TITLE
Update search in new window function to also copy original query text to new window search input

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -170,7 +170,13 @@ function runApp() {
     }
   }
 
-  async function createWindow({ replaceMainWindow = true, windowStartupUrl = null, showWindowNow = false } = { }) {
+  async function createWindow(
+    {
+      replaceMainWindow = true,
+      windowStartupUrl = null,
+      showWindowNow = false,
+      searchQueryText = null
+    } = { }) {
     // Syncing new window background to theme choice.
     const windowBackground = await baseHandlers.settings._findTheme().then(({ value }) => {
       switch (value) {
@@ -300,6 +306,12 @@ function runApp() {
       global.__static = path
         .join(__dirname, '/static')
         .replace(/\\/g, '\\\\')
+    }
+
+    if (typeof searchQueryText === 'string' && searchQueryText.length > 0) {
+      ipcMain.once('searchInputHandlingReady', () => {
+        newWindow.webContents.send('updateSearchInputText', searchQueryText)
+      })
     }
 
     // Show when loaded
@@ -445,11 +457,12 @@ function runApp() {
     return powerSaveBlocker.start('prevent-display-sleep')
   })
 
-  ipcMain.on(IpcChannels.CREATE_NEW_WINDOW, (_e, { windowStartupUrl = null } = { }) => {
+  ipcMain.on(IpcChannels.CREATE_NEW_WINDOW, (_e, { windowStartupUrl = null, searchQueryText = null } = { }) => {
     createWindow({
       replaceMainWindow: false,
       showWindowNow: true,
-      windowStartupUrl: windowStartupUrl
+      windowStartupUrl: windowStartupUrl,
+      searchQueryText: searchQueryText
     })
   })
 

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -264,6 +264,10 @@ export default Vue.extend({
       this.visibleDataList = visList
     },
 
+    updateInputData: function(text) {
+      this.inputData = text
+    },
+
     ...mapActions([
       'getYoutubeUrlInfo'
     ])

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -140,7 +140,8 @@ export default Vue.extend({
             this.openInternalPath({
               path: `/search/${encodeURIComponent(searchQuery)}`,
               query,
-              doCreateNewWindow
+              doCreateNewWindow,
+              searchQueryText: searchQuery
             })
             break
           }
@@ -179,7 +180,8 @@ export default Vue.extend({
                 type: this.searchSettings.type,
                 duration: this.searchSettings.duration
               },
-              doCreateNewWindow
+              doCreateNewWindow,
+              searchQueryText: query
             })
           }
         }
@@ -300,7 +302,7 @@ export default Vue.extend({
       this.$store.commit('toggleSideNav')
     },
 
-    openInternalPath: function({ path, doCreateNewWindow, query = {} }) {
+    openInternalPath: function({ path, doCreateNewWindow, query = {}, searchQueryText = null }) {
       if (process.env.IS_ELECTRON && doCreateNewWindow) {
         const { ipcRenderer } = require('electron')
 
@@ -310,7 +312,8 @@ export default Vue.extend({
           `#${path}?${(new URLSearchParams(query)).toString()}`
         ].join('')
         ipcRenderer.send(IpcChannels.CREATE_NEW_WINDOW, {
-          windowStartupUrl: newWindowStartupURL
+          windowStartupUrl: newWindowStartupURL,
+          searchQueryText
         })
       } else {
         // Web
@@ -334,6 +337,9 @@ export default Vue.extend({
     },
     hideFilters: function () {
       this.showFilters = false
+    },
+    updateSearchInputText: function(text) {
+      this.$refs.searchInput.updateInputData(text)
     },
     ...mapActions([
       'showToast',


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Improvement over #2427

## Description
Update search in new window function to also copy original query text to new window search input

## Screenshots <!-- If appropriate -->

https://user-images.githubusercontent.com/1018543/192958721-de3e8da5-cbec-4cda-930d-4c969b9d2857.mov



## Testing
- Enter search text in top nav text input
- Shift enter/click
- Check new window top nav text input

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6
- **FreeTube version:** e0c3f47c6c4b31e6734c2993eeff59c494ee056e

## Additional context
- Text is only copied for search query, not for video/playlist/channel

