### PR TITLE
Remove the now unused jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "electron-context-menu": "^3.5.0",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
-    "jquery": "^3.6.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "marked": "^4.0.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,11 +4732,6 @@ jest-worker@^27.4.5, jest-worker@^27.5.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jquery@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
# Remove the now unused jquery dependency

## Pull Request Type

- [x] Feature Implementation
- [x] Celebration

## Related issue
closes #2360 

## Description
This is the last pull request in the jquery removal series.

Highlights:
- Dropped 88kb from renderer.js output
- Better (maybe not noticeable) performance as we are now using the native stuff directly
- Had a chance to clean up some components
- One less dependency

## Testing <!-- for code that is not small enough to be easily understandable -->
As all references to jquery are gone, webpack doesn't bundle it in anymore, so this PR doesn't break anything.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1