### PR TITLE
Advertise FT better in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We are actively looking for translations!  We use [Weblate](https://hosted.webla
 For the Linux Flatpak, the desktop entry comment string can be translated at our [Flatpak repository](https://github.com/flathub/io.freetubeapp.FreeTube/blob/master/io.freetubeapp.FreeTube.desktop).
 
 ## Contact
-If you ever have any questions, feel free to ask it on our [Discussions](https://github.com/FreeTubeApp/FreeTube/discussions) page.  Alternatively, you can email me at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://docs.freetubeapp.io/community/matrix/) before joining.
+If you ever have any questions, feel free to ask it on our [Discussions](https://github.com/FreeTubeApp/FreeTube/discussions) page.  Alternatively, you can email us at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://docs.freetubeapp.io/community/matrix/) before joining.
 
 ## Donate
 If you enjoy using FreeTube, you're welcome to leave a donation using the following methods.  

--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ to hide your IP while using FreeTube.
 * View and search your local subscriptions, history, and saved videos
 * Organize your subscriptions into "Profiles" to create a more focused feed
 * Export & import subscriptions
-* Browse videos within a channel
 * Youtube Trending
 * Youtube Chapters
 * Most popular videos page based on the set Invidious instance
 * SponsorBlock 
 * Open videos from your browser directly into FreeTube (with extension)
-* Watch videos using iina, mpv or VLC as external player
+* Watch videos using an external player
 * Full Theme support
 * Make a screenshot within the app
 * Multiple windows

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ to hide your IP while using FreeTube.
 * Open videos from your browser directly into FreeTube (with extension)
 * Mini Player
 * Full Theme support
-* Chapters
+* Youtube Chapters
+* Watch videos using iina, mpv or VLC as external player
+* Show family friendly only content
+* SponsorBlock 
+* Make a screenshot within the app
+* Set tor as proxy
 
 ### Browser Extension
 FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings of the extension for it to work.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We are actively looking for translations!  We use [Weblate](https://hosted.webla
 For the Linux Flatpak, the desktop entry comment string can be translated at our [Flatpak repository](https://github.com/flathub/io.freetubeapp.FreeTube/blob/master/io.freetubeapp.FreeTube.desktop).
 
 ## Contact
-If you ever have any questions, feel free to make an issue here on GitHub.  Alternatively, you can email me at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://docs.freetubeapp.io/community/matrix/) before joining.
+If you ever have any questions, feel free to ask it on our [Discussions](https://github.com/FreeTubeApp/FreeTube/discussions) page.  Alternatively, you can email me at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://docs.freetubeapp.io/community/matrix/) before joining.
 
 ## Donate
 If you enjoy using FreeTube, you're welcome to leave a donation using the following methods.  

--- a/README.md
+++ b/README.md
@@ -30,18 +30,28 @@ to hide your IP while using FreeTube.
 * Use YouTube without Google tracking you using cookies and JavaScript
 * Two extractor APIs to choose from (Built in or Invidious)
 * Subscribe to channels without an account
-* Local subscriptions, history, and saved videos
+* Setup tor as proxy
+* View and search your local subscriptions, history, and saved videos
 * Organize your subscriptions into "Profiles" to create a more focused feed
 * Export & import subscriptions
-* Open videos from your browser directly into FreeTube (with extension)
-* Mini Player
-* Full Theme support
+* Browse videos within a channel
+* Youtube Trending
 * Youtube Chapters
-* Watch videos using iina, mpv or VLC as external player
-* Show family friendly only content
+* Most popular videos page based on the set Invidious instance
 * SponsorBlock 
+* Open videos from your browser directly into FreeTube (with extension)
+* Watch videos using iina, mpv or VLC as external player
+* Full Theme support
 * Make a screenshot within the app
-* Set tor as proxy
+* Multiple windows
+* Mini Player (Picture-in-Picture)
+* Keyboard shortcuts
+* Show family friendly only content
+* Show/hide general information about videos (such as description and likes)
+* Show/hide next/related videos
+* Show/hide comments
+* Show/hide live streams
+* Show/hide live chat 
 
 ### Browser Extension
 FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings of the extension for it to work.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you have issues with the extension working with FreeTube, please create an is
 
 * Flatpak on Flathub: [Download](https://flathub.org/apps/details/io.freetubeapp.FreeTube) [Source](https://github.com/flathub/io.freetubeapp.FreeTube)
 
-### Automated Builds (Nightly / Weekly)
+#### Automated Builds (Nightly / Weekly)
 Builds are automatically created from changes to our development branch via [GitHub Actions](https://github.com/FreeTubeApp/FreeTube/actions?query=workflow%3ABuild).
 
 The first build with a green check mark is the latest build.  You will need to have a GitHub account to download these builds.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to hide your IP while using FreeTube.
 * Use YouTube without Google tracking you using cookies and JavaScript
 * Two extractor APIs to choose from (Built in or Invidious)
 * Subscribe to channels without an account
-* Connect to an externally setup tor proxy
+* Connect to an externally setup proxy such as Tor
 * View and search your local subscriptions, history, and saved videos
 * Organize your subscriptions into "Profiles" to create a more focused feed
 * Export & import subscriptions

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Available for Windows, Mac & Linux thanks to Electron.
 <p align="center"><a href="https://freetubeapp.io/">Website</a> &bull; <a href="https://blog.freetubeapp.io/">Blog</a> &bull; <a href="https://docs.freetubeapp.io/">Documentation</a> &bull; <a href="https://docs.freetubeapp.io/faq/">FAQ</a> &bull; <a href="https://github.com/FreeTubeApp/FreeTube/discussions">Discussions</a></p>
 <hr>
 
-<b>Please note that FreeTube is currently in Beta. While it should work well for most users, there are still bugs and missing features that need to be addressed. If u do encounter bugs, open an issue in our repository by filling out the [issue template](https://github.com/FreeTubeApp/FreeTube/issues/new/choose).</b>
+<b>Please note that FreeTube is currently in Beta. While it should work well for most users, there are still bugs and missing features that need to be addressed. If you have an idea or if you found a bug, please submit a [GitHub issue](https://github.com/FreeTubeApp/FreeTube/issues/new/choose) so that
+we can track it.  Please search [the existing issues](https://github.com/FreeTubeApp/FreeTube/issues) before submitting to
+prevent duplicates!</b>
 
 ## Screenshots
 <img src="https://i.imgur.com/zFgZUUV.png" width=300> <img src="https://i.imgur.com/9evYHgN.png" width=300> <img src="https://i.imgur.com/yT2UzPa.png" width=300> <img src="https://i.imgur.com/47zIEt4.png" width=300> <img src="https://i.imgur.com/hFB2fKC.png" width=300>
@@ -22,8 +24,6 @@ Available for Windows, Mac & Linux thanks to Electron.
 FreeTube uses a built in extractor to grab and serve data / videos.  The [Invidious API](https://github.com/iv-org/invidious) can also optionally be used.  FreeTube does not use any official APIs to obtain data.  While YouTube can still see your video requests, it can no
 longer track you using cookies or JavaScript. Your subscriptions and history are stored locally on your computer and never sent out.  Using a VPN or Tor is highly recommended
 to hide your IP while using FreeTube.
-
-Go to [FreeTube's Documentation](https://docs.freetubeapp.io/) if you'd like to know more about how to operate FreeTube and its features.
 
 ## Features
 * Watch videos without ads
@@ -38,7 +38,6 @@ Go to [FreeTube's Documentation](https://docs.freetubeapp.io/) if you'd like to 
 * Full Theme support
 
 ### Browser Extension
-
 FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings for it to work.
 
 * Download Privacy Redirect for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-redirect/) or [Google Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb).
@@ -50,9 +49,7 @@ Disclaimer: Learn more about why a browser extension is bad for your [privacy](h
 If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository.
 
 ## Download Links
-
 ### Official Downloads
-
 * [GitHub Releases](https://github.com/FreeTubeApp/FreeTube/releases)
 
 * [FreeTube Website](https://freetubeapp.io/#download)
@@ -60,7 +57,6 @@ If you have issues with the extension working with FreeTube, please create an is
 * Flatpak on Flathub: [Download](https://flathub.org/apps/details/io.freetubeapp.FreeTube) [Source](https://github.com/flathub/io.freetubeapp.FreeTube)
 
 ### Unofficial Downloads
-
 These builds are maintained by the community.  While they should be safe, download at your own risk.  There may be issues with using these versus the official builds.  Any issues specific with these builds should be sent to their respective maintainer.
 
 * Arch User Repository (AUR): [Download](https://aur.archlinux.org/packages/freetube-bin/)
@@ -76,16 +72,11 @@ These builds are maintained by the community.  While they should be safe, downlo
 * Windows Package Manager (winget): [Usage](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
 
 ### Automated Builds (Nightly / Weekly)
-
 Builds are automatically created from changes to our development branch via [GitHub Actions](https://github.com/FreeTubeApp/FreeTube/actions?query=workflow%3ABuild).
 
 The first build with a green check mark is the latest build.  You will need to have a GitHub account to download these builds.
 
 ## Contributing
-If you have an idea or if you found a bug, please submit a GitHub issue so that
-we can track it.  Please search the existing issues before submitting to
-prevent duplicates.
-
 If you like to get your hands dirty and want to contribute, we would love to
 have your help.  Send a pull request and someone will review your code. Please
 follow the [Contribution
@@ -104,10 +95,7 @@ We are actively looking for translations!  We use [Weblate](https://hosted.webla
 For the Linux Flatpak, the desktop entry comment string can be translated at our [Flatpak repository](https://github.com/flathub/io.freetubeapp.FreeTube/blob/master/io.freetubeapp.FreeTube.desktop).
 
 ## Contact
-
 If you ever have any questions, feel free to make an issue here on GitHub.  Alternatively, you can email me at FreeTubeApp@protonmail.com or you can join our [Matrix Community](https://matrix.to/#/+freetube:matrix.org).  Don't forget to check out the [rules](https://docs.freetubeapp.io/community/matrix/) before joining.
-
-You can also stay up to date by reading the [FreeTube Blog](https://write.as/freetube/).  [View the welcome blog](https://write.as/freetube/welcome-to-freetube-blogs).
 
 ## Donate
 If you enjoy using FreeTube, you're welcome to leave a donation using the following methods.  

--- a/README.md
+++ b/README.md
@@ -55,21 +55,7 @@ FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/
 
 * Download LibRedirect for [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) or [Google Chrome](https://github.com/libredirect/libredirect/blob/master/chromium.md).
 
-If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository.
-
-The following builds are supported:
-
-* .deb
-
-* .dmg
-
-* .exe
-
-* Flatpak
-
-* Portable (Windows only)
-
-* .rpm
+If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository. This extension does not work on Linux portable builds!
 
 ## Download Links
 ### Official Downloads

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/
 
 * Download LibRedirect for [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) or [Google Chrome](https://github.com/libredirect/libredirect/blob/master/chromium.md).
 
-Disclaimer: Learn more about why a browser extension is bad for your [privacy](https://www.privacyguides.org/desktop-browsers/#additional-resources).
-
 If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository.
 
 ## Download Links

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ to hide your IP while using FreeTube.
 * Open videos from your browser directly into FreeTube (with extension)
 * Mini Player
 * Full Theme support
+* Chapters
 
 ### Browser Extension
 FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings of the extension for it to work.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Thank you very much to the [People and Projects](https://docs.freetubeapp.io/cre
 
 ## Localization
 <a href="https://hosted.weblate.org/engage/free-tube/">
-<img src="https://hosted.weblate.org/widgets/free-tube/-/translations/287x66-grey.png" alt="Translation status" />
+<img src="https://hosted.weblate.org/widgets/free-tube/-/287x66-grey.png" alt="Translation status" />
 </a>
 
 We are actively looking for translations!  We use [Weblate](https://hosted.weblate.org/engage/free-tube/) to make it easy for translators to get involved.  Click on the badge above to learn how to get involved.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to hide your IP while using FreeTube.
 * Use YouTube without Google tracking you using cookies and JavaScript
 * Two extractor APIs to choose from (Built in or Invidious)
 * Subscribe to channels without an account
-* Setup tor as proxy
+* Connect to an externally setup tor proxy
 * View and search your local subscriptions, history, and saved videos
 * Organize your subscriptions into "Profiles" to create a more focused feed
 * Export & import subscriptions

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ to hide your IP while using FreeTube.
 * Full Theme support
 
 ### Browser Extension
-FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings for it to work.
+FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings of the extension for it to work.
 
 * Download Privacy Redirect for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-redirect/) or [Google Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb).
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Available for Windows, Mac & Linux thanks to Electron.
 <p align="center"><a href="https://github.com/FreeTubeApp/FreeTube/releases">Download FreeTube</a></p>
 
 <hr>
-<p align="center"><a href="#browser-extension">Browser Extension</a> &bull; <a href="#how-does-it-work">How does it work?</a> &bull; <a href="#screenshots">Screenshots</a> &bull; <a href="#features">Features</a> &bull; <a href="#download-links">Download Links</a> &bull; <a href="#contributing">Contributing</a> &bull; <a href="#localization">Localization</a> &bull; <a href="#contact">Contact</a> &bull; <a href="#donate">Donate</a> &bull; <a href="#license">License</a></p>
+<p align="center"><a href="#screenshots">Screenshots</a> &bull; <a href="#how-does-it-work">How does it work?</a> &bull; <a href="#features">Features</a> &bull; <a href="#download-links">Download Links</a> &bull; <a href="#contributing">Contributing</a> &bull; <a href="#localization">Localization</a> &bull; <a href="#contact">Contact</a> &bull; <a href="#donate">Donate</a> &bull; <a href="#license">License</a></p>
 <p align="center"><a href="https://freetubeapp.io/">Website</a> &bull; <a href="https://blog.freetubeapp.io/">Blog</a> &bull; <a href="https://docs.freetubeapp.io/">Documentation</a> &bull; <a href="https://docs.freetubeapp.io/faq/">FAQ</a> &bull; <a href="https://github.com/FreeTubeApp/FreeTube/discussions">Discussions</a></p>
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ If you have issues with the extension working with FreeTube, please create an is
 
 * Flatpak on Flathub: [Download](https://flathub.org/apps/details/io.freetubeapp.FreeTube) [Source](https://github.com/flathub/io.freetubeapp.FreeTube)
 
+### Automated Builds (Nightly / Weekly)
+Builds are automatically created from changes to our development branch via [GitHub Actions](https://github.com/FreeTubeApp/FreeTube/actions?query=workflow%3ABuild).
+
+The first build with a green check mark is the latest build.  You will need to have a GitHub account to download these builds.
+
 ### Unofficial Downloads
 These builds are maintained by the community.  While they should be safe, download at your own risk.  There may be issues with using these versus the official builds.  Any issues specific with these builds should be sent to their respective maintainer.
 
@@ -68,11 +73,6 @@ These builds are maintained by the community.  While they should be safe, downlo
 * Scoop (Windows Only): [Usage](https://github.com/ScoopInstaller/Scoop)
 
 * Windows Package Manager (winget): [Usage](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
-
-### Automated Builds (Nightly / Weekly)
-Builds are automatically created from changes to our development branch via [GitHub Actions](https://github.com/FreeTubeApp/FreeTube/actions?query=workflow%3ABuild).
-
-The first build with a green check mark is the latest build.  You will need to have a GitHub account to download these builds.
 
 ## Contributing
 If you like to get your hands dirty and want to contribute, we would love to

--- a/README.md
+++ b/README.md
@@ -46,11 +46,7 @@ to hide your IP while using FreeTube.
 * Mini Player (Picture-in-Picture)
 * Keyboard shortcuts
 * Show family friendly only content
-* Show/hide general information about videos (such as description and likes)
-* Show/hide next/related videos
-* Show/hide comments
-* Show/hide live streams
-* Show/hide live chat 
+* Show/hide functionality or elements within the app using the distraction free settings
 
 ### Browser Extension
 FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings of the extension for it to work.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,17 @@ FreeTube is an open source desktop YouTube player built with privacy in mind.
 Use YouTube without advertisements and prevent Google from tracking you with their cookies and JavaScript.
 Available for Windows, Mac & Linux thanks to Electron.
 
-Please note that FreeTube is currently in Beta. While it should work well for
-most users, there are still bugs and missing features that need to be
-addressed.
+<p align="center"><a href="https://github.com/FreeTubeApp/FreeTube/releases">Download FreeTube</a></p>
 
-[Download FreeTube](https://github.com/FreeTubeApp/FreeTube/releases)
+<hr>
+<p align="center"><a href="#browser-extension">Browser Extension</a> &bull; <a href="#how-does-it-work">How does it work?</a> &bull; <a href="#screenshots">Screenshots</a> &bull; <a href="#features">Features</a> &bull; <a href="#download-links">Download Links</a> &bull; <a href="#contributing">Contributing</a> &bull; <a href="#localization">Localization</a> &bull; <a href="#contact">Contact</a> &bull; <a href="#donate">Donate</a> &bull; <a href="#license">License</a></p>
+<p align="center"><a href="https://freetubeapp.io/">Website</a> &bull; <a href="https://blog.freetubeapp.io/">Blog</a> &bull; <a href="https://docs.freetubeapp.io/">Documentation</a> &bull; <a href="https://docs.freetubeapp.io/faq/">FAQ</a> &bull; <a href="https://github.com/FreeTubeApp/FreeTube/discussions">Discussions</a></p>
+<hr>
 
-### Browser Extension
+<b>Please note that FreeTube is currently in Beta. While it should work well for most users, there are still bugs and missing features that need to be addressed. If u do encounter bugs, open an issue in our repository by filling out the [issue template](https://github.com/FreeTubeApp/FreeTube/issues/new/choose).</b>
 
-FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings for it to work.
-
-* Download Privacy Redirect for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-redirect/) or [Google Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb).
-
-* Download LibRedirect for [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) or [Google Chrome](https://github.com/libredirect/libredirect/blob/master/chromium.md).
-
-Disclaimer: Learn more about why a browser extension is bad for your [privacy](https://www.privacyguides.org/desktop-browsers/#additional-resources).
-
-If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository.
+## Screenshots
+<img src="https://i.imgur.com/zFgZUUV.png" width=300> <img src="https://i.imgur.com/9evYHgN.png" width=300> <img src="https://i.imgur.com/yT2UzPa.png" width=300> <img src="https://i.imgur.com/47zIEt4.png" width=300> <img src="https://i.imgur.com/hFB2fKC.png" width=300>
 
 ## How does it work?
 FreeTube uses a built in extractor to grab and serve data / videos.  The [Invidious API](https://github.com/iv-org/invidious) can also optionally be used.  FreeTube does not use any official APIs to obtain data.  While YouTube can still see your video requests, it can no
@@ -30,9 +24,6 @@ longer track you using cookies or JavaScript. Your subscriptions and history are
 to hide your IP while using FreeTube.
 
 Go to [FreeTube's Documentation](https://docs.freetubeapp.io/) if you'd like to know more about how to operate FreeTube and its features.
-
-## Screenshots
-<img src="https://i.imgur.com/zFgZUUV.png" width=300> <img src="https://i.imgur.com/9evYHgN.png" width=300> <img src="https://i.imgur.com/yT2UzPa.png" width=300> <img src="https://i.imgur.com/47zIEt4.png" width=300> <img src="https://i.imgur.com/hFB2fKC.png" width=300>
 
 ## Features
 * Watch videos without ads
@@ -45,6 +36,18 @@ Go to [FreeTube's Documentation](https://docs.freetubeapp.io/) if you'd like to 
 * Open videos from your browser directly into FreeTube (with extension)
 * Mini Player
 * Full Theme support
+
+### Browser Extension
+
+FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/privacy-redirect) and [LibRedirect](https://github.com/libredirect/libredirect) extensions, which will allow you to open YouTube links into FreeTube. You must enable the option within the advanced settings for it to work.
+
+* Download Privacy Redirect for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-redirect/) or [Google Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb).
+
+* Download LibRedirect for [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) or [Google Chrome](https://github.com/libredirect/libredirect/blob/master/chromium.md).
+
+Disclaimer: Learn more about why a browser extension is bad for your [privacy](https://www.privacyguides.org/desktop-browsers/#additional-resources).
+
+If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository.
 
 ## Download Links
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ to hide your IP while using FreeTube.
 * Open videos from your browser directly into FreeTube (with extension)
 * Watch videos using an external player
 * Full Theme support
-* Make a screenshot within the app
+* Make a screenshot of a video
 * Multiple windows
 * Mini Player (Picture-in-Picture)
 * Keyboard shortcuts

--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ FreeTube is supported by the [Privacy Redirect](https://github.com/SimonBrazell/
 
 If you have issues with the extension working with FreeTube, please create an issue in this repository instead of the extension repository.
 
+The following builds are supported:
+
+* .deb
+
+* .dmg
+
+* .exe
+
+* Flatpak
+
+* Portable (Windows only)
+
+* .rpm
+
 ## Download Links
 ### Official Downloads
 * [GitHub Releases](https://github.com/FreeTubeApp/FreeTube/releases)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to hide your IP while using FreeTube.
 * Multiple windows
 * Mini Player (Picture-in-Picture)
 * Keyboard shortcuts
-* Show family friendly only content
+* Option to show only family friendly content
 * Show/hide functionality or elements within the app using the distraction free settings
 
 ### Browser Extension


### PR DESCRIPTION
# Advertise FT better in README

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [x] Documentation
- [ ] Other

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Notable things that I've done:

- Ordered the headings in a more logical structure for readers
- removed some sentences that were redundant 
- removed browser extension disclaimer because the link didn't provide the adequate info anymore and couldn't find a good replacement

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
I think its better to go to https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/blob/marketing/README.md

## Additional context
<!-- Add any other context about the pull request here. -->
Need your help/opinion on:

- Did i miss some features that we should definitely list?
- Should we update our pictures to show more of our features?
- i've made the nighly builds header smaller because it is a subset of the official downloads but the header is now the same size as plain text. Should i revert this change?
- Do we want to add badges/widgets in the same way https://github.com/privacyguides/privacyguides.org did above their about header?
- Do we want to include the following statement in the extension section?
> In order for the extension to work properly, you must be using an installable, non-portable version of FreeTube. This is because non-portable builds do not setup the required protocol needed for your operating system to redirect the URLs over to FreeTube.
The following builds are supported:
    .exe
    .dmg
    .deb
    .rpm
    Flatpak


