### PR TITLE
Fix the development only js-yaml dependency being included in the release builds

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -163,6 +163,12 @@ if (isDevMode) {
     processLocalesPlugin,
     new webpack.DefinePlugin({
       'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames)
+    }),
+    // webpack doesn't get rid of js-yaml even though it isn't used in the production builds
+    // so we need to manually tell it to ignore any imports for `js-yaml`
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^js-yaml$/,
+      contextRegExp: /i18n$/
     })
   )
 }

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -189,6 +189,12 @@ if (isDevMode) {
             },
           },
       ]
+    }),
+    // webpack doesn't get rid of js-yaml even though it isn't used in the production builds
+    // so we need to manually tell it to ignore any imports for `js-yaml`
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^js-yaml$/,
+      contextRegExp: /i18n$/
     })
   )
 }


### PR DESCRIPTION
# Fix the development only js-yaml dependency being included in the release builds

## Pull Request Type
- [x] Bugfix

## Related issue
follow up to #2603

## Description
`js-yaml` is only used to load the languages for the development builds, as the language files are converted to JSON and compressed during the release build process. Unfortunately webpack doesn't notice that `js-yaml` isn't needed in the release builds and still includes it in the renderer.js file. This pull request fixes that by explicitly telling webpack to ignore the `js-yaml` import for the release builds.

## Screenshots

before:
![before](https://user-images.githubusercontent.com/48293849/193310811-1ec94e8e-60dc-4d46-ab6c-c307e3a28024.jpg)

after:
![after](https://user-images.githubusercontent.com/48293849/193310789-77b062de-75e0-41a7-877a-b904e187389f.jpg)

## Testing
`yarn build` and then change that language to make sure that locales are still loaded properly.

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1