### PR TITLE
Hiding "Disable smooth scroll" option in web

### DIFF
--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -109,6 +109,9 @@ export default Vue.extend({
         const colorName = colorVal.replace(/([A-Z])/g, ' $1').trim()
         return this.$t(`Settings.Theme Settings.Main Color Theme.${colorName}`)
       })
+    },
+    usingElectron: function () {
+      return process.env.IS_ELECTRON
     }
   },
   mounted: function () {

--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -142,9 +142,7 @@ export default Vue.extend({
       this.updateDisableSmoothScrolling(
         this.disableSmoothScrollingToggleValue
       ).then(() => {
-        // FIXME: No electron safeguard
         const { ipcRenderer } = require('electron')
-
         ipcRenderer.send('relaunchRequest')
       })
     },

--- a/src/renderer/components/theme-settings/theme-settings.vue
+++ b/src/renderer/components/theme-settings/theme-settings.vue
@@ -14,6 +14,7 @@
         @change="handleExpandSideBar"
       />
       <ft-toggle-switch
+        v-if="usingElectron"
         :label="$t('Settings.Theme Settings.Disable Smooth Scrolling')"
         :default-value="disableSmoothScrollingToggleValue"
         @change="handleRestartPrompt"


### PR DESCRIPTION

# Hiding "Disable smooth-scroll" setting when not electron

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
MarmadileManteater#24

## Description
The "Disable smooth scroll" setting requires the restart of electron, so this PR hides that setting when not in electron, Additionally, I found this `FIX ME` in the `handleSmoothScrolling` function because there is no electron safeguard. This change would introduce that safeguard.

## Screenshots
*Before: (in a web build)*
![image](https://user-images.githubusercontent.com/106682128/193023510-acab97ec-5637-4421-b7fe-05007be4dbed.png)
*After: (in a web build)*
![image](https://user-images.githubusercontent.com/106682128/193023579-8306e979-edda-4c03-a5f2-0c3b5da9880c.png)

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1