### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -20,5 +20,5 @@ jobs:
             This issue has been automatically closed because there has been no response to our request for more information from the original author. 
             With only the information that is currently in the issue, we don't have enough information to take action. 
             Please reach out if you have or find the answers we need so that we can investigate further.
-          daysUntilClose: 21
+          daysUntilClose: 14
           responseRequiredLabel: "U: Waiting for Response from Author"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10
+          stale-issue-label: 'U: stale'
+          stale-pr-label: 'PR: stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 30
-          days-before-pr-stale: 45
-          days-before-issue-close: 5
-          days-before-pr-close: 10
+          stale-issue-message: 'This issue is stale because it has been open 28 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 28 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
+          days-before-issue-stale: 28
+          days-before-pr-stale: 28
+          days-before-issue-close: 7
+          days-before-pr-close: 14
           stale-issue-label: 'U: stale'
           stale-pr-label: 'PR: stale'


### PR DESCRIPTION
# Create stale.yml

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other - Automation

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
So this workflow will keep our backlog healthy.

- When an issue is stale for 30 days the author gets notified by a bot message to let us know if the issue is still relevant and a stale label gets added. The author will receive 5 days to respond otherwise the issue will be closed. We can remove the stale label when we know the issue still relevant. Removing the label is the same as receiving an comment from the author.
- When a PR is stale for 45 days the author gets notified by a bot message to update the PR or leave a comment with a update why there is no activity and stale label gets added. The author will receive 10 days to comment or update the PR otherwise the PR will be closed. We can remove the stale label if we know its not stale. Removing the label will be the same as comment/update from the author and result in timer reset.

For PR's this means that author dont go lazy on us by not updating their PR and also the other way around that we dont go lazy on them by not reviewing frequently (but that isnt really a problem from our side atm)

For issues this means we have to evaluate if some issues are really valid. Allot are so u can just remove the label :). Sounds like a chore and probably is because allot of issues will receive stale status but im willing to do most of it and go through the backlog.

On another note we still have the `waiting for author workflow` that is more going to be used for new issues when we need more info on something. We probably need to update the time window from 21days to 14 (or something else).

All time stamps u see in the description are open for change!

I suggest 
- 14 days issue close on `waiting author` workflow
- 28 days for issue stale 
- 7 days before issue close
- 42 days for pr stale
- 14 days for pr close

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
tested on issue https://github.com/FreeTubeApp/Test-Repo/issues/82
tested on pr created within repo https://github.com/FreeTubeApp/Test-Repo/pull/90
tested on pr created from fork https://github.com/FreeTubeApp/Test-Repo/pull/91