### PR TITLE
Centering update prompt card

### DIFF
--- a/src/renderer/components/ft-prompt/ft-prompt.css
+++ b/src/renderer/components/ft-prompt/ft-prompt.css
@@ -8,16 +8,17 @@
   z-index: 10;
   padding: 15px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .promptCard {
   width: 95%;
   margin: 0;
   position: absolute;
-  top: 40%;
   left: 2.5%;
-  -ms-transform: translateY(-40%);
-  transform: translateY(-40%);
+  box-sizing: border-box;
 }
 
 .center {

--- a/src/renderer/components/ft-prompt/ft-prompt.css
+++ b/src/renderer/components/ft-prompt/ft-prompt.css
@@ -7,6 +7,7 @@
   background-color: rgba(0, 0, 0, 0.7);
   z-index: 10;
   padding: 15px;
+  box-sizing: border-box;
 }
 
 .promptCard {
@@ -14,6 +15,7 @@
   margin: 0;
   position: absolute;
   top: 40%;
+  left: 2.5%;
   -ms-transform: translateY(-40%);
   transform: translateY(-40%);
 }


### PR DESCRIPTION
# Centering update prompt card

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The update prompt card is a little off center and overflows the window if the window is too small. This PR properly centers the update prompt card vertically and horizontally inside of the window.

## Screenshots <!-- If appropriate -->
![image](https://user-images.githubusercontent.com/106682128/193486880-cb081cff-d152-446e-9f94-c1474d0dc660.png)

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional Information
This might look good with some additional padding.