### PR TITLE
Prevent search from closing when using a virtual keyboard

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -76,6 +76,7 @@ export default Vue.extend({
     }
   },
   mounted: function () {
+    let previousWidth = window.innerWidth
     if (window.innerWidth <= 680) {
       this.showSearchContainer = false
     }
@@ -88,7 +89,12 @@ export default Vue.extend({
     }, 0)
 
     window.addEventListener('resize', () => {
-      this.showSearchContainer = window.innerWidth > 680
+      // Don't change the status of showSearchContainer if only the height of the window changes
+      // Opening the virtual keyboard can trigger this resize event, but it won't change the width
+      if (previousWidth !== window.innerWidth) {
+        this.showSearchContainer = window.innerWidth > 680
+        previousWidth = window.innerWidth
+      }
     })
 
     this.debounceSearchResults = debounce(this.getSearchSuggestions, 200)


### PR DESCRIPTION


# Prevent search from closing when using a virtual keyboard

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
This PR adds a condition to the window `resize` event listener which prevents the search bar from closing unless the width of the page has changed. On mobile, the screen height may change when opening a virtual keyboard, but the screen width does not typically change. This change should prevent issues with the search bar closing when opening a virtual keyboard.

## Screenshots <!-- If appropriate -->
*before* (on Android in my fork)
<img src="https://user-images.githubusercontent.com/106682128/193483213-e998e9a5-cdf4-4401-a81a-76bdfdc18e0b.gif"  width="200" />
*after* (on Android in my fork)
<img src="https://user-images.githubusercontent.com/106682128/193483264-7a7e7237-b95f-4035-b9f6-9c10709acce9.gif"  width="200" /> <img src="https://user-images.githubusercontent.com/106682128/193483312-d43e30a0-73e0-4c4d-8e43-1a70cb5a1a8b.png" width="200" />

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
This would also effect Electron builds. I am open to modifying this PR to only change the existing behavior when `IS_ELECTRON` is `false` if that would make more sense.
