### PR TITLE
Prevent adding extra `/` when concatenating locale paths

### DIFF
--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import fs from 'fs'
+import path from 'path'
 
 // List of locales approved for use
 import activeLocales from '../../../static/locales/activeLocales.json'
@@ -60,7 +61,7 @@ class CustomVueI18n extends VueI18n {
         }
 
         if (url.pathname) {
-          url.pathname += `/static/locales/${locale}.json`
+          url.pathname = path.join(url.pathname, 'static', 'locales', `${locale}.json`)
         } else {
           url.pathname = `/static/locales/${locale}.json`
         }

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -60,7 +60,7 @@ class CustomVueI18n extends VueI18n {
         }
 
         if (url.pathname) {
-          url.pathname += `${!url.pathname.endsWith('/')?'/':''}static/locales/${locale}.json`
+          url.pathname += `${!url.pathname.endsWith('/') ? '/' : ''}static/locales/${locale}.json`
         } else {
           url.pathname = `/static/locales/${locale}.json`
         }

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import fs from 'fs'
-import path from 'path'
 
 // List of locales approved for use
 import activeLocales from '../../../static/locales/activeLocales.json'
@@ -61,7 +60,7 @@ class CustomVueI18n extends VueI18n {
         }
 
         if (url.pathname) {
-          url.pathname = path.join(url.pathname, 'static', 'locales', `${locale}.json`)
+          url.pathname += `${!url.pathname.endsWith('/')?'/':''}static/locales/${locale}.json`
         } else {
           url.pathname = `/static/locales/${locale}.json`
         }


### PR DESCRIPTION

# Prevent adding extra `/` when concatenating locale paths

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other


## Description
This PR formats the URLs used to fetch the locale json (in web builds) to be more consistent using `path.join`. Currently, the URLs that are being fetched can end up looking like this: `path/to/freetube//static/locales/${locale}.json` because of a trailing `/` inside of the path. This typically works fine because it often gets interpreted as `path/to/freetube/static/locales/${locale}.json` which is where the files are actually stored, but if a web build is stored on a server which is more particular about paths or if FreeTube is in Cordova, this causes an error.

## Screenshots <!-- If appropriate -->
*Before* (on Android in Cordova in my fork)
![image](https://user-images.githubusercontent.com/106682128/193472403-1f913bd3-93a3-474a-88d6-db21266d718d.png)
![image](https://user-images.githubusercontent.com/106682128/193472414-9bcb9e46-db16-4117-bfb3-deeac0d717ef.png)
*After* (on Android in Cordova in my fork)
![image](https://user-images.githubusercontent.com/106682128/193472486-5cac2946-37ff-4c65-98d3-f6a712a43687.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
This should only effect locales fetching when `IS_ELECTRON` is `false`. 

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1
