### PR TITLE
Replacing `setImmediate` with `setTimeout`

### DIFF
--- a/src/renderer/components/ft-toast/ft-toast.js
+++ b/src/renderer/components/ft-toast/ft-toast.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import FtToastEvents from './ft-toast-events.js'
-import { setImmediate } from 'timers'
 
 export default Vue.extend({
   name: 'FtToast',
@@ -29,7 +28,7 @@ export default Vue.extend({
     open: function (message, action, time) {
       const toast = { message: message, action: action || (() => { }), isOpen: false, timeout: null }
       toast.timeout = setTimeout(this.close, time || 3000, toast)
-      setImmediate(() => { toast.isOpen = true })
+      setTimeout(() => { toast.isOpen = true })
       if (this.toasts.length > 4) {
         this.remove(0)
       }

--- a/src/renderer/components/ft-toast/ft-toast.js
+++ b/src/renderer/components/ft-toast/ft-toast.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import FtToastEvents from './ft-toast-events.js'
+import { setImmediate } from 'timers'
 
 export default Vue.extend({
   name: 'FtToast',


### PR DESCRIPTION
# Replacing `setImmediate` with `setTimeout`

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
`setImmediate` is a global in node, but it is technically also part of the `timers` module, and it is not a global in web. This causes an error to occur when `showToast` is called in a browser.

## Screenshots <!-- If appropriate -->
_Before: (in a web build)_
![image](https://user-images.githubusercontent.com/106682128/194414767-4aa2047c-b595-4c0b-973e-790bbacd211f.png)
_After:_
![image](https://user-images.githubusercontent.com/106682128/194415383-5dbb7cf6-1929-4f3d-ada2-fc26b4214db7.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
This change can be tested by checking if any toast messages display in both electron and web environments.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
This error did not occur in my original web build because `setImmediate` was being globally defined, but I believe it makes more sense to import it explicitly as to not pollute global scope. Technically, this same behavior could be achieved by modifying the `webpack.web.config.js` to globally define `setImmediate` only in web builds.
