### PR TITLE
Use named parameters instead of $ and % in localised strings

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -207,8 +207,7 @@ export default Vue.extend({
             this.updateChangelog = marked.parse(json[0].body)
             this.changeLogTitle = json[0].name
 
-            const message = this.$t('Version $ is now available!  Click for more details')
-            this.updateBannerMessage = message.replace('$', versionNumber)
+            this.updateBannerMessage = this.$t('Version {versionNumber} is now available!  Click for more details', { versionNumber })
 
             const appVersion = packageDetails.version.split('.')
             const latestVersion = versionNumber.split('.')
@@ -242,8 +241,7 @@ export default Vue.extend({
           const latestPubDate = new Date(latestBlog.pubDate)
 
           if (lastAppWasRunning === null || latestPubDate > lastAppWasRunning) {
-            const message = this.$t('A new blog is now available, $. Click to view more')
-            this.blogBannerMessage = message.replace('$', latestBlog.title)
+            this.blogBannerMessage = this.$t('A new blog is now available, {blogTitle}. Click to view more', { blogTitle: latestBlog.title })
             this.latestBlogUrl = latestBlog.link
             this.showBlogBanner = true
           }

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1013,7 +1013,7 @@ export default Vue.extend({
         const objectKeys = Object.keys(playlistObject)
 
         if ((objectKeys.length < requiredKeys.length) || playlistObject.videos.length === 0) {
-          const message = this.$t('Settings.Data Settings.Playlist insufficient data').replace('$', playlistData.playlistName)
+          const message = this.$t('Settings.Data Settings.Playlist insufficient data', { playlist: playlistData.playlistName })
           this.showToast({
             message: message
           })

--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -47,8 +47,8 @@ export default Vue.extend({
 
       const cmdArgs = this.$store.getters.getExternalPlayerCmdArguments[this.externalPlayer]
       if (cmdArgs && typeof cmdArgs.defaultCustomArguments === 'string' && cmdArgs.defaultCustomArguments !== '') {
-        const defaultArgs = this.$t('Tooltips.External Player Settings.DefaultCustomArgumentsTemplate')
-          .replace('$', cmdArgs.defaultCustomArguments)
+        const defaultArgs = this.$t('Tooltips.External Player Settings.DefaultCustomArgumentsTemplate',
+          { defaultCustomArguments: cmdArgs.defaultCustomArguments })
         return `${tooltip} ${defaultArgs}`
       }
 

--- a/src/renderer/components/ft-age-restricted/ft-age-restricted.js
+++ b/src/renderer/components/ft-age-restricted/ft-age-restricted.js
@@ -16,7 +16,7 @@ export default Vue.extend({
 
     restrictedMessage: function () {
       const contentType = this.$t('Age Restricted.Type.' + this.contentTypeString)
-      return this.$t('Age Restricted.This $contentType is age restricted').replace('$contentType', contentType)
+      return this.$t('Age Restricted.This {videoOrPlaylist} is age restricted', { videoOrPlaylist: contentType })
     }
   }
 })

--- a/src/renderer/components/ft-list-playlist/ft-list-playlist.js
+++ b/src/renderer/components/ft-list-playlist/ft-list-playlist.js
@@ -65,7 +65,6 @@ export default Vue.extend({
   methods: {
     handleExternalPlayer: function () {
       this.openInExternalPlayer({
-        strings: this.$t('Video.External Player'),
         watchProgress: 0,
         playbackRate: this.defaultPlayback,
         videoId: null,

--- a/src/renderer/components/ft-list-playlist/ft-list-playlist.vue
+++ b/src/renderer/components/ft-list-playlist/ft-list-playlist.vue
@@ -25,7 +25,7 @@
     <div class="info">
       <ft-icon-button
         v-if="externalPlayer !== ''"
-        :title="$t('Video.External Player.OpenInTemplate').replace('$', externalPlayer)"
+        :title="$t('Video.External Player.OpenInTemplate', { externalPlayer })"
         :icon="['fas', 'external-link-alt']"
         class="externalPlayerButton"
         theme="base-no-default"

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -265,7 +265,6 @@ export default Vue.extend({
       this.$emit('pause-player')
 
       this.openInExternalPlayer({
-        strings: this.$t('Video.External Player'),
         watchProgress: this.watchProgress,
         playbackRate: this.defaultPlayback,
         videoId: this.id,
@@ -394,10 +393,6 @@ export default Vue.extend({
         // produces a string according to the template in the locales string
         this.toLocalePublicationString({
           publishText: this.publishedText,
-          templateString: this.$t('Video.Publicationtemplate'),
-          timeStrings: this.$t('Video.Published'),
-          liveStreamString: this.$t('Video.Watching'),
-          upcomingString: this.$t('Video.Published.Upcoming'),
           isLive: this.isLive,
           isUpcoming: this.isUpcoming,
           isRSS: this.data.isRSS

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -33,7 +33,7 @@
       </div>
       <ft-icon-button
         v-if="externalPlayer !== ''"
-        :title="$t('Video.External Player.OpenInTemplate').replace('$', externalPlayer)"
+        :title="$t('Video.External Player.OpenInTemplate', { externalPlayer })"
         :icon="['fas', 'external-link-alt']"
         class="externalPlayerIcon"
         theme="base"

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
@@ -49,8 +49,7 @@ export default Vue.extend({
       return this.$store.getters.getProfileList
     },
     selectedText: function () {
-      const localeText = this.$t('Profile.$ selected')
-      return localeText.replace('$', this.selectedLength)
+      return this.$t('Profile.{number} selected', { number: this.selectedLength })
     },
     deletePromptMessage: function () {
       if (this.isMainProfile) {

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -130,7 +130,7 @@ export default Vue.extend({
 
     setDefaultProfile: function () {
       this.updateDefaultProfile(this.profileId)
-      const message = this.$t('Profile.Your default profile has been set to $').replace('$', this.profileName)
+      const message = this.$t('Profile.Your default profile has been set to {profile}', { profile: this.profileName })
       this.showToast({
         message: message
       })
@@ -143,7 +143,7 @@ export default Vue.extend({
 
       this.removeProfile(this.profileId)
 
-      const message = this.$t('Profile.Removed $ from your profiles').replace('$', this.profileName)
+      const message = this.$t('Profile.Removed {profile} from your profiles', { profile: this.profileName })
       this.showToast({ message })
 
       if (this.defaultProfile === this.profileId) {

--- a/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.js
+++ b/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.js
@@ -45,8 +45,7 @@ export default Vue.extend({
       return this.profileList.flatMap((profile) => profile.name !== this.profile.name ? [profile.name] : [])
     },
     selectedText: function () {
-      const localeText = this.$t('Profile.$ selected')
-      return localeText.replace('$', this.selectedLength)
+      return this.$t('Profile.{number} selected', { number: this.selectedLength })
     }
   },
   watch: {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -78,7 +78,7 @@ export default Vue.extend({
         if (targetProfile) {
           this.updateActiveProfile(targetProfile._id)
 
-          const message = this.$t('Profile.$ is now the active profile').replace('$', profile.name)
+          const message = this.$t('Profile.{profile} is now the active profile', { profile: profile.name })
           this.showToast({ message })
         }
       }

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1344,7 +1344,7 @@ export default Vue.extend({
       } catch (err) {
         console.error(`Parse failed: ${err.message}`)
         this.showToast({
-          message: this.$t('Screenshot Error').replace('$', err.message)
+          message: this.$t('Screenshot Error', { error: err.message })
         })
         canvas.remove()
         return
@@ -1412,7 +1412,7 @@ export default Vue.extend({
           } catch (err) {
             console.error(err)
             this.showToast({
-              message: this.$t('Screenshot Error').replace('$', err)
+              message: this.$t('Screenshot Error', { error: err })
             })
             canvas.remove()
             return
@@ -1429,11 +1429,11 @@ export default Vue.extend({
             if (err) {
               console.error(err)
               this.showToast({
-                message: this.$t('Screenshot Error').replace('$', err)
+                message: this.$t('Screenshot Error', { error: err })
               })
             } else {
               this.showToast({
-                message: this.$t('Screenshot Success').replace('$', filePath)
+                message: this.$t('Screenshot Success', { filePath })
               })
             }
           })

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -193,9 +193,8 @@ export default Vue.extend({
       const instance = this.currentInvidiousInstance
       this.updateDefaultInvidiousInstance(instance)
 
-      const message = this.$t('Default Invidious instance has been set to $')
       this.showToast({
-        message: message.replace('$', instance)
+        message: this.$t('Default Invidious instance has been set to {instance}', { instance })
       })
     },
 

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -116,7 +116,7 @@
         v-if="defaultInvidiousInstance !== ''"
         class="center"
       >
-        {{ $t('Settings.General Settings.The currently set default instance is $').replace('$', defaultInvidiousInstance) }}
+        {{ $t('Settings.General Settings.The currently set default instance is {instance}', { instance: defaultInvidiousInstance }) }}
       </p>
       <template v-else>
         <p class="center">

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -249,10 +249,6 @@ export default Vue.extend({
         comment.dataType = 'local'
         this.toLocalePublicationString({
           publishText: (comment.time + ' ago'),
-          templateString: this.$t('Video.Publicationtemplate'),
-          timeStrings: this.$t('Video.Published'),
-          liveStreamString: this.$t('Video.Watching'),
-          upcomingString: this.$t('Video.Published.Upcoming'),
           isLive: false,
           isUpcoming: false,
           isRSS: false

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -118,7 +118,7 @@
             {{ comment.numReplies }}
             <span v-if="comment.numReplies === 1">{{ $t("Comments.Reply").toLowerCase() }}</span>
             <span v-else>{{ $t("Comments.Replies").toLowerCase() }}</span>
-            <span v-if="comment.hasOwnerReplied && !comment.showReplies"> {{ $t("Comments.From $channelName").replace("$channelName", channelName) }}</span>
+            <span v-if="comment.hasOwnerReplied && !comment.showReplies"> {{ $t("Comments.From {channelName}", { channelName }) }}</span>
             <span v-if="comment.numReplies > 1 && comment.hasOwnerReplied && !comment.showReplies">{{ $t("Comments.And others") }}</span>
           </span>
         </p>

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -318,7 +318,6 @@ export default Vue.extend({
       this.$emit('pause-player')
 
       this.openInExternalPlayer({
-        strings: this.$t('Video.External Player'),
         watchProgress: this.getTimestamp(),
         playbackRate: this.defaultPlayback,
         videoId: this.id,
@@ -387,9 +386,8 @@ export default Vue.extend({
           })
 
           if (duplicateSubscriptions > 0) {
-            const message = this.$t('Channel.Removed subscription from $ other channel(s)')
             this.showToast({
-              message: message.replace('$', duplicateSubscriptions)
+              message: this.$t('Channel.Removed subscription from {count} other channel(s)', { count: duplicateSubscriptions })
             })
           }
         }

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -97,7 +97,7 @@
         />
         <ft-icon-button
           v-if="externalPlayer !== ''"
-          :title="$t('Video.External Player.OpenInTemplate').replace('$', externalPlayer)"
+          :title="$t('Video.External Player.OpenInTemplate', { externalPlayer })"
           :icon="['fas', 'external-link-alt']"
           class="option"
           theme="secondary"

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -18,7 +18,7 @@ if (isDev) {
       const doc = load(fs.readFileSync(`static/locales/${locale}.yaml`))
       messages[locale] = doc
     } catch (e) {
-      console.error(e)
+      console.error(locale, e)
     }
   })
 }
@@ -50,7 +50,7 @@ class CustomVueI18n extends VueI18n {
           const data = JSON.parse(brotliDecompressSync(compressed).toString())
           this.setLocaleMessage(locale, data)
         } catch (err) {
-          console.error(err)
+          console.error(locale, err)
         }
       } else {
         const url = new URL(window.location.href)

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -623,9 +623,8 @@ export default Vue.extend({
           })
 
           if (duplicateSubscriptions > 0) {
-            const message = this.$t('Channel.Removed subscription from $ other channel(s)')
             this.showToast({
-              message: message.replace('$', duplicateSubscriptions)
+              message: this.$t('Channel.Removed subscription from {count} other channel(s)', { count: duplicateSubscriptions })
             })
           }
         }

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -160,7 +160,7 @@ export default Vue.extend({
 
     thumbnailURL: function(originalURL) {
       let newURL = originalURL
-      if (new URL(originalURL).hostname.endsWith('ggpht.com')) {
+      if (new URL(originalURL).hostname === 'yt3.ggpht.com') {
         if (this.backendPreference === 'invidious') { // YT to IV
           newURL = originalURL.replace(this.re.ytToIv, `${this.currentInvidiousInstance}/ggpht/$1`)
         }

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -140,7 +140,7 @@ export default Vue.extend({
 
       this.updateProfile(currentProfile)
       this.showToast({
-        message: this.$t('Channels.Unsubscribed').replace('$', this.channelToUnsubscribe.name)
+        message: this.$t('Channels.Unsubscribed', { channelName: this.channelToUnsubscribe.name })
       })
 
       index = this.subscribedChannels.findIndex(channel => {
@@ -160,7 +160,7 @@ export default Vue.extend({
 
     thumbnailURL: function(originalURL) {
       let newURL = originalURL
-      if (originalURL.indexOf('ggpht.com') > -1) {
+      if (new URL(originalURL).hostname.endsWith('ggpht.com')) {
         if (this.backendPreference === 'invidious') { // YT to IV
           newURL = originalURL.replace(this.re.ytToIv, `${this.currentInvidiousInstance}/ggpht/$1`)
         }

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -21,7 +21,7 @@
       </ft-flex-box>
       <template v-else>
         <ft-flex-box class="count">
-          {{ $t('Channels.Count').replace('$', channelList.length) }}
+          {{ $t('Channels.Count', { number: channelList.length }) }}
         </ft-flex-box>
         <ft-flex-box class="channels">
           <div
@@ -58,7 +58,7 @@
     </ft-card>
     <ft-prompt
       v-if="showUnsubscribePrompt"
-      :label="$t('Channels.Unsubscribe Prompt').replace('$', channelToUnsubscribe.name)"
+      :label="$t('Channels.Unsubscribe Prompt', { channelName: channelToUnsubscribe.name })"
       :option-names="unsubscribePromptNames"
       :option-values="unsubscribePromptValues"
       @click="handleUnsubscribePromptClick"

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -141,7 +141,7 @@ Settings:
     Current instance will be randomized on startup: سيتم عشوائية المثيل الحالي عند
       بدء التشغيل
     No default instance has been set: لم يتم تعيين مثيل افتراضي
-    The currently set default instance is $: المثيل الافتراضي المحدد حاليا هو $
+    The currently set default instance is {instance}: المثيل الافتراضي المحدد حاليا هو {instance}
     Current Invidious Instance: المثيل الحالي Invidious
     Clear Default Instance: مسح المثيل الافتراضي
     External Link Handling:
@@ -502,11 +502,11 @@ Profile:
   Your profile name cannot be empty: 'لا يمكن أن يكون اسم ملفك الشخصي فارغاً'
   Profile has been created: 'تم إنشاء الملف الشخصي'
   Profile has been updated: 'تم تحديث الملف الشخصي'
-  Your default profile has been set to $: 'تم تعيين $ كملف شخصي افتراضي'
-  Removed $ from your profiles: 'تم إزالة $ من ملفاتك الشخصية'
+  Your default profile has been set to {profile}: 'تم تعيين $ كملف شخصي افتراضي'
+  Removed {profile} from your profiles: 'تم إزالة $ من ملفاتك الشخصية'
   Your default profile has been changed to your primary profile: 'تم تغيير ملفك الشخصي
     الافتراضي إلى ملفك الشخصي الأساسي'
-  $ is now the active profile: '$ هو الآن الملف الشخصي النشط'
+  '{profile} is now the active profile': '{profile} هو الآن الملف الشخصي النشط'
 #On Channel Page
   Profile Select: اختيار الملف الشخصي
   Are you sure you want to delete the selected channels?  This will not delete the channel from any other profile.: هل
@@ -521,7 +521,7 @@ Profile:
   Delete Selected: حذف المُحدد
   Select None: إلغاء التحديد
   Select All: تحديد الكل
-  $ selected: $ تم اختياره
+  '{number} selected': $ تم اختياره
   Other Channels: قنوات أُخرى
   Subscription List: قائمة الاشتراكات
   Profile Filter: مرشح الملف الشخصي
@@ -555,7 +555,7 @@ Channel:
     Channel Description: 'وصف القناة'
     Featured Channels: 'القنوات المميزة'
   Added channel to your subscriptions: تم إضافة القناة إلى اشتراكاتك
-  Removed subscription from $ other channel(s): تم إزالة الاشتراك من $ قناة/قنوات
+  Removed subscription from {count} other channel(s): تم إزالة الاشتراك من $ قناة/قنوات
     أخرى
   Channel has been removed from your subscriptions: تمت إزالة القناة من اشتراكاتك
 Video:
@@ -619,8 +619,7 @@ Video:
     Less than a minute: أقل من دقيقة
     In less than a minute: في أقل من دقيقة
   Published on: 'نُشر في'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'قبل $ %'
+  Publicationtemplate: 'قبل {number} {unit}'
 #& Videos
   Autoplay: تشغيل تلقائي
   Play Previous Video: شغل الفيديو السابق
@@ -668,11 +667,11 @@ Video:
       opening playlists: فتح قوائم التشغيل
       setting a playback rate: ضبط معدل التشغيل
       starting video at offset: بدء تشغيل الفيديو عند الإزاحة
-    UnsupportedActionTemplate: '$ لا يدعم: ٪'
-    OpeningTemplate: فتح $ في ٪...
+    UnsupportedActionTemplate: '{externalPlayer} لا يدعم: {action}'
+    OpeningTemplate: فتح $ في {externalPlayer}...
     playlist: قائمة التشغيل
     video: فيديو
-    OpenInTemplate: فتح في $
+    OpenInTemplate: فتح في {externalPlayer}
   Premieres on: العرض الأول بتاريخ
   Stats:
     video id: معرف الفيديو (يوتيوب)
@@ -765,7 +764,7 @@ Comments:
   Show More Replies: إظهار المزيد من الردود
   Pinned by: تم التثبيت بواسطة
   And others: و اخرين
-  From $channelName: من $ channelName
+  From {channelName}: من {channelName}
   Member: عضو
 Up Next: 'التالي'
 
@@ -790,10 +789,10 @@ Canceled next video autoplay: 'تم إلغاء التشغيل التلقائي �
 Yes: 'نعم'
 No: 'لا'
 The playlist has been reversed: تم عكس قائمة التشغيل
-A new blog is now available, $. Click to view more: مدوّنة جديدة متاحة الآن، $. انقر
+A new blog is now available, {blogTitle}. Click to view more: مدوّنة جديدة متاحة الآن، $. انقر
   لعرض المزيد
 Download From Site: تنزيل من الموقع
-Version $ is now available!  Click for more details: الإصدار $ متاح الآن! انقر للحصول
+Version {versionNumber} is now available!  Click for more details: الإصدار $ متاح الآن! انقر للحصول
   على المزيد من التفاصيل
 Tooltips:
   General Settings:
@@ -848,7 +847,7 @@ Tooltips:
     External Player: سيؤدي اختيار مشغل خارجي إلى عرض رمز لفتح الفيديو (قائمة التشغيل
       إذا كانت مدعومة) في المشغل الخارجي على الصورة المصغرة. تحذير ، لا تؤثر إعدادات
       Invidious على المشغلات الخارجية.
-    DefaultCustomArgumentsTemplate: "(الافتراضي: '$')"
+    DefaultCustomArgumentsTemplate: "(الافتراضي: '{defaultCustomArguments}')"
 This video is unavailable because of missing formats. This can happen due to country unavailability.: هذا
   الفيديو غير متاح الآن لعدم وجود ملفات فيديو . هذا قد يكون بسبب أن الفيديو غير متاح
   في بلدك.
@@ -861,28 +860,28 @@ Unknown YouTube url type, cannot be opened in app: نوع URL غير معروف 
   لا يمكن فتحه في التطبيق
 Open New Window: افتح نافذة جديدة
 Default Invidious instance has been cleared: تم مسح مثيل Invidious الافتراضي
-Default Invidious instance has been set to $: تم تعيين المثيل الافتراضي Invidious
-  إلى $
+Default Invidious instance has been set to {instance}: تم تعيين المثيل الافتراضي Invidious
+  إلى {instance}
 Search Bar:
   Clear Input: مسح المدخلات
 External link opening has been disabled in the general settings: تم تعطيل فتح الارتباط
   الخارجي في الإعدادات العامة
 Are you sure you want to open this link?: هل أنت متأكد أنك تريد فتح هذا الرابط؟
 Downloading has completed: انتهى "$" من التنزيل
-Downloading failed: حدثت مشكلة أثناء تنزيل "$"
+Downloading failed: حدثت مشكلة أثناء تنزيل "{videoTitle}"
 Download folder does not exist: دليل التحميل "$" غير موجود. الرجوع إلى وضع "طلب المجلد".
 Downloading canceled: تم إلغاء التحميل من قبل المستخدم
-Starting download: بدء تنزيل "$"
-Screenshot Success: تم حفظ لقطة الشاشة كا"$"
-Screenshot Error: فشل أخذ لقطة للشاشة. $
+Starting download: بدء تنزيل "{videoTitle}"
+Screenshot Success: تم حفظ لقطة الشاشة كا"{filePath}"
+Screenshot Error: فشل أخذ لقطة للشاشة. {error}
 New Window: نافذة جديدة
 Age Restricted:
   Type:
     Channel: القناة
     Video: فيديو
-  This $contentType is age restricted: هذا $ مقيد بالفئة العمرية
+  This {videoOrPlaylist} is age restricted: هذا $ مقيد بالفئة العمرية
 Channels:
-  Count: تم العثور على قناة (قنوات) $.
+  Count: تم العثور على قناة (قنوات) {number}.
   Unsubscribed: تمت إزالة $ من اشتراكاتك
   Channels: القنوات
   Title: قائمة القنوات

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -352,7 +352,7 @@ Settings:
     Check for Legacy Subscriptions: تحقق من وجود اشتراكات بالصيغة القديمة
     Manage Subscriptions: إدارة الإشتراكات
     All playlists has been successfully imported: تم استيراد جميع قوائم التشغيل بنجاح
-    Playlist insufficient data: بيانات غير كافية لقائمة التشغيل "$"، تخطي العنصر
+    Playlist insufficient data: ''
     All playlists has been successfully exported: تم تصدير جميع قوائم التشغيل بنجاح
     Import Playlists: استيراد قوائم التشغيل
     Export Playlists: تصدير قوائم التشغيل
@@ -502,8 +502,8 @@ Profile:
   Your profile name cannot be empty: 'لا يمكن أن يكون اسم ملفك الشخصي فارغاً'
   Profile has been created: 'تم إنشاء الملف الشخصي'
   Profile has been updated: 'تم تحديث الملف الشخصي'
-  Your default profile has been set to {profile}: 'تم تعيين $ كملف شخصي افتراضي'
-  Removed {profile} from your profiles: 'تم إزالة $ من ملفاتك الشخصية'
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: 'تم تغيير ملفك الشخصي
     الافتراضي إلى ملفك الشخصي الأساسي'
   '{profile} is now the active profile': '{profile} هو الآن الملف الشخصي النشط'
@@ -521,7 +521,7 @@ Profile:
   Delete Selected: حذف المُحدد
   Select None: إلغاء التحديد
   Select All: تحديد الكل
-  '{number} selected': $ تم اختياره
+  '{number} selected': ''
   Other Channels: قنوات أُخرى
   Subscription List: قائمة الاشتراكات
   Profile Filter: مرشح الملف الشخصي
@@ -555,8 +555,7 @@ Channel:
     Channel Description: 'وصف القناة'
     Featured Channels: 'القنوات المميزة'
   Added channel to your subscriptions: تم إضافة القناة إلى اشتراكاتك
-  Removed subscription from {count} other channel(s): تم إزالة الاشتراك من $ قناة/قنوات
-    أخرى
+  Removed subscription from {count} other channel(s): ''
   Channel has been removed from your subscriptions: تمت إزالة القناة من اشتراكاتك
 Video:
   Mark As Watched: 'علّمه كفيديو تمت مشاهدته'
@@ -668,7 +667,7 @@ Video:
       setting a playback rate: ضبط معدل التشغيل
       starting video at offset: بدء تشغيل الفيديو عند الإزاحة
     UnsupportedActionTemplate: '{externalPlayer} لا يدعم: {action}'
-    OpeningTemplate: فتح $ في {externalPlayer}...
+    OpeningTemplate: ''
     playlist: قائمة التشغيل
     video: فيديو
     OpenInTemplate: فتح في {externalPlayer}
@@ -789,11 +788,9 @@ Canceled next video autoplay: 'تم إلغاء التشغيل التلقائي �
 Yes: 'نعم'
 No: 'لا'
 The playlist has been reversed: تم عكس قائمة التشغيل
-A new blog is now available, {blogTitle}. Click to view more: مدوّنة جديدة متاحة الآن، $. انقر
-  لعرض المزيد
+A new blog is now available, {blogTitle}. Click to view more: ''
 Download From Site: تنزيل من الموقع
-Version {versionNumber} is now available!  Click for more details: الإصدار $ متاح الآن! انقر للحصول
-  على المزيد من التفاصيل
+Version {versionNumber} is now available!  Click for more details: ''
 Tooltips:
   General Settings:
     Thumbnail Preference: كلّ الصّور المصغّرة في FreeTube سيتمّ استبدالها بإطار من
@@ -867,9 +864,9 @@ Search Bar:
 External link opening has been disabled in the general settings: تم تعطيل فتح الارتباط
   الخارجي في الإعدادات العامة
 Are you sure you want to open this link?: هل أنت متأكد أنك تريد فتح هذا الرابط؟
-Downloading has completed: انتهى "$" من التنزيل
+Downloading has completed: ''
 Downloading failed: حدثت مشكلة أثناء تنزيل "{videoTitle}"
-Download folder does not exist: دليل التحميل "$" غير موجود. الرجوع إلى وضع "طلب المجلد".
+Download folder does not exist: ''
 Downloading canceled: تم إلغاء التحميل من قبل المستخدم
 Starting download: بدء تنزيل "{videoTitle}"
 Screenshot Success: تم حفظ لقطة الشاشة كا"{filePath}"
@@ -879,23 +876,22 @@ Age Restricted:
   Type:
     Channel: القناة
     Video: فيديو
-  This {videoOrPlaylist} is age restricted: هذا $ مقيد بالفئة العمرية
+  This {videoOrPlaylist} is age restricted: ''
 Channels:
   Count: تم العثور على قناة (قنوات) {number}.
-  Unsubscribed: تمت إزالة $ من اشتراكاتك
+  Unsubscribed: ''
   Channels: القنوات
   Title: قائمة القنوات
   Search bar placeholder: البحث في القنوات
   Empty: قائمة قنواتك فارغة حاليا.
   Unsubscribe: إلغاء الاشتراك
-  Unsubscribe Prompt: هل أنت متأكد من أنك تريد إلغاء الاشتراك من "$"؟
+  Unsubscribe Prompt: ''
 Clipboard:
   Cannot access clipboard without a secure connection: لا يمكن الوصول إلى الحافظة
     دون اتصال آمن
   Copy failed: فشل النسخ إلى الحافظة
 Chapters:
   Chapters: الفصول
-  'Chapters list hidden, current chapter: {chapterName}': 'قائمة الفصول مخفية، الفصل
-    الحالي: {اسم الفصل}'
+  'Chapters list hidden, current chapter: {chapterName}': ''
   'Chapters list visible, current chapter: {chapterName}': 'قائمة الفصول المرئية ،
     الفصل الحالي: {sectionName}'

--- a/static/locales/as.yaml
+++ b/static/locales/as.yaml
@@ -297,7 +297,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -30,10 +30,10 @@ Back: 'Geri'
 Forward: 'İrəli'
 Open New Window: 'Yeni Pəncərə Açın'
 
-Version $ is now available!  Click for more details: '$ versiyası artıq mövcuddur!
+Version {versionNumber} is now available!  Click for more details: '{versionNumber} versiyası artıq mövcuddur!
   Ətraflı məlumat üçün klikləyin'
 Download From Site: 'Saytdan Endirin'
-A new blog is now available, $. Click to view more: 'İndi yeni blog mövcuddur, $.
+A new blog is now available, {blogTitle}. Click to view more: 'İndi yeni blog mövcuddur, {blogTitle}.
   Daha çoxuna baxmaq üçün klikləyin'
 Are you sure you want to open this link?: 'Bu linki açmaq istədiyinizə əminsiniz?'
 
@@ -147,9 +147,8 @@ Settings:
       Middle: 'Orta'
       End: 'Son'
     Current Invidious Instance: 'Cari Invidious Nümunəsi'
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: 'Hazırda təyin edilmiş standart nümunə
-      $-dır'
+    The currently set default instance is {instance}: 'Hazırda təyin edilmiş standart nümunə
+      {instance}-dır'
     No default instance has been set: 'Defolt nümunə təyin edilməyib'
     Current instance will be randomized on startup: 'Cari nümunə başlanğıcda təsadüfi
       olacaq'
@@ -403,13 +402,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -426,7 +425,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -530,7 +529,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -543,13 +541,10 @@ Video:
     recap: ''
     filler: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -636,7 +631,7 @@ Comments:
   Replies: ''
   Show More Replies: ''
   Reply: ''
-  From $channelName: ''
+  From {channelName}: ''
   And others: ''
   There are no comments available for this video: ''
   Load More Comments: ''
@@ -653,7 +648,7 @@ Tooltips:
     Thumbnail Preference: ''
     Invidious Instance: ''
     Region for Trending: ''
-    External Link Handling: |
+    External Link Handling: ''
   Player Settings:
     Force Local Backend for Legacy Formats: ''
     Proxy Videos Through Invidious: ''
@@ -664,7 +659,6 @@ Tooltips:
     Custom External Player Executable: ''
     Ignore Warnings: ''
     Custom External Player Arguments: ''
-    # $ is replaced with the default custom arguments for the current player, if defined.
     DefaultCustomArgumentsTemplate: ''
   Subscription Settings:
     Fetch Feeds from RSS: ''
@@ -689,8 +683,7 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 External link opening has been disabled in the general settings: ''

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -30,10 +30,10 @@ Close: 'Затваряне'
 Back: 'Назад'
 Forward: 'Напред'
 
-Version $ is now available!  Click for more details: 'Версия $ е вече налична! Щракнете
+Version {versionNumber} is now available!  Click for more details: 'Версия {versionNumber} е вече налична! Щракнете
   за повече детайли'
 Download From Site: 'Сваляне от сайта'
-A new blog is now available, $. Click to view more: 'Нова публикация в блога, $. Щракнете
+A new blog is now available, {blogTitle}. Click to view more: 'Нова публикация в блога, {blogTitle}. Щракнете
   за преглед'
 
 # Search Bar
@@ -153,8 +153,8 @@ Settings:
     Current instance will be randomized on startup: Текущият сървър при стартиране
       ще бъде случаен
     No default instance has been set: Няма зададен сървър по подразбиране
-    The currently set default instance is $: Текущо зададеният сървър по подразбиране
-      е $
+    The currently set default instance is {instance}: Текущо зададеният сървър по подразбиране
+      е {instance}
     Current Invidious Instance: Текущ Invidious сървър
     External Link Handling:
       No Action: Без действие
@@ -338,7 +338,7 @@ Settings:
     Export Playlists: Изнасяне на плейлисти
     All playlists has been successfully imported: Всички плейлисти са внесени успешно
     Import Playlists: Внасяне на плейлисти
-    Playlist insufficient data: Недостатъчно данни за плейлист "$", прескачане на
+    Playlist insufficient data: Недостатъчно данни за плейлист "{playlist}", прескачане на
       елемент
     All playlists has been successfully exported: Всички плейлисти са изнесени успешно
   Advanced Settings:
@@ -515,15 +515,15 @@ Profile:
   Your profile name cannot be empty: 'Името на профила не може да е празно'
   Profile has been created: 'Профилът беше създаден'
   Profile has been updated: 'Профилът беше актуализиран'
-  Your default profile has been set to $: 'Вашият профил по подразбиране беше указан
-    да е $'
-  Removed $ from your profiles: '$ е премахнат от вашите профили'
+  Your default profile has been set to {profile}: 'Вашият профил по подразбиране беше указан
+    да е {profile}'
+  Removed {profile} from your profiles: '{profile} е премахнат от вашите профили'
   Your default profile has been changed to your primary profile: 'Профилът по подразбиране
     е променен на вашия първоначален профил'
-  $ is now the active profile: 'Активният профил сега е $'
+  '{profile} is now the active profile': 'Активният профил сега е {profile}'
   Subscription List: 'Списък с абонаменти'
   Other Channels: 'Други канали'
-  $ selected: '$ избран(и)'
+  '{number} selected': '{number} избран(и)'
   Select All: 'Избиране на всички'
   Select None: 'Без избиране'
   Delete Selected: 'Изтриване на избраните'
@@ -546,7 +546,7 @@ Channel:
   Unsubscribe: 'Отписване'
   Channel has been removed from your subscriptions: 'Каналът беше премахнат от вашите
     абонаменти'
-  Removed subscription from $ other channel(s): 'Премахнат абонамент от $ друг(и)
+  Removed subscription from {count} other channel(s): 'Премахнат абонамент от {count} друг(и)
     канал(и)'
   Added channel to your subscriptions: 'Добавен канал към вашите абонаменти'
   Search Channel: 'Търсене в канала'
@@ -642,8 +642,7 @@ Video:
     Less than a minute: По-малко от минута
     In less than a minute: След по-малко от минута
   Published on: 'Публикуван на'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Преди $ %'
+  Publicationtemplate: 'Преди {number} {unit}'
 #& Videos
   Audio:
     Best: Най-добро
@@ -684,11 +683,11 @@ Video:
       opening playlists: отваряне на плейлист
       setting a playback rate: задаване на скорост за възпроизвеждане
       starting video at offset: стартиране на видео при отместване
-    UnsupportedActionTemplate: '$ не поддържа: %'
-    OpeningTemplate: Отваряне на $ във %...
+    UnsupportedActionTemplate: '{externalPlayer} не поддържа: {action}'
+    OpeningTemplate: Отваряне на {videoOrPlaylist} във {externalPlayer}...
     playlist: плейлист
     video: видео
-    OpenInTemplate: Отваряне във $
+    OpenInTemplate: Отваряне във {externalPlayer}
   Stats:
     fps: Кадри в секунда
     video id: Идентификатор на видеоклип (YouTube)
@@ -783,7 +782,7 @@ Comments:
   Sort by: Сортиране по
   Show More Replies: Показване на още отговори
   Pinned by: Прихванато от
-  From $channelName: от $channelName
+  From {channelName}: от {channelName}
   And others: и други
   Member: Член
 Up Next: 'Следващ'
@@ -869,7 +868,7 @@ Tooltips:
     External Player: При избора на външен плейър, върху миниатюрата ще се покаже икона
       за отваряне на видеото (плейлиста, ако се поддържа) във външния плейър. Внимание,
       настройките на Invidious не влияят на външните плейъри.
-    DefaultCustomArgumentsTemplate: "(По подразбиране: '$')"
+    DefaultCustomArgumentsTemplate: "(По подразбиране: '{defaultCustomArguments}')"
 More: Още
 Playing Next Video Interval: Пускане на следващото видео веднага. Щракнете за отказ.
   | Пускане на следващото видео след {nextVideoInterval} секунда. Щракнете за отказ.
@@ -881,30 +880,30 @@ Unknown YouTube url type, cannot be opened in app: Неизвестен тип U
 Open New Window: Отваряне на нов прозорец
 Default Invidious instance has been cleared: Сървъра по подразбиране за Invidious
   е изчистен
-Default Invidious instance has been set to $: Сървъра по подразбиране за Invidious
-  е зададен на $
+Default Invidious instance has been set to {instance}: Сървъра по подразбиране за Invidious
+  е зададен на {instance}
 External link opening has been disabled in the general settings: Отварянето на външни
   връзки е изключено в общите настройки
 Search Bar:
   Clear Input: Изчистване на въведеното
 Are you sure you want to open this link?: Сигурни ли сте, че искате да отворите тази
   връзка?
-Downloading has completed: '"$" приключи изтеглянето'
-Starting download: Започва изтегляне на "$"
-Downloading failed: Имаше проблем при изтеглянето на "$"
-Screenshot Error: Снимката на екрана е неуспешна. $
-Screenshot Success: Запазена снимка на екрана като "$"
+Downloading has completed: '"{videoTitle}" приключи изтеглянето'
+Starting download: Започва изтегляне на "{videoTitle}"
+Downloading failed: Имаше проблем при изтеглянето на "{videoTitle}"
+Screenshot Error: Снимката на екрана е неуспешна. {error}
+Screenshot Success: Запазена снимка на екрана като "{filePath}"
 New Window: Нов прозорец
 Age Restricted:
-  This $contentType is age restricted: Този $ е с възрастово ограничение
+  This {videoOrPlaylist} is age restricted: Този {videoOrPlaylist} е с възрастово ограничение
   Type:
     Channel: Канал
     Video: Видео
 Channels:
-  Count: Намерени са $ канала.
+  Count: Намерени са {number} канала.
   Unsubscribe: Отписване
-  Unsubscribed: $ е премахнат от абонаментите
-  Unsubscribe Prompt: Сигурни ли сте, че искате да се отпишете от "$"?
+  Unsubscribed: '{channelName} е премахнат от абонаментите'
+  Unsubscribe Prompt: Сигурни ли сте, че искате да се отпишете от "{channelName}"?
   Search bar placeholder: Търсене на канали
   Channels: Канали
   Title: Списък с канали

--- a/static/locales/bn.yaml
+++ b/static/locales/bn.yaml
@@ -29,10 +29,10 @@ Close: 'বন্ধ'
 Back: 'পিছনে'
 Forward: 'সামনে'
 
-Version $ is now available!  Click for more details: 'সংস্করণ $ এসে গেছে!  আরো জানতে
+Version {versionNumber} is now available!  Click for more details: 'সংস্করণ {versionNumber} এসে গেছে!  আরো জানতে
   টিপ দাও'
 Download From Site: 'সাইট থেকে ডাউনলোড করো'
-A new blog is now available, $. Click to view more: 'নতুন ব্লগ আছে, $. আরো দেখতে টিপ
+A new blog is now available, {blogTitle}. Click to view more: 'নতুন ব্লগ আছে, {blogTitle}. আরো দেখতে টিপ
   দাও'
 
 # Search Bar
@@ -294,13 +294,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -317,7 +317,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -419,7 +419,6 @@ Video:
   Published on: ''
   Streamed on: ''
   Started streaming on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/bs.yaml
+++ b/static/locales/bs.yaml
@@ -29,10 +29,10 @@ Close: 'Zatvori'
 Back: 'Nazad'
 Forward: 'Unapred'
 
-Version $ is now available!  Click for more details: 'Verzija $ je sada dostupna!
+Version {versionNumber} is now available!  Click for more details: 'Verzija {versionNumber} je sada dostupna!
   Kliknite za više detalja'
 Download From Site: 'Instaliraj preko stranice'
-A new blog is now available, $. Click to view more: 'Sada je dostupan novi blog, $.
+A new blog is now available, {blogTitle}. Click to view more: 'Sada je dostupan novi blog, {blogTitle}.
   Kliknite da vidite više'
 
 # Search Bar
@@ -306,13 +306,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -329,7 +329,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -428,7 +428,6 @@ Video:
   Published on: ''
   Streamed on: ''
   Started streaming on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/ca.yaml
+++ b/static/locales/ca.yaml
@@ -30,11 +30,11 @@ Close: 'Tancar'
 Back: 'Enrere'
 Forward: 'Endavant'
 
-Version $ is now available!  Click for more details: 'La versió $ està disponible!
+Version {versionNumber} is now available!  Click for more details: 'La versió {versionNumber} està disponible!
   Fes clic per a més detalls'
 Download From Site: 'Descarrega des del web'
-A new blog is now available, $. Click to view more: 'Nova publicació al blog disponible,
-  $. Fes clic per saber-ne més'
+A new blog is now available, {blogTitle}. Click to view more: 'Nova publicació al blog disponible,
+  {blogTitle}. Fes clic per saber-ne més'
 
 # Search Bar
 Search / Go to URL: 'Cercar / Vés a l''enllaç'
@@ -148,8 +148,8 @@ Settings:
     System Default: Per defecte del sistema
     Clear Default Instance: Esborra la instància per defecte
     Current Invidious Instance: Instància actual d'Invidious
-    The currently set default instance is $: La instància per defecte establerta actualment
-      és $
+    The currently set default instance is {instance}: La instància per defecte establerta actualment
+      és {instance}
     No default instance has been set: No s'ha definit cap instància per defecte
     External Link Handling:
       Open Link: Obre l'enllaç
@@ -299,7 +299,7 @@ Settings:
     Unknown data key: 'Clau de dades desconegut'
     How do I import my subscriptions?: 'Com puc importar les meves subscripcions?'
     Playlist insufficient data: Dades insuficients per a la llista de reproducció
-      "$", saltant l'objecte
+      "{playlist}", saltant l'objecte
     Manage Subscriptions: Gestiona les subscripcions
     Import Playlists: Importa llistes de reproducció
     All playlists has been successfully exported: Totes les llistes de reproducció
@@ -444,15 +444,15 @@ Profile:
   Your profile name cannot be empty: 'El nom del perfil no pot estar buit'
   Profile has been created: 'S''ha creat el perfil'
   Profile has been updated: 'S''ha actualitzat el perfil'
-  Your default profile has been set to $: 'El vostre perfil predeterminat s''ha establert
-    a $'
-  Removed $ from your profiles: 'S''ha eliminat $ dels teus perfils'
+  Your default profile has been set to {profile}: 'El vostre perfil predeterminat s''ha establert
+    a {profile}'
+  Removed {profile} from your profiles: 'S''ha eliminat {profile} dels teus perfils'
   Your default profile has been changed to your primary profile: 'El perfil per defecte
     s''ha canviat al perfil principal'
-  $ is now the active profile: '$ és ara el perfil actiu'
+  '{profile} is now the active profile': '{profile} és ara el perfil actiu'
   Subscription List: 'Lista de Subcripcions'
   Other Channels: 'Altres Canals'
-  $ selected: '$ seleccionat'
+  '{number} selected': '{number} seleccionat'
   Select All: 'Selecciona Tot'
   Select None: 'Selecciona Ningú'
   Delete Selected: 'Esborra Seleccionats'
@@ -475,7 +475,7 @@ Channel:
   Unsubscribe: 'Des-subscriu-te'
   Channel has been removed from your subscriptions: 'El canal s''ha eliminat de les
     teves subscripcions'
-  Removed subscription from $ other channel(s): 'Elimina subscripció de altres $ canals(s)'
+  Removed subscription from {count} other channel(s): 'Elimina subscripció de altres {count} canals(s)'
   Added channel to your subscriptions: 'Afegeix canal a les teves subscripcions'
   Search Channel: 'Cerca Canal'
   Your search results have returned 0 results: 'Els resultats de la teva cerca han
@@ -567,8 +567,7 @@ Video:
     Ago: 'Fa'
     Upcoming: 'S''estrena el'
   Published on: 'Publicat el'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % fa'
+  Publicationtemplate: '{number} {unit} fa'
 #& Videos
   Audio:
     High: Alta
@@ -588,11 +587,11 @@ Video:
     Unsupported Actions:
       starting video at offset: començant el vídeo al òfset
       setting a playback rate: establint una velocitat de reproducció
-    OpenInTemplate: Obri a $
-    OpeningTemplate: Obrint $ a %…
+    OpenInTemplate: Obri a {externalPlayer}
+    OpeningTemplate: Obrint {videoOrPlaylist} a {externalPlayer}…
     video: vídeo
     playlist: llista de reproducció
-    UnsupportedActionTemplate: '$ no soporta: %'
+    UnsupportedActionTemplate: '{externalPlayer} no soporta: {action}'
   Save Video: Desa el Vídeo
   Premieres on: S'estrena el
   audio only: només àudio

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -29,11 +29,11 @@ Close: 'Zavřít'
 Back: 'Zpět'
 Forward: 'Dopředu'
 
-Version $ is now available!  Click for more details: 'Verze $ je k dispozici! Klikněte
+Version {versionNumber} is now available!  Click for more details: 'Verze {versionNumber} je k dispozici! Klikněte
   pro více informací'
 Download From Site: 'Stáhnout ze stránky'
-A new blog is now available, $. Click to view more: 'Je dostupný nový článek na blogu:
-  $. Kliknutím zobrazíte více'
+A new blog is now available, {blogTitle}. Click to view more: 'Je dostupný nový článek na blogu:
+  {blogTitle}. Kliknutím zobrazíte více'
 
 # Search Bar
 Search / Go to URL: 'Hledat / Přejít na URL'
@@ -156,7 +156,7 @@ Settings:
       instance
     Current Invidious Instance: Současná instance Invidious
     No default instance has been set: Není nastavena žádná výchozí instance
-    The currently set default instance is $: Současné výchozí instance je $
+    The currently set default instance is {instance}: Současné výchozí instance je {instance}
     External Link Handling:
       No Action: Žádná akce
       Ask Before Opening Link: Před otevřením odkazu se zeptat
@@ -350,7 +350,7 @@ Settings:
     Manage Subscriptions: Spravovat odběry
     Import Playlists: Importovat playlisty
     Export Playlists: Exportovat playlisty
-    Playlist insufficient data: Nedostačující data pro playlist "$", přeskakuji
+    Playlist insufficient data: Nedostačující data pro playlist "{playlist}", přeskakuji
     All playlists has been successfully imported: Všechny playlisty byly úspěšně importovány
     All playlists has been successfully exported: Všechny playlisty byly úspěšně exportovány
     History File: Soubor historie
@@ -506,14 +506,14 @@ Profile:
   Your profile name cannot be empty: 'Jméno profilu nemůže být prázdné'
   Profile has been created: 'Profil byl vytvořen'
   Profile has been updated: 'Profil byl upraven'
-  Your default profile has been set to $: 'Váš výchozí profil byl nastaven na $'
-  Removed $ from your profiles: 'Odstranit $ z vašeho profilu'
+  Your default profile has been set to {profile}: 'Váš výchozí profil byl nastaven na {profile}'
+  Removed {profile} from your profiles: 'Odstranit {profile} z vašeho profilu'
   Your default profile has been changed to your primary profile: 'Váš výchozí profil
     byl změněn na primární profil'
-  $ is now the active profile: '$ je nyní aktivním profilem'
+  '{profile} is now the active profile': '{profile} je nyní aktivním profilem'
   Subscription List: 'List odebíraných kanálů'
   Other Channels: 'Ostatní kanály'
-  $ selected: '$ vybrán'
+  '{number} selected': '{number} vybrán'
   Select All: 'Vybrat vše'
   Select None: 'Zrušit výběr'
   Delete Selected: 'Smazat vybrané'
@@ -535,7 +535,7 @@ Channel:
   Subscribe: 'Odebírat'
   Unsubscribe: 'Zrušit odběr'
   Channel has been removed from your subscriptions: 'Kanál byl odebrán z vašich odběrů'
-  Removed subscription from $ other channel(s): 'Odběr odebrán z $ jiných kanálů'
+  Removed subscription from {count} other channel(s): 'Odběr odebrán z {count} jiných kanálů'
   Added channel to your subscriptions: 'K vašim odběrům byl přidán kanál'
   Search Channel: 'Hledat v kanálu'
   Your search results have returned 0 results: 'Vaše vyhledávání přineslo 0 výsledků'
@@ -641,8 +641,7 @@ Video:
     Less than a minute: Méně než minuta
     In less than a minute: Za méně než minutu
   Published on: 'Publikováno'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ %'
+  Publicationtemplate: '{number} {unit}'
 #& Videos
   Started streaming on: Začátek vysílání
   Streamed on: Vysíláno
@@ -672,10 +671,10 @@ Video:
       reversing playlists: obrácení seznamů skladeb
       setting a playback rate: nastavení rychlosti přehrávání
     playlist: playlist
-    UnsupportedActionTemplate: '$ nepodporuje: %'
-    OpeningTemplate: Otevřít $ v %...
+    UnsupportedActionTemplate: '{externalPlayer} nepodporuje: {action}'
+    OpeningTemplate: Otevřít {videoOrPlaylist} v {externalPlayer}...
     video: video
-    OpenInTemplate: Otevřít v $
+    OpenInTemplate: Otevřít v {externalPlayer}
   Premieres on: Premiéra
   Stats:
     Mimetype: Typ int. média
@@ -768,7 +767,7 @@ Comments:
   No more comments available: 'Žádné další komentáře nejsou k dispozici'
   Show More Replies: Načíst více výsledků
   Pinned by: připnuto uživatelem
-  From $channelName: z $channelName
+  From {channelName}: z {channelName}
   And others: a ostatní
   Member: Člen
 Up Next: 'Další'
@@ -830,7 +829,7 @@ Tooltips:
     Custom External Player Executable: Ve výchozím nastavení Freetube předpokládá,
       že vybraný externí přehrávač lze nalézt přes proměnnou prostředí cesty PATH.
       V případě potřeby zde lze nastavit vlastní cestu.
-    DefaultCustomArgumentsTemplate: "(Výchozí: '$')"
+    DefaultCustomArgumentsTemplate: "(Výchozí: '{defaultCustomArguments}')"
 Local API Error (Click to copy): 'Chyba lokálního API (kliknutím zkopírujete)'
 Invidious API Error (Click to copy): 'Chyba Invidious API (kliknutím zkopírujete)'
 Falling back to Invidious API: 'Přepínám na Invidious API'
@@ -864,33 +863,33 @@ Unknown YouTube url type, cannot be opened in app: Neznámý typ adresy URL YouT
   nelze v aplikaci otevřít
 Open New Window: Otevřít nové okno
 Default Invidious instance has been cleared: Výchozí Invidious instance byla vymazána
-Default Invidious instance has been set to $: Výchozí Invidious instance byla nastavena
-  na $
+Default Invidious instance has been set to {instance}: Výchozí Invidious instance byla nastavena
+  na {instance}
 Search Bar:
   Clear Input: Vymazat
 External link opening has been disabled in the general settings: Otevírání externích
   odkazů bylo v obecném nastavení zakázáno
 Are you sure you want to open this link?: Opravdu chcete otevřít tento dokaz?
-Downloading has completed: Bylo dokončeno stahování "$"
-Downloading failed: Došlo k problému při stahování "$"
-Starting download: Zahájení stahování "$"
+Downloading has completed: Bylo dokončeno stahování "{videoTitle}"
+Downloading failed: Došlo k problému při stahování "{videoTitle}"
+Starting download: Zahájení stahování "{videoTitle}"
 New Window: Nové okno
 Age Restricted:
-  This $contentType is age restricted: Toto $ je omezeno věkem
+  This {videoOrPlaylist} is age restricted: Toto {videoOrPlaylist} je omezeno věkem
   Type:
     Channel: kanál
     Video: video
 Channels:
   Channels: Kanály
   Title: Seznam kanálů
-  Unsubscribed: Kanál $ byl odebrán z vašich odběrů
-  Unsubscribe Prompt: Opavdu chcete zrušit odběr kanálu "$"?
+  Unsubscribed: Kanál {channelName} byl odebrán z vašich odběrů
+  Unsubscribe Prompt: Opavdu chcete zrušit odběr kanálu "{channelName}"?
   Empty: Seznam vašich kanálů je momentálně prázdný.
   Search bar placeholder: Hledat kanály
-  Count: Nalezeno $ kanálů.
+  Count: Nalezeno {number} kanálů.
   Unsubscribe: Zrušit odběr
-Screenshot Success: Snímek uložen jako „$“
-Screenshot Error: Snímek selhal. $
+Screenshot Success: Snímek uložen jako „{filePath}“
+Screenshot Error: Snímek selhal. {error}
 Clipboard:
   Cannot access clipboard without a secure connection: Nelze přistupovat ke schránce
     bez zabezpečeného připojení

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -29,11 +29,11 @@ Close: 'Luk'
 Back: 'Tilbage'
 Forward: 'Fremad'
 
-Version $ is now available!  Click for more details: 'Version $ er nu tilgængelig!  Klik
+Version {versionNumber} is now available!  Click for more details: 'Version {versionNumber} er nu tilgængelig!  Klik
   for flere detaljer'
 Download From Site: 'Hent Fra Netsted'
-A new blog is now available, $. Click to view more: 'En ny blog er nu tilgængelig,
-  $. Klik for at vise mere'
+A new blog is now available, {blogTitle}. Click to view more: 'En ny blog er nu tilgængelig,
+  {blogTitle}. Klik for at vise mere'
 
 # Search Bar
 Search / Go to URL: 'Søg / Gå til URL'
@@ -152,7 +152,7 @@ Settings:
     Current instance will be randomized on startup: Nuværende instans vil blive randomiseret
       ved opstart
     System Default: Systemstandard
-    The currently set default instance is $: Den nuværende standardinstans er $
+    The currently set default instance is {instance}: Den nuværende standardinstans er {instance}
     Current Invidious Instance: Nuværende Invidious-instans
     No default instance has been set: Ingen standardinstans er angivet
     Set Current Instance as Default: Angiv Nuværende Instans som Standard
@@ -323,7 +323,7 @@ Settings:
     Manage Subscriptions: Abonnementshåndtering
     Check for Legacy Subscriptions: Søg efter Gamle Abonnementer
     Export Playlists: Eksportér Playlister
-    Playlist insufficient data: Utilstrækkeligt data for "$" playlist, springer objektet
+    Playlist insufficient data: Utilstrækkeligt data for "{playlist}" playlist, springer objektet
       over
     Import Playlists: Importér Playlister
     All playlists has been successfully imported: Alle playlister er blevet importeret
@@ -501,15 +501,15 @@ Profile:
   Your profile name cannot be empty: 'Dit profilnavn må ikke være tomt'
   Profile has been created: 'Profil er blevet oprettet'
   Profile has been updated: 'Profil er blevet opdateret'
-  Your default profile has been set to $: 'Din standardprofil er blevet indstillet
-    til $'
-  Removed $ from your profiles: 'Fjernede $ fra dine profiler'
+  Your default profile has been set to {profile}: 'Din standardprofil er blevet indstillet
+    til {profile}'
+  Removed {profile} from your profiles: 'Fjernede {profile} fra dine profiler'
   Your default profile has been changed to your primary profile: 'Din standardprofil
     er blevet ændret til din primære profil'
-  $ is now the active profile: '$ er nu den aktive profil'
+  '{profile} is now the active profile': '{profile} er nu den aktive profil'
   Subscription List: 'Abonnementsliste'
   Other Channels: 'Andre Kanaler'
-  $ selected: '$ valgt'
+  '{number} selected': '{number} valgt'
   Select All: 'Vælg Alt'
   Select None: 'Vælg Intet'
   Delete Selected: 'Slet Valgte'
@@ -532,7 +532,7 @@ Channel:
   Unsubscribe: 'Afmeld'
   Channel has been removed from your subscriptions: 'Kanal er blevet fjernet fra dine
     abonnementer'
-  Removed subscription from $ other channel(s): 'Fjernede abonnement fra $ andre kanaler'
+  Removed subscription from {count} other channel(s): 'Fjernede abonnement fra {count} andre kanaler'
   Added channel to your subscriptions: 'Føjede kanal til dine abonnementer'
   Search Channel: 'Kanalsøgning'
   Your search results have returned 0 results: 'Dine søgeresultater har givet 0 resultater'
@@ -625,8 +625,7 @@ Video:
     Ago: 'Siden'
     Upcoming: 'Har premiere'
   Published on: 'Udgivet'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % siden'
+  Publicationtemplate: '{number} {unit} siden'
 #& Videos
   Copy Invidious Channel Link: Kopiér Invidious Kanal-Link
   Open Channel in Invidious: Åbn Kanal i Invidious
@@ -679,11 +678,11 @@ Video:
       setting a playback rate: indstiller en afspilningshastighed
       shuffling playlists: blander playlister
       looping playlists: gentager playlister
-    OpeningTemplate: Åbner $ i %...
-    OpenInTemplate: Åbn i $
+    OpeningTemplate: Åbner {videoOrPlaylist} i {externalPlayer}...
+    OpenInTemplate: Åbn i {externalPlayer}
     video: video
     playlist: playliste
-    UnsupportedActionTemplate: '$ understøtter ikke: %'
+    UnsupportedActionTemplate: '{externalPlayer} understøtter ikke: {action}'
   Skipped segment: Sprunget over segment
 Videos:
   #& Sort By
@@ -756,7 +755,7 @@ Comments:
   Newest first: Nyeste Først
   Top comments: Topkommentarer
   Sort by: Sortér efter
-  From $channelName: fra $channelName
+  From {channelName}: fra {channelName}
   Pinned by: Fastgjort af
   And others: og andre
   Show More Replies: Vis Flere Svar
@@ -829,7 +828,7 @@ Tooltips:
     Custom External Player Executable: Som standard antager FreeTube at den valgte
       eksterne afspiller kan findes via miljøvariablet PATH. En brugerdefineret sti
       kan blive angivet her hvis det er nødvendigt.
-    DefaultCustomArgumentsTemplate: "(Standard: '$')"
+    DefaultCustomArgumentsTemplate: "(Standard: '{defaultCustomArguments}')"
     Custom External Player Arguments: Alle brugerdefinerede kommandolinjeargumenter,
       opdelt med semikoloner (';'), du ønsker viderebragt til den eksterne afspiller.
     External Player: 'Valg af ekstern afspiller vil fremvise et ikon, for åbning af
@@ -846,14 +845,14 @@ Open New Window: Åbn Nyt Vindue
 Channels:
   Channels: Kanaler
   Title: Kanalliste
-  Count: $ kanal(er) fundet.
-  Unsubscribe Prompt: Er du sikker på at du vil afmelde dit abonnement på "$"?
+  Count: '{number} kanal(er) fundet.'
+  Unsubscribe Prompt: Er du sikker på at du vil afmelde dit abonnement på "{channelName}"?
   Search bar placeholder: Søg Kanaler
   Empty: Din kanalliste er i øjeblikket tom.
   Unsubscribe: Afmeld
-  Unsubscribed: $ er fjernet fra dine abonnementer
-Default Invidious instance has been set to $: Standard Invidious-instans er blevet
-  sat til $
+  Unsubscribed: '{channelName} er fjernet fra dine abonnementer'
+Default Invidious instance has been set to {instance}: Standard Invidious-instans er blevet
+  sat til {instance}
 Default Invidious instance has been cleared: Standard Invidious-instans er blevet
   ryddet
 Are you sure you want to open this link?: Er du sikker på at du vil åbne dette link?
@@ -863,18 +862,18 @@ Age Restricted:
   Type:
     Video: Video
     Channel: Kanal
-  This $contentType is age restricted: Denne $ er aldersbegrænset
-Downloading failed: Der var et problem med at downloade "$"
+  This {videoOrPlaylist} is age restricted: Denne {videoOrPlaylist} er aldersbegrænset
+Downloading failed: Der var et problem med at downloade "{videoTitle}"
 Unknown YouTube url type, cannot be opened in app: Ukendt YouTube URL-type, kan ikke
   åbnes i appen
-Screenshot Error: Skærmbillede mislykkedes. $
+Screenshot Error: Skærmbillede mislykkedes. {error}
 Hashtags have not yet been implemented, try again later: Hashtags er ikke implementeret
   endnu, prøv igen senere
 External link opening has been disabled in the general settings: Åbning af eksterne
   links er slået fra i generelle indstillinger
-Starting download: Starter download af "$"
-Downloading has completed: '"$" er færdig med at downloade'
-Screenshot Success: Gemte skærmbillede som "$"
+Starting download: Starter download af "{videoTitle}"
+Downloading has completed: '"{videoTitle}" er færdig med at downloade'
+Screenshot Success: Gemte skærmbillede som "{filePath}"
 Playing Next Video Interval: Afspiller næste video om lidt. Klik for at afbryde. |
   Afspiller næste video om {nextVideoInterval} sekund. Klik for at afbryde. | Afspiller
   næste video om {nextVideoInterval} sekunder. Klik for at afbryde.

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -148,7 +148,7 @@ Settings:
     Current instance will be randomized on startup: Beim Start wird eine zufällige
       Instanz festgelegt
     No default instance has been set: Es wurde keine Standardinstanz gesetzt
-    The currently set default instance is $: Die aktuelle Standardinstanz ist $
+    The currently set default instance is {instance}: Die aktuelle Standardinstanz ist {instance}
     Current Invidious Instance: Aktuelle Invidious-Instanz
     Clear Default Instance: Standardinstanz zurücksetzen
     Set Current Instance as Default: Derzeitige Instanz als Standard festlegen
@@ -365,7 +365,7 @@ Settings:
     Manage Subscriptions: Abonnements verwalten
     Export Playlists: Wiedergabelisten exportieren
     Import Playlists: Wiedergabelisten importieren
-    Playlist insufficient data: Unzureichende Daten für „$“-Wiedergabeliste, Element
+    Playlist insufficient data: Unzureichende Daten für „{playlist}“-Wiedergabeliste, Element
       übersprungen
     All playlists has been successfully imported: Alle Wiedergabelisten wurden erfolgreich
       importiert
@@ -540,7 +540,7 @@ Channel:
     Channel Description: Kanalbeschreibung
     Featured Channels: Empfohlene Kanäle
   Added channel to your subscriptions: Der Kanal wurde deinen Abonnements hinzugefügt
-  Removed subscription from $ other channel(s): Es wurden $ anderen Kanälen deabonniert
+  Removed subscription from {count} other channel(s): Es wurden {count} anderen Kanälen deabonniert
   Channel has been removed from your subscriptions: Der Kanal wurde von deinen Abonnements
     entfernt
 Video:
@@ -601,7 +601,7 @@ Video:
     Less than a minute: Weniger als einer Minute
     In less than a minute: In weniger als einer Minute
   Published on: Veröffentlicht am
-  Publicationtemplate: vor $ %
+  Publicationtemplate: vor {number} {unit}
 
 #& Videos
   Video has been removed from your history: Das Video wurde aus deinem Verlauf entfernt
@@ -646,7 +646,7 @@ Video:
     filler: Füller
   Skipped segment: Segment übersprungen
   External Player:
-    OpenInTemplate: In $ öffnen
+    OpenInTemplate: In {externalPlayer} öffnen
     Unsupported Actions:
       setting a playback rate: Wiedergabegeschwindigkeit festlegen
       starting video at offset: Starte Video an Stelle
@@ -657,8 +657,8 @@ Video:
         gewähltes Video aus einer Wiedergabeliste (Falle zurück auf normales Öffnen
         des Videos)
       opening playlists: Wiedergabelisten öffnen
-    UnsupportedActionTemplate: '$ unterstützt das nicht: %'
-    OpeningTemplate: $ wird in % geöffnet …
+    UnsupportedActionTemplate: '{externalPlayer} unterstützt das nicht: {action}'
+    OpeningTemplate: '{videoOrPlaylist} wird in {externalPlayer} geöffnet …'
     playlist: Wiedergabeliste
     video: Video
   Premieres on: Premiere am
@@ -765,7 +765,7 @@ Comments:
   Top comments: Top-Kommentare
   Sort by: Sortiert nach
   Show More Replies: Mehr Antworten zeigen
-  From $channelName: von $channelName
+  From {channelName}: von {channelName}
   And others: und andere
   Pinned by: Angeheftet von
   Member: Mitglied
@@ -796,11 +796,11 @@ Yes: Ja
 No: Nein
 Locale Name: Deutsch
 Profile:
-  $ is now the active profile: $ ist jetzt dein aktives Profil
+  '{profile} is now the active profile': '{profile} ist jetzt dein aktives Profil'
   Your default profile has been changed to your primary profile: Dein Hauptprofil
     wurde als Standardprofil festgelegt
-  Removed $ from your profiles: $ wurde aus deinen Profilen entfernt
-  Your default profile has been set to $: $ wurde als Standardprofil festgelegt
+  Removed {profile} from your profiles: '{profile} wurde aus deinen Profilen entfernt'
+  Your default profile has been set to {profile}: '{profile} wurde als Standardprofil festgelegt'
   Profile has been created: Das Profil wurde erstellt
   Profile has been updated: Das Profil wurde aktualisiert
   Your profile name cannot be empty: Der Profilname darf nicht leer sein
@@ -831,17 +831,17 @@ Profile:
   Delete Selected: Ausgewählte löschen
   Select None: Alles abwählen
   Select All: Alles auswählen
-  $ selected: $ ausgewählt
+  '{number} selected': '{number} ausgewählt'
   Other Channels: Andere Kanäle
   Subscription List: Abonnement-Liste
   Profile Select: Profilauswahl
   Profile Filter: Profilfilter
   Profile Settings: Profileinstellungen
 The playlist has been reversed: Die Wiedergabeliste wurde umgedreht
-A new blog is now available, $. Click to view more: Ein neuer Blogeintrag ist verfügbar,
-  $. Um ihn zu öffnen klicken
+A new blog is now available, {blogTitle}. Click to view more: Ein neuer Blogeintrag ist verfügbar,
+  {blogTitle}. Um ihn zu öffnen klicken
 Download From Site: Von der Website herunterladen
-Version $ is now available!  Click for more details: Version $ ist jetzt verfügbar!  Für
+Version {versionNumber} is now available!  Click for more details: Version {versionNumber} ist jetzt verfügbar!  Für
   mehr Details klicken
 Tooltips:
   General Settings:
@@ -899,7 +899,7 @@ Tooltips:
       ein Symbol angezeigt, mit dem Sie das Video (und die Wiedergabeliste, falls
       unterstützt) im externen Player öffnen können. Achtung, die Einstellungen von
       Invidious wirken sich nicht auf externe Player aus.
-    DefaultCustomArgumentsTemplate: '(Standardwert: „$“)'
+    DefaultCustomArgumentsTemplate: '(Standardwert: „{defaultCustomArguments}“)'
 Playing Next Video Interval: Nächstes Video wird sofort abgespielt. Zum Abbrechen
   klicken. | Nächstes Video wird in {nextVideoInterval} Sekunden abgespielt. Zum Abbrechen
   klicken. | Nächstes Video wird in {nextVideoInterval} Sekunden abgespielt. Zum Abbrechen
@@ -911,34 +911,34 @@ Unknown YouTube url type, cannot be opened in app: Unbekannte YouTube-Adresse, k
   in FreeTube nicht geöffnet werden
 Open New Window: Neues Fenster öffnen
 Default Invidious instance has been cleared: Standard-Invidious-Instanz wurde zurückgesetzt
-Default Invidious instance has been set to $: Standard-Invidious-Instanz wurde auf
-  $ gesetzt
+Default Invidious instance has been set to {instance}: Standard-Invidious-Instanz wurde auf
+  {instance} gesetzt
 Search Bar:
   Clear Input: Eingabe löschen
 Are you sure you want to open this link?: Bist du sicher, dass du diesen Link öffnen
   willst?
 External link opening has been disabled in the general settings: Das Öffnen externer
   Links wurde in den allgemeinen Einstellungen deaktiviert
-Downloading has completed: Das Herunterladen von $ ist abgeschlossen
-Starting download: Das Herunterladen von $ hat begonnen
-Downloading failed: Es gab ein Problem beim Herunterladen von $
-Screenshot Success: Bildschirmfoto gespeichert als „$“
-Screenshot Error: Bildschirmfoto fehlgeschlagen. $
+Downloading has completed: Das Herunterladen von {videoTitle} ist abgeschlossen
+Starting download: Das Herunterladen von {videoTitle} hat begonnen
+Downloading failed: Es gab ein Problem beim Herunterladen von {videoTitle}
+Screenshot Success: Bildschirmfoto gespeichert als „{filePath}“
+Screenshot Error: Bildschirmfoto fehlgeschlagen. {error}
 New Window: Neues Fenster
 Age Restricted:
   Type:
     Video: Video
     Channel: Kanal
-  This $contentType is age restricted: Dieses $ ist altersbeschränkt
+  This {videoOrPlaylist} is age restricted: Dieses {videoOrPlaylist} ist altersbeschränkt
 Channels:
   Channels: Kanäle
   Title: Kanalliste
   Search bar placeholder: Kanäle durchsuchen
-  Count: $ Kanal/Kanäle gefunden.
+  Count: '{number} Kanal/Kanäle gefunden.'
   Empty: Ihre Kanalliste ist derzeit leer.
   Unsubscribe: Abo entfernen
-  Unsubscribed: $ wurde aus deinen Abonnements entfernt
-  Unsubscribe Prompt: Bist du sicher, dass du „$“ aus dem Abos entfernen willst?
+  Unsubscribed: '{channelName} wurde aus deinen Abonnements entfernt'
+  Unsubscribe Prompt: Bist du sicher, dass du „{channelName}“ aus dem Abos entfernen willst?
 Clipboard:
   Copy failed: Kopieren in die Zwischenablage fehlgeschlagen
   Cannot access clipboard without a secure connection: Zugriff auf die Zwischenablage

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -144,8 +144,8 @@ Settings:
       περιπτώσεων
     System Default: Προεπιλογή συστήματος
     Current Invidious Instance: Τρέχων στιγμιότυπο Invidious
-    The currently set default instance is $: Το τρέχων προεπιλεγμένο στιγμιότυπο είναι
-      $
+    The currently set default instance is {instance}: 'Το τρέχων προεπιλεγμένο στιγμιότυπο είναι
+      {instance}'
     No default instance has been set: Δεν έχει οριστεί κανένα προεπιλεγμένο στιγμιότυπο
     External Link Handling:
       External Link Handling: Χειρισμός εξωτερικών συνδέσμων
@@ -301,7 +301,7 @@ Settings:
     Manage Subscriptions: Διαχείριση συνδρομών
     Import Playlists: Εισαγωγή λιστών αναπαραγωγής
     Export Playlists: Εξαγωγή Λιστών Αναπαραγωγής
-    Playlist insufficient data: Ανεπαρκή δεδομένα για τη λίστα αναπαραγωγής "$", γίνεται
+    Playlist insufficient data: Ανεπαρκή δεδομένα για τη λίστα αναπαραγωγής "{playlist}", γίνεται
       παράκαμψη του αντικειμένου
     All playlists has been successfully imported: Όλες οι λίστες αναπαραγωγής έχουν
       εισαχθεί με επιτυχία
@@ -465,15 +465,15 @@ Profile:
     άδειο'
   Profile has been created: 'Το προφίλ σας έχει δημιουργηθεί'
   Profile has been updated: 'Το προφίλ σας έχει ενημερωθεί'
-  Your default profile has been set to $: 'Το $ έχει οριστεί ως το προεπιλεγμένο σας
+  Your default profile has been set to {profile}: 'Το {profile} έχει οριστεί ως το προεπιλεγμένο σας
     προφίλ'
-  Removed $ from your profiles: 'Το $ έχει αφαιρεθεί από τα προφίλ σας'
+  Removed {profile} from your profiles: 'Το {profile} έχει αφαιρεθεί από τα προφίλ σας'
   Your default profile has been changed to your primary profile: 'Το κύριο προφίλ
     σας έχει οριστεί ως το προεπιλεγμένο'
-  $ is now the active profile: 'Το $ είναι τώρα το ενεργό προφίλ'
+  '{profile} is now the active profile': 'Το {profile} είναι τώρα το ενεργό προφίλ'
   Subscription List: 'Λίστα Συνδρομών/Εγγραφών'
   Other Channels: 'Άλλα κανάλια'
-  $ selected: '$ επιλεγμένο'
+  '{number} selected': '{number} επιλεγμένο'
   Select All: 'Επιλογή όλων'
   Select None: 'Επιλογή κανενός'
   Delete Selected: 'Διαγραφή επιλεγμένου στοιχείου'
@@ -496,7 +496,7 @@ Channel:
   Unsubscribe: 'Απεγγραφή'
   Channel has been removed from your subscriptions: 'Το κανάλι έχει καταργηθεί από
     τις Συνδρομές/Εγγραφές σας'
-  Removed subscription from $ other channel(s): 'Αφαιρέθηκε η συνδρομή από $ άλλα
+  Removed subscription from {count} other channel(s): 'Αφαιρέθηκε η συνδρομή από {count} άλλα
     κανάλια'
   Added channel to your subscriptions: 'Προστέθηκε κανάλι στις συνδρομές/εγγραφές
     σας'
@@ -592,8 +592,7 @@ Video:
     Ago: 'Πριν'
     Upcoming: 'Κάνει πρεμιέρα στις'
   Published on: 'Δημοσιεύθηκε στις'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'δημοσιεύθηκε πριν από $ %'
+  Publicationtemplate: 'δημοσιεύθηκε πριν από {number} {unit}'
 #& Videos
   Audio:
     Best: Καλύτερο
@@ -625,7 +624,7 @@ Video:
     music offtopic: μουσική εκτός θέματος
   External Player:
     video: βίντεο
-    OpenInTemplate: Άνοιγμα σε $
+    OpenInTemplate: Άνοιγμα σε {externalPlayer}
     Unsupported Actions:
       looping playlists: επανάληψη των λιστών αναπαραγωγής
       starting video at offset: εκκίνηση βίντεο στη μετατόπιση
@@ -637,8 +636,8 @@ Video:
         βίντεο)
       reversing playlists: αντιστροφή λιστών αναπαραγωγής
     playlist: λίστα αναπαραγωγής
-    OpeningTemplate: Άνοιγμα $ σε %...
-    UnsupportedActionTemplate: 'Το $ δεν υποστηρίζει: %'
+    OpeningTemplate: Άνοιγμα {videoOrPlaylist} σε {externalPlayer}...
+    UnsupportedActionTemplate: 'Το {externalPlayer} δεν υποστηρίζει: {action}'
   Premieres on: Πρεμιέρες στις
   Stats:
     video id: Αναγνωριστικό του βίντεο (YouTube)
@@ -735,7 +734,7 @@ Comments:
   There are no more comments for this video: Δεν υπάρχουν άλλα σχόλια για αυτό το
     βίντεο
   And others: και άλλοι
-  From $channelName: από $channelName
+  From {channelName}: από {channelName}
   Show More Replies: Εμφάνιση περισσότερων απαντήσεων
   Pinned by: Καρφώθηκε από
 Up Next: 'Επόμενο'
@@ -764,10 +763,10 @@ Canceled next video autoplay: 'Η αναπαραγωγή του επόμενου
 
 Yes: 'Ναι'
 No: 'Όχι'
-A new blog is now available, $. Click to view more: Ένα καινούριο ιστολόγιο είναι
-  πλέον διαθέσιμο, $. Για περισσότερες λεπτομέρειες κάντε κλικ εδώ
+A new blog is now available, {blogTitle}. Click to view more: Ένα καινούριο ιστολόγιο είναι
+  πλέον διαθέσιμο, {blogTitle}. Για περισσότερες λεπτομέρειες κάντε κλικ εδώ
 Download From Site: Κάντε λήψη απο την Ιστοσελίδα
-Version $ is now available!  Click for more details: Η έκδοση $ είναι πλέον διαθέσιμη.
+Version {versionNumber} is now available!  Click for more details: Η έκδοση {versionNumber} είναι πλέον διαθέσιμη.
   Κάντε κλικ για περισσότερες λεπτομέρειες
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Αυτό
   το βίντεο δεν είναι διαθέσιμο λόγω έλλειψης μορφών. Αυτό μπορεί να συμβαίνει λόγω
@@ -830,7 +829,7 @@ Tooltips:
     External Player: Η επιλογή ενός εξωτερικού προγράμματος αναπαραγωγής θα εμφανίσει
       ένα εικονίδιο, για το άνοιγμα του βίντεο (λίστα αναπαραγωγής, εάν υποστηρίζεται)
       στο εξωτερικό πρόγραμμα αναπαραγωγής, στη μικρογραφία.
-    DefaultCustomArgumentsTemplate: "(Προεπιλογή: '$')"
+    DefaultCustomArgumentsTemplate: "(Προεπιλογή: '{defaultCustomArguments}')"
     Custom External Player Arguments: Τυχόν προσαρμοσμένα ορίσματα γραμμής εντολών,
       διαχωρισμένα με ερωτηματικά (';'), που θέλετε να μεταβιβαστούν στο εξωτερικό
       πρόγραμμα αναπαραγωγής.
@@ -846,14 +845,14 @@ Unknown YouTube url type, cannot be opened in app: Άγνωστος τύπος �
 Search Bar:
   Clear Input: Εκκαθάριση εισαγωγής
 Open New Window: Άνοιγμα Νέου παραθύρου
-Default Invidious instance has been set to $: Το προεπιλεγμένο στιγμιότυπο Invidious
-  έχει οριστεί σε $
-Downloading has completed: Η λήψη του "$" ολοκληρώθηκε
-Starting download: Έναρξη λήψης του "$"
+Default Invidious instance has been set to {instance}: Το προεπιλεγμένο στιγμιότυπο Invidious
+  έχει οριστεί σε {instance}
+Downloading has completed: Η λήψη του "{videoTitle}" ολοκληρώθηκε
+Starting download: Έναρξη λήψης του "{videoTitle}"
 Default Invidious instance has been cleared: Το προεπιλεγμένο στιγμιότυπο Invidious
   έχει διαγραφεί
 External link opening has been disabled in the general settings: Το άνοιγμα εξωτερικών
   συνδέσμων έχει απενεργοποιηθεί στις γενικές ρυθμίσεις
 Are you sure you want to open this link?: Είστε σίγουροι ότι θέλετε να ανοίξετε αυτόν
   τον σύνδεσμο;
-Downloading failed: Παρουσιάστηκε ένα πρόβλημα κατά τη λήψη του "$"
+Downloading failed: Παρουσιάστηκε ένα πρόβλημα κατά τη λήψη του "{videoTitle}"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -31,10 +31,10 @@ Back: Back
 Forward: Forward
 Open New Window: Open New Window
 
-Version $ is now available!  Click for more details: Version $ is now available!  Click
+Version {versionNumber} is now available!  Click for more details: Version {versionNumber} is now available!  Click
   for more details
 Download From Site: Download From Site
-A new blog is now available, $. Click to view more: A new blog is now available, $.
+A new blog is now available, {blogTitle}. Click to view more: A new blog is now available, {blogTitle}.
   Click to view more
 Are you sure you want to open this link?: Are you sure you want to open this link?
 
@@ -95,11 +95,11 @@ Channels:
   Channels: Channels
   Title: Channel List
   Search bar placeholder: Search Channels
-  Count: $ channel(s) found.
+  Count: '{number} channel(s) found.'
   Empty: Your channel list is currently empty.
   Unsubscribe: Unsubscribe
-  Unsubscribed: $ has been removed from your subscriptions
-  Unsubscribe Prompt: Are you sure you want to unsubscribe from "$"?
+  Unsubscribed: '{channelName} has been removed from your subscriptions'
+  Unsubscribe Prompt: Are you sure you want to unsubscribe from "{channelName}"?
 Trending:
   Trending: Trending
   Default: Default
@@ -155,8 +155,7 @@ Settings:
       Middle: Middle
       End: End
     Current Invidious Instance: Current Invidious Instance
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: The currently set default instance is $
+    The currently set default instance is {instance}: The currently set default instance is {instance}
     No default instance has been set: No default instance has been set
     Current instance will be randomized on startup: Current instance will be randomized on startup
     Set Current Instance as Default: Set Current Instance as Default
@@ -359,7 +358,7 @@ Settings:
       successfully imported
     All watched history has been successfully exported: All watched history has been
       successfully exported
-    Playlist insufficient data: Insufficient data for "$" playlist, skipping item
+    Playlist insufficient data: Insufficient data for "{playlist}" playlist, skipping item
     All playlists has been successfully imported: All playlists has been
       successfully imported
     All playlists has been successfully exported: All playlists has been
@@ -457,14 +456,14 @@ Profile:
   Your profile name cannot be empty: Your profile name cannot be empty
   Profile has been created: Profile has been created
   Profile has been updated: Profile has been updated
-  Your default profile has been set to $: Your default profile has been set to $
-  Removed $ from your profiles: Removed $ from your profiles
+  Your default profile has been set to {profile}: Your default profile has been set to {profile}
+  Removed {profile} from your profiles: Removed {profile} from your profiles
   Your default profile has been changed to your primary profile: Your default profile
     has been changed to your primary profile
-  $ is now the active profile: $ is now the active profile
+  '{profile} is now the active profile': '{profile} is now the active profile'
   Subscription List: Subscription List
   Other Channels: Other Channels
-  $ selected: $ selected
+  '{number} selected': '{number} selected'
   Select All: Select All
   Select None: Select None
   Delete Selected: Delete Selected
@@ -485,8 +484,7 @@ Channel:
   Unsubscribe: Unsubscribe
   Channel has been removed from your subscriptions: Channel has been removed from
     your subscriptions
-  Removed subscription from $ other channel(s): Removed subscription from $ other
-    channel(s)
+  Removed subscription from {count} other channel(s): Removed subscription from {count} other channel(s)
   Added channel to your subscriptions: Added channel to your subscriptions
   Search Channel: Search Channel
   Your search results have returned 0 results: Your search results have returned 0
@@ -601,8 +599,7 @@ Video:
   Streamed on: Streamed on
   Started streaming on: Started streaming on
   translated from English: translated from English
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: $ % ago
+  Publicationtemplate: '{number} {unit} ago'
   Skipped segment: Skipped segment
   Sponsor Block category:
     sponsor: Sponsor
@@ -614,14 +611,11 @@ Video:
     recap: Recap
     filler: Filler
   External Player:
-    # $ is replaced with the external player
-    OpenInTemplate: Open in $
+    OpenInTemplate: Open in {externalPlayer}
     video: video
     playlist: playlist
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
-    OpeningTemplate: Opening $ in %...
-    # $ is replaced with the external player and % with the unsupported action
-    UnsupportedActionTemplate: '$ does not support: %'
+    OpeningTemplate: Opening {videoOrPlaylist} in {externalPlayer}...
+    UnsupportedActionTemplate: '{externalPlayer} does not support: {action}'
     Unsupported Actions:
       starting video at offset: starting video at offset
       setting a playback rate: setting a playback rate
@@ -717,7 +711,7 @@ Comments:
   Replies: Replies
   Show More Replies: Show More Replies
   Reply: Reply
-  From $channelName: from $channelName
+  From {channelName}: from {channelName}
   And others: and others
   There are no comments available for this video: There are no comments available
     for this video
@@ -770,8 +764,7 @@ Tooltips:
       the current action (e.g. reversing playlists, etc.).
     Custom External Player Arguments: Any custom command line arguments, separated by semicolons (';'),
       you want to be passed to the external player.
-    # $ is replaced with the default custom arguments for the current player, if defined.
-    DefaultCustomArgumentsTemplate: '(Default: ''$'')'
+    DefaultCustomArgumentsTemplate: "(Default: '{defaultCustomArguments}')"
   Subscription Settings:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
@@ -802,23 +795,22 @@ Playing Next Video: Playing Next Video
 Playing Previous Video: Playing Previous Video
 Playing Next Video Interval: Playing next video in no time. Click to cancel. | Playing next video in {nextVideoInterval} second. Click to cancel. | Playing next video in {nextVideoInterval} seconds. Click to cancel.
 Canceled next video autoplay: Canceled next video autoplay
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: Default Invidious instance has been set to $
+
+Default Invidious instance has been set to {instance}: Default Invidious instance has been set to {instance}
 Default Invidious instance has been cleared: Default Invidious instance has been cleared
 'The playlist has ended.  Enable loop to continue playing': 'The playlist has ended.  Enable
   loop to continue playing'
 Age Restricted:
-  # $contentType is replaced with video or channel
-  This $contentType is age restricted: This $ is age restricted
+  This {videoOrPlaylist} is age restricted: This {videoOrPlaylist} is age restricted
   Type:
     Channel: Channel
     Video: Video
 External link opening has been disabled in the general settings: 'External link opening has been disabled in the general settings'
-Downloading has completed: '"$" has finished downloading'
-Starting download: 'Starting download of "$"'
-Downloading failed: 'There was an issue downloading "$"'
-Screenshot Success: Saved screenshot as "$"
-Screenshot Error: Screenshot failed. $
+Downloading has completed: '"{videoTitle}" has finished downloading'
+Starting download: 'Starting download of "{videoTitle}"'
+Downloading failed: 'There was an issue downloading "{videoTitle}"'
+Screenshot Success: Saved screenshot as "{filePath}"
+Screenshot Error: Screenshot failed. {error}
 
 Yes: Yes
 No: No

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -29,11 +29,11 @@ Close: 'Close'
 Back: 'Back'
 Forward: 'Forward'
 
-Version $ is now available!  Click for more details: 'Version $ is now available!  Click
+Version {versionNumber} is now available!  Click for more details: 'Version {versionNumber} is now available!  Click
   for more details'
 Download From Site: 'Download From Site'
-A new blog is now available, $. Click to view more: 'A new blog is now available,
-  $. Click to view more'
+A new blog is now available, {blogTitle}. Click to view more: 'A new blog is now available,
+  {blogTitle}. Click to view more'
 
 # Search Bar
 Search / Go to URL: 'Search / Go to URL'
@@ -148,8 +148,7 @@ Settings:
     Current instance will be randomized on startup: Current instance will be randomised
       on startup
     No default instance has been set: No default instance has been set
-    The currently set default instance is $: The currently set default instance is
-      $
+    The currently set default instance is {instance}: The currently set default instance is {instance}
     Current Invidious Instance: Current Invidious Instance
     External Link Handling:
       No Action: No Action
@@ -335,7 +334,7 @@ Settings:
     Manage Subscriptions: Manage Subscriptions
     Import Playlists: Import playlists
     Export Playlists: Export playlists
-    Playlist insufficient data: Insufficient data for ‘$’ playlist, skipping item
+    Playlist insufficient data: Insufficient data for ‘{playlist}’ playlist, skipping item
     All playlists has been successfully imported: All playlists has been successfully
       imported
     All playlists has been successfully exported: All playlists has been successfully
@@ -485,14 +484,14 @@ Profile:
   Your profile name cannot be empty: 'Your profile name cannot be empty'
   Profile has been created: 'Profile has been created'
   Profile has been updated: 'Profile has been updated'
-  Your default profile has been set to $: 'Your default profile has been set to $'
-  Removed $ from your profiles: 'Removed $ from your profiles'
+  Your default profile has been set to {profile}: 'Your default profile has been set to {profile}'
+  Removed {profile} from your profiles: 'Removed {profile} from your profiles'
   Your default profile has been changed to your primary profile: 'Your default profile
     has been changed to your primary profile'
-  $ is now the active profile: '$ is now the active profile'
+  '{profile} is now the active profile': '{profile} is now the active profile'
   Subscription List: 'Subscription List'
   Other Channels: 'Other Channels'
-  $ selected: '$ selected'
+  '{count} selected': '{count} selected'
   Select All: 'Select All'
   Select None: 'Select None'
   Delete Selected: 'Delete Selected'
@@ -514,8 +513,7 @@ Channel:
   Unsubscribe: 'Unsubscribe'
   Channel has been removed from your subscriptions: 'Channel has been removed from
     your subscriptions'
-  Removed subscription from $ other channel(s): 'Removed subscription from $ other
-    channel(s)'
+  Removed subscription from {count} other channel(s): 'Removed subscription from {count} other channel(s)'
   Added channel to your subscriptions: 'Added channel to your subscriptions'
   Search Channel: 'Search Channel'
   Your search results have returned 0 results: 'Your search results have returned
@@ -610,8 +608,7 @@ Video:
     Upcoming: 'Premieres on'
     Less than a minute: Less than a minute
   Published on: 'Published on'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % ago'
+  Publicationtemplate: '{number} {unit} ago'
 #& Videos
   Started streaming on: Started streaming on
   Streamed on: Streamed on
@@ -643,14 +640,11 @@ Video:
     filler: Filler
   Skipped segment: Skipped segment
   External Player:
-    # $ is replaced with the external player
-    OpenInTemplate: Open in $
+    OpenInTemplate: Open in {externalPlayer}
     video: video
     playlist: playlist
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
-    OpeningTemplate: Opening $ in %...
-    # $ is replaced with the external player and % with the unsupported action
-    UnsupportedActionTemplate: '$ does not support: %'
+    OpeningTemplate: Opening {videoOrPlaylist} in {externalPlayer}...
+    UnsupportedActionTemplate: '{externalPlayer} does not support: {action}'
     Unsupported Actions:
       starting video at offset: starting video at offset
       setting a playback rate: setting a playback rate
@@ -754,7 +748,7 @@ Comments:
   Sort by: Sort by
   Show More Replies: Show more replies
   Pinned by: Pinned by
-  From $channelName: from $channelName
+  From {channelName}: from {channelName}
   And others: and others
   Member: Member
 Up Next: 'Up Next'
@@ -831,8 +825,7 @@ Tooltips:
       support the current action (e.g. reversing playlists, etc.).
     Custom External Player Arguments: Any custom command line arguments, separated
       by semicolons (';'), you want to be passed to the external player.
-    # $ is replaced with the default custom arguments for the current player, if defined.
-    DefaultCustomArgumentsTemplate: '(Default: ‘$’)'
+    DefaultCustomArgumentsTemplate: '(Default: ‘{defaultCustomArguments}’)'
   Privacy Settings:
     Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files
       created during video playback, when the watch page is closed.
@@ -846,30 +839,29 @@ Unknown YouTube url type, cannot be opened in app: Unknown YouTube url type, can
   be opened in app
 Open New Window: Open New Window
 Default Invidious instance has been cleared: Default Invidious instance has been cleared
-Default Invidious instance has been set to $: Default Invidious instance has been
-  set to $
+Default Invidious instance has been set to {instance}: Default Invidious instance has been set to {instance}
 Search Bar:
   Clear Input: Clear input
 External link opening has been disabled in the general settings: External link opening
   has been disabled in the general settings
 Are you sure you want to open this link?: Are you sure you want to open this link?
-Downloading has completed: '‘$’ has finished downloading'
-Starting download: Starting download of ‘$’
-Downloading failed: There was an issue downloading ‘$’
-Screenshot Error: Screenshot failed. $
-Screenshot Success: Saved screenshot as ‘$’
+Downloading has completed: '‘{videoTitle}’ has finished downloading'
+Starting download: Starting download of ‘{videoTitle}’
+Downloading failed: There was an issue downloading ‘{videoTitle}’
+Screenshot Error: Screenshot failed. {error}
+Screenshot Success: Saved screenshot as ‘{filePath}’
 New Window: New window
 Channels:
   Empty: Your channel list is currently empty.
   Unsubscribe: Unsubscribe
-  Unsubscribed: $ has been removed from your subscriptions
-  Unsubscribe Prompt: Are you sure you want to unsubscribe from ‘$’?
+  Unsubscribed: '{channelName} has been removed from your subscriptions'
+  Unsubscribe Prompt: Are you sure you want to unsubscribe from ‘{channelName}’?
   Title: Channel list
   Search bar placeholder: Search channels
   Channels: Channels
-  Count: $ channel(s) found.
+  Count: '{number} channel(s) found.'
 Age Restricted:
-  This $contentType is age restricted: This $ is age restricted
+  This {videoOrPlaylist} is age restricted: This {videoOrPlaylist} is age restricted
   Type:
     Video: Video
     Channel: Channel

--- a/static/locales/eo.yaml
+++ b/static/locales/eo.yaml
@@ -28,10 +28,10 @@ Close: 'Fermi'
 Back: 'Reen'
 Forward: 'Antaŭen'
 
-Version $ is now available!  Click for more details: 'Versio $ disponeblas nun!  Alklaki
+Version {versionNumber} is now available!  Click for more details: 'Versio {versionNumber} disponeblas nun!  Alklaki
   por pli informoj.'
 Download From Site: 'Elŝuti el retejo'
-A new blog is now available, $. Click to view more: ''
+A new blog is now available, {blogTitle}. Click to view more: ''
 
 # Search Bar
 Search / Go to URL: 'Serĉi / Iri al URL'
@@ -288,13 +288,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -311,7 +311,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -395,7 +395,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -137,8 +137,8 @@ Settings:
       al iniciar la app
     System Default: Por defecto
     Current Invidious Instance: 'Dirección de Invidious actual:'
-    The currently set default instance is $: La dirección por defecto actualmente
-      establecida es $
+    The currently set default instance is {instance}: La dirección por defecto actualmente
+      establecida es {instance}
     No default instance has been set: No se ha establecido ninguna dirección por defecto
     Set Current Instance as Default: Establecer la dirección actual por defecto
     Clear Default Instance: Borrar dirección por defecto
@@ -328,7 +328,7 @@ Settings:
       han sido exportadas con éxito
     All playlists has been successfully imported: Todas sus listas han sido importadas
       con éxito
-    Playlist insufficient data: Datos insuficientes de la lista "$", omitiendo
+    Playlist insufficient data: Datos insuficientes de la lista "{playlist}", omitiendo
     Manage Subscriptions: Administrar suscripciones
   The app needs to restart for changes to take effect. Restart and apply change?: El
     programa requiere reiniciarse para que los cambios hagan efecto. ¿Desea reiniciar
@@ -464,7 +464,7 @@ Channel:
     Channel Description: 'Descripción del canal'
     Featured Channels: 'Canales destacados'
   Added channel to your subscriptions: Canal añadido a sus suscripciones
-  Removed subscription from $ other channel(s): Suscripción eliminada de $ otros canales
+  Removed subscription from {count} other channel(s): Suscripción eliminada de {count} otros canales
   Channel has been removed from your subscriptions: El canal ha sido eliminado de
     sus suscripciones
 Video:
@@ -528,8 +528,7 @@ Video:
     Minutes: minutos
     Minute: minuto
   Published on: 'Publicado en'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Hace $ %'
+  Publicationtemplate: 'Hace {number} {unit}'
 #& Videos
   Autoplay: Reproducción Automática
   Play Previous Video: Reproducir el video anterior
@@ -570,9 +569,9 @@ Video:
         el video específico en una lista (reponiéndolo para abrir el video)
       looping playlists: listas de reproducción en bucle
       shuffling playlists: listas de reproducción mezcladas
-    OpeningTemplate: Abriendo $ en %...
-    UnsupportedActionTemplate: '$ no soporta: %'
-    OpenInTemplate: Abrir en $
+    OpeningTemplate: Abriendo {videoOrPlaylist} en {externalPlayer}...
+    UnsupportedActionTemplate: '{externalPlayer} no soporta: {action}'
+    OpenInTemplate: Abrir en {externalPlayer}
     video: video
     playlist: lista de reproducción
   Sponsor Block category:
@@ -664,7 +663,7 @@ Comments:
   Top comments: Más populares
   Member: Miembro
   Pinned by: Fijado por
-  From $channelName: de $channelName
+  From {channelName}: de {channelName}
   And others: y otros
   There are no more comments for this video: No hay más comentarios en este video
   Newest first: Más recientes
@@ -696,12 +695,12 @@ Yes: 'Sí'
 No: 'No'
 Locale Name: español (MX)
 Profile:
-  $ is now the active profile: $ ahora es el perfil activo
+  '{profile} is now the active profile': '{profile} ahora es el perfil activo'
   Your default profile has been changed to your primary profile: Su perfil predeterminado
     se ha cambiado a su perfil principal
-  Removed $ from your profiles: Se eliminó $ de sus perfiles
-  Your default profile has been set to $: Su perfil predeterminado ha sido establecido
-    a $
+  Removed {profile} from your profiles: Se eliminó {profile} de sus perfiles
+  Your default profile has been set to {profile}: Su perfil predeterminado ha sido establecido
+    a {profile}
   Profile has been updated: El perfil ha sido actualizado
   Profile has been created: El profil ha sido creado
   Your profile name cannot be empty: Su nombre de perfil no puede estar vacío
@@ -734,16 +733,16 @@ Profile:
   Add Selected To Profile: Añadir Seleccionado al Perfil
   Delete Selected: Borrar Seleccionado
   Select All: Seleccionar Todo
-  $ selected: $ seleccionado
+  '{number} selected': '{number} seleccionado'
   Other Channels: Otros Canales
   Subscription List: Lista de Suscripciones
   Profile Filter: Filtro de Perfil
   Profile Settings: Configuración de perfil
 The playlist has been reversed: La lista de reproducción ha sido invertida
-A new blog is now available, $. Click to view more: Un nuevo blog ya está disponible,
-  $. Presione para ver más
+A new blog is now available, {blogTitle}. Click to view more: Un nuevo blog ya está disponible,
+  {blogTitle}. Presione para ver más
 Download From Site: Descargar desde el sitio
-Version $ is now available!  Click for more details: Versión $ ya está disponible!
+Version {versionNumber} is now available!  Click for more details: Versión {versionNumber} ya está disponible!
   Presione para más detalles
 Open New Window: Abrir nueva ventana
 More: Más
@@ -771,7 +770,7 @@ Tooltips:
   External Player Settings:
     Custom External Player Arguments: Cualquier argumento, con separaciones de punto
       y coma (';'), que deseé anticipar al reproductor externo.
-    DefaultCustomArgumentsTemplate: "(Por defecto: '$')"
+    DefaultCustomArgumentsTemplate: "(Por defecto: '{defaultCustomArguments}')"
     External Player: Elegir un reproductor externo mostrará un ícono, para abrir el
       video (o lista, si es compatible) en el reproductor externo, sobre la miniatura
       del video.
@@ -807,18 +806,18 @@ Tooltips:
       para recibir videos de sus suscripciones. RSS es más rápido y previene que bloqueen
       su IP, pero no es capaz de proveer ciertos datos del video, como su duración,
       o si está en directo
-Downloading has completed: '"$" ha acabado de descargarse'
+Downloading has completed: '"{videoTitle}" ha acabado de descargarse'
 Default Invidious instance has been cleared: La dirección de Invidious predeterminada
   se ha borrado
 External link opening has been disabled in the general settings: La apertura de links
   externos está deshabilitada en la configuración general
-Starting download: Comenzando descarga de "$"
-Downloading failed: Ha habido un error al descargar "$"
+Starting download: Comenzando descarga de "{videoTitle}"
+Downloading failed: Ha habido un error al descargar "{videoTitle}"
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Este
   video no está disponible debido a que no se encontraron formatos. Esto puede suceder
   a causa de indisponibilidad en su región.
-Default Invidious instance has been set to $: La dirección de Invidious predeterminada
-  se ha establecido en $
+Default Invidious instance has been set to {instance}: La dirección de Invidious predeterminada
+  se ha establecido en {instance}
 Unknown YouTube url type, cannot be opened in app: Tipo de URL de YouTube desconocida,
   imposible de abrir en la app
 Hashtags have not yet been implemented, try again later: Las etiquetas aún no han

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -144,8 +144,8 @@ Settings:
     Current instance will be randomized on startup: La instancia actual será elegida
       aleatoriamente al inicio
     No default instance has been set: No se ha especificado una instancia predeterminada
-    The currently set default instance is $: La instancia predeterminada actual es
-      $
+    The currently set default instance is {instance}: La instancia predeterminada actual es
+      {instance}
     Current Invidious Instance: Instancia actual de Invidious
     Clear Default Instance: Quitar la instancia por defecto
     Set Current Instance as Default: Establecer la instancia actual como la instancia
@@ -331,7 +331,7 @@ Settings:
     Import Playlists: Importar listas de reproducción
     Export Playlists: Exportar listas de reproducción
     Playlist insufficient data: Datos insuficientes para la lista de reproducción
-      «$», omitiendo el elemento
+      «{playlist}», omitiendo el elemento
     All playlists has been successfully imported: Todas las listas de reproducción
       se han importado con éxito
     All playlists has been successfully exported: Todas las listas de reproducción
@@ -511,12 +511,12 @@ Profile:
   Your profile name cannot be empty: 'Tu nombre de perfil no puede estar vacío'
   Profile has been created: 'Se ha creado el perfil'
   Profile has been updated: 'El perfil se ha actualizado'
-  Your default profile has been set to $: 'Tu perfil predeterminado se ha establecido
-    como $'
-  Removed $ from your profiles: 'Eliminado $ de tus perfiles'
+  Your default profile has been set to {profile}: 'Tu perfil predeterminado se ha establecido
+    como {profile}'
+  Removed {profile} from your profiles: 'Eliminado {profile} de tus perfiles'
   Your default profile has been changed to your primary profile: 'Tu perfil predeterminado
     ha sido cambiado a tu perfil principal'
-  $ is now the active profile: '$ es ahora el perfil activo'
+  '{profile} is now the active profile': '{profile} es ahora el perfil activo'
 #On Channel Page
   Are you sure you want to delete the selected channels?  This will not delete the channel from any other profile.: ¿Está
     seguro de que desea eliminar los canales seleccionados? Esto no eliminará el canal
@@ -530,7 +530,7 @@ Profile:
   Delete Selected: Eliminar seleccionados
   Select None: No seleccionar nada
   Select All: Seleccionar todo
-  $ selected: $ seleccionados
+  '{number} selected': '{number} seleccionados'
   Other Channels: Otros canales
   Subscription List: Lista de suscripciones
   Profile Select: Seleccionar perfil
@@ -565,7 +565,7 @@ Channel:
     Channel Description: 'Descripción del canal'
     Featured Channels: 'Canales destacados'
   Added channel to your subscriptions: Canal añadido a tus suscripciones
-  Removed subscription from $ other channel(s): Suscripción eliminada de $ otros canales
+  Removed subscription from {count} other channel(s): Suscripción eliminada de {count} otros canales
   Channel has been removed from your subscriptions: El canal ha sido eliminado de
     tus suscripciones
 Video:
@@ -632,8 +632,7 @@ Video:
     Less than a minute: Menos de un minuto
     In less than a minute: En menos de un minuto
   Published on: 'Publicado el'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Hace $ %'
+  Publicationtemplate: 'Hace {number} {unit}'
 #& Videos
   Play Previous Video: Reproducir el vídeo anterior
   Play Next Video: Reproducir vídeo siguiente
@@ -674,7 +673,7 @@ Video:
   External Player:
     playlist: lista de reproducción
     video: vídeo
-    OpenInTemplate: Abrir en $
+    OpenInTemplate: Abrir en {externalPlayer}
     Unsupported Actions:
       looping playlists: reproducir en bucle las listas de reproducción
       shuffling playlists: aleatorizar las listas de reproducción
@@ -684,8 +683,8 @@ Video:
       opening playlists: abrir listas de reproducción
       setting a playback rate: establecer una velocidad de reproducción
       starting video at offset: iniciar el vídeo en un punto dado
-    UnsupportedActionTemplate: '$ no soporta: %'
-    OpeningTemplate: Abriendo $ en %...
+    UnsupportedActionTemplate: '{externalPlayer} no soporta: {action}'
+    OpeningTemplate: Abriendo {videoOrPlaylist} en {externalPlayer}...
   Premieres on: Se estrena el
   Stats:
     bandwidth: Velocidad de conexión
@@ -782,7 +781,7 @@ Comments:
   Sort by: Ordenar por
   No more comments available: No hay más comentarios
   Show More Replies: Mostrar más respuestas
-  From $channelName: de $channelName
+  From {channelName}: de {channelName}
   And others: y otros
   Pinned by: Fijado por
   Member: Miembro
@@ -809,10 +808,10 @@ Canceled next video autoplay: 'La reproducción del vídeo siguiente se ha cance
 
 Yes: 'Sí'
 No: 'No'
-A new blog is now available, $. Click to view more: Nueva publicación del blog disponible,
-  $. Haga clic para saber más
+A new blog is now available, {blogTitle}. Click to view more: 'Nueva publicación del blog disponible,
+  {blogTitle}. Haga clic para saber más'
 Download From Site: Descargar desde el sitio web
-Version $ is now available!  Click for more details: ¡La versión $ está disponible!
+Version {versionNumber} is now available!  Click for more details: ¡La versión {versionNumber} está disponible!
   Haz clic para saber más
 The playlist has been reversed: Orden de lista de reproducción invertido
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Este
@@ -875,7 +874,7 @@ Tooltips:
       abrir el vídeo (lista de reproducción si es compatible) en el reproductor externo,
       en la miniatura. Atención, los ajustes de Invidious no afectan a los reproductores
       externos.
-    DefaultCustomArgumentsTemplate: '(Predeterminado: «$»)'
+    DefaultCustomArgumentsTemplate: '(Predeterminado: «{defaultCustomArguments}»)'
 More: Más
 Unknown YouTube url type, cannot be opened in app: Tipo de URL desconocido. No se
   puede abrir en la aplicación
@@ -888,34 +887,34 @@ Playing Next Video Interval: Reproduciendo el vídeo a continuación. Haz clic p
   Haz clic para cancelar.
 Default Invidious instance has been cleared: La instancia de Invidious predeterminada
   ha sido borrada
-Default Invidious instance has been set to $: La instancia de Invidious predeterminada
-  ha sido establecida como $
+Default Invidious instance has been set to {instance}: La instancia de Invidious predeterminada
+  ha sido establecida como {instance}
 Search Bar:
   Clear Input: Borrar entrada
 External link opening has been disabled in the general settings: Se ha desactivado
   la apertura de enlaces externos en la configuración general
 Are you sure you want to open this link?: ¿Estás seguro/a de que quieres abrir este
   enlace?
-Starting download: Inicio de la descarga de «$»
-Downloading has completed: '«$» ha terminado de descargarse'
-Downloading failed: Hubo un problema al descargar «$»
-Screenshot Success: Captura de pantalla guardada como «$»
-Screenshot Error: Captura de pantalla fallida. $
+Starting download: Inicio de la descarga de «{videoTitle}»
+Downloading has completed: '«{videoTitle}» ha terminado de descargarse'
+Downloading failed: Hubo un problema al descargar «{videoTitle}»
+Screenshot Success: Captura de pantalla guardada como «{filePath}»
+Screenshot Error: Captura de pantalla fallida. {error}
 New Window: Nueva ventana
 Channels:
   Channels: Canales
   Title: Lista de canales
   Search bar placeholder: Buscar canales
-  Count: $ canal(es) encontrado(s).
+  Count: '{number} canal(es) encontrado(s).'
   Empty: Tu lista de canales está actualmente vacía.
   Unsubscribe: Cancelar la suscripción
-  Unsubscribed: $ ha sido eliminado de tus suscripciones
-  Unsubscribe Prompt: ¿Esta seguro de querer desuscribirse de "$"?
+  Unsubscribed: '{channelName} ha sido eliminado de tus suscripciones'
+  Unsubscribe Prompt: ¿Esta seguro de querer desuscribirse de "{channelName}"?
 Age Restricted:
   Type:
     Channel: Canal
     Video: Vídeo
-  This $contentType is age restricted: Este $ tiene restricción de edad
+  This {videoOrPlaylist} is age restricted: Este {videoOrPlaylist} tiene restricción de edad
 Clipboard:
   Copy failed: Error al copiar al portapapeles
   Cannot access clipboard without a secure connection: No se puede acceder al portapapeles

--- a/static/locales/es_AR.yaml
+++ b/static/locales/es_AR.yaml
@@ -138,7 +138,7 @@ Settings:
     Set Current Instance as Default: Definir Instancia Actual como Por Defecto
     Clear Default Instance: Limpiar Instancia Por Defecto
     Current Invidious Instance: Instancia Actual de Individuous
-    The currently set default instance is $: La instancia actual es $
+    The currently set default instance is {instance}: La instancia actual es {instance}
     No default instance has been set: No se ha elegido ninguna instancia
     Current instance will be randomized on startup: La instancia actual será aleatorizada
       en el inicio
@@ -350,10 +350,10 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
 #On Channel Page
 Channel:
   Subscriber: ''
@@ -437,7 +437,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
   translated from English: traducido del inglés
@@ -518,10 +517,10 @@ Canceled next video autoplay: ''
 
 Yes: 'Sí'
 No: 'No'
-A new blog is now available, $. Click to view more: Un nuevo blog está disponible,
-  $. Hacé clic para ver más
+A new blog is now available, {blogTitle}. Click to view more: 'Un nuevo blog está disponible,
+  {blogTitle}. Hacé clic para ver más'
 Download From Site: Descargar desde el sitio
-Version $ is now available!  Click for more details: La versión $ ya está disponible.  Hacé
+Version {versionNumber} is now available!  Click for more details: La versión {versionNumber} ya está disponible.  Hacé
   clic acá para más detalles.
 More: Más
 Are you sure you want to open this link?: ¿Está seguro que desea abrir este enlace?

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -29,11 +29,11 @@ Close: 'Sulge'
 Back: 'Tagasi'
 Forward: 'Edasi'
 
-Version $ is now available!  Click for more details: 'Versioon $ in nüüd saadaval!
+Version {versionNumber} is now available!  Click for more details: 'Versioon {versionNumber} in nüüd saadaval!
   Lisateavet leiad siit'
 Download From Site: 'Laadi veebisaidist alla'
-A new blog is now available, $. Click to view more: 'Uus blogiartikkel on saadaval.
-  Loe siit $'
+A new blog is now available, {blogTitle}. Click to view more: 'Uus blogiartikkel on saadaval.
+  Loe siit {blogTitle}'
 
 # Search Bar
 Search / Go to URL: 'Otsi aadressi või ava see'
@@ -149,7 +149,7 @@ Settings:
     Current instance will be randomized on startup: Hetkel kasutatav vaikimisi teenus
       valitakse rakenduse käivitamisel juhuslikult
     No default instance has been set: Vaikimisi kasutatav teenus on seadistamata
-    The currently set default instance is $: Hetkel kehtiv vaikimisi teenus on $
+    The currently set default instance is {instance}: Hetkel kehtiv vaikimisi teenus on {instance}
     Current Invidious Instance: Hetkel kasutusel olev Invidious'e teenuse server
     External Link Handling:
       No Action: Tegevus puudub
@@ -328,7 +328,7 @@ Settings:
     All playlists has been successfully imported: Kõikide esitusloendite import õnnestus
     All playlists has been successfully exported: Kõikide esitusloendite eksport õnnestus
     Import Playlists: Impordi esitusloendeid
-    Playlist insufficient data: „$“ esitusloendi kohta pole piisavalt andmeid, jätame
+    Playlist insufficient data: „{playlist}“ esitusloendi kohta pole piisavalt andmeid, jätame
       vahele
   Advanced Settings:
     Advanced Settings: ''
@@ -484,14 +484,14 @@ Profile:
   Your profile name cannot be empty: 'Profiilil peab olema nimi'
   Profile has been created: 'Profiili loomine õnnestus'
   Profile has been updated: 'Profiili uuendamine õnnestus'
-  Your default profile has been set to $: 'Määrasin $ sinu vaikimisi profiiliks'
-  Removed $ from your profiles: 'Kustutasin $ sinu profiilide loendist'
+  Your default profile has been set to {profile}: 'Määrasin {profile} sinu vaikimisi profiiliks'
+  Removed {profile} from your profiles: 'Kustutasin {profile} sinu profiilide loendist'
   Your default profile has been changed to your primary profile: 'Muutsin sinu esmase
     profiili vaikimisi kasutatavaks profiiliks'
-  $ is now the active profile: '$ on nüüd kasutusel olev profiil'
+  '{profile} is now the active profile': '{profile} on nüüd kasutusel olev profiil'
   Subscription List: 'Tellimuste loend'
   Other Channels: 'Muud kanalid'
-  $ selected: '$ on valitud'
+  '{number} selected': '{number} on valitud'
   Select All: 'Vali kõik'
   Select None: 'Ära vali mitte midagi'
   Delete Selected: 'Kustuta valik'
@@ -513,7 +513,7 @@ Channel:
   Subscribe: 'Telli'
   Unsubscribe: 'Lõpeta tellimus'
   Channel has been removed from your subscriptions: 'Kustutasin kanali sinu tellimustest'
-  Removed subscription from $ other channel(s): 'Kustutasin tellimuse ka $''st muust
+  Removed subscription from {count} other channel(s): 'Kustutasin tellimuse ka {count}''st muust
     kanalist'
   Added channel to your subscriptions: 'Lisasin kanali sinu tellimuste hulka'
   Search Channel: 'Otsi kanalit'
@@ -607,8 +607,7 @@ Video:
     Ago: 'tagasi'
     Upcoming: 'Esilinastus'
   Published on: 'Avaldatud'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % tagasi'
+  Publicationtemplate: '{number} {unit} tagasi'
 #& Videos
   Copy Invidious Channel Link: Kopeeri kanali link Invidious'e veebirakenduses
   Open Channel in Invidious: Ava kanal Invidious'e veebirakenduses
@@ -640,11 +639,11 @@ Video:
     recap: Kokkuvõte
   Skipped segment: Vahelejäetud lõik
   External Player:
-    UnsupportedActionTemplate: 'Rakenduses $ puudub tugi: %'
-    OpeningTemplate: Avan $ % rakendusega...
+    UnsupportedActionTemplate: 'Rakenduses {externalPlayer} puudub tugi: {action}'
+    OpeningTemplate: Avan {videoOrPlaylist} {externalPlayer} rakendusega...
     playlist: esitusloend
     video: video
-    OpenInTemplate: Ava rakendusega $
+    OpenInTemplate: Ava rakendusega {externalPlayer}
     Unsupported Actions:
       looping playlists: esitusloendi kordamine
       shuffling playlists: esitusloendi segamine
@@ -748,7 +747,7 @@ Comments:
   Show More Replies: Näita järgmisi vastuseid
   And others: ja teised
   Pinned by: Esiplaanile tõstja
-  From $channelName: kanalist $channelName
+  From {channelName}: kanalist {channelName}
   Member: Liige
 Up Next: 'Järgmisena'
 
@@ -794,7 +793,7 @@ Tooltips:
     External Player: "Seadistades välise meediamängija kuvame pisipildil ikooni video\
       \ (või esitusloendi) esitamiseks välises meediamängijas. Hoiatus: Invidious'e\
       \ seadistused ei mõjuta välise meediamängija kasutamist."
-    DefaultCustomArgumentsTemplate: "(Vaikimisi: '$')"
+    DefaultCustomArgumentsTemplate: "(Vaikimisi: '{defaultCustomArguments}')"
   Subscription Settings:
     Fetch Feeds from RSS: Selle valiku kasutamisel FreeTube pruugib tellimuste andmete
       laadimisel vaikimisi meetodi asemel RSS-uudisvoogu. RSS on kiirem ja välistab
@@ -836,30 +835,30 @@ Playing Next Video Interval: Kohe esitan järgmist videot. Tühistamiseks klõps
   | {nextVideoInterval} sekundi möödumisel esitan järgmist videot. Tühistamiseks klõpsi.
 Default Invidious instance has been cleared: Vaikimisi kasutatav Invidious'e teenus
   on kustutatud
-Default Invidious instance has been set to $: Vaikimisi kasutatav Invidious'e teenus
-  on $
+Default Invidious instance has been set to {instance}: Vaikimisi kasutatav Invidious'e teenus
+  on {instance}
 Search Bar:
   Clear Input: Kustuta sisend
 External link opening has been disabled in the general settings: Väliste linkide avamine
   on üldistes seadistustes keelatud
 Are you sure you want to open this link?: Oled kindel, et soovid seda linki avada?
-Downloading has completed: „$“ allalaadimine on lõppenud
-Starting download: „$“ allalaadimine algas
-Downloading failed: „$“ allalaadimisel tekkis viga
+Downloading has completed: „{videoTitle}“ allalaadimine on lõppenud
+Starting download: „{videoTitle}“ allalaadimine algas
+Downloading failed: „{videoTitle}“ allalaadimisel tekkis viga
 New Window: Uus aken
-Screenshot Error: Kuvatõmmise tegemine ei õnnestunud. $
+Screenshot Error: Kuvatõmmise tegemine ei õnnestunud. {error}
 Channels:
   Channels: Kanalid
   Title: Kanalite loend
   Search bar placeholder: Otsi kanaleid
-  Count: Leidsime $ kanali(t).
+  Count: Leidsime {number} kanali(t).
   Empty: Sinu kanalite loend on praegu tühi.
   Unsubscribe: Loobu tellimusest
-  Unsubscribed: $ on sinu tellimustest eemaldatud
-  Unsubscribe Prompt: Kas oled kindel, et soovid „$“ tellimusest loobuda?
+  Unsubscribed: '{channelName} on sinu tellimustest eemaldatud'
+  Unsubscribe Prompt: Kas oled kindel, et soovid „{channelName}“ tellimusest loobuda?
 Age Restricted:
-  This $contentType is age restricted: See $ on vanusepiiranguga
+  This {videoOrPlaylist} is age restricted: See {videoOrPlaylist} on vanusepiiranguga
   Type:
     Channel: Kanal
     Video: Video
-Screenshot Success: Kuvatõmmis on salvestatud faili „$“
+Screenshot Success: Kuvatõmmis on salvestatud faili „{filePath}“

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -29,11 +29,11 @@ Close: 'Itxi'
 Back: 'Atzera'
 Forward: 'Aurrera'
 
-Version $ is now available!  Click for more details: '$ bertsioa erabilgarri! Klikatu
+Version {versionNumber} is now available!  Click for more details: '{versionNumber} bertsioa erabilgarri! Klikatu
   azalpen gehiagorako'
 Download From Site: 'Webgunetik jaitsi'
-A new blog is now available, $. Click to view more: 'Blog berri bat erabilgarri dago,
-  $. Klikatu gehiagorako'
+A new blog is now available, {blogTitle}. Click to view more: 'Blog berri bat erabilgarri dago,
+  {blogTitle}. Klikatu gehiagorako'
 
 # Search Bar
 Search / Go to URL: 'Bilatu / Helbidera joan'
@@ -145,8 +145,8 @@ Settings:
       ikusi'
     Region for Trending: 'Joeren eskualdea'
         #! List countries
-    The currently set default instance is $: Une honetan ezarritako instantzia lehenetsia
-      $ da
+    The currently set default instance is {instance}: 'Une honetan ezarritako instantzia lehenetsia
+      {instance} da'
     Current Invidious Instance: Oraingo Invidious instantzia
     External Link Handling:
       External Link Handling: Kanpo esteken kudeaketa
@@ -350,7 +350,7 @@ Settings:
       inportatu dira
     All playlists has been successfully exported: Erreprodukzio zerrenda guztiak ongi
       esportatu dira
-    Playlist insufficient data: Ez da datu nahikorik "$" erreprodukzio zerrendarentzat,
+    Playlist insufficient data: Ez da datu nahikorik "{playlist}" erreprodukzio zerrendarentzat,
       elementutik ateratzen
   Proxy Settings:
     Proxy Settings: 'Proxy-aren ezarpenak'
@@ -452,15 +452,15 @@ Profile:
   Your profile name cannot be empty: 'Zure profilaren izena ezin da hutsik egon'
   Profile has been created: 'Profila ongi eratu da'
   Profile has been updated: 'Profila ongi eguneratu da'
-  Your default profile has been set to $: 'Zure lehenetsitako profila $ gisa ezarri
+  Your default profile has been set to {profile}: 'Zure lehenetsitako profila {profile} gisa ezarri
     da'
-  Removed $ from your profiles: '$ ezabatu berri da zure profiletatik'
+  Removed {profile} from your profiles: '{profile} ezabatu berri da zure profiletatik'
   Your default profile has been changed to your primary profile: 'Profil lehenetsia
     zure profil nagusi gisa ezarri da'
-  $ is now the active profile: '$ da profil aktibo berria'
+  '{profile} is now the active profile': '{profile} da profil aktibo berria'
   Subscription List: 'Harpidetzen zerrenda'
   Other Channels: 'Beste kanalak'
-  $ selected: '$ ezarria'
+  '{number} selected': '{number} ezarria'
   Select All: 'Denak hautatu'
   Select None: 'Bat ere ez hautatu'
   Delete Selected: 'hautatutakoa ezabatu'
@@ -482,7 +482,7 @@ Channel:
   Unsubscribe: 'Harpidetza kendu'
   Channel has been removed from your subscriptions: 'kanala zure harpidetzetatik kendu
     da'
-  Removed subscription from $ other channel(s): 'Harpidetza beste $ kanaletatik ezabatu
+  Removed subscription from {count} other channel(s): 'Harpidetza beste {count} kanaletatik ezabatu
     da'
   Added channel to your subscriptions: 'Kanala zure harpidetzetara gehitu da'
   Search Channel: 'Kanala bilatu'
@@ -596,8 +596,7 @@ Video:
   Streamed on: 'Noiz zuzenean emana'
   Started streaming on: 'Noiz hasi zen zuzenekoa'
   translated from English: 'Ingelesetik itzulia'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Duela $ %'
+  Publicationtemplate: 'Duela {number} {unit}'
 #& Videos
   External Player:
     Unsupported Actions:
@@ -609,10 +608,10 @@ Video:
       opening specific video in a playlist (falling back to opening the video): erreprodukzio
         zerrenda batean bideoa irekitzen (bideoa berriz ere irekitzen)
       looping playlists: erreprodukzio zerrendak etengabe erreproduzitzen
-    OpenInTemplate: $-an irekia
+    OpenInTemplate: '{externalPlayer}-an irekia'
     video: bideoa
-    OpeningTemplate: $ irekitzen %-an...
-    UnsupportedActionTemplate: '$-k ez du onartzen: %'
+    OpeningTemplate: '{videoOrPlaylist} irekitzen {externalPlayer}-an...'
+    UnsupportedActionTemplate: '{externalPlayer}-k ez du onartzen: {action}'
     playlist: erreprodukzio zerrenda
   Stats:
     Video ID: Bideoaren identifikatzailea
@@ -714,7 +713,7 @@ Comments:
   No more comments available: 'Iruzkin eskuragarri gehiagorik ez'
   Member: Kide
   Show More Replies: Erantzun gehiago erakutsi
-  From $channelName: $kanalIzenetik
+  From {channelName}: ''
   And others: eta bestelakoak
   Pinned by: Honengatik ainguratuta
 Up Next: 'Hurrengoa'
@@ -772,7 +771,7 @@ Tooltips:
     Custom External Player Executable: Lehentasunez, Freetube-k uste izango du hautatutako
       kanpo erreproduzitzailea aurkitu dezakeela PATH ingurune aldagaiari esker. Beharrezkoa
       balitz, ohiko PATH-a ezarri ahalko litzateke.
-    DefaultCustomArgumentsTemplate: "(Lehenetsia: '$')"
+    DefaultCustomArgumentsTemplate: "(Lehenetsia: '{defaultCustomArguments}')"
     Ignore Warnings: Jakinarazpenak kendu, uneko kanpo erreproduzitzaileak uneko ekintza
       onartzen ez duenean (esaterako, alderantzizko erreprodukzio zerrendak, etab.).
     External Player: Kanpo erreproduzitzaile bat hautatuz gero, bideoa edo erreproduzkio
@@ -810,33 +809,33 @@ Search Bar:
   Clear Input: Sarrera garbitu
 Are you sure you want to open this link?: Ziur al zaude ataka hau ireki nahi duzula?
 Open New Window: Leiho berria ireki
-Default Invidious instance has been set to $: Lehenetsitako Individious-eko instantzia
-  $ gisa ezarri da
+Default Invidious instance has been set to {instance}: 'Lehenetsitako Individious-eko instantzia
+  {instance} gisa ezarri da'
 Default Invidious instance has been cleared: Lehenetsitako Individious-eko instantzia
   ezabatu egin da
 External link opening has been disabled in the general settings: Kanpo estekak irekitzea
   desaktibatu egin da ezarpen orokorretan
-Downloading has completed: '"$" deskargatu egin da'
+Downloading has completed: '"{videoTitle}" deskargatu egin da'
 Unknown YouTube url type, cannot be opened in app: Youtube-ko URL mota ezezaguna,
   ezin da aplikazioan ireki
 Hashtags have not yet been implemented, try again later: Etiketak ez dira oraindik
   aktibatu, berriz ere saiatu zaitez beranduago
-Downloading failed: Akats bat gertatu da "$" deskargatzerakoan
-Screenshot Success: Pantaila-argazkia gode da "$" gisa
-Screenshot Error: Pantaila-argazkiak huts egin du. $
-Starting download: '"$"-ren deskarga abiatzen'
+Downloading failed: Akats bat gertatu da "{videoTitle}" deskargatzerakoan
+Screenshot Success: Pantaila-argazkia gode da "{filePath}" gisa
+Screenshot Error: Pantaila-argazkiak huts egin du. {error}
+Starting download: '"{videoTitle}"-ren deskarga abiatzen'
 New Window: Leiho berria
 Channels:
   Channels: Kanalak
   Title: Kanalen zerrenda
   Search bar placeholder: Kanalak bilatu
   Unsubscribe: Harpidetza kendu
-  Unsubscribed: $ zure harpidetzen zerrendatik ezabatu da
-  Unsubscribe Prompt: Ziur al zaude "$"-ren harpidetza kendu nahi duzula?
-  Count: $ kanal aurkitu dira.
+  Unsubscribed: '{channelName} zure harpidetzen zerrendatik ezabatu da'
+  Unsubscribe Prompt: Ziur al zaude "{channelName}"-ren harpidetza kendu nahi duzula?
+  Count: '{number} kanal aurkitu dira.'
   Empty: Zure kanalen zerrenda hutsik da.
 Age Restricted:
-  This $contentType is age restricted: Honako $ adin muga du
+  This {videoOrPlaylist} is age restricted: Honako {videoOrPlaylist} adin muga du
   Type:
     Channel: Kanala
     Video: Bideoa

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -30,10 +30,10 @@ Back: 'بازگشت'
 Forward: 'پیشروی'
 Open New Window: 'بازکردن پنجره جدید'
 
-Version $ is now available!  Click for more details: 'نسخه $ هم اکنون در دسترس است!  برای
+Version {versionNumber} is now available!  Click for more details: 'نسخه $ هم اکنون در دسترس است!  برای
   اطلاعات بیشتر کلیک کنید'
 Download From Site: 'دانلود از وبگاه'
-A new blog is now available, $. Click to view more: 'بلاگ جدیدی در دسترس است، $. کلیک
+A new blog is now available, {blogTitle}. Click to view more: 'بلاگ جدیدی در دسترس است، $. کلیک
   کنید تا بیشتر ببینید.'
 
 # Search Bar
@@ -143,8 +143,7 @@ Settings:
       Middle: 'وسط'
       End: 'انتها'
     Current Invidious Instance: 'نمونه فعلی Invidious'
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: 'در حال حاضر نمونه Invidious پیشفرض $
+    The currently set default instance is {instance}: 'در حال حاضر نمونه Invidious پیشفرض {instance}
       است'
     No default instance has been set: 'هیچ نمونه پیشفرضی تنظیم نشده'
     Current instance will be randomized on startup: 'نمونه فعلی هنگام شروع برنامه
@@ -391,13 +390,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -414,7 +413,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -517,7 +516,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -528,13 +526,10 @@ Video:
     interaction: ''
     music offtopic: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -655,8 +650,7 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -30,11 +30,9 @@ Back: 'بازگشت'
 Forward: 'پیشروی'
 Open New Window: 'بازکردن پنجره جدید'
 
-Version {versionNumber} is now available!  Click for more details: 'نسخه $ هم اکنون در دسترس است!  برای
-  اطلاعات بیشتر کلیک کنید'
+Version {versionNumber} is now available!  Click for more details: ''
 Download From Site: 'دانلود از وبگاه'
-A new blog is now available, {blogTitle}. Click to view more: 'بلاگ جدیدی در دسترس است، $. کلیک
-  کنید تا بیشتر ببینید.'
+A new blog is now available, {blogTitle}. Click to view more: ''
 
 # Search Bar
 Search / Go to URL: 'جست و جو / برو به لینک'
@@ -317,7 +315,7 @@ Settings:
     Manage Subscriptions: ''
     Import Playlists: وارد کردن فهرست های پخش
     Export Playlists: استخراج فهرست های پخش
-    Playlist insufficient data: داده ناکافی برای لیست پخش "$" ، در حال چشم پوشی
+    Playlist insufficient data: ''
     All playlists has been successfully imported: همه لیست های پخش با موفقیت وارد
       شدند
     All playlists has been successfully exported: همه لیست های پخش با موفقیت صادر

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -140,7 +140,7 @@ Settings:
     Current instance will be randomized on startup: Nykyinen palveluntarjoaja valitaan
       satunnaisesti käynnistyksen yhteydessä
     No default instance has been set: Oletuspalveluntarjoajaa ei ole määritelty
-    The currently set default instance is $: Nykyinen oletuspalveluntarjoaja on $
+    The currently set default instance is {instance}: Nykyinen oletuspalveluntarjoaja on {instance}
     Current Invidious Instance: Nykyinen Invidious-palveluntarjoaja
     External Link Handling:
       No Action: Ei toimintoa
@@ -355,7 +355,7 @@ Settings:
     All playlists has been successfully exported: Kaikki soittolistat on viety onnistuneesti
     Import Playlists: Tuo soittolistoja
     Export Playlists: Vie soittolistoja
-    Playlist insufficient data: Riittämätön määrä tietoja ”$” -soittolistalle, ohitetaan
+    Playlist insufficient data: Riittämätön määrä tietoja ”{playlist}” -soittolistalle, ohitetaan
       kohde
   Distraction Free Settings:
     Hide Live Chat: Piilota Live-keskustelu
@@ -510,7 +510,7 @@ Channel:
     Channel Description: 'Kanavan kuvaus'
     Featured Channels: 'Suositellut kanavat'
   Added channel to your subscriptions: Kanava on lisätty tilauksiisi
-  Removed subscription from $ other channel(s): Poistettu tilaus $ muulta kanavalta
+  Removed subscription from {count} other channel(s): Poistettu tilaus {count} muulta kanavalta
   Channel has been removed from your subscriptions: Kanava on poistettu tilauksistasi
 Video:
   Open in YouTube: 'Avaa Youtubessa'
@@ -569,8 +569,7 @@ Video:
     Less than a minute: Vähemmän kuin minuutti
     In less than a minute: Alle minuutin kuluessa
   Published on: 'Julkaistu'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % sitten'
+  Publicationtemplate: '{number} {unit} sitten'
 #& Videos
   Video has been removed from your history: Video on poistettu historiastasi
   Video has been marked as watched: Video on merkitty katsotuksi
@@ -608,11 +607,11 @@ Video:
       opening playlists: avataan soittoluettelot
       setting a playback rate: asetetaan toiston suhde
       starting video at offset: aloitetaan video poikkeamassa
-    UnsupportedActionTemplate: '$ ei tue: %'
-    OpeningTemplate: Avataan $ täten %...
+    UnsupportedActionTemplate: '{externalPlayer} ei tue: {action}'
+    OpeningTemplate: Avataan {videoOrPlaylist} täten {externalPlayer}...
     playlist: soittoluettelo
     video: video
-    OpenInTemplate: Avaa täten $
+    OpenInTemplate: Avaa täten {externalPlayer}
   Sponsor Block category:
     music offtopic: Musiikki aihepiirin ulkopuolelta
     interaction: Kanssakäyminen
@@ -718,7 +717,7 @@ Comments:
   Sort by: Lajitteluperuste
   Show More Replies: Näytä enemmän vastauksia
   Pinned by: Kiinnittänyt
-  From $channelName: kanavalta $channelName
+  From {channelName}: kanavalta {channelName}
   And others: ja muut
   Member: Jäsen
 Up Next: 'Seuraavaksi'
@@ -746,11 +745,11 @@ No: 'Ei'
 Locale Name: suomi
 The playlist has been reversed: Soittolista on muutettu käänteiseksi
 Profile:
-  $ is now the active profile: $ on nyt aktiivinen profiili
+  '{profile} is now the active profile': '{profile} on nyt aktiivinen profiili'
   Your default profile has been changed to your primary profile: Oletusprofiilisi
     on vaihdettu ensisijaiseksi profiiliksesi
-  Removed $ from your profiles: $ on poistettu profiileistasi
-  Your default profile has been set to $: Oletusprofiiliksesi on määritetty $
+  Removed {profile} from your profiles: '{profile} on poistettu profiileistasi'
+  Your default profile has been set to {profile}: Oletusprofiiliksesi on määritetty {profile}
   Profile has been updated: Profiili on päivitetty
   Profile has been created: Profiili on luotu
   Your profile name cannot be empty: Profiililla täytyy olla nimi
@@ -780,17 +779,17 @@ Profile:
   Delete Selected: Poista valitut
   Select None: Älä valitse mitään
   Select All: Valitse kaikki
-  $ selected: $ valittu
+  '{number} selected': '{number} valittu'
   Other Channels: Muut kanavat
   Subscription List: Tilauslista
   Profile Filter: Profiilisuodatin
   Profile Settings: Profiiliasetukset
-Version $ is now available!  Click for more details: Versio $ on nyt saatavilla! Napsauta
+Version {versionNumber} is now available!  Click for more details: Versio {versionNumber} on nyt saatavilla! Napsauta
   saadaksesi lisätietoja
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Tämä
   video ei ole saatavilla puuttuvien formaattien takia. Tämä voi tapahtua koska video
   ei ole saatavilla maassasi.
-A new blog is now available, $. Click to view more: Uusi blogi on saatavilla, $. Klikkaa
+A new blog is now available, {blogTitle}. Click to view more: Uusi blogi on saatavilla, {blogTitle}. Klikkaa
   nähdäksesi lisää
 Download From Site: Lataa sivustolta
 Tooltips:
@@ -841,7 +840,7 @@ Tooltips:
     External Player: Ulkoisen soittimen valitsemisen johdosta näkyy kuvake videon
       avaamiseen (soittoluettelonkin avaamiseen jos tuettu) ulkoisessa toistimessa.
       Varoitus, Invidious-asetukset eivät vaikuta ulkoisiin toistimiin.
-    DefaultCustomArgumentsTemplate: "(Oletus: '$')"
+    DefaultCustomArgumentsTemplate: "(Oletus: '{defaultCustomArguments}')"
 More: Lisää
 Playing Next Video Interval: Seuraava video alkaa. Klikkaa peruuttaaksesi. |Seuraava
   video alkaa {nextVideoInterval} sekunnin kuluttua. Klikkaa peruuttaaksesi. | Seuraava
@@ -853,32 +852,32 @@ Unknown YouTube url type, cannot be opened in app: Tuntematon YouTube-videon oso
   ei voida avata sovelluksessa
 Default Invidious instance has been cleared: Oletusarvoinen Invidious-palveluntarjoaja
   on tyhjennetty
-Default Invidious instance has been set to $: Oletusarvoinen Invidious-palveluntarjoaja
-  on jatkossa $
+Default Invidious instance has been set to {instance}: Oletusarvoinen Invidious-palveluntarjoaja
+  on jatkossa {instance}
 Search Bar:
   Clear Input: Tyhjennä syöte
 External link opening has been disabled in the general settings: Ulkoisen linkin avaaminen
   on poistettu käytöstä yleisissä asetuksissa
 Are you sure you want to open this link?: Haluatko varmasti avata tämän linkin?
-Downloading failed: Videon "$" lataamisessa havaittiin ongelma
-Downloading has completed: Videon "$" lataus on valmis
-Starting download: Aloitetaan lataamaan "$"
-Screenshot Success: Kuvakaappaus tallennettu nimellä ”$”
+Downloading failed: Videon "{videoTitle}" lataamisessa havaittiin ongelma
+Downloading has completed: Videon "{videoTitle}" lataus on valmis
+Starting download: Aloitetaan lataamaan "{videoTitle}"
+Screenshot Success: Kuvakaappaus tallennettu nimellä ”{filePath}”
 New Window: Uusi ikkuna
 Age Restricted:
-  This $contentType is age restricted: Tämä $ on ikärajoitettu
+  This {videoOrPlaylist} is age restricted: Tämä {videoOrPlaylist} on ikärajoitettu
   Type:
     Video: Video
     Channel: Kanava
-Screenshot Error: Ruutukaappaus epäonnistui. $
+Screenshot Error: Ruutukaappaus epäonnistui. {error}
 Channels:
   Channels: Kanavat
   Title: Kanavaluettelo
   Search bar placeholder: Etsi kanavia
-  Count: $ kanava(a) löydetty.
+  Count: '{number} kanava(a) löydetty.'
   Empty: Kanavaluettelosi on tällä hetkellä tyhjä.
   Unsubscribe: Peruuta tilaus
-  Unsubscribe Prompt: Oletko varma että haluat peruuttaa tilauksen kanavalle ”$”?
-  Unsubscribed: $ on poistettu tilauksistasi
+  Unsubscribe Prompt: Oletko varma että haluat peruuttaa tilauksen kanavalle ”{channelName}”?
+  Unsubscribed: '{channelName} on poistettu tilauksistasi'
 Clipboard:
   Copy failed: Kopiointi leikepöydälle epäonnistui

--- a/static/locales/fil.yaml
+++ b/static/locales/fil.yaml
@@ -276,10 +276,10 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
 #On Channel Page
 Channel:
   Subscriber: ''
@@ -368,7 +368,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -153,8 +153,8 @@ Settings:
     Current instance will be randomized on startup: L'instance actuelle sera choisie
       au hasard au démarrage
     No default instance has been set: Aucune instance par défaut n'a été définie
-    The currently set default instance is $: L'instance par défaut actuellement définie
-      est $
+    The currently set default instance is {instance}: L'instance par défaut actuellement définie
+      est {instance}
     Current Invidious Instance: Instance Invidious actuelle
     External Link Handling:
       No Action: Aucune action
@@ -377,7 +377,7 @@ Settings:
     Manage Subscriptions: Gérer les abonnements
     Import Playlists: Importer des listes de lecture
     Export Playlists: Exporter des listes de lecture
-    Playlist insufficient data: Données insuffisantes pour la liste de lecture « $ »,
+    Playlist insufficient data: Données insuffisantes pour la liste de lecture « {playlist} »,
       saut de l'élément
     All playlists has been successfully imported: Toutes les listes de lecture ont
       été importées avec succès
@@ -554,7 +554,7 @@ Channel:
     Channel Description: 'Description de la chaîne'
     Featured Channels: 'Chaînes en vedette'
   Added channel to your subscriptions: Chaîne ajoutée à vos abonnements
-  Removed subscription from $ other channel(s): Abonnement supprimé de $ autre(s)
+  Removed subscription from {count} other channel(s): Abonnement supprimé de {count} autre(s)
     chaîne(s)
   Channel has been removed from your subscriptions: La chaîne a été retirée de vos
     abonnements
@@ -620,8 +620,7 @@ Video:
     Less than a minute: Moins d'une minute
     In less than a minute: En moins d'une minute
   Published on: 'Mise en ligne le'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Il y a $ %'
+  Publicationtemplate: 'Il y a {number} {unit}'
 #& Videos
   Play Previous Video: Lire la vidéo précédente
   Play Next Video: Lire la vidéo suivante
@@ -673,9 +672,9 @@ Video:
       opening playlists: ouvrir des listes de lecture
       setting a playback rate: régler la vitesse de lecture
       starting video at offset: démarrer la vidéo avec un décalage
-    UnsupportedActionTemplate: '$ non pris en charge : %'
-    OpeningTemplate: Ouverture de $ en %…
-    OpenInTemplate: Ouvrir avec $
+    UnsupportedActionTemplate: '{externalPlayer} non pris en charge : {action}'
+    OpeningTemplate: Ouverture de {videoOrPlaylist} en {externalPlayer}…
+    OpenInTemplate: Ouvrir avec {externalPlayer}
   Stats:
     video id: "Identifiant de la vidéo (YouTube)"
     player resolution: "Résolution du lecteur"
@@ -774,7 +773,7 @@ Comments:
   Sort by: Trier par
   No more comments available: Pas d'autres commentaires disponibles
   Show More Replies: Afficher plus de réponses
-  From $channelName: de $channelName
+  From {channelName}: de {channelName}
   Pinned by: Épinglé par
   And others: et d'autres
   Member: Membre
@@ -803,11 +802,11 @@ Yes: 'Oui'
 No: 'Non'
 Locale Name: français
 Profile:
-  $ is now the active profile: $ est maintenant le profil actif
+  '{profile} is now the active profile': '{profile} est maintenant le profil actif'
   Your default profile has been changed to your primary profile: Votre profil par
     défaut a été modifié en votre profil principal
-  Removed $ from your profiles: Supprimer $ de vos profils
-  Your default profile has been set to $: Votre profil par défaut a été fixé à $
+  Removed {profile} from your profiles: Supprimer {profile} de vos profils
+  Your default profile has been set to {profile}: Votre profil par défaut a été fixé à {profile}
   Profile has been updated: Le profil a été mis à jour
   Profile has been created: Le profil a été créé
   Your profile name cannot be empty: Le nom de votre profil ne peut pas être vide
@@ -841,15 +840,15 @@ Profile:
   Delete Selected: Supprimer la sélection
   Select None: Ne rien sélectionner
   Select All: Tout sélectionner
-  $ selected: $ sélectionné(s)
+  '{number} selected': '{number} sélectionné(s)'
   Other Channels: Autres chaînes
   Profile Filter: Filtre de profil
   Profile Settings: Paramètres du profil
 The playlist has been reversed: La liste de lecture a été inversée
-A new blog is now available, $. Click to view more: Un nouveau billet est maintenant
-  disponible, $. Cliquez pour en savoir plus
+A new blog is now available, {blogTitle}. Click to view more: Un nouveau billet est maintenant
+  disponible, {blogTitle}. Cliquez pour en savoir plus
 Download From Site: Télécharger depuis le site
-Version $ is now available!  Click for more details: La version $ est maintenant disponible
+Version {versionNumber} is now available!  Click for more details: La version {versionNumber} est maintenant disponible
   !  Cliquez pour plus de détails
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Cette
   vidéo est indisponible car elle n'est pas dans un format valide. Cela peut arriver
@@ -916,7 +915,7 @@ Tooltips:
     External Player: La sélection du lecteur externe affichera une icône sur la miniature
       qui ouvrira la vidéo (liste de lecture, si prise en charge) dans le lecteur
       externe. Attention, les paramètres Invidious n'affectent pas les lecteurs externes.
-    DefaultCustomArgumentsTemplate: '(Par défaut : « $ »)'
+    DefaultCustomArgumentsTemplate: '(Par défaut : « {defaultCustomArguments} »)'
 More: Plus
 Playing Next Video Interval: Lecture de la prochaine vidéo en un rien de temps. Cliquez
   pour annuler. | Lecture de la prochaine vidéo dans {nextVideoInterval} seconde.
@@ -929,36 +928,36 @@ Unknown YouTube url type, cannot be opened in app: Type d'URL YouTube inconnu, n
 Open New Window: Ouvrir une nouvelle fenêtre
 Default Invidious instance has been cleared: L'instance Invidious par défaut a été
   effacée
-Default Invidious instance has been set to $: L'instance Invidious par défaut a été
-  définie sur $
+Default Invidious instance has been set to {instance}: L'instance Invidious par défaut a été
+  définie sur {instance}
 Search Bar:
   Clear Input: Effacer l'entrée
 Are you sure you want to open this link?: Êtes-vous sûr(e) de vouloir ouvrir ce lien ?
 External link opening has been disabled in the general settings: L'ouverture des liens
   externes a été désactivée dans les paramètres généraux
-Downloading has completed: '$ a fini de se télécharger'
-Starting download: 'Début du téléchargement de $'
-Downloading failed: 'Il y a eu un problème lors du téléchargement de $'
+Downloading has completed: '{videoTitle} a fini de se télécharger'
+Starting download: 'Début du téléchargement de {videoTitle}'
+Downloading failed: 'Il y a eu un problème lors du téléchargement de {videoTitle}'
 Downloading canceled: 'Le téléchargement est annulé par l''utilisateur'
 Download folder does not exist: 'Le répertoire "$" de téléchargement n''existe pas.
   Mode sans répertoire activé.'
-Screenshot Success: Capture d'écran enregistrée sous « $ »
-Screenshot Error: La capture d'écran a échoué. $
+Screenshot Success: Capture d'écran enregistrée sous « {filePath} »
+Screenshot Error: La capture d'écran a échoué. {error}
 New Window: Nouvelle fenêtre
 Age Restricted:
   Type:
     Video: Vidéo
     Channel: Chaîne
-  This $contentType is age restricted: Ce $ est soumis à une limite d'âge
+  This {videoOrPlaylist} is age restricted: Ce {videoOrPlaylist} est soumis à une limite d'âge
 Channels:
   Channels: Chaînes
   Title: Liste des chaînes
   Empty: Votre liste de chaînes est actuellement vide.
   Unsubscribe: Se désabonner
   Search bar placeholder: Rechercher des chaînes
-  Count: $ chaîne(s) trouvée(s).
-  Unsubscribed: $ a été supprimé de vos abonnements
-  Unsubscribe Prompt: Êtes-vous sûr·e de vouloir vous désabonner de « $ » ?
+  Count: '{number} chaîne(s) trouvée(s).'
+  Unsubscribed: '{channelName} a été supprimé de vos abonnements'
+  Unsubscribe Prompt: Êtes-vous sûr·e de vouloir vous désabonner de « {channelName} » ?
 Clipboard:
   Copy failed: La copie dans le presse-papiers a échoué
   Cannot access clipboard without a secure connection: Impossible d'accéder au presse-papiers

--- a/static/locales/gl.yaml
+++ b/static/locales/gl.yaml
@@ -30,11 +30,11 @@ Close: 'Pechar'
 Back: 'Atrás'
 Forward: 'Adiante'
 
-Version $ is now available!  Click for more details: 'A versión $ está dispoñible!  Fai
+Version {versionNumber} is now available!  Click for more details: 'A versión {versionNumber} está dispoñible!  Fai
   clic para veres máis detalles'
 Download From Site: 'Descargar do sitio web'
-A new blog is now available, $. Click to view more: 'Hai unha nova entrada no blog
-  dispoñible, $. Fai clic para veres máis'
+A new blog is now available, {blogTitle}. Click to view more: 'Hai unha nova entrada no blog
+  dispoñible, {blogTitle}. Fai clic para veres máis'
 
 # Search Bar
 Search / Go to URL: 'Buscar / Ir á URL'
@@ -144,8 +144,8 @@ Settings:
     Current instance will be randomized on startup: A instancia actual será aleatoria
       no arranque
     No default instance has been set: Ningunha instancia foi habilitada por defecto
-    The currently set default instance is $: A Instancia Actualmente Habilitada Por
-      Defecto é $
+    The currently set default instance is {instance}: A Instancia Actualmente Habilitada Por
+      Defecto é {instance}
     Current Invidious Instance: Instancia Actual de Invidious
   Theme Settings:
     Theme Settings: 'Axustes de tema'
@@ -424,14 +424,14 @@ Profile:
   Your profile name cannot be empty: 'O nome do perfil non pode estar en branco'
   Profile has been created: 'Creouse o perfil'
   Profile has been updated: 'Actualizouse o perfil'
-  Your default profile has been set to $: '$ é agora o teu perfil predeterminado'
-  Removed $ from your profiles: 'Eliminouse $ dos teus perfís'
+  Your default profile has been set to {profile}: '{profile} é agora o teu perfil predeterminado'
+  Removed {profile} from your profiles: 'Eliminouse {profile} dos teus perfís'
   Your default profile has been changed to your primary profile: 'O teu perfil predeterminado
     cambiouse ao teu perfil primario'
-  $ is now the active profile: '$ é agora o perfil activo'
+  '{profile} is now the active profile': '{profile} é agora o perfil activo'
   Subscription List: 'Listaxe de subcricións'
   Other Channels: 'Outras canles'
-  $ selected: '$ seleccionado'
+  '{number} selected': '{number} seleccionado'
   Select All: 'Seleccionar todos'
   Select None: 'Non seleccionar ningún'
   Delete Selected: 'Eliminar seleccionados'
@@ -453,7 +453,7 @@ Channel:
   Unsubscribe: 'Desubscribirse'
   Channel has been removed from your subscriptions: 'Esta canle foi eliminada das
     túas subscricións'
-  Removed subscription from $ other channel(s): 'Eliminouse a subscrición de $ a outra(s)
+  Removed subscription from {count} other channel(s): 'Eliminouse a subscrición de {count} a outra(s)
     canle(s)'
   Added channel to your subscriptions: 'Canle engadida ás túas subscricións'
   Search Channel: 'Buscar na canle'
@@ -561,8 +561,7 @@ Video:
   Published on: 'Publicado'
   Streamed on: 'Transmitido'
   Started streaming on: 'A transmisión comezou'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Fai $ %'
+  Publicationtemplate: 'Fai {number} {unit}'
 #& Videos
   External Player:
     Unsupported Actions:
@@ -574,11 +573,11 @@ Video:
       opening playlists: abrindo as listas de reprodución
       setting a playback rate: axustar unha taxa de reprodución
       starting video at offset: vídeo de inicio en compensado
-    UnsupportedActionTemplate: '$ non admite: %'
-    OpeningTemplate: Abrindo $ en %...
+    UnsupportedActionTemplate: '{externalPlayer} non admite: {action}'
+    OpeningTemplate: Abrindo {videoOrPlaylist} en {externalPlayer}...
     playlist: lista de reprodución
     video: vídeo
-    OpenInTemplate: Aberto en $
+    OpenInTemplate: Aberto en {externalPlayer}
   Sponsor Block category:
     music offtopic: Música Offtopic
     interaction: Interacción

--- a/static/locales/gsw.yaml
+++ b/static/locales/gsw.yaml
@@ -32,11 +32,11 @@ Back: 'Zrugg'
 Forward: 'Füre'
 Open New Window: 'Nois Fäischter ufmache'
 
-Version $ is now available!  Click for more details: 'Version $ isch jetzt verfüegbar!
+Version {versionNumber} is now available!  Click for more details: 'Version {versionNumber} isch jetzt verfüegbar!
   Klick für meh Details.'
 Download From Site: 'Vo de Website abelade'
-A new blog is now available, $. Click to view more: 'En neue Blogiitrag isch jetzt
-  verfüegbar, $. Klick zum en aaluege'
+A new blog is now available, {blogTitle}. Click to view more: 'En neue Blogiitrag isch jetzt
+  verfüegbar, {blogTitle}. Klick zum en aaluege'
 Are you sure you want to open this link?: 'Bisch du sicher, dass du de Link ufmache
   wotsch?'
 
@@ -149,8 +149,7 @@ Settings:
       Middle: ''
       End: ''
     Current Invidious Instance: ''
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: ''
+    The currently set default instance is {instance}: ''
     No default instance has been set: ''
     Current instance will be randomized on startup: ''
     Set Current Instance as Default: ''
@@ -432,13 +431,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -455,7 +454,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -559,7 +558,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -572,13 +570,10 @@ Video:
     recap: ''
     filler: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -665,7 +660,7 @@ Comments:
   Replies: ''
   Show More Replies: ''
   Reply: ''
-  From $channelName: ''
+  From {channelName}: ''
   And others: ''
   There are no comments available for this video: ''
   Load More Comments: ''
@@ -693,7 +688,6 @@ Tooltips:
     Custom External Player Executable: ''
     Ignore Warnings: ''
     Custom External Player Arguments: ''
-    # $ is replaced with the default custom arguments for the current player, if defined.
     DefaultCustomArgumentsTemplate: ''
   Subscription Settings:
     Fetch Feeds from RSS: ''
@@ -718,13 +712,11 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 Age Restricted:
-  # $contentType is replaced with video or channel
-  This $contentType is age restricted: ''
+  This {videoOrPlaylist} is age restricted: ''
   Type:
     Channel: ''
     Video: ''

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -29,10 +29,10 @@ Close: 'סגירה'
 Back: 'אחורה'
 Forward: 'קדימה'
 
-Version $ is now available!  Click for more details: 'גרסה $ זמינה כעת! יש ללחוץ לפרטים
+Version {versionNumber} is now available!  Click for more details: 'גרסה $ זמינה כעת! יש ללחוץ לפרטים
   נוספים'
 Download From Site: 'הורדה מהאתר'
-A new blog is now available, $. Click to view more: 'פוסט חדש יצא לבלוג, $. יש ללחוץ
+A new blog is now available, {blogTitle}. Click to view more: 'פוסט חדש יצא לבלוג, $. יש ללחוץ
   כדי לראות עוד'
 
 # Search Bar
@@ -143,7 +143,7 @@ Settings:
     View all Invidious instance information: הצגת כל פרטי העותק של Invidious
     Current Invidious Instance: עותק נוכחי של Invidious
     System Default: בררת המחדל של המערכת
-    The currently set default instance is $: עותק ברירת המחדל שהוגדר הוא $
+    The currently set default instance is {instance}: עותק ברירת המחדל שהוגדר הוא {instance}
     Set Current Instance as Default: הגדרת העותק הנוכחי כברירת מחדל
     External Link Handling:
       Open Link: פתיחת הקישור
@@ -506,14 +506,14 @@ Profile:
   Your profile name cannot be empty: 'לא ניתן לרוקן את הפרופיל שלך'
   Profile has been created: 'הפרופיל נוצר'
   Profile has been updated: 'הפרופיל עודכן'
-  Your default profile has been set to $: 'הגדרת את $ כפרופיל ברירת המחדל'
-  Removed $ from your profiles: '$ נמחק מהפרופילים שלך'
+  Your default profile has been set to {profile}: 'הגדרת את $ כפרופיל ברירת המחדל'
+  Removed {profile} from your profiles: '{profile} נמחק מהפרופילים שלך'
   Your default profile has been changed to your primary profile: 'פרופיל ברירת המחדל
     שלך השתנה לפרופיל הראשי שלך'
-  $ is now the active profile: 'פרופיל $ פעיל עכשיו'
+  '{profile} is now the active profile': 'פרופיל $ פעיל עכשיו'
   Subscription List: 'רשימת מינויים'
   Other Channels: 'ערוצים אחרים'
-  $ selected: '$ נבחר'
+  '{number} selected': '{number} נבחר'
   Select All: 'לבחור הכול'
   Select None: 'לבטל בחירה'
   Delete Selected: 'למחוק את הנבחרים'
@@ -534,7 +534,7 @@ Channel:
   Subscribe: 'הרשמה למינוי'
   Unsubscribe: 'ביטול המינוי'
   Channel has been removed from your subscriptions: 'הערוץ נמחק מרשימת המנויים שלך'
-  Removed subscription from $ other channel(s): 'המנוי הוסר מ-$ ערוצ/ים אחר/ים'
+  Removed subscription from {count} other channel(s): 'המנוי הוסר מ-$ ערוצ/ים אחר/ים'
   Added channel to your subscriptions: 'הערוץ נוסף לרשימת המנויים שלך'
   Search Channel: 'חיפוש בערוץ'
   Your search results have returned 0 results: 'לא נמצאו תוצאות'
@@ -625,8 +625,7 @@ Video:
     Less than a minute: פחות מדקה
     In less than a minute: עוד פחות מדקה
   Published on: 'פורסם'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'לפני $ %'
+  Publicationtemplate: 'לפני {number} {unit}'
 #& Videos
   Audio:
     Best: איכות הכי טובה
@@ -659,9 +658,9 @@ Video:
   External Player:
     video: סרטון
     playlist: פלייליסט
-    OpenInTemplate: פתיחה בתוך $
-    OpeningTemplate: מתבצעת פתיחת $ בתוך %...
-    UnsupportedActionTemplate: 'ל־$ אין תמיכה ב־: %'
+    OpenInTemplate: פתיחה בתוך {externalPlayer}
+    OpeningTemplate: מתבצעת פתיחת $ בתוך {externalPlayer}...
+    UnsupportedActionTemplate: 'ל־$ אין תמיכה ב־: {action}'
     Unsupported Actions:
       opening playlists: פתיחת רשימות נגינה
       setting a playback rate: הגדרת מהירות נגינה
@@ -760,7 +759,7 @@ Comments:
   Top comments: תגובות מובילות
   No more comments available: אין עוד תגובות זמינות
   Show More Replies: הצגת תגובות נוספות
-  From $channelName: מערוץ $channelName
+  From {channelName}: מערוץ {channelName}
   And others: ואחרים
   Pinned by: ננעץ על ידי
   Member: חבר
@@ -826,7 +825,7 @@ Tooltips:
     Fetch Automatically: כאשר האפשרות פעילה, FreeTube ימשוך את הזנת המינויים שלך אוטומטית
       עם פתיחת חלון חדש ובעת החלפת פרופיל.
   External Player Settings:
-    DefaultCustomArgumentsTemplate: '(ברירת מחדל: ‚$’)'
+    DefaultCustomArgumentsTemplate: '(ברירת מחדל: ‚{defaultCustomArguments}’)'
     Ignore Warnings: 'להשבית אזהרות כאשר הנגן החיצוני הנוכחי לא תומך בפעולה הנוכחית
       (למשל: היפוך רשימת נגינה וכו׳).'
     External Player: בחירה בנגן חיצוני תציג סמל, לפתיחת הווידאו (רשימת הנגינה אם יש
@@ -846,27 +845,27 @@ Search Bar:
 Are you sure you want to open this link?: לפתוח את הקישור הזה?
 Unknown YouTube url type, cannot be opened in app: סוג כתובת לא ידוע ל־YouTube, לא
   ניתן לפתיחה ביישום
-Default Invidious instance has been set to $: עותק Invidious שהוגדר כברירת מחדל הוא
-  $
+Default Invidious instance has been set to {instance}: עותק Invidious שהוגדר כברירת מחדל הוא
+  {instance}
 Default Invidious instance has been cleared: נוקתה העדפת עותק ברירת המחדל של Invidious
 External link opening has been disabled in the general settings: פתיחת הקישורים החיצוניים
   מושבתת בהגדרות הכלליות
 Hashtags have not yet been implemented, try again later: עדיין לא הוטמעו תגיות הקבץ,
   נא לנסות בהמשך
-Downloading failed: אירעה שגיאה בהורדת "$"
+Downloading failed: אירעה שגיאה בהורדת "{videoTitle}"
 Starting download: הורדת "$" מתחילה
 Downloading has completed: הורדת "$" הסתיימה
 Playing Next Video Interval: הסרטון הבא יתחיל מיד. לחיצה לביטול. | הסרטון הבא יתנגן
   בעוד שנייה. לחיצה לביטול. | הסרטון הבא יתנגן בעוד {nextVideoInterval} שניות. לחיצה
   לביטול.
-Screenshot Success: צילום המסך נשמר בתור „$”
-Screenshot Error: צילום המסך נכשל. $
+Screenshot Success: צילום המסך נשמר בתור „{filePath}”
+Screenshot Error: צילום המסך נכשל. {error}
 New Window: חלון חדש
 Age Restricted:
   Type:
     Channel: ערוץ
     Video: סרטון
-  This $contentType is age restricted: ה$ הזה מוגבל בגיל
+  This {videoOrPlaylist} is age restricted: ה$ הזה מוגבל בגיל
 Channels:
   Search bar placeholder: חיפוש ערוצים
   Empty: רשימת הערוצים שלך ריקה כרגע.
@@ -875,7 +874,7 @@ Channels:
   Count: נמצאו $ ערוצים.
   Channels: ערוצים
   Title: רשימת ערוצים
-  Unsubscribe Prompt: לבטל את המינוי על „$”?
+  Unsubscribe Prompt: לבטל את המינוי על „{channelName}”?
 Chapters:
   'Chapters list hidden, current chapter: {chapterName}': 'רשימת הפרקים מוסתרת, הפרק
     הנוכחי: {chapterName}'

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -29,11 +29,9 @@ Close: 'סגירה'
 Back: 'אחורה'
 Forward: 'קדימה'
 
-Version {versionNumber} is now available!  Click for more details: 'גרסה $ זמינה כעת! יש ללחוץ לפרטים
-  נוספים'
+Version {versionNumber} is now available!  Click for more details: ''
 Download From Site: 'הורדה מהאתר'
-A new blog is now available, {blogTitle}. Click to view more: 'פוסט חדש יצא לבלוג, $. יש ללחוץ
-  כדי לראות עוד'
+A new blog is now available, {blogTitle}. Click to view more: ''
 
 # Search Bar
 Search / Go to URL: 'חיפוש / מעבר לכתובת'
@@ -324,7 +322,7 @@ Settings:
     All playlists has been successfully imported: כל הפלייליסטים יובאו בהצלחה
     Export Playlists: ייצוא פלייליסטים
     Import Playlists: ייבוא פלייליסטים
-    Playlist insufficient data: אין מספיק נתונים לרשימת הנגינה „$”, הפריט ידולג
+    Playlist insufficient data: ''
     Playlist File: קובץ רשימת נגינה
     Subscription File: קובץ מינוי
     History File: קובץ היסטוריה
@@ -506,11 +504,11 @@ Profile:
   Your profile name cannot be empty: 'לא ניתן לרוקן את הפרופיל שלך'
   Profile has been created: 'הפרופיל נוצר'
   Profile has been updated: 'הפרופיל עודכן'
-  Your default profile has been set to {profile}: 'הגדרת את $ כפרופיל ברירת המחדל'
+  Your default profile has been set to {profile}: ''
   Removed {profile} from your profiles: '{profile} נמחק מהפרופילים שלך'
   Your default profile has been changed to your primary profile: 'פרופיל ברירת המחדל
     שלך השתנה לפרופיל הראשי שלך'
-  '{profile} is now the active profile': 'פרופיל $ פעיל עכשיו'
+  '{profile} is now the active profile': ''
   Subscription List: 'רשימת מינויים'
   Other Channels: 'ערוצים אחרים'
   '{number} selected': '{number} נבחר'
@@ -534,7 +532,7 @@ Channel:
   Subscribe: 'הרשמה למינוי'
   Unsubscribe: 'ביטול המינוי'
   Channel has been removed from your subscriptions: 'הערוץ נמחק מרשימת המנויים שלך'
-  Removed subscription from {count} other channel(s): 'המנוי הוסר מ-$ ערוצ/ים אחר/ים'
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: 'הערוץ נוסף לרשימת המנויים שלך'
   Search Channel: 'חיפוש בערוץ'
   Your search results have returned 0 results: 'לא נמצאו תוצאות'
@@ -659,8 +657,8 @@ Video:
     video: סרטון
     playlist: פלייליסט
     OpenInTemplate: פתיחה בתוך {externalPlayer}
-    OpeningTemplate: מתבצעת פתיחת $ בתוך {externalPlayer}...
-    UnsupportedActionTemplate: 'ל־$ אין תמיכה ב־: {action}'
+    OpeningTemplate: ''
+    UnsupportedActionTemplate: ''
     Unsupported Actions:
       opening playlists: פתיחת רשימות נגינה
       setting a playback rate: הגדרת מהירות נגינה
@@ -853,8 +851,8 @@ External link opening has been disabled in the general settings: פתיחת הק
 Hashtags have not yet been implemented, try again later: עדיין לא הוטמעו תגיות הקבץ,
   נא לנסות בהמשך
 Downloading failed: אירעה שגיאה בהורדת "{videoTitle}"
-Starting download: הורדת "$" מתחילה
-Downloading has completed: הורדת "$" הסתיימה
+Starting download: ''
+Downloading has completed: ''
 Playing Next Video Interval: הסרטון הבא יתחיל מיד. לחיצה לביטול. | הסרטון הבא יתנגן
   בעוד שנייה. לחיצה לביטול. | הסרטון הבא יתנגן בעוד {nextVideoInterval} שניות. לחיצה
   לביטול.
@@ -865,13 +863,13 @@ Age Restricted:
   Type:
     Channel: ערוץ
     Video: סרטון
-  This {videoOrPlaylist} is age restricted: ה$ הזה מוגבל בגיל
+  This {videoOrPlaylist} is age restricted: ''
 Channels:
   Search bar placeholder: חיפוש ערוצים
   Empty: רשימת הערוצים שלך ריקה כרגע.
   Unsubscribe: ביטול מינוי
-  Unsubscribed: $ הוסר מרשימת המינויים שלך
-  Count: נמצאו $ ערוצים.
+  Unsubscribed: ''
+  Count: ''
   Channels: ערוצים
   Title: רשימת ערוצים
   Unsubscribe Prompt: לבטל את המינוי על „{channelName}”?

--- a/static/locales/hi.yaml
+++ b/static/locales/hi.yaml
@@ -29,10 +29,10 @@ Close: 'बंद करे'
 Back: 'पीछे'
 Forward: 'आगे'
 
-Version $ is now available!  Click for more details: 'Version $ आ गया है! और details
+Version {versionNumber} is now available!  Click for more details: 'Version {versionNumber} आ गया है! और details
   के लिए इधर click करे।'
 Download From Site: 'साइट से डाउनलोड (download) करे'
-A new blog is now available, $. Click to view more: 'एक नया ब्लॉग है, $। और जानने
+A new blog is now available, {blogTitle}. Click to view more: 'एक नया ब्लॉग है, {blogTitle}। और जानने
   के लिए इधर click करिए'
 
 # Search Bar
@@ -314,13 +314,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -337,7 +337,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -436,7 +436,6 @@ Video:
   Published on: ''
   Streamed on: ''
   Started streaming on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -144,8 +144,8 @@ Settings:
     Current instance will be randomized on startup: Trenutačna instanca će se slučajno
       odrediti nakon pokretanja računala
     No default instance has been set: Nema standardno postavljene instance
-    The currently set default instance is $: Trenutačno postavljena standardna instanca
-      je $
+    The currently set default instance is {instance}: Trenutačno postavljena standardna instanca
+      je {instance}
     Current Invidious Instance: Trenutačna Invidious instanca
     External Link Handling:
       No Action: Bez radnje
@@ -356,7 +356,7 @@ Settings:
     Manage Subscriptions: Upravljaj pretplatama
     Import Playlists: Uvezi zbirke
     Export Playlists: Izvezi zbirke
-    Playlist insufficient data: Nedovoljno podataka za „$” zbirku, element se preskače
+    Playlist insufficient data: Nedovoljno podataka za „{playlist}” zbirku, element se preskače
     All playlists has been successfully imported: Sve zbirke su uspješno uvezene
     All playlists has been successfully exported: Sve zbirke su uspješno izvezene
   Distraction Free Settings:
@@ -511,12 +511,12 @@ Profile:
   Your profile name cannot be empty: 'Ime profila ne smije biti prazno'
   Profile has been created: 'Profil je stvoren'
   Profile has been updated: 'Profil je aktualiziran'
-  Your default profile has been set to $: 'Tvoj standardni profil je postavljen na
-    $'
-  Removed $ from your profiles: '$ je uklonjen iz tvojih profila'
+  Your default profile has been set to {profile}: 'Tvoj standardni profil je postavljen na
+    {profile}'
+  Removed {profile} from your profiles: '{profile} je uklonjen iz tvojih profila'
   Your default profile has been changed to your primary profile: 'Tvoj standardni
     profil je promijenjen u tvoj primarni profil'
-  $ is now the active profile: '$ je sada aktivni profil'
+  '{profile} is now the active profile': '{profile} je sada aktivni profil'
 #On Channel Page
   Profile Select: Biranje profila
   Are you sure you want to delete the selected channels?  This will not delete the channel from any other profile.: Stvarno
@@ -530,7 +530,7 @@ Profile:
   Delete Selected: Izbriši odabrane
   Select None: Odaberi ništa
   Select All: Odaberi sve
-  $ selected: 'Broj odabranih: $'
+  '{number} selected': 'Broj odabranih: {number}'
   Other Channels: Ostali kanali
   Subscription List: Popis pretplata
   Profile Filter: Filtar profila
@@ -564,7 +564,7 @@ Channel:
     Channel Description: 'Opis kanala'
     Featured Channels: 'Istaknuti kanali'
   Added channel to your subscriptions: Kanal je dodan tvojim pretplatama
-  Removed subscription from $ other channel(s): Uklonjena pretplata iz $ drugih kanala
+  Removed subscription from {count} other channel(s): Uklonjena pretplata iz {count} drugih kanala
   Channel has been removed from your subscriptions: Kanal je uklonjen iz tvojih pretplata
 Video:
   Mark As Watched: 'Označi kao pogledano'
@@ -628,8 +628,7 @@ Video:
     Less than a minute: Manje od jedne minute
     In less than a minute: Manje od minute
   Published on: 'Objavljeno'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'prije $ %'
+  Publicationtemplate: 'prije {number} {unit}'
 #& Videos
   Autoplay: Automatska reprodukcija
   Play Previous Video: Reproduciraj prethodni video
@@ -678,11 +677,11 @@ Video:
       opening specific video in a playlist (falling back to opening the video): otvaranje
         određenog videa u zbirki (vraćanje na otvaranje videa)
       setting a playback rate: postavljanje brzine reprodukcije
-    UnsupportedActionTemplate: '$ ne podržava: %'
-    OpeningTemplate: Otvara se $ u % …
+    UnsupportedActionTemplate: '{externalPlayer} ne podržava: {action}'
+    OpeningTemplate: Otvara se {videoOrPlaylist} u {externalPlayer} …
     playlist: zbirka
     video: video
-    OpenInTemplate: Otvori u $
+    OpenInTemplate: Otvori u {externalPlayer}
   Premieres on: Premijera
   Stats:
     fps: Kadrova u sekundi
@@ -777,7 +776,7 @@ Comments:
   Top comments: Najpopularniji komentari
   Sort by: Redoslijed
   Show More Replies: Pokaži više odgovora
-  From $channelName: od $channelName
+  From {channelName}: od {channelName}
   And others: i drugi
   Pinned by: Prikvačio/la
   Member: Član
@@ -804,10 +803,10 @@ Canceled next video autoplay: 'Automatska reprodukcija sljedećeg videa je preki
 Yes: 'Da'
 No: 'Ne'
 The playlist has been reversed: Redoslijed zbirke je obrnut
-A new blog is now available, $. Click to view more: Dostupan je novi blog, $. Pritisni
+A new blog is now available, {blogTitle}. Click to view more: Dostupan je novi blog, {blogTitle}. Pritisni
   za prikaz detalja
 Download From Site: Preuzmi s web-stranice
-Version $ is now available!  Click for more details: Dostupna je verzija $! Pritisni
+Version {versionNumber} is now available!  Click for more details: Dostupna je verzija {versionNumber}! Pritisni
   za prikaz detalja
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Ovaj
   video nije dostupan zbog nedostajućih formata. Uzrok tome može biti nedostupnost
@@ -864,7 +863,7 @@ Tooltips:
     Custom External Player Executable: Prema standardnim postavkama, FreeTube će pretpostaviti
       da se odabrani vanjski player može pronaći putem varijable okruženja PATH (putanja).
       Ako je potrebno, ovdje se može postaviti prilagođena putanja.
-    DefaultCustomArgumentsTemplate: '(Standardno: „$”)'
+    DefaultCustomArgumentsTemplate: '(Standardno: „{defaultCustomArguments}”)'
 Playing Next Video Interval: Trenutna reprodukcija sljedećeg videa. Pritisni za prekid.
   | Reprodukcija sljedećeg videa za {nextVideoInterval} sekunde. Pritisni za prekid.
   | Reprodukcija sljedećeg videa za {nextVideoInterval} sekundi. Pritisni za prekid.
@@ -875,21 +874,21 @@ Unknown YouTube url type, cannot be opened in app: Nepoznata vrsta URL adrese na
   ne može se otvoriti u programu
 Open New Window: Otvori novi prozor
 Default Invidious instance has been cleared: Standardna Invidious instanca je izbrisana
-Default Invidious instance has been set to $: Standardna Invidious instanca je postavljena
-  na $
+Default Invidious instance has been set to {instance}: Standardna Invidious instanca je postavljena
+  na {instance}
 External link opening has been disabled in the general settings: Vanjsko otvaranje
   poveznica je deaktivirano u općim postavkama
 Search Bar:
   Clear Input: Izbriši unos
 Are you sure you want to open this link?: Stvarno želiš otvoriti ovu poveznicu?
-Downloading failed: Došlo je do problema prilikom preuzimanja „$”
-Downloading has completed: „$” je preuzeto
-Starting download: Početak preuzimanja „$”
-Screenshot Success: Snimka ekrana je spremljena pod „$”
-Screenshot Error: Neuspjela snimka ekrana. $
+Downloading failed: Došlo je do problema prilikom preuzimanja „{videoTitle}”
+Downloading has completed: „{videoTitle}” je preuzeto
+Starting download: Početak preuzimanja „{videoTitle}”
+Screenshot Success: Snimka ekrana je spremljena pod „{filePath}”
+Screenshot Error: Neuspjela snimka ekrana. {error}
 New Window: Novi prozor
 Age Restricted:
-  This $contentType is age restricted: Ovaj $ je dobno ograničen
+  This {videoOrPlaylist} is age restricted: Ovaj {videoOrPlaylist} je dobno ograničen
   Type:
     Channel: Kanal
     Video: Video
@@ -897,11 +896,11 @@ Channels:
   Channels: Kanali
   Title: Popis kanala
   Search bar placeholder: Pretraži kanale
-  Count: $ kanala pronađena.
+  Count: '{number} kanala pronađena.'
   Empty: Tvoj popis kanala je trenutačno prazan.
   Unsubscribe: Prekini pretplatu
-  Unsubscribe Prompt: Stvarno želiš prekinuti pretplatu na „$”?
-  Unsubscribed: $ je uklonjen iz tvojih pretplata
+  Unsubscribe Prompt: Stvarno želiš prekinuti pretplatu na „{channelName}”?
+  Unsubscribed: '{channelName} je uklonjen iz tvojih pretplata'
 Clipboard:
   Copy failed: Neuspjelo kopiranje u međuspremnik
   Cannot access clipboard without a secure connection: Pristup međuspremniku nije

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -30,10 +30,10 @@ Close: 'Bezárás'
 Back: 'Vissza'
 Forward: 'Előre'
 
-Version $ is now available!  Click for more details: 'A(z) $ verzió már elérhető!
+Version {versionNumber} is now available!  Click for more details: 'A(z) {versionNumber} verzió már elérhető!
   Kattintson a további részletekért'
 Download From Site: 'Letöltés a webhelyről'
-A new blog is now available, $. Click to view more: 'Új blog már elérhető: $. Kattintson
+A new blog is now available, {blogTitle}. Click to view more: 'Új blog már elérhető: {blogTitle}. Kattintson
   további információk megtekintéséhez'
 
 # Search Bar
@@ -157,8 +157,8 @@ Settings:
     Set Current Instance as Default: Állítsa be a jelenlegi példányt alapértelmezettként
     Current instance will be randomized on startup: Jelenlegi példány indításkor véletlenszerűsített
     No default instance has been set: Az alapértelmezett példány nincs beállítva
-    The currently set default instance is $: A jelenleg beállított alapértelmezett
-      példány $
+    The currently set default instance is {instance}: A jelenleg beállított alapértelmezett
+      példány {instance}
     External Link Handling:
       No Action: Nincs művelet
       Ask Before Opening Link: Hivatkozás megnyitása előtt kérése
@@ -336,7 +336,7 @@ Settings:
     How do I import my subscriptions?: 'Hogyan lehet importálni feliratkozásaimmal?'
     Check for Legacy Subscriptions: Örökölt feliratkozások keresése
     Manage Subscriptions: Feliratkozások kezelése
-    Playlist insufficient data: Nincs elegendő adat a(z) „$” lejátszási listához,
+    Playlist insufficient data: Nincs elegendő adat a(z) „{playlist}” lejátszási listához,
       elem kihagyása
     Export Playlists: Lejátszási listák exportálása
     Import Playlists: Lejátszási listák importálása
@@ -523,15 +523,15 @@ Profile:
   Your profile name cannot be empty: 'A profil neve nem lehet üres'
   Profile has been created: 'Profil létrehozva'
   Profile has been updated: 'A profil frissült'
-  Your default profile has been set to $: 'Alapértelmezett profilja a következőre
-    lett beállítva: $'
-  Removed $ from your profiles: 'A(z) $ eltávolítva a profiljaidból'
+  Your default profile has been set to {profile}: 'Alapértelmezett profilja a következőre
+    lett beállítva: {profile}'
+  Removed {profile} from your profiles: 'A(z) {profile} eltávolítva a profiljaidból'
   Your default profile has been changed to your primary profile: 'Az alapértelmezett
     profil az elsődleges profilra változott'
-  $ is now the active profile: 'A(z) $ most az aktív profil'
+  '{profile} is now the active profile': 'A(z) {profile} most az aktív profil'
   Subscription List: 'Feliratkozási lista'
   Other Channels: 'Egyéb csatornák'
-  $ selected: '$ kiválasztva'
+  '{number} selected': '{number} kiválasztva'
   Select All: 'Összes kijelölése'
   Select None: 'Kijelölések megszüntetése'
   Delete Selected: 'Kijelöltek törlése'
@@ -553,7 +553,7 @@ Channel:
   Unsubscribe: 'Leiratkozás'
   Channel has been removed from your subscriptions: 'A csatornát eltávolítottuk a
     feliratkozásokból'
-  Removed subscription from $ other channel(s): '$ másik csatornából eltávolította
+  Removed subscription from {count} other channel(s): '{count} másik csatornából eltávolította
     a feliratkozást'
   Added channel to your subscriptions: 'Csatorna hozzáadva a feliratkozásaihoz'
   Search Channel: 'Csatornakeresés'
@@ -648,8 +648,7 @@ Video:
     Upcoming: 'Az első előadás hamarosan lesz'
     In less than a minute: Kevesebb, mint egy perce ezelőtt
   Published on: 'Megjelent'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % ezelőtt'
+  Publicationtemplate: '{number} {unit} ezelőtt'
 #& Videos
   Audio:
     Best: Legjobb
@@ -689,11 +688,11 @@ Video:
       opening playlists: lejátszási listák megnyitása
       setting a playback rate: lejátszási sebesség beállítása
       starting video at offset: Videó kezdése eltolás
-    UnsupportedActionTemplate: 'A(z) $ külső lejátszó nem támogatja: %'
-    OpeningTemplate: A(z) $ videó megnyitása a(z) % külső lejátszóban…
+    UnsupportedActionTemplate: 'A(z) {externalPlayer} külső lejátszó nem támogatja: {action}'
+    OpeningTemplate: A(z) {videoOrPlaylist} videó megnyitása a(z) {externalPlayer} külső lejátszóban…
     playlist: lejátszási lista
     video: videó
-    OpenInTemplate: $ megnyításaban
+    OpenInTemplate: '{externalPlayer} megnyításaban'
   Premieres on: 'Bemutatkozás dátuma:'
   Stats:
     Player Dimensions: Lejátszó méretei
@@ -783,7 +782,7 @@ Comments:
   Top comments: Legnépszerűbb megjegyzések
   Sort by: Rendezés alapja
   Show More Replies: További válaszok megjelenítése
-  From $channelName: 'forrás: $channelName'
+  From {channelName}: 'forrás: {channelName}'
   And others: és mások
   Pinned by: 'Kitűzte:'
   Member: Tag
@@ -872,7 +871,7 @@ Tooltips:
     External Player: Külső lejátszó kiválasztása esetén megjelenik egy ikon a videó
       (lejátszási lista, ha támogatott) megnyitásához a külső lejátszóban, az indexképen.
       Figyelem! Az Invidious beállításai nincsenek hatással a külső lejátszókra.
-    DefaultCustomArgumentsTemplate: '(Alapértelmezett: „$”)'
+    DefaultCustomArgumentsTemplate: '(Alapértelmezett: „{defaultCustomArguments}”)'
 Playing Next Video Interval: A következő videó lejátszása folyamatban van. Kattintson
   a törléshez. | A következő videó lejátszása {nextVideoInterval} másodperc múlva
   történik. Kattintson a törléshez. | A következő videó lejátszása {nextVideoInterval}
@@ -885,8 +884,8 @@ Unknown YouTube url type, cannot be opened in app: Ismeretlen YouTube URL-típus
 Open New Window: Új ablak megnyitása
 Default Invidious instance has been cleared: Az alapértelmezett Invidious-példányt
   eltávolítva
-Default Invidious instance has been set to $: Az alapértelmezett Invidious-példány
-  $ beállítva
+Default Invidious instance has been set to {instance}: 'Az alapértelmezett Invidious-példány
+  {instance} beállítva'
 Search Bar:
   Clear Input: Bemenet törlése
 External link opening has been disabled in the general settings: A külső hivatkozás
@@ -897,20 +896,20 @@ Channels:
   Channels: Csatornák
   Title: Csatornalista
   Search bar placeholder: Csatornák keresése
-  Count: $ csatorna találat.
+  Count: '{number} csatorna találat.'
   Empty: Csatornalista jelenleg üres.
   Unsubscribe: Leiratkozás
-  Unsubscribed: $ eltávolítva az feliratkozásáiból
-  Unsubscribe Prompt: Biztosan le szeretne iratkozni a(z) „$” csatornáról?
+  Unsubscribed: '{channelName} eltávolítva az feliratkozásáiból'
+  Unsubscribe Prompt: Biztosan le szeretne iratkozni a(z) „{channelName}” csatornáról?
 Age Restricted:
   Type:
     Video: Videó
     Channel: Csatorna
-  This $contentType is age restricted: A(z) $ korhatáros
-Downloading failed: Hiba történt a(z) „$” letöltése során
-Starting download: „$” letöltésének indítása
-Downloading has completed: A(z) „$” letöltése befejeződött
-Screenshot Success: Képernyőkép „$” néven mentve
+  This {videoOrPlaylist} is age restricted: A(z) {videoOrPlaylist} korhatáros
+Downloading failed: Hiba történt a(z) „{videoTitle}” letöltése során
+Starting download: „{videoTitle}” letöltésének indítása
+Downloading has completed: A(z) „{videoTitle}” letöltése befejeződött
+Screenshot Success: Képernyőkép „{filePath}” néven mentve
 Chapters:
   Chapters: Fejezetek
   'Chapters list visible, current chapter: {chapterName}': 'Fejezeteklista látható,
@@ -921,4 +920,4 @@ Clipboard:
   Cannot access clipboard without a secure connection: Biztonságos kapcsolat nélkül
     nem lehet hozzáférni a vágólaphoz
   Copy failed: A vágólapra másolás nem sikerült
-Screenshot Error: A képernyőkép nem sikerült. $
+Screenshot Error: A képernyőkép nem sikerült. {error}

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -30,11 +30,11 @@ Close: 'Tutup'
 Back: 'Kembali'
 Forward: 'Maju'
 
-Version $ is now available!  Click for more details: 'Versi $ sekarang tersedia!  Klik
+Version {versionNumber} is now available!  Click for more details: 'Versi {versionNumber} sekarang tersedia!  Klik
   untuk detail lebih lanjut'
 Download From Site: 'Unduh dari Situs'
-A new blog is now available, $. Click to view more: 'Blog baru sekarang tersedia,
-  $. Klik untuk lihat lebih lanjut'
+A new blog is now available, {blogTitle}. Click to view more: 'Blog baru sekarang tersedia,
+  {blogTitle}. Klik untuk lihat lebih lanjut'
 
 # Search Bar
 Search / Go to URL: 'Cari / Pergi ke URL'
@@ -152,8 +152,8 @@ Settings:
       Open Link: Buka link
       Ask Before Opening Link: Tanya sebelum membuka link
       No Action: Tidak ada
-    The currently set default instance is $: Instans default yang saat ini disetel
-      adalah $
+    The currently set default instance is {instance}: Instans default yang saat ini disetel
+      adalah {instance}
     No default instance has been set: Tidak ada instans default yang disetel
     Set Current Instance as Default: Tetapkan Instans Saat Ini sebagai Default
     Clear Default Instance: Hapus Instans Default
@@ -298,7 +298,7 @@ Settings:
     Manage Subscriptions: Kelola Langganan
     Import Playlists: Impor Playlist
     Export Playlists: Ekspor Playlist
-    Playlist insufficient data: Data tidak mencukupi untuk "$" playlist, melewatkan
+    Playlist insufficient data: Data tidak mencukupi untuk "{playlist}" playlist, melewatkan
       item
     All playlists has been successfully imported: Semua playlist berhasil diimpor
     All playlists has been successfully exported: Semua playlist berhasil diekspor
@@ -449,14 +449,14 @@ Profile:
   Your profile name cannot be empty: 'Nama profil Anda tidak boleh kosong'
   Profile has been created: 'Profil telah dibuat'
   Profile has been updated: 'Profil telah diperbarui'
-  Your default profile has been set to $: 'Profil bawaan Anda telah diatur ke $'
-  Removed $ from your profiles: '$ dihapus dari profil Anda'
+  Your default profile has been set to {profile}: 'Profil bawaan Anda telah diatur ke {profile}'
+  Removed {profile} from your profiles: '{profile} dihapus dari profil Anda'
   Your default profile has been changed to your primary profile: 'Profil bawaan Anda
     telah diubah ke profil utama Anda'
-  $ is now the active profile: '$ sekarang adalah profil aktif'
+  '{profile} is now the active profile': '{profile} sekarang adalah profil aktif'
   Subscription List: 'Daftar Langganan'
   Other Channels: 'Kanal Lain'
-  $ selected: '$ terpilih'
+  '{number} selected': '{number} terpilih'
   Select All: 'Pilih Semua'
   Select None: 'Tidak Pilih'
   Delete Selected: 'Hapus Terpilih'
@@ -479,7 +479,7 @@ Channel:
   Unsubscribe: 'Berhenti Langganan'
   Channel has been removed from your subscriptions: 'Kanal telah dihapus dari langganan
     Anda'
-  Removed subscription from $ other channel(s): 'Langganan terhapus dari $ kanal lainnya'
+  Removed subscription from {count} other channel(s): 'Langganan terhapus dari {count} kanal lainnya'
   Added channel to your subscriptions: 'Kanal ditambahkan ke langganan Anda'
   Search Channel: 'Cari Kanal'
   Your search results have returned 0 results: 'Hasil pencarian Anda memberikan 0
@@ -571,8 +571,7 @@ Video:
     Ago: 'Lalu'
     Upcoming: 'Segera tayang di'
   Published on: 'Dipublikasi pada'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % yang lalu'
+  Publicationtemplate: '{number} {unit} yang lalu'
 #& Videos
   Audio:
     Best: Terbaik
@@ -614,11 +613,11 @@ Video:
         video)
       opening playlists: membuka daftar putar
       setting a playback rate: menetapkan laju pemutaran
-    UnsupportedActionTemplate: '$ tidak mendukung: %'
-    OpeningTemplate: Membuka $ dalam %...
+    UnsupportedActionTemplate: '{externalPlayer} tidak mendukung: {action}'
+    OpeningTemplate: Membuka {videoOrPlaylist} dalam {externalPlayer}...
     playlist: daftar putar
     video: video
-    OpenInTemplate: Buka di $
+    OpenInTemplate: Buka di {externalPlayer}
   Premieres on: Pemutaran Perdana pada
   Stats:
     bandwidth: Kecepatan Koneksi
@@ -710,7 +709,7 @@ Comments:
   Sort by: Urut berdasarkan
   There are no more comments for this video: Tidak ada komentar lagi untuk video ini
   Show More Replies: Tampilkan Lebih Banyak Balasan
-  From $channelName: dari $channelName
+  From {channelName}: dari {channelName}
   And others: dan lain-lain
   Pinned by: Dipin oleh
 Up Next: 'Akan Datang'
@@ -792,7 +791,7 @@ Tooltips:
     External Player: Memilih pemutar eksternal akan menampilkan ikon khusus, untuk
       membuka video (daftar putar jika didukung) di dalam pemutar eksternal, pada
       thumbnail.
-    DefaultCustomArgumentsTemplate: "(Default: '$')"
+    DefaultCustomArgumentsTemplate: "(Default: '{defaultCustomArguments}')"
 Playing Next Video Interval: Langsung putar video berikutnya. Klik untuk batal. |
   Putar video berikutnya dalam {nextVideoInterval} detik. Klik untuk batal. | Putar
   video berikutnya dalam {nextVideoInterval} detik. Klik untuk batal.
@@ -807,9 +806,9 @@ Search Bar:
 External link opening has been disabled in the general settings: Pembukaan link eksternal
   telah dimatikan pada pengaturan umum
 Are you sure you want to open this link?: Yakin ingin membuka link ini?
-Default Invidious instance has been set to $: Situs Invidious baku telah di atur ke
-  $
+Default Invidious instance has been set to {instance}: 'Situs Invidious baku telah di atur ke
+  {instance}'
 Default Invidious instance has been cleared: Situs Invidious baku telah dikosongkan
-Downloading has completed: '"$" telah selesai diunduh'
-Starting download: Mulai mengunduh "$"
-Downloading failed: Ada masalah mengunduh "$"
+Downloading has completed: '"{videoTitle}" telah selesai diunduh'
+Starting download: Mulai mengunduh "{videoTitle}"
+Downloading failed: Ada masalah mengunduh "{videoTitle}"

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -30,11 +30,11 @@ Close: 'Loka'
 Back: 'Til baka'
 Forward: 'Áfram'
 
-Version $ is now available!  Click for more details: 'Útgáfa $ er tiltæk!  Smelltu
+Version {versionNumber} is now available!  Click for more details: 'Útgáfa {versionNumber} er tiltæk!  Smelltu
   til að skoða nánar'
 Download From Site: 'Sækja af vefsvæði'
-A new blog is now available, $. Click to view more: 'Ný bloggfærsla er núna er tiltæk,
-  $. Smelltu til að skoða nánar'
+A new blog is now available, {blogTitle}. Click to view more: 'Ný bloggfærsla er núna er tiltæk,
+  {blogTitle}. Smelltu til að skoða nánar'
 
 # Search Bar
 Search / Go to URL: 'Leita / Fara á slóð'
@@ -159,8 +159,8 @@ Settings:
     Current instance will be randomized on startup: Fyrirliggjandi tilvik verður tilgreint
       af handahófi í ræsingu
     No default instance has been set: Ekkert sjálfgefið tilvik hefur verið stillt
-    The currently set default instance is $: Fyrirliggjandi sjálfgefna tilvikið er
-      $
+    The currently set default instance is {instance}: 'Fyrirliggjandi sjálfgefna tilvikið er
+      {instance}'
     Current Invidious Instance: Fyrirliggjandi Invidious-tilvik
     External Link Handling:
       No Action: Ekkert gert
@@ -357,7 +357,7 @@ Settings:
     Manage Subscriptions: 'Sýsla með áskriftir'
     Import Playlists: Flytja inn spilunarlista
     Export Playlists: Flytja út spilunarlista
-    Playlist insufficient data: Ónóg gögn fyrir "$" spilunarlista, sleppi atriðinu
+    Playlist insufficient data: Ónóg gögn fyrir "{playlist}" spilunarlista, sleppi atriðinu
     All playlists has been successfully imported: Tekist hefur að flytja inn alla
       spilunarlista
     All playlists has been successfully exported: Tekist hefur að flytja út alla spilunarlista
@@ -464,15 +464,15 @@ Profile:
   Your profile name cannot be empty: 'Nafn notkunarsniðsins má ekki vera tómt'
   Profile has been created: 'Notkunarsnið hefur verið útbúið'
   Profile has been updated: 'Notkunarsnið hefur verið uppfært'
-  Your default profile has been set to $: 'Sjálfgefið notandasnið þitt hefur stillt
-    sem $'
-  Removed $ from your profiles: 'Fjarlægði $ úr notkunarsniðunum þínum'
+  Your default profile has been set to {profile}: 'Sjálfgefið notandasnið þitt hefur stillt
+    sem {profile}'
+  Removed {profile} from your profiles: 'Fjarlægði {profile} úr notkunarsniðunum þínum'
   Your default profile has been changed to your primary profile: 'Sjálfgefið notandasnið
     þitt hefur stillt á aðalnotkunarsniðið þitt'
-  $ is now the active profile: '$ er núna virka notkunarsniðið'
+  '{profile} is now the active profile': '{profile} er núna virka notkunarsniðið'
   Subscription List: 'Áskriftalisti'
   Other Channels: 'Aðrar rásir'
-  $ selected: '$ valið'
+  '{number} selected': '{number} valið'
   Select All: 'Velja allt'
   Select None: 'Velja ekkert'
   Delete Selected: 'Eyða völdu'
@@ -494,7 +494,7 @@ Channel:
   Unsubscribe: 'Segja upp áskrift'
   Channel has been removed from your subscriptions: 'Rás var fjarlægð úr áskriftunum
     þínum'
-  Removed subscription from $ other channel(s): 'Fjarlægði áskrift úr $ rás(um) til
+  Removed subscription from {count} other channel(s): 'Fjarlægði áskrift úr {count} rás(um) til
     viðbótar'
   Added channel to your subscriptions: 'Bætti rás í áskriftirnar þínar'
   Search Channel: 'Leita á rás'
@@ -608,8 +608,7 @@ Video:
   Published on: 'Gefið út'
   Streamed on: 'Streymt'
   Started streaming on: 'Byrjaði streymi'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Fyrir $ % síðan'
+  Publicationtemplate: 'Fyrir {number} {unit} síðan'
 #& Videos
   translated from English: þýtt úr ensku
   Sponsor Block category:
@@ -632,11 +631,11 @@ Video:
       starting video at offset: byrja myndskeið á hliðrun
       opening specific video in a playlist (falling back to opening the video): opna
         tiltekið myndskeið í spilunarlista (til vara að opna myndskeiðið)
-    UnsupportedActionTemplate: '$ styður ekki: %'
-    OpeningTemplate: Opna $ eftir %...
+    UnsupportedActionTemplate: '{externalPlayer} styður ekki: {action}'
+    OpeningTemplate: Opna {videoOrPlaylist} eftir {externalPlayer}...
     playlist: spilunarlisti
     video: myndskeið
-    OpenInTemplate: Opna í $
+    OpenInTemplate: Opna í {externalPlayer}
   Premieres on: Frumsýnt
   Stats:
     player resolution: Myndgluggi
@@ -732,7 +731,7 @@ Comments:
   Load More Comments: 'Hlaða inn fleiri athugasemdum'
   No more comments available: 'Engar fleiri athugasemdir eru tiltækar'
   Show More Replies: Birta fleiri svör
-  From $channelName: frá $channelName
+  From {channelName}: frá {channelName}
   And others: og fleirum
   Pinned by: Fest af
   Member: Meðlimur
@@ -799,7 +798,7 @@ Tooltips:
       til að opna myndskeiðið (í spilunarlista ef stuðningur er við slíkt) í þessum
       utanaðkomandi spilara. Aðvörun, stillingar Invidious hafa ekki áhrif á utanaðkomandi
       spilara.
-    DefaultCustomArgumentsTemplate: "(Sjálfgefið: '$')"
+    DefaultCustomArgumentsTemplate: "(Sjálfgefið: '{defaultCustomArguments}')"
 Local API Error (Click to copy): 'Villa í staðværu API-kerfisviðmóti (smella til að
   afrita)'
 Invidious API Error (Click to copy): 'Villa í Invidious API-kerfisviðmóti (smella
@@ -834,30 +833,30 @@ Unknown YouTube url type, cannot be opened in app: Óþekkt gerð YouTube-slóð
 Open New Window: Opna í nýjum glugga
 Default Invidious instance has been cleared: Sjálfgefið Invidious-tilvik hefur verið
   hreinsað út
-Default Invidious instance has been set to $: Sjálfgefið Invidious-tilvik hefur verið
-  stillt sem $
+Default Invidious instance has been set to {instance}: Sjálfgefið Invidious-tilvik hefur verið
+  stillt sem {instance}
 Search Bar:
   Clear Input: Hreinsa reit
 External link opening has been disabled in the general settings: Opnun ytri tengla
   hefur verið gerð óvirk í almennum stillingum
 Are you sure you want to open this link?: Ertu viss um að þú viljir opna þennan tengil?
-Downloading has completed: Búið er að sækja "$"
-Starting download: Byrja að sækja "$"
-Downloading failed: Vandamál kom upp við að sækja "$"
-Screenshot Error: Skjámyndataka mistókst. $
-Screenshot Success: Vistaði skjámynd sem "$"
+Downloading has completed: Búið er að sækja "{videoTitle}"
+Starting download: Byrja að sækja "{videoTitle}"
+Downloading failed: Vandamál kom upp við að sækja "{videoTitle}"
+Screenshot Error: Skjámyndataka mistókst. {error}
+Screenshot Success: Vistaði skjámynd sem "{filePath}"
 Age Restricted:
   Type:
     Channel: Rás
     Video: Myndskeið
-  This $contentType is age restricted: Þetta $ er með aldurstakmörkunum
+  This {videoOrPlaylist} is age restricted: Þetta {videoOrPlaylist} er með aldurstakmörkunum
 New Window: Nýr gluggi
 Channels:
   Search bar placeholder: Leita í rásum
-  Count: $ rás/rásir fundust.
+  Count: '{number} rás/rásir fundust.'
   Empty: Rásalistinn þinn er tómur.
-  Unsubscribed: $ hefur verið fjarlægð úr áskriftunum þínum
-  Unsubscribe Prompt: Ertu viss um að þú viljir hætta áskrift að "$"?
+  Unsubscribed: '{channelName} hefur verið fjarlægð úr áskriftunum þínum'
+  Unsubscribe Prompt: Ertu viss um að þú viljir hætta áskrift að "{channelName}"?
   Channels: Rásir
   Title: Rásalisti
   Unsubscribe: Segja upp áskrift

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -150,7 +150,7 @@ Settings:
     Current instance will be randomized on startup: L'istanza attuale sarà sostituita
       all'avvio da una generata casualmente
     No default instance has been set: Non è stata impostata alcuna istanza predefinita
-    The currently set default instance is $: L'attuale istanza predefinita è $
+    The currently set default instance is {instance}: L'attuale istanza predefinita è {instance}
     Current Invidious Instance: Istanza attuale di Invidious
     System Default: Predefinito del sistema
     External Link Handling:
@@ -369,7 +369,7 @@ Settings:
     Manage Subscriptions: Gestisci i profili
     Import Playlists: Importa playlist
     Export Playlists: Esporta playlist
-    Playlist insufficient data: Dati insufficienti per la playlist «$», elemento saltato
+    Playlist insufficient data: Dati insufficienti per la playlist «{playlist}», elemento saltato
     All playlists has been successfully imported: Tutte le playlist sono state importate
       con successo
     All playlists has been successfully exported: Tutte le playlist sono state esportate
@@ -536,8 +536,8 @@ Channel:
     Channel Description: 'Descrizione canale'
     Featured Channels: 'Canali suggeriti'
   Added channel to your subscriptions: Il canale è stato aggiunto alle tue iscrizioni
-  Removed subscription from $ other channel(s): È stata rimossa l'iscrizione dagli
-    altri canali di $
+  Removed subscription from {count} other channel(s): È stata rimossa l'iscrizione dagli
+    altri canali di {count}
   Channel has been removed from your subscriptions: Il canale è stato rimosso dalle
     tue iscrizioni
 Video:
@@ -602,8 +602,7 @@ Video:
     Less than a minute: Meno di un minuto
     In less than a minute: In meno di un minuto
   Published on: 'Pubblicato il'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % fa'
+  Publicationtemplate: '{number} {unit} fa'
 #& Videos
   Play Previous Video: Riproduci il video precedente
   Play Next Video: Riproduci il prossimo video
@@ -641,11 +640,11 @@ Video:
       setting a playback rate: impostando la velocità di riproduzione
       opening playlists: aprendo la playlist
       starting video at offset: avviando il video con uno sfasamento
-    UnsupportedActionTemplate: '$ non supporta: %'
-    OpeningTemplate: Apertura del $ con %…
+    UnsupportedActionTemplate: '{externalPlayer} non supporta: {action}'
+    OpeningTemplate: Apertura del {videoOrPlaylist} con {externalPlayer}…
     playlist: playlist
     video: video
-    OpenInTemplate: Apri con $
+    OpenInTemplate: Apri con {externalPlayer}
   Sponsor Block category:
     music offtopic: Musica fuori tema
     interaction: Interazione
@@ -755,7 +754,7 @@ Comments:
   Newest first: I più nuovi
   Sort by: Ordina per
   Show More Replies: Mostra altre risposte
-  From $channelName: di $channelName
+  From {channelName}: di {channelName}
   And others: e altri
   Pinned by: Messo in primo piano da
   Member: Membro
@@ -782,9 +781,9 @@ Canceled next video autoplay: 'Riproduzione automatica del prossimo video annull
 
 Yes: 'Sì'
 No: 'No'
-A new blog is now available, $. Click to view more: Un nuovo blog è ora disponibile,
-  $. Clicca per saperne di più
-Version $ is now available!  Click for more details: La versione $ è ora disponibile!
+A new blog is now available, {blogTitle}. Click to view more: 'Un nuovo blog è ora disponibile,
+  {blogTitle}. Clicca per saperne di più'
+Version {versionNumber} is now available!  Click for more details: La versione {versionNumber} è ora disponibile!
   Clicca per maggiori dettagli
 Download From Site: Scarica dal sito
 The playlist has been reversed: La playlist è stata invertita
@@ -801,14 +800,14 @@ Profile:
   Delete Selected: Elimina i selezionati
   Select None: Deseleziona tutto
   Select All: Seleziona tutto
-  $ selected: '$ selezionato'
+  '{number} selected': '{number} selezionato'
   Other Channels: Altri canali
   Subscription List: Lista iscrizioni
-  $ is now the active profile: '$ è diventato il tuo profilo attivo'
+  '{profile} is now the active profile': '{profile} è diventato il tuo profilo attivo'
   Your default profile has been changed to your primary profile: Il tuo profilo predefinito
     è stato cambiato in profilo primario
-  Removed $ from your profiles: Hai rimosso $ dai tuoi profili
-  Your default profile has been set to $: '$ è stato impostato come profilo predefinito'
+  Removed {profile} from your profiles: Hai rimosso {profile} dai tuoi profili
+  Your default profile has been set to {profile}: '{profile} è stato impostato come profilo predefinito'
   Profile has been updated: Il profilo è stato aggiornato
   Profile has been created: Il profilo è stato creato
   Your profile name cannot be empty: Il nome del profilo non può essere vuoto
@@ -885,7 +884,7 @@ Tooltips:
     External Player: Scegliendo un lettore esterno sarà visualizzata sulla miniatura
       un'icona per aprire il video nel lettore esterno (se la playlist lo supporta).
       Attenzione, le impostazioni Invidious non influiscono sui lettori esterni.
-    DefaultCustomArgumentsTemplate: '(Predefinito: $)'
+    DefaultCustomArgumentsTemplate: '(Predefinito: {defaultCustomArguments})'
   Privacy Settings:
     Remove Video Meta Files: Se abilitato, quando chiuderai la pagina di riproduzione
       , FreeTube eliminerà automaticamente i metafile creati durante la visione del
@@ -898,8 +897,8 @@ More: Altro
 Open New Window: Apri una nuova finestra
 Default Invidious instance has been cleared: L'istanza predefinita di Invidious è
   stata cancellata
-Default Invidious instance has been set to $: L'istanza predefinita di Invidious è
-  stata impostata a $
+Default Invidious instance has been set to {instance}: L'istanza predefinita di Invidious è
+  stata impostata a {instance}
 Hashtags have not yet been implemented, try again later: Gli hashtag non sono ancora
   stati implementati, riprova più tardi
 Unknown YouTube url type, cannot be opened in app: Tipo di link YouTube sconosciuto,
@@ -909,25 +908,25 @@ Search Bar:
 External link opening has been disabled in the general settings: L'apertura dei collegamenti
   esterni è stata disabilitata nelle impostazioni generali
 Are you sure you want to open this link?: Sei sicuro di voler aprire questo link?
-Downloading has completed: 'Il download di "$" è terminato'
-Starting download: Avvio del download di "$"
-Downloading failed: Si è verificato un problema durante il download di "$"
-Screenshot Success: Cattura schermata salvato come «$»
-Screenshot Error: Cattura schermata fallito. $
+Downloading has completed: 'Il download di "{videoTitle}" è terminato'
+Starting download: Avvio del download di "{videoTitle}"
+Downloading failed: Si è verificato un problema durante il download di "{videoTitle}"
+Screenshot Success: Cattura schermata salvato come «{filePath}»
+Screenshot Error: Cattura schermata fallito. {error}
 Age Restricted:
-  This $contentType is age restricted: Questo $ è limitato dall'età
+  The currently set default instance is {instance}: Questo {instance} è limitato dall'età
   Type:
     Channel: Canale
     Video: Video
 New Window: Nuova finestra
 Channels:
-  Unsubscribed: $ è stato rimosso dalle tue iscrizioni
+  Unsubscribed: {channelName} è stato rimosso dalle tue iscrizioni
   Title: Elenco canali
   Channels: Canali
   Search bar placeholder: Cerca canali
-  Count: $ canale/i trovato/i.
+  Count: {number} canale/i trovato/i.
   Empty: L'elenco dei tuoi canali è attualmente vuoto.
-  Unsubscribe Prompt: Sei sicuro/sicura di voler annullare l'iscrizione a «$»?
+  Unsubscribe Prompt: Sei sicuro/sicura di voler annullare l'iscrizione a «{channelName}»?
   Unsubscribe: Annulla l'iscrizione
 Clipboard:
   Cannot access clipboard without a secure connection: Impossibile accedere agli appunti

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -920,11 +920,11 @@ Age Restricted:
     Video: Video
 New Window: Nuova finestra
 Channels:
-  Unsubscribed: {channelName} è stato rimosso dalle tue iscrizioni
+  Unsubscribed: '{channelName} è stato rimosso dalle tue iscrizioni'
   Title: Elenco canali
   Channels: Canali
   Search bar placeholder: Cerca canali
-  Count: {number} canale/i trovato/i.
+  Count: '{number} canale/i trovato/i.'
   Empty: L'elenco dei tuoi canali è attualmente vuoto.
   Unsubscribe Prompt: Sei sicuro/sicura di voler annullare l'iscrizione a «{channelName}»?
   Unsubscribe: Annulla l'iscrizione

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -134,7 +134,7 @@ Settings:
     Set Current Instance as Default: 現在のインスタンスを既定として設定する
     Current instance will be randomized on startup: 現在のインスタンスは起動時にランダム化されます
     No default instance has been set: 既定のインスタンスが設定されていません
-    The currently set default instance is $: 現在設定されている既定のインスタンスは $です
+    The currently set default instance is {instance}: 現在設定されている既定のインスタンスは {instance}です
     Current Invidious Instance: 現在の invidious インスタンス
     External Link Handling:
       No Action: 何もしない
@@ -328,7 +328,7 @@ Settings:
     One or more subscriptions were unable to be imported: いくつかの登録チャンネルはインポートできませんでした
     Check for Legacy Subscriptions: 旧型式の登録チャンネルの確認
     Manage Subscriptions: 登録チャンネルの管理
-    Playlist insufficient data: 再生リスト"$"のデータが不完全なため、このアイテムは飛ばされます
+    Playlist insufficient data: 再生リスト"{playlist}"のデータが不完全なため、このアイテムは飛ばされます
     All playlists has been successfully imported: 全ての再生リストは成功にインポートされました
     All playlists has been successfully exported: 全ての再生リストは成功にエキスポートされました
     Import Playlists: 再生リストのインポート
@@ -479,7 +479,7 @@ Channel:
     Featured Channels: '注目のチャンネル'
   Added channel to your subscriptions: 登録にチャンネルを追加しました
   Channel has been removed from your subscriptions: 登録からチャンネルを削除しました
-  Removed subscription from $ other channel(s): ほかの $ チャンネルから登録を削除しました
+  Removed subscription from {count} other channel(s): ほかの {count} チャンネルから登録を削除しました
 Video:
   Open in YouTube: 'YouTube で表示'
   Copy YouTube Link: 'YouTube リンクのコピー'
@@ -534,8 +534,7 @@ Video:
     Less than a minute: 1分以内
     In less than a minute: 1 分以内に
   Published on: '公開日'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % 前'
+  Publicationtemplate: '{number} {unit} 前'
 #& Videos
   Video has been removed from your history: 動画を履歴から削除しました
   Remove From History: 履歴から削除
@@ -577,7 +576,7 @@ Video:
     filler: フィラー（穴埋め）
   Skipped segment: スキップされたセグメント
   External Player:
-    OpeningTemplate: '% で $ を開く...'
+    OpeningTemplate: '{externalPlayer} で {videoOrPlaylist} を開く...'
     Unsupported Actions:
       looping playlists: 再生リストのループ
       shuffling playlists: シャッフル動画リスト
@@ -587,10 +586,10 @@ Video:
       opening playlists: 動画リストを開く
       setting a playback rate: 再生レートの設定
       starting video at offset: オフセットで動画の再生
-    UnsupportedActionTemplate: '$ はサポートしていません: %'
+    UnsupportedActionTemplate: '{externalPlayer} はサポートしていません: {action}'
     playlist: 再生リスト
     video: 動画
-    OpenInTemplate: $ で開く
+    OpenInTemplate: '{externalPlayer} で開く'
   Premieres on: プレミア公開
   Stats:
     player resolution: 表示領域
@@ -682,7 +681,7 @@ Comments:
   Show More Replies: その他の返信を表示する
   And others: その他
   Pinned by: によって固定されています
-  From $channelName: $channelName から
+  From {channelName}: '{channelName} から'
   Member: メンバー
 Up Next: '次の動画'
 
@@ -706,10 +705,10 @@ Yes: 'はい'
 No: 'いいえ'
 Locale Name: '日本語'
 Profile:
-  $ is now the active profile: $ プロファイルに変更しました
+  '{profile} is now the active profile': {profile} プロファイルに変更しました
   Your default profile has been changed to your primary profile: 起動時のプロファイルを、上位のプロファイルに変更しました
-  Removed $ from your profiles: プロファイルから $ を削除しました
-  Your default profile has been set to $: 起動時のプロファイルを $ に設定しました
+  Removed {profile} from your profiles: プロファイルから {profile} を削除しました
+  Your default profile has been set to {profile}: 起動時のプロファイルを {profile} に設定しました
   Profile has been updated: プロファイルを更新しました
   Profile has been created: プロファイルを作成しました
   Your profile name cannot be empty: プロファイル名は空にできません
@@ -735,7 +734,7 @@ Profile:
   Select All: すべて選択
   Other Channels: ほかのチャンネル
   Subscription List: 登録チャンネル一覧
-  $ selected: $ 項目選択
+  '{number} selected': {number} 項目選択
   Add Selected To Profile: 選択項目をプロファイルに追加
   ? This is your primary profile.  Are you sure you want to delete the selected channels?  The
     same channels will be deleted in any profile they are found in.
@@ -743,9 +742,9 @@ Profile:
   Profile Filter: プロファイルのフィルター
   Profile Settings: プロファイル設定
 The playlist has been reversed: 再生リストを逆順にしました
-A new blog is now available, $. Click to view more: '新着ブログ公開、$。クリックしてブログを読む'
+A new blog is now available, {blogTitle}. Click to view more: '新着ブログ公開、{blogTitle}。クリックしてブログを読む'
 Download From Site: サイトからダウンロード
-Version $ is now available!  Click for more details: 最新バージョン $ 配信中！　詳細はクリックして確認してください
+Version {versionNumber} is now available!  Click for more details: 最新バージョン {versionNumber} 配信中！　詳細はクリックして確認してください
 This video is unavailable because of missing formats. This can happen due to country unavailability.: この動画は、動画形式の情報が利用できないため再生できません。再生が許可されていない国で発生します。
 Tooltips:
   Subscription Settings:
@@ -779,7 +778,7 @@ Tooltips:
       パスをここで設定できます。
     External Player: 外部プレーヤーを選択すると、動画（対応している場合は再生リスト）を開くためのアイコンがサムネイルに表示されます。警告：Invidious
       の設定は、外部プレーヤーには影響しません。
-    DefaultCustomArgumentsTemplate: "（デフォルト: '$'）"
+    DefaultCustomArgumentsTemplate: "（デフォルト: '{defaultCustomArguments}'）"
 Playing Next Video Interval: すぐに次の動画を再生します。クリックするとキャンセル。|次の動画を {nextVideoInterval}
   秒で再生します。クリックするとキャンセル。|次の動画を {nextVideoInterval} 秒で再生します。クリックするとキャンセル。
 More: もっと見る
@@ -787,30 +786,30 @@ Hashtags have not yet been implemented, try again later: ハッシュタグは�
 Unknown YouTube url type, cannot be opened in app: 不明な YouTube URL の種類、アプリで実行できません
 Open New Window: 新しいウィンドウを開く
 Default Invidious instance has been cleared: デフォルトの Invidious インスタンスがクリアされました
-Default Invidious instance has been set to $: デフォルトの Invidious インスタンスは$に設定されています
+Default Invidious instance has been set to {instance}: デフォルトの Invidious インスタンスは{instance}に設定されています
 External link opening has been disabled in the general settings: 一般設定で外部リンクの表示は無効になっています
 Search Bar:
   Clear Input: 入力の消去
 Are you sure you want to open this link?: このリンクを開きますか？
-Starting download: '"$" のダウンロードを開始します'
-Downloading has completed: '"$" のダウンロードが終了しました'
-Downloading failed: '"$" のダウンロード中に問題が発生しました'
+Starting download: '"{videoTitle}" のダウンロードを開始します'
+Downloading has completed: '"{videoTitle}" のダウンロードが終了しました'
+Downloading failed: '"{videoTitle}" のダウンロード中に問題が発生しました'
 Age Restricted:
-  This $contentType is age restricted: $ は 18 歳以上の視聴者向け動画です
+  The currently set default instance is {instance}: '{instance} は 18 歳以上の視聴者向け動画です'
   Type:
     Channel: チャンネル
     Video: 動画
 Channels:
   Channels: チャンネル
   Unsubscribe: 登録解除
-  Unsubscribed: $ のチャンネル登録を解除しました
+  Unsubscribed: {channelName} のチャンネル登録を解除しました
   Title: チャンネル一覧
   Search bar placeholder: チャンネル検索
-  Unsubscribe Prompt: 「$」のチャンネル登録を解除しますか？
-  Count: $ 件のチャンネルが見つかりました。
+  Unsubscribe Prompt: 「{channelName}」のチャンネル登録を解除しますか？
+  Count: {number} 件のチャンネルが見つかりました。
   Empty: 現在、チャンネル一覧は空です。
-Screenshot Success: スクリーンショットを「$」として保存しました
-Screenshot Error: スクリーンショットに失敗しました。$
+Screenshot Success: スクリーンショットを「{filePath}」として保存しました
+Screenshot Error: スクリーンショットに失敗しました。{error}
 New Window: 新しいウィンドウ
 Clipboard:
   Copy failed: クリップボードにコピーできませんでした

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -705,7 +705,7 @@ Yes: 'はい'
 No: 'いいえ'
 Locale Name: '日本語'
 Profile:
-  '{profile} is now the active profile': {profile} プロファイルに変更しました
+  '{profile} is now the active profile': '{profile} プロファイルに変更しました'
   Your default profile has been changed to your primary profile: 起動時のプロファイルを、上位のプロファイルに変更しました
   Removed {profile} from your profiles: プロファイルから {profile} を削除しました
   Your default profile has been set to {profile}: 起動時のプロファイルを {profile} に設定しました
@@ -734,7 +734,7 @@ Profile:
   Select All: すべて選択
   Other Channels: ほかのチャンネル
   Subscription List: 登録チャンネル一覧
-  '{number} selected': {number} 項目選択
+  '{number} selected': '{number} 項目選択'
   Add Selected To Profile: 選択項目をプロファイルに追加
   ? This is your primary profile.  Are you sure you want to delete the selected channels?  The
     same channels will be deleted in any profile they are found in.
@@ -802,11 +802,11 @@ Age Restricted:
 Channels:
   Channels: チャンネル
   Unsubscribe: 登録解除
-  Unsubscribed: {channelName} のチャンネル登録を解除しました
+  Unsubscribed: '{channelName} のチャンネル登録を解除しました'
   Title: チャンネル一覧
   Search bar placeholder: チャンネル検索
   Unsubscribe Prompt: 「{channelName}」のチャンネル登録を解除しますか？
-  Count: {number} 件のチャンネルが見つかりました。
+  Count: '{number} 件のチャンネルが見つかりました。'
   Empty: 現在、チャンネル一覧は空です。
 Screenshot Success: スクリーンショットを「{filePath}」として保存しました
 Screenshot Error: スクリーンショットに失敗しました。{error}

--- a/static/locales/ka.yaml
+++ b/static/locales/ka.yaml
@@ -32,10 +32,10 @@ Back: 'უკან'
 Forward: 'წინ'
 Open New Window: 'ახალი ფანჯრის გახსნა'
 
-Version $ is now available!  Click for more details: 'ხელმისაწვდომია $ ვერსია!  დააჭირეთ
+Version {versionNumber} is now available!  Click for more details: 'ხელმისაწვდომია {versionNumber} ვერსია!  დააჭირეთ
   დამატებითი ინფორმაციისთვის'
 Download From Site: 'საიტიდან ჩამოტვირთვა'
-A new blog is now available, $. Click to view more: 'ხელმისაწვდომია ახალი ბლოგი, $.
+A new blog is now available, {blogTitle}. Click to view more: 'ხელმისაწვდომია ახალი ბლოგი, {blogTitle}.
   დააჭირეთ დამატებითი ინფორმაციისთვის'
 Are you sure you want to open this link?: 'დარწმუნებული ხართ, რომ გსურთ ამ ბმულის
   გახსნა?'
@@ -98,11 +98,11 @@ Channels:
   Channels: 'არხები'
   Title: 'არხების სია'
   Search bar placeholder: 'არხების ძიება'
-  Count: 'ნაპოვნია $ არხი.'
+  Count: 'ნაპოვნია {number} არხი.'
   Empty: 'თქვენი არხების სია ამჟამად ცარიელია.'
   Unsubscribe: 'გამოწერის გაუქმება'
-  Unsubscribed: '$ წაიშალა თქვენი გამოწერებიდან'
-  Unsubscribe Prompt: 'დარწმუნებული ხართ, რომ გსურთ "$"ის გამოწერის გაუქმება?'
+  Unsubscribed: '{channelName} წაიშალა თქვენი გამოწერებიდან'
+  Unsubscribe Prompt: 'დარწმუნებული ხართ, რომ გსურთ "{channelName}"ის გამოწერის გაუქმება?'
 Trending:
   Trending: 'პოპულარული'
   Default: 'სტანდარტულად'
@@ -162,8 +162,7 @@ Settings:
       Middle: 'შუაში'
       End: 'ბოლოში'
     Current Invidious Instance: 'Invidious-ის მიმდინარე ასლი'
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: 'ამჟამად დაყენებული ასლია $'
+    The currently set default instance is {instance}: 'ამჟამად დაყენებული ასლია {number}'
     No default instance has been set: 'სტანდარტული ასლი არ არის დაყენებული'
     Current instance will be randomized on startup: 'ჩართვისას მიმდინარე ასლი იქნება
       შემთხვევით არჩეული'
@@ -444,13 +443,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -467,7 +466,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -571,7 +570,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -584,13 +582,10 @@ Video:
     recap: ''
     filler: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -677,7 +672,7 @@ Comments:
   Replies: ''
   Show More Replies: ''
   Reply: ''
-  From $channelName: ''
+  From {channelName}: ''
   And others: ''
   There are no comments available for this video: ''
   Load More Comments: ''
@@ -705,7 +700,6 @@ Tooltips:
     Custom External Player Executable: ''
     Ignore Warnings: ''
     Custom External Player Arguments: ''
-    # $ is replaced with the default custom arguments for the current player, if defined.
     DefaultCustomArgumentsTemplate: ''
   Subscription Settings:
     Fetch Feeds from RSS: ''
@@ -730,13 +724,11 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 Age Restricted:
-  # $contentType is replaced with video or channel
-  This $contentType is age restricted: ''
+  This {videoOrPlaylist} is age restricted: ''
   Type:
     Channel: ''
     Video: ''

--- a/static/locales/km.yaml
+++ b/static/locales/km.yaml
@@ -30,9 +30,9 @@ Back: ''
 Forward: ''
 Open New Window: ''
 
-Version $ is now available!  Click for more details: ''
+Version {versionNumber} is now available!  Click for more details: ''
 Download From Site: ''
-A new blog is now available, $. Click to view more: ''
+A new blog is now available, {blogTitle}. Click to view more: ''
 Are you sure you want to open this link?: ''
 
 # Search Bar
@@ -133,8 +133,7 @@ Settings:
       Middle: ''
       End: ''
     Current Invidious Instance: ''
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: ''
+    The currently set default instance is {instance}: ''
     No default instance has been set: ''
     Current instance will be randomized on startup: ''
     Set Current Instance as Default: ''
@@ -366,13 +365,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -389,7 +388,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -493,7 +492,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -504,13 +502,10 @@ Video:
     interaction: ''
     music offtopic: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -597,7 +592,7 @@ Comments:
   Replies: ''
   Show More Replies: ''
   Reply: ''
-  From $channelName: ''
+  From {channelName}: ''
   And others: ''
   There are no comments available for this video: ''
   Load More Comments: ''
@@ -624,7 +619,6 @@ Tooltips:
     Custom External Player Executable: ''
     Ignore Warnings: ''
     Custom External Player Arguments: ''
-    # $ is replaced with the default custom arguments for the current player, if defined.
     DefaultCustomArgumentsTemplate: ''
   Subscription Settings:
     Fetch Feeds from RSS: ''
@@ -649,8 +643,7 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 External link opening has been disabled in the general settings: ''

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -29,10 +29,10 @@ Close: '닫기'
 Back: '뒤로가기'
 Forward: '앞으로가기'
 
-Version $ is now available!  Click for more details: '$ 버전이 사용가능합니다! 클릭하여 자세한 정보를
+Version {versionNumber} is now available!  Click for more details: '{versionNumber} 버전이 사용가능합니다! 클릭하여 자세한 정보를
   확인하세요'
 Download From Site: '사이트로부터 다운로드'
-A new blog is now available, $. Click to view more: '새로운 블로그가 업로드되었습니다, $. 클릭하여 확인하세요'
+A new blog is now available, {blogTitle}. Click to view more: '새로운 블로그가 업로드되었습니다, {blogTitle}. 클릭하여 확인하세요'
 
 # Search Bar
 Search / Go to URL: '검색 / URL로 이동'
@@ -141,7 +141,7 @@ Settings:
     Current Invidious Instance: 현재 Invidious 인스턴스
     System Default: 시스템 기본설정
     No default instance has been set: 기본 인스턴스가 설정되지 않았습니다
-    The currently set default instance is $: 현재 설정된 기본 인스턴스는 $입니다
+    The currently set default instance is {instance}: 현재 설정된 기본 인스턴스는 {instance}입니다
     Current instance will be randomized on startup: 현재 인스턴스는 시작 시 무작위로 지정됩니다
     Set Current Instance as Default: 현재 인스턴스를 기본값으로 설정
     Clear Default Instance: 기본 인스턴스 지우기
@@ -323,7 +323,7 @@ Settings:
     Unknown data key: '알 수 없는 데이터 키입니다'
     How do I import my subscriptions?: '구독을 가져오려면 어떻게 해야 합니까?'
     Manage Subscriptions: 구독 관리
-    Playlist insufficient data: '"$" 재생 목록에 대한 데이터가 부족하여 항목을 건너뜁니다'
+    Playlist insufficient data: '"{playlist}" 재생 목록에 대한 데이터가 부족하여 항목을 건너뜁니다'
     All playlists has been successfully imported: 모든 재생 목록을 성공적으로 가져왔습니다
     All playlists has been successfully exported: 모든 재생 목록을 내보냈습니다
     Import Playlists: 재생 목록 가져오기
@@ -464,14 +464,14 @@ Profile:
   Your profile name cannot be empty: '프로필 이름은 비워 둘 수 없습니다'
   Profile has been created: '프로필이 생성되었습니다'
   Profile has been updated: '프로필이 업데이트되었습니다'
-  Your default profile has been set to $: '기본 프로필이 $로 설정되었습니다'
-  Removed $ from your profiles: '프로필에서 $가 제거되었습니다'
+  Your default profile has been set to {profile}: '기본 프로필이 {profile}로 설정되었습니다'
+  Removed {profile} from your profiles: '프로필에서 {profile}가 제거되었습니다'
   Your default profile has been changed to your primary profile: '기본값 프로필이 기본 프로필로
     변경되었습니다'
-  $ is now the active profile: '$가 현재 활성 프로필입니다'
+  '{profile} is now the active profile': '{profile}가 현재 활성 프로필입니다'
   Subscription List: '구독 목록'
   Other Channels: '기타 채널'
-  $ selected: '$선택되었습니다'
+  '{number} selected': '{number}선택되었습니다'
   Select All: '모두 선택'
   Select None: '선택 안 함'
   Delete Selected: '선택한 항목 삭제'
@@ -491,7 +491,7 @@ Channel:
   Subscribe: '구독'
   Unsubscribe: '구독 취소'
   Channel has been removed from your subscriptions: '채널이 구독에서 제거되었습니다'
-  Removed subscription from $ other channel(s): '$ 다른 채널에서 구독을 제거했습니다'
+  Removed subscription from {count} other channel(s): '{count} 다른 채널에서 구독을 제거했습니다'
   Added channel to your subscriptions: '구독에 채널을 추가했습니다'
   Search Channel: '채널 검색'
   Your search results have returned 0 results: '0 건이 검색되었습니다'
@@ -593,8 +593,7 @@ Video:
   Published on: '게시일'
   Streamed on: '스트리밍됨'
   Started streaming on: '스트리밍 시작'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % 전'
+  Publicationtemplate: '{number} {unit} 전'
 #& Videos
   Video has been saved: 동영상이 저장되었습니다
   Video has been removed from your saved list: 저장된 목록에서 동영상이 제거되었습니다
@@ -622,9 +621,9 @@ Video:
       starting video at offset: 오프셋에서 비디오 시작
       setting a playback rate: 재생 속도 설정
       opening playlists: 재생 목록 열기
-    UnsupportedActionTemplate: '$ 지원하지 않음: %'
-    OpenInTemplate: $로 열기
-    OpeningTemplate: '%에서 $를 여는 중...'
+    UnsupportedActionTemplate: '{externalPlayer} 지원하지 않음: {action}'
+    OpenInTemplate: '{externalPlayer}로 열기'
+    OpeningTemplate: '{externalPlayer}에서 {videoOrPlaylist}를 여는 중...'
     video: 비디오
     playlist: 재생목록
   Sponsor Block category:
@@ -707,7 +706,7 @@ Comments:
   Load More Comments: '더 많은 댓글 불러오기'
   No more comments available: '더 이상 사용할 수 있는 댓글이 없습니다'
   Show More Replies: 더 많은 답글 보기
-  From $channelName: $channelName에서
+  From {channelName}: '{channelName}에서'
   Pinned by: 에 의해 고정
   And others: 및 기타
   Member: 구성원
@@ -743,7 +742,7 @@ Tooltips:
 
 # Toast Messages
   External Player Settings:
-    DefaultCustomArgumentsTemplate: "(기본: '$')"
+    DefaultCustomArgumentsTemplate: "(기본: '{defaultCustomArguments}')"
     External Player: 외부 플레이어를 선택하면 썸네일에서 비디오 (지원되는 경우 재생 목록)를 열 수 있는 아이콘이 표시됩니다. 경고,
       위반 설정은 외부 플레이어에 영향을 주지 않습니다.
     Custom External Player Executable: 기본적으로 FreeTube는 PATH 환경 변수를 통해 선택한 외부 플레이어를
@@ -782,7 +781,7 @@ Hashtags have not yet been implemented, try again later: 해시태그가 아직 
   다시 시도하세요
 Playing Next Video Interval: 즉시 다음 동영상을 재생합니다. 취소하려면 클릭하세요. | {nextVideoInterval}초
   후에 다음 동영상을 재생합니다. 취소하려면 클릭하세요. | {nextVideoInterval}초 후에 다음 동영상을 재생합니다. 취소하려면 클릭하세요.
-Default Invidious instance has been set to $: 기본 Invidious 인스턴스가 $로 설정되었습니다
+Default Invidious instance has been set to {instance}: 기본 Invidious 인스턴스가 {instance}로 설정되었습니다
 External link opening has been disabled in the general settings: 일반 설정에서 외부 링크 열기가
   비활성화되었습니다
 Open New Window: 새 창 열기
@@ -797,19 +796,19 @@ Channels:
   Search bar placeholder: 채널 검색
   Empty: 채널 목록이 비어 있습니다.
   Unsubscribe: 구독 취소
-  Unsubscribe Prompt: '"$"에서 구독을 취소하시겠습니까?'
-  Count: $ 채널이 발견되었습니다.
-  Unsubscribed: $ 구독에서 제거되었습니다
+  Unsubscribe Prompt: '"{channelName}"에서 구독을 취소하시겠습니까?'
+  Count: {number} 채널이 발견되었습니다.
+  Unsubscribed: {channelName} 구독에서 제거되었습니다
 Age Restricted:
   Type:
     Video: 비디오
     Channel: 채널
-  This $contentType is age restricted: 이 $는 연령 제한입니다
-Downloading has completed: '"$" 다운로드가 완료되었습니다'
-Starting download: '"$" 다운로드를 시작하는 중'
-Downloading failed: '"$"를 다운로드하는 동안 문제가 발생했습니다'
-Screenshot Error: 스크린샷이 실패했습니다. $
-Screenshot Success: 스크린샷을 "$"로 저장
+  The currently set default instance is {instance}: 이 {instance}는 연령 제한입니다
+Downloading has completed: '"{videoTitle}" 다운로드가 완료되었습니다'
+Starting download: '"{videoTitle}" 다운로드를 시작하는 중'
+Downloading failed: '"{videoTitle}"를 다운로드하는 동안 문제가 발생했습니다'
+Screenshot Error: 스크린샷이 실패했습니다. {error}
+Screenshot Success: 스크린샷을 "{filePath}"로 저장
 Clipboard:
   Copy failed: 클립보드에 복사 실패
   Cannot access clipboard without a secure connection: 안전한 연결 없이 클립보드에 접근할 수 없습니다

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -797,8 +797,8 @@ Channels:
   Empty: 채널 목록이 비어 있습니다.
   Unsubscribe: 구독 취소
   Unsubscribe Prompt: '"{channelName}"에서 구독을 취소하시겠습니까?'
-  Count: {number} 채널이 발견되었습니다.
-  Unsubscribed: {channelName} 구독에서 제거되었습니다
+  Count: '{number} 채널이 발견되었습니다.'
+  Unsubscribed: '{channelName} 구독에서 제거되었습니다'
 Age Restricted:
   Type:
     Video: 비디오

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -30,10 +30,10 @@ Close: 'داخستن'
 Back: 'گەڕانەوە'
 Forward: 'چونەپێشەوە'
 
-Version $ is now available!  Click for more details: 'ڤێرژنی $ ئێستا بەردەستە! کلیک
+Version {versionNumber} is now available!  Click for more details: 'ڤێرژنی {versionNumber} ئێستا بەردەستە! کلیک
   بکە بۆ زانیاری زیاتر'
 Download From Site: 'دایبەزێنە لە سایتەکەوە'
-A new blog is now available, $. Click to view more: 'بڵۆگێکی نوێ بەردەستە، $. کلیک
+A new blog is now available, {blogTitle}. Click to view more: 'بڵۆگێکی نوێ بەردەستە، {blogTitle}. کلیک
   بکە بۆ بینینی زیاتر'
 
 # Search Bar
@@ -338,13 +338,13 @@ Profile:
   Your profile name cannot be empty: 'ناوی پڕۆفایلەکەت نابێت بەتاڵبێت'
   Profile has been created: 'پڕۆفایلەکە دروستکرا'
   Profile has been updated: 'پرۆفایلەکە تازەکرایەوە'
-  Your default profile has been set to $: 'پرۆفایلە ئاساییەکەت دانراوە بۆ $'
-  Removed $ from your profiles: 'سڕاوەتەوە لە پرۆفایلەکانت $'
+  Your default profile has been set to {profile}: 'پرۆفایلە ئاساییەکەت دانراوە بۆ {profile}'
+  Removed {profile} from your profiles: 'سڕاوەتەوە لە پرۆفایلەکانت {profile}'
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -361,7 +361,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -446,7 +446,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/la.yaml
+++ b/static/locales/la.yaml
@@ -29,11 +29,11 @@ Close: 'Claude'
 Back: 'Redeo'
 Forward: 'Promoveo'
 
-Version $ is now available!  Click for more details: 'Editio $ nunc praesto! Tactus
+Version {versionNumber} is now available!  Click for more details: 'Editio {versionNumber} nunc praesto! Tactus
   pro magis singula res'
 Download From Site: 'Adepto ex situ'
-A new blog is now available, $. Click to view more: 'Novum scripturam creata est,
-  $. Tangere hic pro magis notitia'
+A new blog is now available, {blogTitle}. Click to view more: 'Novum scripturam creata est,
+  {blogTitle}. Tangere hic pro magis notitia'
 
 # Search Bar
 Search / Go to URL: 'Requiro / Adeo URL'
@@ -299,13 +299,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -322,7 +322,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -406,7 +406,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/lt.yaml
+++ b/static/locales/lt.yaml
@@ -30,11 +30,11 @@ Back: 'Atgal'
 Forward: 'Pirmyn'
 Open New Window: 'Atidaryti naują langą'
 
-Version $ is now available!  Click for more details: 'Versija $ jau prieinama!  Spustelėkite,
+Version {versionNumber} is now available!  Click for more details: 'Versija {versionNumber} jau prieinama!  Spustelėkite,
   jei norite gauti daugiau informacijos'
 Download From Site: 'Atsisiųsti iš svetainės'
-A new blog is now available, $. Click to view more: 'Naujas įrašas tinklaraštyje,
-  $. Spustelėkite norėdami pamatyti daugiau'
+A new blog is now available, {blogTitle}. Click to view more: 'Naujas įrašas tinklaraštyje,
+  {blogTitle}. Spustelėkite norėdami pamatyti daugiau'
 
 # Search Bar
 Search / Go to URL: 'Paieška / Eiti į URL'
@@ -149,8 +149,8 @@ Settings:
     Current instance will be randomized on startup: Esama instancija bus atsitiktinai
       parinkta paleidimo metu
     No default instance has been set: Nenustatytas jokia numatytoji instancija
-    The currently set default instance is $: Šiuo metu nustatyta numatytoji instancija
-      yra $
+    The currently set default instance is {instance}: Šiuo metu nustatyta numatytoji instancija
+      yra {instance}
     External Link Handling:
       No Action: Jokio veiksmo
       Ask Before Opening Link: Klausti prieš atidarant nuorodą
@@ -382,14 +382,14 @@ Profile:
   Your profile name cannot be empty: 'Jūsų profilio vardas negali būti tuščias'
   Profile has been created: 'Profilis sukurtas'
   Profile has been updated: 'Profilis atnaujintas'
-  Your default profile has been set to $: '$ buvo nustatytas kaip numatytasis profilis'
-  Removed $ from your profiles: '$ buvo pašalintas iš tavo profilių'
+  Your default profile has been set to {profile}: '{profile} buvo nustatytas kaip numatytasis profilis'
+  Removed {profile} from your profiles: '{profile} buvo pašalintas iš tavo profilių'
   Your default profile has been changed to your primary profile: 'Numatytasis profilis
     buvo nustatytas kaip pagrindinis'
-  $ is now the active profile: '$ yra dabar aktyvus profilis'
+  '{profile} is now the active profile': '{profile} yra dabar aktyvus profilis'
   Subscription List: 'Prenumeratų sąrašas'
   Other Channels: 'Kiti kanalai'
-  $ selected: '$ pasirinktas'
+  '{number} selected': '{number} pasirinktas'
   Select All: 'Pasirinkti visus'
   Select None: 'Nesirinkti nieko'
   Delete Selected: 'Pašalinti pasirinktus'
@@ -409,7 +409,7 @@ Channel:
   Subscribe: 'Prenumeruoti'
   Unsubscribe: 'Atšaukti prenumeratą'
   Channel has been removed from your subscriptions: 'Kanalas pašalintas iš jūsų prenumeratų'
-  Removed subscription from $ other channel(s): 'Prenumerata pašalinta iš $ kito(-ų)
+  Removed subscription from {count} other channel(s): 'Prenumerata pašalinta iš {count} kito(-ų)
     kanalo(-ų)'
   Added channel to your subscriptions: 'Prie jūsų prenumeratų pridėtas kanalas'
   Search Channel: 'Ieškoti kanalų'
@@ -523,8 +523,7 @@ Video:
   Streamed on: 'Transliuota'
   Started streaming on: 'Transliaciją pradėjo'
   translated from English: 'išversta iš anglų kalbos'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % prieš'
+  Publicationtemplate: '{number} {unit} prieš'
   Skipped segment: 'Praleistas segmentas'
   Sponsor Block category:
     sponsor: 'rėmėjas'
@@ -534,14 +533,11 @@ Video:
     interaction: 'interakcija'
     music offtopic: 'nesusijusi muzika'
   External Player:
-    # $ is replaced with the external player
-    OpenInTemplate: 'Atidaryti $'
+    OpenInTemplate: 'Atidaryti {externalPlayer}'
     video: 'vaizdo įrašas'
     playlist: 'grojaraštis'
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
-    OpeningTemplate: 'Atidaroma $ per %...'
-    # $ is replaced with the external player and % with the unsupported action
-    UnsupportedActionTemplate: '$ nepalaiko: %'
+    OpeningTemplate: 'Atidaroma {videoOrPlaylist} per {externalPlayer}...'
+    UnsupportedActionTemplate: '{externalPlayer} nepalaiko: {action}'
     Unsupported Actions:
       starting video at offset: 'Pradedant vaizdo įrašą kompensuojant'
       setting a playback rate: 'nustatomas atkūrimo dažnis'
@@ -635,7 +631,7 @@ Comments:
   Load More Comments: 'Pakrauti daugiau komentarų'
   No more comments available: 'Daugiau komentarų nėra'
   Show More Replies: Rodyti daugiau atsakymų
-  From $channelName: nuo $channelName
+  From {channelName}: nuo {channelName}
   And others: ir kt.
   Pinned by: Prisegė
 Up Next: 'Sekantis'
@@ -688,7 +684,7 @@ Tooltips:
     Custom External Player Arguments: 'Bet kokius pasirinktinius komandinės eilutės
       argumentus, atskirtus kabliataškiais ('';''), kuriuos norite perduoti išoriniam
       grotuvui.'
-    DefaultCustomArgumentsTemplate: '(Numatytasis: „$“)'
+    DefaultCustomArgumentsTemplate: '(Numatytasis: „{defaultCustomArguments}“)'
   Subscription Settings:
     Fetch Feeds from RSS: 'Kai bus įgalinta, „FreeTube“ naudos RSS, o ne numatytąjį
       metodą, kad užpildytų jūsų prenumeratos kanalą. RSS yra greitesnė ir išvengia
@@ -730,8 +726,8 @@ Canceled next video autoplay: 'Atšauktas sekančio vaizdo įrašo automatinis p
 Yes: 'Taip'
 No: 'Ne'
 Default Invidious instance has been cleared: Numatytoji Invidious instancija išvalyta
-Default Invidious instance has been set to $: Numatytoji Invidious instancija buvo
-  nustatyta į $
+Default Invidious instance has been set to {instance}: Numatytoji Invidious instancija buvo
+  nustatyta į {instance}
 Search Bar:
   Clear Input: Išvalyti įvestį
 External link opening has been disabled in the general settings: Išorinės nuorodos

--- a/static/locales/nb_NO.yaml
+++ b/static/locales/nb_NO.yaml
@@ -667,7 +667,7 @@ Canceled next video autoplay: 'Avbryter automatisk avspilling av neste video'
 Yes: 'Ja'
 No: 'Nei'
 Profile:
-  '{profile} is now the active profile': {profile} er nå den aktive profilen
+  '{profile} is now the active profile': '{profile} er nå den aktive profilen'
   Your default profile has been changed to your primary profile: Din forvalgte profil
     har blitt endret til din hovedprofil
   Removed {profile} from your profiles: Fjernet {profile} fra dine profiler
@@ -688,7 +688,7 @@ Profile:
     noen andre profiler.
   No channel(s) have been selected: Ingen kanal(er) har blitt valgt
   Select All: Velg alle
-  '{number} selected': {number} valgt
+  '{number} selected': '{number} valgt'
   Other Channels: Andre kanaler
   Color Picker: Fargevelger
   Profile Select: Velg profil
@@ -787,7 +787,7 @@ Channels:
   Count: Fant {number} kanal(er).
   Empty: Kanallisten din er tom.
   Unsubscribe: Opphev abonnement
-  Unsubscribed: {channelName} ble fjernet fra dine abonnementer
+  Unsubscribed: '{channelName} ble fjernet fra dine abonnementer'
   Unsubscribe Prompt: Opphev abonnement på «{channelName}»?
 Age Restricted:
   Type:

--- a/static/locales/nb_NO.yaml
+++ b/static/locales/nb_NO.yaml
@@ -141,7 +141,7 @@ Settings:
     Current instance will be randomized on startup: Valgt instans vil bli plukket
       tilfeldig ved oppstart
     No default instance has been set: Ingen forvalgt instans satt
-    The currently set default instance is $: Valgt instans er $
+    The currently set default instance is {instance}: Valgt instans er {instance}
     Current Invidious Instance: Nåværende Invidious-instans
     External Link Handling:
       No Action: Ingen handling
@@ -448,7 +448,7 @@ Channel:
     Channel Description: 'Kanalbeskrivelse'
     Featured Channels: 'Framhevede kanaler'
   Added channel to your subscriptions: Lagt til kanal til dine abonnenter
-  Removed subscription from $ other channel(s): Fjernet abonnement fra $ andre kanal(er)
+  Removed subscription from {count} other channel(s): Fjernet abonnement fra {count} andre kanal(er)
   Channel has been removed from your subscriptions: Kanalen har blitt fjernet fra
     dine abonnement
 Video:
@@ -511,8 +511,7 @@ Video:
     Minutes: Minutter
     Minute: Minutt
   Published on: 'Publisert'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % siden'
+  Publicationtemplate: '{number} {unit} siden'
 #& Videos
   Audio:
     High: Høy
@@ -559,11 +558,11 @@ Video:
       starting video at offset: starting av video med forskyvning
       looping playlists: gjentakelse av spillelister
       reversing playlists: reversering av spillelister
-    UnsupportedActionTemplate: '$ støtter ikke: %'
-    OpeningTemplate: Åpner $ om % …
+    UnsupportedActionTemplate: '{externalPlayer} støtter ikke: {action}'
+    OpeningTemplate: Åpner {videoOrPlaylist} om {externalPlayer} …
     playlist: spilleliste
     video: video
-    OpenInTemplate: Åpne i $
+    OpenInTemplate: Åpne i {externalPlayer}
   Stats:
     Bitrate: Bitrate
     Volume: Lydstyrke
@@ -641,7 +640,7 @@ Comments:
   Sort by: Sorter etter
   Top comments: Toppkommentarer
   Show More Replies: Vis flere svar
-  From $channelName: Fra $channelName
+  From {channelName}: Fra {channelName}
   Pinned by: Festet av
   Member: Medlem
 Up Next: 'Neste'
@@ -668,12 +667,12 @@ Canceled next video autoplay: 'Avbryter automatisk avspilling av neste video'
 Yes: 'Ja'
 No: 'Nei'
 Profile:
-  $ is now the active profile: $ er nå den aktive profilen
+  '{profile} is now the active profile': {profile} er nå den aktive profilen
   Your default profile has been changed to your primary profile: Din forvalgte profil
     har blitt endret til din hovedprofil
-  Removed $ from your profiles: Fjernet $ fra dine profiler
-  Your default profile has been set to $: Din forvalgte profil har blitt satt til
-    $
+  Removed {profile} from your profiles: Fjernet {profile} fra dine profiler
+  Your default profile has been set to {profile}: 'Din forvalgte profil har blitt satt til
+    {profile}'
   Profile has been updated: Profil oppdatert
   Profile has been created: Profil opprettet
   Your profile name cannot be empty: Profilnavnet ditt kan ikke stå tomt
@@ -689,7 +688,7 @@ Profile:
     noen andre profiler.
   No channel(s) have been selected: Ingen kanal(er) har blitt valgt
   Select All: Velg alle
-  $ selected: $ valgt
+  '{number} selected': {number} valgt
   Other Channels: Andre kanaler
   Color Picker: Fargevelger
   Profile Select: Velg profil
@@ -756,12 +755,12 @@ Tooltips:
       sti settes her.
     External Player: Valg av ekstern avspiller viser et ikon for åpning av video (spilleliste
       hvis det støttes) i den eksterne avspilleren, på miniatyrbildet.
-    DefaultCustomArgumentsTemplate: "(Forvalg: '$')"
-A new blog is now available, $. Click to view more: Et nytt blogginnlegg er tilgjengelig,
-  $. Klikk her for å se mer
+    DefaultCustomArgumentsTemplate: "(Forvalg: '{defaultCustomArguments}')"
+A new blog is now available, {blogTitle}. Click to view more: Et nytt blogginnlegg er tilgjengelig,
+  {blogTitle}. Klikk her for å se mer
 The playlist has been reversed: Spillelisten har blitt snudd
 Download From Site: Last ned fra nettside
-Version $ is now available!  Click for more details: Versjon $ er nå tilgjengelig!
+Version {versionNumber} is now available!  Click for more details: Versjon {versionNumber} er nå tilgjengelig!
   Klikk her for detaljer
 Playing Next Video Interval: Spiller av neste video nå. Klikk her for å avbryte. |
   Spiller av neste video om {nextVideoInterval} sekund. Klikk her for å avbryte. |
@@ -773,8 +772,8 @@ Hashtags have not yet been implemented, try again later: Emneknagger er ikke imp
   enda, prøv igjen senere
 Open New Window: Åpne et nytt vindu
 Default Invidious instance has been cleared: Fjernet forvalgt Invidious-instans
-Default Invidious instance has been set to $: Forvalgt Invidious-instans satt til
-  $
+Default Invidious instance has been set to {instance}: Forvalgt Invidious-instans satt til
+  {instance}
 External link opening has been disabled in the general settings: Åpning av eksterne
   lenker er avskrudd i de generelle innstillingene
 Search Bar:
@@ -785,11 +784,11 @@ Channels:
   Channels: Kanaler
   Title: Kanalliste
   Search bar placeholder: Søk i kanaler
-  Count: Fant $ kanal(er).
+  Count: Fant {number} kanal(er).
   Empty: Kanallisten din er tom.
   Unsubscribe: Opphev abonnement
-  Unsubscribed: $ ble fjernet fra dine abonnementer
-  Unsubscribe Prompt: Opphev abonnement på «$»?
+  Unsubscribed: {channelName} ble fjernet fra dine abonnementer
+  Unsubscribe Prompt: Opphev abonnement på «{channelName}»?
 Age Restricted:
   Type:
     Channel: Kanal

--- a/static/locales/ne.yaml
+++ b/static/locales/ne.yaml
@@ -30,10 +30,10 @@ Back: 'पछाडि'
 Forward: 'अगाडि'
 Open New Window: 'नयाँ विन्डो खोल्नुहोस्'
 
-Version $ is now available!  Click for more details: 'भर्जन $ उपलब्ध छ! थप बुझ्न यहाँ
+Version {versionNumber} is now available!  Click for more details: 'भर्जन {versionNumber} उपलब्ध छ! थप बुझ्न यहाँ
   थिच्नुहोस्'
 Download From Site: 'साइटबाट डाउनलोड गर्नुहोस्'
-A new blog is now available, $. Click to view more: 'एउटा नयाँ ब्लग उपलब्ध छ, $। थप
+A new blog is now available, {blogTitle}. Click to view more: 'एउटा नयाँ ब्लग उपलब्ध छ, {blogTitle}। थप
   बुझ्न यहाँ थिच्नुहोस्'
 
 # Search Bar
@@ -134,8 +134,7 @@ Settings:
       Middle: ''
       End: ''
     Current Invidious Instance: ''
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: ''
+    The currently set default instance is {instance}: ''
     No default instance has been set: ''
     Current instance will be randomized on startup: ''
     Set Current Instance as Default: ''
@@ -341,13 +340,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -364,7 +363,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -467,7 +466,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -478,13 +476,10 @@ Video:
     interaction: ''
     music offtopic: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -605,8 +600,7 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -148,8 +148,8 @@ Settings:
     Current instance will be randomized on startup: Momenteel gebruikte instantie
       zal willekeurig worden gekozen wanneer de applicatie start
     No default instance has been set: Er is geen standaard instantie ingesteld
-    The currently set default instance is $: De momenteel als standaard ingestelde
-      instantie is $
+    The currently set default instance is {instance}: De momenteel als standaard ingestelde
+      instantie is {instance}
     External Link Handling:
       Ask Before Opening Link: Vraag bij het openen van koppelingen
       No Action: Geen actie
@@ -245,7 +245,7 @@ Settings:
       File Name Label: Bestandsnaam indeling
       File Name Tooltip: 'U kunt de volgende variabelen gebruiken: %Y viercijferig
         jaartal; %M tweecijferige maand; %D tweecijferige dagstelling; %H tweecijferig
-        uur; $N tweecijferige minuut; %S tweecijferige seconde; %T driecijferige milliseconde;
+        uur; %N tweecijferige minuut; %S tweecijferige seconde; %T driecijferige milliseconde;
         %s tweecijferige seconde in de video; %t driecijferige milliseconde in de
         video; %i ID van de video. U kunt ook "\" of "/" gebruiken om deelmappen aan
         te maken.'
@@ -349,7 +349,7 @@ Settings:
     All playlists has been successfully imported: Alle speellijsten zijn met succes
       geïmporteerd
     Import Playlists: Afspeellijsten importeren
-    Playlist insufficient data: Onvoldoende gegevens voor speellijst "$", item word
+    Playlist insufficient data: Onvoldoende gegevens voor speellijst "{playlist}", item word
       overgeslagen
     All playlists has been successfully exported: Alle speellijsten zijn met succes
       geëxporteerd
@@ -508,7 +508,7 @@ Channel:
     Channel Description: 'Kanaalbeschrijving'
     Featured Channels: 'Uitgelichte kanalen'
   Added channel to your subscriptions: Kanaal is toegevoegd aan uw abonnementen
-  Removed subscription from $ other channel(s): Abonnementen van $ andere kanalen
+  Removed subscription from {count} other channel(s): Abonnementen van {count} andere kanalen
     zijn verwijderd
   Channel has been removed from your subscriptions: Kanaal is verwijderd uit uw abonnementen
 Video:
@@ -571,8 +571,7 @@ Video:
     Minutes: minuten
     Minute: minuut
   Published on: 'Gepubliceerd op'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % geleden'
+  Publicationtemplate: '{number} {unit} geleden'
 #& Videos
   Autoplay: Automatisch afspelen
   Play Previous Video: Vorige video afspelen
@@ -621,11 +620,11 @@ Video:
       setting a playback rate: afspeelsnelheid instellen
       looping playlists: afspeellijsten herhalen
       starting video at offset: begin afspelen video bij offset
-    UnsupportedActionTemplate: '$ ondersteund niet: %'
-    OpeningTemplate: $ Openen in %...
+    UnsupportedActionTemplate: '{externalPlayer} ondersteund niet: {action}'
+    OpeningTemplate: '{videoOrPlaylist} Openen in {externalPlayer}...'
     playlist: afspeellijst
     video: video
-    OpenInTemplate: Open in $
+    OpenInTemplate: Open in {externalPlayer}
   Stats:
     player resolution: Venster
     volume: Volume
@@ -721,7 +720,7 @@ Comments:
   Top comments: Beste reacties
   Sort by: Sorteer op
   Show More Replies: Toon meer reacties
-  From $channelName: van $channelName
+  From {channelName}: van {channelName}
   And others: en anderen
   Pinned by: Vastgemaakt door
   Member: lid
@@ -749,11 +748,11 @@ Yes: 'Ja'
 No: 'Nee'
 The playlist has been reversed: De afspeellijst is omgedraaid
 Profile:
-  $ is now the active profile: $ is nu het actieve profiel
+  '{profile} is now the active profile': '{profile} is nu het actieve profiel'
   Your default profile has been changed to your primary profile: Uw standaardprofiel
     is veranderd naar uw hoofdprofiel
-  Removed $ from your profiles: $ is verwijderd uit uw profielen
-  Your default profile has been set to $: Uw standaard profiel is ingesteld op $
+  Removed {profile} from your profiles: '{profile} is verwijderd uit uw profielen'
+  Your default profile has been set to {profile}: Uw standaard profiel is ingesteld op {profile}
   Profile has been updated: Profiel is bijgewerkt
   Profile has been created: Profiel is aangemaakt
   Your profile name cannot be empty: Uw profielnaam mag niet leeg zijn
@@ -785,15 +784,15 @@ Profile:
   Delete Selected: Selectie verwijderen
   Select None: Niks selecteren
   Select All: Alles selecteren
-  $ selected: $ is geselecteerd
+  '{number} selected': '{number} is geselecteerd'
   Other Channels: Andere kanalen
   Subscription List: Abonnementen
   Profile Filter: Profielfilter
   Profile Settings: Profielinstellingen
-A new blog is now available, $. Click to view more: Een nieuwe blogpost is beschikbaar,
-  $. Klik voor meer informatie
+A new blog is now available, {blogTitle}. Click to view more: Een nieuwe blogpost is beschikbaar,
+  {blogTitle}. Klik voor meer informatie
 Download From Site: Van website downloaden
-Version $ is now available!  Click for more details: Versie $ is nu beschikbaar! Klik
+Version {versionNumber} is now available!  Click for more details: Versie {versionNumber} is nu beschikbaar! Klik
   voor meer informatie
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Deze
   video is niet beschikbaar vanwege ontbrekende videoformaten. Dit kan gebeuren als
@@ -855,7 +854,7 @@ Tooltips:
       verschijnen op het thumbnail waarmee de video (of afspeellijst indien ondersteund)
       in de gekozen externe videospeler kan worden geopend. Let op: Invidious instellingen
       beïnvloeden externe videospelers niet.'
-    DefaultCustomArgumentsTemplate: "(Standaard: '$')"
+    DefaultCustomArgumentsTemplate: "(Standaard: '{defaultCustomArguments}')"
 Playing Next Video Interval: Volgende video wordt afgespeeld. Klik om te onderbreken.
   | Volgende video wordt afgespeeld in {nextVideoInterval} seconde. Klik om te onderbreken.
   | Volgende video wordt afgespeeld in {nextVideoInterval} seconden. Klik om te onderbreken.
@@ -866,32 +865,32 @@ Unknown YouTube url type, cannot be opened in app: Onbekende YouTube-URL; de URL
   niet worden geopend in de app
 Open New Window: Nieuw venster openen
 Default Invidious instance has been cleared: Standaard Invidious-instantie is verwijderd
-Default Invidious instance has been set to $: Standaard Invidious-instantie is ingesteld
-  op $
+Default Invidious instance has been set to {instance}: Standaard Invidious-instantie is ingesteld
+  op {instance}
 Are you sure you want to open this link?: Weet je zeker dat je deze link wilt openen?
 Search Bar:
   Clear Input: Invoer wissen
 External link opening has been disabled in the general settings: Het openen van externe
   links is uitgeschakeld in de algemene instellingen
 Downloading canceled: De gebruiker heeft de download geannuleerd
-Downloading has completed: '"$" is gedownload'
-Starting download: Begin download van "$"
-Downloading failed: Probleem bij download van "$"
+Downloading has completed: '"{videoTitle}" is gedownload'
+Starting download: Begin download van "{videoTitle}"
+Downloading failed: Probleem bij download van "{videoTitle}"
 Download folder does not exist: De download map "$" bestaat niet. Valt terug op "vraag
   map" modus.
 New Window: Nieuw Venster
 Age Restricted:
-  This $contentType is age restricted: Deze $ is leeftijdsbeperkt
+  The currently set default instance is {instance}: Deze {instance} is leeftijdsbeperkt
   Type:
     Channel: Kanaal
     Video: Video
-Screenshot Success: Schermafbeelding opgeslagen als "$"
+Screenshot Success: Schermafbeelding opgeslagen als "{filePath}"
 Channels:
   Title: Lijst van kanalen
   Search bar placeholder: Zoek naar kanalen
-  Count: $ kanalen gevonden.
+  Count: '{number} kanalen gevonden.'
   Channels: Kanalen
   Empty: Uw lijst van kanalen is thans leeg.
   Unsubscribe: Afmelden
-  Unsubscribed: $ is verwijderd uit uw lijst van abonnees
-Screenshot Error: Schermafbeelding kon niet worden opgeslagen. $
+  Unsubscribed: '{channelName} is verwijderd uit uw lijst van abonnees'
+Screenshot Error: Schermafbeelding kon niet worden opgeslagen. {error}

--- a/static/locales/nn.yaml
+++ b/static/locales/nn.yaml
@@ -30,11 +30,11 @@ Close: 'Lukk'
 Back: 'Tilbake'
 Forward: 'Framover'
 
-Version $ is now available!  Click for more details: 'Versjon $ er no tilgjengeleg!
+Version {versionNumber} is now available!  Click for more details: 'Versjon {versionNumber} er no tilgjengeleg!
   Klikk for meir informasjon'
 Download From Site: 'Last ned frå nettstaden'
-A new blog is now available, $. Click to view more: 'Eit nytt blogginnlegg er tilgjengeleg,
-  $. Klikk her for å sjå meir'
+A new blog is now available, {blogTitle}. Click to view more: 'Eit nytt blogginnlegg er tilgjengeleg,
+  {blogTitle}. Klikk her for å sjå meir'
 
 # Search Bar
 Search / Go to URL: 'Søk/gå til nettadresse'
@@ -367,15 +367,15 @@ Profile:
   Your profile name cannot be empty: 'Profilnamnet ditt kan ikkje vere tomt'
   Profile has been created: 'Profilet har blitt laga'
   Profile has been updated: 'Profilet har blitt oppdatert'
-  Your default profile has been set to $: 'Ditt forvalte profil har blitt satt til
-    $'
-  Removed $ from your profiles: 'Fjerna $ frå profila dine'
+  Your default profile has been set to {profile}: 'Ditt forvalte profil har blitt satt til
+    {profile}'
+  Removed {profile} from your profiles: 'Fjerna {profile} frå profila dine'
   Your default profile has been changed to your primary profile: 'Ditt forvalte profil
     har blitt endra til ditt hovudprofil'
-  $ is now the active profile: '$ er no det aktive profilet'
+  '{profile} is now the active profile': '{profile} er no det aktive profilet'
   Subscription List: 'Abonnementliste'
   Other Channels: 'Andre kanalar'
-  $ selected: '$ valt'
+  '{number} selected': '{number} valt'
   Select All: 'Vel alle'
   Select None: 'Vel ingen'
   Delete Selected: 'Slett valte'
@@ -398,7 +398,7 @@ Channel:
   Unsubscribe: 'Opphev abonnement'
   Channel has been removed from your subscriptions: 'Kanalen har blitt fjerna frå
     dine abonnement'
-  Removed subscription from $ other channel(s): 'Fjerna abonnement frå $ kanal(ar)'
+  Removed subscription from {count} other channel(s): 'Fjerna abonnement frå {count} kanal(ar)'
   Added channel to your subscriptions: 'Lagt til kanal til dine abonnentar'
   Search Channel: 'Søk i kanal'
   Your search results have returned 0 results: 'Søket gitt gav 0 resultat'
@@ -509,8 +509,7 @@ Video:
   Published on: 'Publisert på'
   Streamed on: 'Strauma på'
   Started streaming on: 'Begynte å straume på'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % sidan'
+  Publicationtemplate: '{number} {unit} sidan'
 #& Videos
   translated from English: omsett frå engelsk
   Sponsor Block category:
@@ -524,9 +523,9 @@ Video:
   External Player:
     video: video
     playlist: speleliste
-    UnsupportedActionTemplate: '$ støtter ikkje: %'
-    OpeningTemplate: Opner $ om % ...
-    OpenInTemplate: Opne i $
+    UnsupportedActionTemplate: '{externalPlayer} støtter ikkje: {action}'
+    OpeningTemplate: Opner {videoOrPlaylist} om {externalPlayer} ...
+    OpenInTemplate: Opne i {externalPlayer}
     Unsupported Actions:
       opening playlists: Opner spelelister
       setting a playback rate: set ein avspelingshastigheit
@@ -644,7 +643,7 @@ Tooltips:
     Remove Video Meta Files: Viss denne innstillinga er på, vil FreeTube automatisk
       slette metadata generert under videoavspeling når du lukker avspelingsida.
   External Player Settings:
-    DefaultCustomArgumentsTemplate: "(Forval: '$')"
+    DefaultCustomArgumentsTemplate: "(Forval: '{defaultCustomArguments}')"
 Local API Error (Click to copy): 'Lokal API-feil (Klikk her for å kopiere)'
 Invidious API Error (Click to copy): 'Invidious-API-feil (Klikk her for å kopiere)'
 Falling back to Invidious API: 'Faller tilbake til Invidious-API-et'

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -148,7 +148,7 @@ Settings:
     Current instance will be randomized on startup: Obecna instancja będzie losowana
       przy uruchamianiu
     No default instance has been set: Nie ustawiono domyślnej instancji
-    The currently set default instance is $: Obecnie domyślną instancją jest $
+    The currently set default instance is {instance}: Obecnie domyślną instancją jest {instance}
     Current Invidious Instance: Obecna instancja Invidious
     External Link Handling:
       No Action: Brak akcji
@@ -365,7 +365,7 @@ Settings:
     Manage Subscriptions: Zarządzaj subskrypcjami
     Export Playlists: Wyeksportuj playlisty
     All playlists has been successfully exported: Wszystkie playlisty pomyślnie wyeksportowano
-    Playlist insufficient data: Niewystarczająca ilość danych dla playlisty „$”, pomijam
+    Playlist insufficient data: Niewystarczająca ilość danych dla playlisty „{playlist}”, pomijam
       element
     Import Playlists: Zaimportuj playlisty
     All playlists has been successfully imported: Wszystkie playlisty pomyślnie zaimportowano
@@ -535,7 +535,7 @@ Channel:
     Channel Description: 'Opis kanału'
     Featured Channels: 'Polecane kanały'
   Added channel to your subscriptions: Dodano kanał do twoich subskrypcji
-  Removed subscription from $ other channel(s): Usunięto subskrypcje z $ pozostałych
+  Removed subscription from {count} other channel(s): Usunięto subskrypcje z {count} pozostałych
     kanałów
   Channel has been removed from your subscriptions: Kanał został usunięty z twoich
     subskrypcji
@@ -601,8 +601,7 @@ Video:
     Less than a minute: mniej niż minutę
     In less than a minute: Za mniej niż minutę
   Published on: 'Opublikowano'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % temu'
+  Publicationtemplate: '{number} {unit} temu'
 #& Videos
   Autoplay: Autoodtwarzanie
   Play Previous Video: Odtwórz poprzedni film
@@ -651,11 +650,11 @@ Video:
       opening playlists: otwierania playlist
       setting a playback rate: ustawienia prędkości odtwarzania
       starting video at offset: rozpoczynania filmu z przesunięciem
-    UnsupportedActionTemplate: '$ nie obsługuje: %'
-    OpeningTemplate: Otwieranie $ w %...
+    UnsupportedActionTemplate: '{externalPlayer} nie obsługuje: {action}'
+    OpeningTemplate: Otwieranie {videoOrPlaylist} w {externalPlayer}...
     playlist: playlisty
     video: filmu
-    OpenInTemplate: Otwórz w $
+    OpenInTemplate: Otwórz w {externalPlayer}
   Premieres on: Premiera
   Stats:
     buffered: Zbuforowano
@@ -754,7 +753,7 @@ Comments:
   Show More Replies: Pokaż więcej odpowiedzi
   And others: i innych
   Pinned by: Przypięty przez
-  From $channelName: od $channelName
+  From {channelName}: od {channelName}
   Member: Wspierający
 Up Next: 'Następne'
 
@@ -780,11 +779,11 @@ Yes: 'Tak'
 No: 'Nie'
 Locale Name: Polski
 Profile:
-  $ is now the active profile: $ jest teraz aktywnym profilem
+  '{profile} is now the active profile': '{profile} jest teraz aktywnym profilem'
   Your default profile has been changed to your primary profile: Twój domyślny profil
     został zmieniony na profil główny
-  Removed $ from your profiles: Usunięto $ z twoich profili
-  Your default profile has been set to $: $ został ustawiony jako Twój domyślny profil
+  Removed {profile} from your profiles: Usunięto {profile} z twoich profili
+  Your default profile has been set to {profile}: '{profile} został ustawiony jako Twój domyślny profil'
   Profile has been updated: Zaktualizowano profil
   Profile has been created: Utworzono profil
   Your profile name cannot be empty: Nazwa profilu nie może być pusta
@@ -816,16 +815,16 @@ Profile:
   Delete Selected: Usuń wybrane
   Select None: Nic nie wybieraj
   Select All: Wybierz wszystkie
-  $ selected: Wybrano $
+  '{number} selected': Wybrano {number}
   Other Channels: Inne kanały
   Subscription List: Lista subskrypcji
   Profile Filter: Filtr profilu
   Profile Settings: Ustawienia profilu
 The playlist has been reversed: Playlista została odwrócona
-A new blog is now available, $. Click to view more: Nowy wpis na blogu jest dostępny,
-  $. Kliknij, aby zobaczyć więcej
+A new blog is now available, {blogTitle}. Click to view more: 'Nowy wpis na blogu jest dostępny,
+  {blogTitle}. Kliknij, aby zobaczyć więcej'
 Download From Site: Pobierz ze strony
-Version $ is now available!  Click for more details: Wersja $ jest już dostępna! Kliknij
+Version {versionNumber} is now available!  Click for more details: Wersja {versionNumber} jest już dostępna! Kliknij
   po więcej szczegółów
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Ten
   film jest niedostępny z powodu brakujących formatów. Przyczyną może być blokada
@@ -884,7 +883,7 @@ Tooltips:
     Custom External Player Executable: FreeTube domyślnie przyjmie, że wybrany odtwarzacz
       jest do znalezienia za pomocą zmiennej środowiskowej PATH. Jeśli trzeba, można
       tutaj ustawić niestandardową ścieżkę.
-    DefaultCustomArgumentsTemplate: "(Domyślnie: '$')"
+    DefaultCustomArgumentsTemplate: "(Domyślnie: '{defaultCustomArguments}')"
 Playing Next Video Interval: Odtwarzanie kolejnego filmu już za chwilę. Wciśnij aby
   przerwać. | Odtwarzanie kolejnego filmu za {nextVideoInterval} sekundę. Wciśnij
   aby przerwać. | Odtwarzanie kolejnego filmu za {nextVideoInterval} sekund. Wciśnij
@@ -897,34 +896,34 @@ Hashtags have not yet been implemented, try again later: Hashtagi nie zostały j
 Open New Window: Otwórz nowe okno
 Default Invidious instance has been cleared: Domyślna instancja Invidious została
   wyczyszczona
-Default Invidious instance has been set to $: Domyślna instancja Invidious została
-  ustawiona na $
+Default Invidious instance has been set to {instance}: Domyślna instancja Invidious została
+  ustawiona na {instance}
 Search Bar:
   Clear Input: Wyczyść pole
 External link opening has been disabled in the general settings: Otwieranie zewnętrznych
   linków zostało wyłączone w ustawieniach ogólnych
 Are you sure you want to open this link?: Czy na pewno chcesz otworzyć ten link?
-Downloading has completed: '„$” został pobrany'
-Starting download: Rozpoczęto pobieranie „$”
-Downloading failed: Wystąpił problem z pobieraniem „$”
+Downloading has completed: '„{videoTitle}” został pobrany'
+Starting download: Rozpoczęto pobieranie „{videoTitle}”
+Downloading failed: Wystąpił problem z pobieraniem „{videoTitle}”
 Downloading canceled: Pobieranie zostało przerwane przez użytkownika
 Download folder does not exist: Katalog pobierania "$" nie istnieje. Przełączono na
   tryb "pytaj o folder".
-Screenshot Error: Wykonanie zrzutu nie powiodło się. $
-Screenshot Success: Zapisano zrzut ekranu jako „$”
+Screenshot Error: Wykonanie zrzutu nie powiodło się. {error}
+Screenshot Success: Zapisano zrzut ekranu jako „{filePath}”
 Age Restricted:
   Type:
     Channel: kanał
     Video: film
-  This $contentType is age restricted: Ten $ ma ograniczenie wiekowe
+  The currently set default instance is {instance}: Ten {instance} ma ograniczenie wiekowe
 New Window: Nowe okno
 Channels:
   Title: Lista kanałów
-  Count: Znaleziono $ kanał(y/ów).
+  Count: Znaleziono {number} kanał(y/ów).
   Empty: Twoja lista kanałów jest na razie pusta.
   Unsubscribe: Odsubskrybuj
-  Unsubscribe Prompt: Czy na pewno chcesz zrezygnować z subskrypcji „$”?
-  Unsubscribed: $ został usunięty z Twoich subskrypcji
+  Unsubscribe Prompt: Czy na pewno chcesz zrezygnować z subskrypcji „{channelName}”?
+  Unsubscribed: '{channelName} został usunięty z Twoich subskrypcji'
   Channels: Kanały
   Search bar placeholder: Przeszukaj kanały
 Clipboard:

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -138,8 +138,8 @@ Settings:
       Invidious
     System Default: Padrão do Sistema
     No default instance has been set: Nenhuma instância padrão foi definida
-    The currently set default instance is $: A instância padrão atualmente definida
-      é $
+    The currently set default instance is {instance}: A instância padrão atualmente definida
+      é {instance}
     Current instance will be randomized on startup: A instância atual será randomizada
       na inicialização
     Set Current Instance as Default: Definir instância atual como padrão
@@ -360,7 +360,7 @@ Settings:
     Manage Subscriptions: Administrar Inscrições
     Import Playlists: Importar listas de reprodução
     Export Playlists: Exportar listas de reprodução
-    Playlist insufficient data: Dados insuficientes para "$" playlist, pulando item
+    Playlist insufficient data: Dados insuficientes para "{playlist}" playlist, pulando item
     All playlists has been successfully exported: Todas as listas de reprodução foram
       exportadas com sucesso
     All playlists has been successfully imported: Todas as listas de reprodução foram
@@ -520,7 +520,7 @@ Channel:
     Channel Description: 'Descrição do canal'
     Featured Channels: 'Canais destacados'
   Added channel to your subscriptions: Canal adicionado às suas inscrições
-  Removed subscription from $ other channel(s): Inscrição removida de outros $ canais
+  Removed subscription from {count} other channel(s): Inscrição removida de outros {count} canais
   Channel has been removed from your subscriptions: O canal foi removido da suas inscrições
 Video:
   Mark As Watched: 'Marcar como assistido'
@@ -583,8 +583,7 @@ Video:
     Minute: Minuto
     Less than a minute: Menos de um minuto
   Published on: 'Publicado em'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Há $ %'
+  Publicationtemplate: 'Há {number} {unit}'
 #& Videos
   Started streaming on: Transmissão iniciada em
   Streamed on: Transmitido em
@@ -633,10 +632,10 @@ Video:
       starting video at offset: começando vídeo em deslocamento
       setting a playback rate: definindo uma taxa de reprodução
       looping playlists: Listas de reprodução em loop
-    UnsupportedActionTemplate: '$ não suporta: %'
+    UnsupportedActionTemplate: '{externalPlayer} não suporta: {action}'
     playlist: playlist
-    OpeningTemplate: Abrindo $ em %...
-    OpenInTemplate: Aberto em $
+    OpeningTemplate: Abrindo {videoOrPlaylist} em {externalPlayer}...
+    OpenInTemplate: Aberto em {externalPlayer}
     video: vídeo
   Premieres on: Estreia em
   Stats:
@@ -736,7 +735,7 @@ Comments:
   Show More Replies: Mostrar Mais Respostas
   Pinned by: Fixado por
   And others: e outros
-  From $channelName: de $channelName
+  From {channelName}: de {channelName}
   Member: Membro
 Up Next: 'Próximo'
 
@@ -790,23 +789,23 @@ Profile:
   Delete Selected: Apagar Selecionados
   Select None: Selecionar Nenhum
   Select All: Selecionar Todos
-  $ selected: $ selecionado
+  '{number} selected': '{number} selecionado'
   Other Channels: Outros Canais
   Subscription List: Lista de Inscrições
-  $ is now the active profile: $ é agora o perfil ativo
+  '{profile} is now the active profile': '{profile} é agora o perfil ativo'
   Your default profile has been changed to your primary profile: Seu perfil padrão
     foi mudado para o seu perfil principal
-  Removed $ from your profiles: $ foi removido dos seus perfis
-  Your default profile has been set to $: Seu perfil padrão foi definido como $
+  Removed {profile} from your profiles: '{profile} foi removido dos seus perfis'
+  Your default profile has been set to {profile}: Seu perfil padrão foi definido como {profile}
   Profile has been updated: Perfil atualizado
   Profile has been created: Perfil criado
   Your profile name cannot be empty: Seu nome de perfil não pode ficar em branco
   Profile Filter: Filtro de Perfil
   Profile Settings: Configurações de Perfil
-Version $ is now available!  Click for more details: A versão $ já está disponível!
+Version {versionNumber} is now available!  Click for more details: A versão {versionNumber} já está disponível!
   Clique para mais detalhes
-A new blog is now available, $. Click to view more: Um novo blog está disponível,
-  $. Clique para ver mais
+A new blog is now available, {blogTitle}. Click to view more: 'Um novo blog está disponível,
+  {blogTitle}. Clique para ver mais'
 Download From Site: Baixar do site
 The playlist has been reversed: A lista de reprodução foi invertida
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Este
@@ -869,7 +868,7 @@ Tooltips:
     External Player: A escolha de um player externo exibirá um ícone, para abrir o
       vídeo (lista de reprodução, se compatível) no player externo, na miniatura.
       Aviso, as configurações do Invidious não afetam os players externos.
-    DefaultCustomArgumentsTemplate: "(Padrão: '$')"
+    DefaultCustomArgumentsTemplate: "(Padrão: '{defaultCustomArguments}')"
 More: Mais
 Playing Next Video Interval: Reproduzindo o próximo vídeo imediatamente. Clique para
   cancelar. | Reproduzindo o próximo vídeo em {nextVideoInterval} segundo(s). Clique
@@ -881,16 +880,16 @@ Unknown YouTube url type, cannot be opened in app: Tipo de URL do YouTube descon
   não pode ser aberta no aplicativo
 Open New Window: Abrir uma nova janela
 Default Invidious instance has been cleared: A instância padrão Invidious foi limpa
-Default Invidious instance has been set to $: A instância padrão Invidious foi definida
-  para $
+Default Invidious instance has been set to {instance}: A instância padrão Invidious foi definida
+  para {instance}
 Search Bar:
   Clear Input: Limpar entrada
 External link opening has been disabled in the general settings: A abertura de link
   externo foi desativada nas configurações gerais
 Are you sure you want to open this link?: Quer mesmo abrir este link?
-Downloading has completed: '"$" terminou de baixar'
-Starting download: Iniciando o download de "$"
-Downloading failed: Ocorreu um problema ao fazer o download de "$"
+Downloading has completed: '"{videoTitle}" terminou de baixar'
+Starting download: Iniciando o download de "{videoTitle}"
+Downloading failed: Ocorreu um problema ao fazer o download de "{videoTitle}"
 New Window: Nova janela
 Channels:
   Channels: Canais
@@ -898,13 +897,13 @@ Channels:
   Search bar placeholder: Buscar canais
   Empty: Sua lista de canais está vazia no momento.
   Unsubscribe: Cancelar inscrição
-  Unsubscribed: $ foi removido de suas assinaturas
-  Unsubscribe Prompt: Tem certeza de que quer cancelar a sua inscrição de "$"?
-  Count: $ canal(is) encontrado(s).
+  Unsubscribed: '{channelName} foi removido de suas assinaturas'
+  Unsubscribe Prompt: Tem certeza de que quer cancelar a sua inscrição de "{channelName}"?
+  Count: '{number} canal(is) encontrado(s).'
 Age Restricted:
-  This $contentType is age restricted: Este $ tem restrição de idade
+  The currently set default instance is {instance}: Este {instance} tem restrição de idade
   Type:
     Channel: Canal
     Video: Vídeo
-Screenshot Success: Captura de tela salva como "$"
-Screenshot Error: Falha na captura de tela. $
+Screenshot Success: Captura de tela salva como "{filePath}"
+Screenshot Error: Falha na captura de tela. {error}

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -29,11 +29,11 @@ Close: Fechar
 Back: Voltar
 Forward: Avançar
 
-Version $ is now available!  Click for more details: A versão $ já está disponível!
+Version {versionNumber} is now available!  Click for more details: A versão {versionNumber} já está disponível!
   Clique aqui para mais informações
 Download From Site: Descarregar do site
-A new blog is now available, $. Click to view more: Está disponível um novo blogue,
-  $. Clique para ver mais
+A new blog is now available, {blogTitle}. Click to view more: 'Está disponível um novo blogue,
+  {blogTitle}. Clique para ver mais'
 
 # Search Bar
 Search / Go to URL: Pesquisar / ir para o URL
@@ -150,7 +150,7 @@ Settings:
     Current instance will be randomized on startup: A instância irá ser escolhida
       aleatoriamente ao iniciar
     No default instance has been set: Não foi definida nenhuma instância
-    The currently set default instance is $: A instância definida como padrão é $
+    The currently set default instance is {instance}: A instância definida como padrão é {instance}
     Current Invidious Instance: Instância do Invidious atual
     Clear Default Instance: Apagar instância predefinida
     Set Current Instance as Default: Escolher a instância atual como a predefinida
@@ -338,7 +338,7 @@ Settings:
     Manage Subscriptions: Gerir subscrições
     Import Playlists: Importar listas de reprodução
     Export Playlists: Exportar listas de reprodução
-    Playlist insufficient data: Dados insuficientes para a lista de reprodução "$",
+    Playlist insufficient data: Dados insuficientes para a lista de reprodução "{playlist}",
       a ignorar o item
     All playlists has been successfully imported: Todas as listas de reprodução foram
       importadas com êxito
@@ -439,14 +439,14 @@ Profile:
   Your profile name cannot be empty: O nome do perfil não pode ficar em branco
   Profile has been created: Perfil criado
   Profile has been updated: Perfil atualizado
-  Your default profile has been set to $: $ é agora o seu perfil padrão
-  Removed $ from your profiles: O perfil $ foi eliminado
+  Your default profile has been set to {profile}: '{profile} é agora o seu perfil padrão'
+  Removed {profile} from your profiles: O perfil {profile} foi eliminado
   Your default profile has been changed to your primary profile: O seu perfil padrão
     é agora o seu perfil principal
-  $ is now the active profile: Está agora a ver as subscrições do perfil $
+  '{profile} is now the active profile': Está agora a ver as subscrições do perfil {profile}
   Subscription List: Lista de subscrições
   Other Channels: Outros canais
-  $ selected: $ selecionado
+  '{number} selected': '{number} selecionado'
   Select All: Selecionar tudo
   Select None: Não selecionar nada
   Delete Selected: Eliminar selecionados
@@ -470,7 +470,7 @@ Channel:
   Unsubscribe: Anular subscrição
   Channel has been removed from your subscriptions: O canal foi removido das suas
     subscrições
-  Removed subscription from $ other channel(s): Subscrição removida de mais $ canais
+  Removed subscription from {count} other channel(s): Subscrição removida de mais {count} canais
   Added channel to your subscriptions: Canal adicionado às suas subscrições
   Search Channel: Procurar canal
   Your search results have returned 0 results: Pesquisa devolveu 0 resultados
@@ -575,8 +575,7 @@ Video:
   Published on: Publicado a
   Streamed on: Transmitido em
   Started streaming on: Transmissão iniciada em
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: Há $ %
+  Publicationtemplate: Há {number} {unit}
 #& Videos
   Play Previous Video: Reproduzir vídeo anterior
   Play Next Video: Reproduzir vídeo seguinte
@@ -594,11 +593,11 @@ Video:
       opening playlists: abrir listas de reprodução
       setting a playback rate: mudar velocidade de reprodução
       starting video at offset: iniciar vídeo num tempo específico
-    UnsupportedActionTemplate: '$ não suporta: %'
-    OpeningTemplate: A abrir $ em %...
+    UnsupportedActionTemplate: '{externalPlayer} não suporta: {action}'
+    OpeningTemplate: A abrir {videoOrPlaylist} em {externalPlayer}...
     playlist: lista de reprodução
     video: vídeo
-    OpenInTemplate: Abrir com $
+    OpenInTemplate: Abrir com {externalPlayer}
   Sponsor Block category:
     music offtopic: Música fora de tópico
     interaction: Interação
@@ -698,7 +697,7 @@ Comments:
   No more comments available: Não existem mais comentários
   Show More Replies: Mostrar mais respostas
   And others: e outros
-  From $channelName: de $channelName
+  From {channelName}: de {channelName}
   Pinned by: Fixado por
   Member: Membro
 Up Next: Próximo
@@ -759,7 +758,7 @@ Tooltips:
       um caminho personalizado pode ser escolhido aqui.
     External Player: Escolher um leitor externo irá mostrar um ícone na miniatura
       do vídeo, para abrir o vídeo (lista de reprodução se possível) nesse leitor.
-    DefaultCustomArgumentsTemplate: "(padrão: '$')"
+    DefaultCustomArgumentsTemplate: "(padrão: '{defaultCustomArguments}')"
 Local API Error (Click to copy): API local encontrou um erro (Clique para copiar)
 Invidious API Error (Click to copy): API Invidious encontrou um erro (Clique para
   copiar)
@@ -795,7 +794,7 @@ Unknown YouTube url type, cannot be opened in app: Tipo de URL do YouTube descon
   não pode ser aberto numa aplicação
 Open New Window: Abrir uma nova janela
 Default Invidious instance has been cleared: Predefinição apagada
-Default Invidious instance has been set to $: Servidor Invidious $ foi estabelecido
+Default Invidious instance has been set to {instance}: Servidor Invidious {instance} foi estabelecido
   como predefenição
 External link opening has been disabled in the general settings: A abertura da ligação
   externa foi desativada nas configurações gerais
@@ -807,18 +806,18 @@ Channels:
   Channels: Canais
   Title: Lista de canais
   Search bar placeholder: Procurar canais
-  Count: $ canais encontrados.
+  Count: '{number} canais encontrados.'
   Empty: A sua lista de canais está neste momento vazia.
   Unsubscribe: Anular subscrição
-  Unsubscribed: $ foi removido das suas subscrições
-  Unsubscribe Prompt: Quer mesmo deixar a subscrição de "$"?
+  Unsubscribed: '{channelName} foi removido das suas subscrições'
+  Unsubscribe Prompt: Quer mesmo deixar a subscrição de "{channelName}"?
 Age Restricted:
-  This $contentType is age restricted: Este $ tem restrição de idade
+  The currently set default instance is {instance}: Este {instance} tem restrição de idade
   Type:
     Channel: Canal
     Video: Vídeo
-Downloading has completed: '"$" foi descarregado'
-Starting download: A descarregar "$"
-Downloading failed: Ouve um problema ao descarregar "$"
-Screenshot Success: Captura de ecrã guardada como "$"
-Screenshot Error: A captura de ecrã falhou. $
+Downloading has completed: '"{videoTitle}" foi descarregado'
+Starting download: A descarregar "{videoTitle}"
+Downloading failed: Ouve um problema ao descarregar "{videoTitle}"
+Screenshot Success: Captura de ecrã guardada como "{filePath}"
+Screenshot Error: A captura de ecrã falhou. {error}

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -28,11 +28,11 @@ Close: 'Fechar'
 Back: 'Voltar'
 Forward: 'Avançar'
 
-Version $ is now available!  Click for more details: 'A versão $ já está disponível!
+Version {versionNumber} is now available!  Click for more details: 'A versão {versionNumber} já está disponível!
   Clique aqui para mais informações'
 Download From Site: 'Descarregar do site'
-A new blog is now available, $. Click to view more: 'Está disponível um novo blogue,
-  $. Clique para ver mais'
+A new blog is now available, {blogTitle}. Click to view more: 'Está disponível um novo blogue,
+  {blogTitle}. Clique para ver mais'
 
 # Search Bar
 Search / Go to URL: 'Pesquisar / ir para o URL'
@@ -150,7 +150,7 @@ Settings:
     Current instance will be randomized on startup: A instância irá ser escolhida
       aleatoriamente ao iniciar
     No default instance has been set: Não foi definida nenhuma instância
-    The currently set default instance is $: A instância definida como padrão é $
+    The currently set default instance is {instance}: A instância definida como padrão é {instance}
     Current Invidious Instance: Instância do Invidious atual
     System Default: Definições do sistema
     External Link Handling:
@@ -331,7 +331,7 @@ Settings:
     Check for Legacy Subscriptions: Verificar se há subscrições no formato pré-v0.8.0
     Import Playlists: Importar listas de reprodução
     Export Playlists: Exportar listas de reprodução
-    Playlist insufficient data: Dados insuficientes para a lista de reprodução "$",
+    Playlist insufficient data: Dados insuficientes para a lista de reprodução "{playlist}",
       a ignorar o item
     All playlists has been successfully imported: Todas as listas de reprodução foram
       importadas com êxito
@@ -513,14 +513,14 @@ Profile:
   Your profile name cannot be empty: 'O nome do perfil não pode ficar em branco'
   Profile has been created: 'Perfil criado'
   Profile has been updated: 'Perfil atualizado'
-  Your default profile has been set to $: '$ é agora o seu perfil padrão'
-  Removed $ from your profiles: 'O perfil $ foi eliminado'
+  Your default profile has been set to {profile}: '{profile} é agora o seu perfil padrão'
+  Removed {profile} from your profiles: 'O perfil {profile} foi eliminado'
   Your default profile has been changed to your primary profile: 'O seu perfil padrão
     é agora o seu perfil principal'
-  $ is now the active profile: 'Está agora a ver as subscrições do perfil $'
+  '{profile} is now the active profile': 'Está agora a ver as subscrições do perfil {profile}'
   Subscription List: 'Lista de subscrições'
   Other Channels: 'Outros canais'
-  $ selected: '$ selecionado'
+  '{number} selected': '{number} selecionado'
   Select All: 'Selecionar tudo'
   Select None: 'Não selecionar nada'
   Delete Selected: 'Eliminar selecionados'
@@ -543,7 +543,7 @@ Channel:
   Unsubscribe: 'Anular subscrição'
   Channel has been removed from your subscriptions: 'O canal foi removido das suas
     subscrições'
-  Removed subscription from $ other channel(s): 'Subscrição removida de mais $ canais'
+  Removed subscription from {count} other channel(s): 'Subscrição removida de mais {count} canais'
   Added channel to your subscriptions: 'Canal adicionado às suas subscrições'
   Search Channel: 'Procurar canal'
   Your search results have returned 0 results: 'Pesquisa devolveu 0 resultados'
@@ -636,8 +636,7 @@ Video:
     Less than a minute: Menos de um minuto
     In less than a minute: Em menos de um minuto
   Published on: 'Publicado a'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'Há $ %'
+  Publicationtemplate: 'Há {number} {unit}'
 #& Videos
   Starting soon, please refresh the page to check again: A começar em breve, recarregue
     a página para voltar a verificar
@@ -651,11 +650,11 @@ Video:
       reversing playlists: inverter lista de reprodução
       opening specific video in a playlist (falling back to opening the video): abrir
         um vídeo específico numa lista (vai apenas abrir o vídeo)
-    UnsupportedActionTemplate: '$ não suporta: %'
-    OpeningTemplate: A abrir $ em %...
+    UnsupportedActionTemplate: '{externalPlayer} não suporta: {action}'
+    OpeningTemplate: A abrir {videoOrPlaylist} em {externalPlayer}...
     playlist: lista de reprodução
     video: vídeo
-    OpenInTemplate: Abrir com $
+    OpenInTemplate: Abrir com {externalPlayer}
   Sponsor Block category:
     music offtopic: Música fora de tópico
     interaction: Interação
@@ -783,7 +782,7 @@ Comments:
   Sort by: Ordenar por
   Pinned by: Fixado por
   And others: e outros
-  From $channelName: de $channelName
+  From {channelName}: de {channelName}
   Member: Membro
 Up Next: 'Próximo'
 
@@ -812,7 +811,7 @@ No: 'Não'
 More: Mais
 Open New Window: Abrir uma nova janela
 Default Invidious instance has been cleared: Predefinição apagada
-Default Invidious instance has been set to $: Servidor Invidious $ foi estabelecido
+Default Invidious instance has been set to {instance}: Servidor Invidious {instance} foi estabelecido
   como predefenição
 Playing Next Video Interval: A reproduzir o vídeo seguinte imediatamente. Clique para
   cancelar. | A reproduzir o vídeo seguinte em {nextVideoInterval} segundo. Clique
@@ -847,7 +846,7 @@ Tooltips:
     External Player: Escolher um leitor externo irá mostrar um ícone, para abrir o
       vídeo (lista de reprodução, se suportado) no leitor externo, na miniatura do
       vídeo. Aviso, as configurações do Invidious não afetam os reprodutores externos.
-    DefaultCustomArgumentsTemplate: "(padrão: '$')"
+    DefaultCustomArgumentsTemplate: "(padrão: '{defaultCustomArguments}')"
   Player Settings:
     Default Video Format: Define os formatos usados quando um vídeo é reproduzido.
       Formatos DASH podem reproduzir qualidades mais altas. Os formatos antigos são
@@ -887,26 +886,26 @@ Search Bar:
 Are you sure you want to open this link?: Quer mesmo abrir esta ligação?
 External link opening has been disabled in the general settings: A abertura da ligação
   externa foi desativada nas configurações gerais
-Starting download: A descarregar "$"
-Downloading failed: Ouve um problema ao descarregar "$"
-Downloading has completed: '"$" foi descarregado'
-Screenshot Success: Captura de ecrã guardada como "$"
-Screenshot Error: A captura de ecrã falhou. $
+Starting download: A descarregar "{videoTitle}"
+Downloading failed: Ouve um problema ao descarregar "{videoTitle}"
+Downloading has completed: '"{videoTitle}" foi descarregado'
+Screenshot Success: Captura de ecrã guardada como "{filePath}"
+Screenshot Error: A captura de ecrã falhou. {error}
 Age Restricted:
-  This $contentType is age restricted: Este $ tem restrição de idade
+  The currently set default instance is {instance}: Este {instance} tem restrição de idade
   Type:
     Channel: Canal
     Video: Vídeo
 New Window: Nova janela
 Channels:
-  Count: $ canais encontrados.
+  Count: '{number} canais encontrados.'
   Empty: A sua lista de canais está neste momento vazia.
   Unsubscribe: Anular subscrição
-  Unsubscribed: $ foi removido das suas subscrições
+  Unsubscribed: '{channelName} foi removido das suas subscrições'
   Search bar placeholder: Procurar canais
   Channels: Canais
   Title: Lista de canais
-  Unsubscribe Prompt: Quer mesmo deixar a subscrição de "$"?
+  Unsubscribe Prompt: Quer mesmo deixar a subscrição de "{channelName}"?
 Chapters:
   'Chapters list hidden, current chapter: {chapterName}': 'Lista de capítulos ocultos,
     capítulo atual: {capítuloNoto}'

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -29,11 +29,11 @@ Close: 'Închideți'
 Back: 'Înapoi'
 Forward: 'Înainte'
 
-Version $ is now available!  Click for more details: 'Versiunea $ este acum disponibilă!  Click
+Version {versionNumber} is now available!  Click for more details: 'Versiunea {versionNumber} este acum disponibilă!  Click
   pentru mai multe detalii'
 Download From Site: 'Descărcați de pe site'
-A new blog is now available, $. Click to view more: 'Un nou blog este acum disponibil,
-  $. Click to view more'
+A new blog is now available, {blogTitle}. Click to view more: 'Un nou blog este acum disponibil,
+  {blogTitle}. Click to view more'
 
 # Search Bar
 Search / Go to URL: 'Căutare / Du-te la URL'
@@ -157,8 +157,8 @@ Settings:
     Current instance will be randomized on startup: Instanța curentă va fi aleatorie
       la pornire
     No default instance has been set: Nu a fost setată nicio instanță implicită
-    The currently set default instance is $: Instanța implicită setată în prezent
-      este $
+    The currently set default instance is {instance}: Instanța implicită setată în prezent
+      este {instance}
     Current Invidious Instance: Instanța actuală Invidious
     System Default: Prestabilită de sistem
   Theme Settings:
@@ -336,7 +336,7 @@ Settings:
       importate cu succes
     Import Playlists: Importați liste de redare
     Export Playlists: Exportați liste de redare
-    Playlist insufficient data: Date insuficiente pentru lista de redare "$", se omite
+    Playlist insufficient data: Date insuficiente pentru lista de redare "{playlist}", se omite
     All playlists has been successfully exported: Toate listele de redare au fost
       exportate cu succes
   Advanced Settings:
@@ -499,15 +499,15 @@ Profile:
   Your profile name cannot be empty: 'Numele profilului nu poate fi gol'
   Profile has been created: 'Profilul a fost creat'
   Profile has been updated: 'Profilul a fost actualizat'
-  Your default profile has been set to $: 'Profilul dvs. implicit a fost setat la
-    $'
-  Removed $ from your profiles: 'Ai eliminat $ din profilurile tale'
+  Your default profile has been set to {profile}: 'Profilul dvs. implicit a fost setat la
+    {profile}'
+  Removed {profile} from your profiles: 'Ai eliminat {profile} din profilurile tale'
   Your default profile has been changed to your primary profile: 'Profilul dvs. implicit
     a fost schimbat în profilul dvs. principal'
-  $ is now the active profile: '$ este acum profilul activ'
+  '{profile} is now the active profile': '{profile} este acum profilul activ'
   Subscription List: 'Lista de abonamente'
   Other Channels: 'Alte canale'
-  $ selected: '$ selectat'
+  '{number} selected': '{number} selectat'
   Select All: 'Selectați toate'
   Select None: 'Selectați niciunul'
   Delete Selected: 'Ștergeți selectat'
@@ -530,7 +530,7 @@ Channel:
   Unsubscribe: 'Dezabonați-vă'
   Channel has been removed from your subscriptions: 'Canalul a fost eliminat din abonamentele
     tale'
-  Removed subscription from $ other channel(s): 'Abonament eliminat de pe $ alt(e)
+  Removed subscription from {count} other channel(s): 'Abonament eliminat de pe {count} alt(e)
     canal(e)'
   Added channel to your subscriptions: 'Adăugat canal la abonamentele tale'
   Search Channel: 'Căutare canal'
@@ -626,8 +626,7 @@ Video:
     Upcoming: 'În premieră la'
     Less than a minute: Mai putin de un minut
   Published on: 'Publicat pe'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'acum $ %'
+  Publicationtemplate: 'acum {number} {unit}'
 #& Videos
   External Player:
     Unsupported Actions:
@@ -639,11 +638,11 @@ Video:
       reversing playlists: inversarea listelor de redare
       opening specific video in a playlist (falling back to opening the video): deschiderea
         unui anumit videoclip dintr-o listă de redare (revenirea la deschiderea videoclipului)
-    UnsupportedActionTemplate: '$ nu acceptă: %'
-    OpeningTemplate: Se deschide $ în %...
+    UnsupportedActionTemplate: '{externalPlayer} nu acceptă: {action}'
+    OpeningTemplate: Se deschide {videoOrPlaylist} în {externalPlayer}...
     playlist: listă de redare
     video: video
-    OpenInTemplate: Deschideți în $
+    OpenInTemplate: Deschideți în {externalPlayer}
   Sponsor Block category:
     music offtopic: Muzică offtopic
     interaction: Interacțiune
@@ -770,7 +769,7 @@ Comments:
   Top comments: Cele mai bune comentarii
   Sort by: Sortați după
   And others: și altele
-  From $channelName: de la $channelName
+  From {channelName}: de la {channelName}
   Pinned by: Lipit de
   Member: Membru
 Up Next: 'În continuare'
@@ -805,8 +804,8 @@ Are you sure you want to open this link?: Sunteți sigur că doriți să deschid
   link?
 Open New Window: Deschide fereastră nouă
 Default Invidious instance has been cleared: Instanța implicită Invidious a fost eliminată
-Default Invidious instance has been set to $: Instanța implicită Invidious a fost
-  setată la $
+Default Invidious instance has been set to {instance}: Instanța implicită Invidious a fost
+  setată la {instance}
 Playing Next Video Interval: Se redară următorul videoclip în cel mai scurt timp.
   Faceți clic pentru a anula. | Se redă următorul videoclip în {nextVideoInterval}
   secundă. Faceți clic pentru a anula. | Se redă următorul videoclip în {nextVideoInterval}
@@ -836,7 +835,7 @@ Tooltips:
     External Player: Alegerea unui player extern va afișa o pictogramă, pentru a deschide
       videoclipul (playlist, dacă este acceptat) în playerul extern, pe thumbnail.
       Atenție, setările Invidious nu afectează playerele externe.
-    DefaultCustomArgumentsTemplate: "(Implicit: '$')"
+    DefaultCustomArgumentsTemplate: "(Implicit: '{defaultCustomArguments}')"
   Player Settings:
     Default Video Format: Setați formatele utilizate la redarea unui videoclip. Formatele
       DASH pot reda calități superioare. Formatele tradiționale sunt limitate la maximum
@@ -874,12 +873,12 @@ Tooltips:
       un server Invidious la care să vă conectați.
 External link opening has been disabled in the general settings: Deschiderea linkurilor
   externe a fost dezactivată în setările generale
-Starting download: Se începe descărcarea a "$"
-Downloading failed: A existat o problemă la descărcarea "$"
-Downloading has completed: '"$" s-a terminat de descărcat'
+Starting download: Se începe descărcarea a "{videoTitle}"
+Downloading failed: A existat o problemă la descărcarea "{videoTitle}"
+Downloading has completed: '"{videoTitle}" s-a terminat de descărcat'
 New Window: Fereastră nouă
 Age Restricted:
-  This $contentType is age restricted: Acest $ este restricționat datorită vârstei
+  The currently set default instance is {instance}: Acest {instance} este restricționat datorită vârstei
   Type:
     Channel: Canal
     Video: Video
@@ -887,10 +886,10 @@ Channels:
   Channels: Canale
   Title: Listă de canale
   Search bar placeholder: Caută canale
-  Count: $ canal(e) găsit(e).
+  Count: '{number} canal(e) găsit(e).'
   Empty: Lista ta de canale este goală.
   Unsubscribe: Dezabonează-te
-  Unsubscribed: $ a fost eliminat din lista ta de abonamente
-  Unsubscribe Prompt: Ești sigur că dorești să te dezabonezi de la "$"?
-Screenshot Success: Capturi de ecran salvate ca "$"
+  Unsubscribed: '{channelName} a fost eliminat din lista ta de abonamente'
+  Unsubscribe Prompt: Ești sigur că dorești să te dezabonezi de la "{channelName}"?
+Screenshot Success: Capturi de ecran salvate ca "{filePath}"
 Screenshot Error: Captura de ecran a eșuat

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -145,8 +145,8 @@ Settings:
     Current instance will be randomized on startup: Текущий экземпляр при запуске
       будет выбран случайно
     No default instance has been set: Не установлен экземпляр по умолчанию
-    The currently set default instance is $: 'Текущий установленный экземпляр по умолчанию:
-      $'
+    The currently set default instance is {instance}: 'Текущий установленный экземпляр по умолчанию:
+      {instance}'
     Current Invidious Instance: Текущий экземпляр Invidious
     External Link Handling:
       No Action: Ничего
@@ -362,7 +362,7 @@ Settings:
     All playlists has been successfully exported: Все плейлисты успешно экспортированы
     Export Playlists: Экспортировать плейлисты
     All playlists has been successfully imported: Все плейлисты успешно импортированы
-    Playlist insufficient data: Недостаточно данных для плейлиста "$", пропуск элемента
+    Playlist insufficient data: Недостаточно данных для плейлиста "{playlist}", пропуск элемента
     Playlist File: Файл плейлиста
     Subscription File: Файл подписок
     History File: Файл истории
@@ -523,7 +523,7 @@ Channel:
     Channel Description: 'Описание канала'
     Featured Channels: 'Избранные каналы'
   Added channel to your subscriptions: Канал добавлен в ваши подписки
-  Removed subscription from $ other channel(s): Подписка удалена с $ другого(их) канала(ов)
+  Removed subscription from {count} other channel(s): Подписка удалена с {count} другого(их) канала(ов)
   Channel has been removed from your subscriptions: Канал был удалён из подписок
 Video:
   Mark As Watched: 'Отметить как просмотренное'
@@ -588,8 +588,7 @@ Video:
     Less than a minute: Менее минуты
     In less than a minute: Меньше чем через минуту
   Published on: 'Опубликовано'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % назад'
+  Publicationtemplate: '{number} {unit} назад'
 #& Videos
   Autoplay: Автовоспроизведение
   Play Previous Video: Воспроизвести предыдущее видео
@@ -637,11 +636,11 @@ Video:
       opening playlists: открытие плейлистов
       setting a playback rate: настройка скорости воспроизведения
       starting video at offset: начинать видео со смещением
-    UnsupportedActionTemplate: '$ не поддерживает: %'
-    OpeningTemplate: Открытие $ в %...
+    UnsupportedActionTemplate: '{externalPlayer} не поддерживает: {action}'
+    OpeningTemplate: Открытие {videoOrPlaylist} в {externalPlayer}...
     playlist: плейлист
     video: видео
-    OpenInTemplate: Открыть в $
+    OpenInTemplate: Открыть в {externalPlayer}
   Stats:
     frame drop: Пропущенные кадры
     video id: ID видео (YouTube)
@@ -739,7 +738,7 @@ Comments:
   Top comments: Лучшим комментариям
   Sort by: Упорядочивать по
   Show More Replies: Показать больше ответов
-  From $channelName: от $channelName
+  From {channelName}: от {channelName}
   And others: и других
   Pinned by: Закреплено
   Member: Участник
@@ -769,12 +768,12 @@ Yes: 'Да'
 No: 'Нет'
 Locale Name: Русский
 Profile:
-  $ is now the active profile: Теперь $ активный профиль
+  '{profile} is now the active profile': Теперь {profile} активный профиль
   Your default profile has been changed to your primary profile: Профиль по умолчанию
     был изменен на ваш основной
   Profile has been updated: Профиль был обновлён
-  Removed $ from your profiles: Теперь $ удалён из профилей
-  Your default profile has been set to $: Теперь $ установлен профилем по умолчанию
+  Removed {profile} from your profiles: Теперь {profile} удалён из профилей
+  Your default profile has been set to {profile}: Теперь {profile} установлен профилем по умолчанию
   Profile has been created: Профиль был создан
   Your profile name cannot be empty: Имя профиля не может быть пустым
   Profile could not be found: Не удалось найти профиль
@@ -804,16 +803,16 @@ Profile:
   Delete Selected: Удалить выбранное
   Select None: Ничего не выбрано
   Select All: Выбрать все
-  $ selected: Выбрано $
+  '{number} selected': Выбрано {number}
   Other Channels: Другие каналы
   Subscription List: Список подписок
   Profile Filter: Фильтр профилей
   Profile Settings: Настройки профиля
 The playlist has been reversed: Плейлист был перевернут
-A new blog is now available, $. Click to view more: Доступен новый блог $. Нажмите
+A new blog is now available, {blogTitle}. Click to view more: Доступен новый блог {blogTitle}. Нажмите
   здесь, чтобы посмотреть подробности
 Download From Site: Скачать с сайта
-Version $ is now available!  Click for more details: Доступна версия $! Чтобы узнать
+Version {versionNumber} is now available!  Click for more details: Доступна версия {versionNumber}! Чтобы узнать
   подробности, нажмите здесь
 This video is unavailable because of missing formats. This can happen due to country unavailability.: Это
   видео недоступно из-за отсутствия форматов. Это может произойти из-за региональных
@@ -875,7 +874,7 @@ Tooltips:
     External Player: При выборе внешнего проигрывателя на миниатюре появится значок,
       позволяющий открыть видео (плейлист, если поддерживается) во внешнем проигрывателе.
       Внимание, настройки Invidious не применяются к внешним проигрывателям.
-    DefaultCustomArgumentsTemplate: "(По умолчанию: '$')"
+    DefaultCustomArgumentsTemplate: "(По умолчанию: '{defaultCustomArguments}')"
 More: Больше
 Playing Next Video Interval: Воспроизведение следующего видео без задержки. Нажмите
   для отмены. | Воспроизведение следующего видео через {nextVideoInterval} сек. Нажмите
@@ -887,33 +886,33 @@ Unknown YouTube url type, cannot be opened in app: Неизвестный тип
   невозможно открыть в приложении
 Open New Window: Открыть новое окно
 Default Invidious instance has been cleared: Образец Invidious по умолчанию очищен
-Default Invidious instance has been set to $: Образец Invidious по умолчанию установлен
-  на $
+Default Invidious instance has been set to {instance}: Образец Invidious по умолчанию установлен
+  на {instance}
 External link opening has been disabled in the general settings: Открытие внешних
   ссылок отключено в настройках
 Search Bar:
   Clear Input: Очистить
 Are you sure you want to open this link?: Вы действительно хотите открыть эту ссылку?
-Starting download: Запуск загрузки "$"
-Downloading has completed: '"$" закончил загрузку'
-Downloading failed: Возникла проблема с загрузкой "$"
-Screenshot Success: Снимок экрана сохранён как "$"
-Screenshot Error: Снимок экрана не удался. $
+Starting download: Запуск загрузки "{videoTitle}"
+Downloading has completed: '"{videoTitle}" закончил загрузку'
+Downloading failed: Возникла проблема с загрузкой "{videoTitle}"
+Screenshot Success: Снимок экрана сохранён как "{filePath}"
+Screenshot Error: Снимок экрана не удался. {error}
 New Window: Новое окно
 Age Restricted:
-  This $contentType is age restricted: У $ ограничение по возрасту
+  The currently set default instance is {instance}: У {instance} ограничение по возрасту
   Type:
     Channel: Канал
     Video: Видео
 Channels:
   Title: Список каналов
-  Count: $ канал(ов) найдено.
+  Count: '{number} канал(ов) найдено.'
   Empty: Список каналов пуст.
   Channels: Каналы
   Search bar placeholder: Поиск каналов
   Unsubscribe: Отписаться
-  Unsubscribed: $ был удален из ваших подписок
-  Unsubscribe Prompt: Вы уверены, что хотите отписаться от "$"?
+  Unsubscribed: '{channelName} был удален из ваших подписок'
+  Unsubscribe Prompt: Вы уверены, что хотите отписаться от "{channelName}"?
 Clipboard:
   Copy failed: Не удалось скопировать в буфер обмена
   Cannot access clipboard without a secure connection: Невозможно получить доступ

--- a/static/locales/sat.yaml
+++ b/static/locales/sat.yaml
@@ -29,9 +29,9 @@ Close: ''
 Back: ''
 Forward: ''
 
-Version $ is now available!  Click for more details: ''
+Version {versionNumber} is now available!  Click for more details: ''
 Download From Site: ''
-A new blog is now available, $. Click to view more: ''
+A new blog is now available, {blogTitle}. Click to view more: ''
 
 # Search Bar
 Search / Go to URL: ''
@@ -296,13 +296,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -319,7 +319,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -418,7 +418,6 @@ Video:
   Published on: ''
   Streamed on: ''
   Started streaming on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/si.yaml
+++ b/static/locales/si.yaml
@@ -29,10 +29,10 @@ Close: 'වසන්න'
 Back: 'ආපසු'
 Forward: ''
 
-Version $ is now available!  Click for more details: '$ අනුවාදය දැන් ලබා ගත හැකිය!  වැඩි
+Version {versionNumber} is now available!  Click for more details: '{versionNumber} අනුවාදය දැන් ලබා ගත හැකිය!  වැඩි
   විස්තර සඳහා ඔබන්න'
 Download From Site: 'අඩවියෙන් බාගන්න'
-A new blog is now available, $. Click to view more: ''
+A new blog is now available, {blogTitle}. Click to view more: ''
 
 # Search Bar
 Search / Go to URL: 'සොයන්න / ඒ.ස.නි.(URL) වෙත යන්න'
@@ -297,13 +297,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -320,7 +320,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -410,7 +410,6 @@ Video:
     Ago: ''
     Upcoming: ''
   Published on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -136,8 +136,8 @@ Settings:
       No Action: Žiadna akcia
       Ask Before Opening Link: Spýtať sa pred otvorením odkazu
       Open Link: Otvoriť odkaz
-    The currently set default instance is $: Aktuálne nastavená predvolená inštancia
-      je $
+    The currently set default instance is {instance}: Aktuálne nastavená predvolená inštancia
+      je {instance}
     No default instance has been set: Žiadna predvolená inštancia nebola nastavená
     Current instance will be randomized on startup: Aktuálne nastavená inštancia bude
       vybraná náhodne pri spustení
@@ -444,7 +444,7 @@ Channel:
   Added channel to your subscriptions: Kanál bol pridaný k vašim odberom
   Channel has been removed from your subscriptions: Kanál bol odstránený z vašich
     odberov
-  Removed subscription from $ other channel(s): Odstránené predplatné z $ iných kanálov
+  Removed subscription from {count} other channel(s): Odstránené predplatné z {count} iných kanálov
 Video:
   Mark As Watched: 'Označiť ako zhliadnuté'
   Remove From History: 'Vymazať z histórie'
@@ -505,8 +505,7 @@ Video:
     Minute: Minúta
     Minutes: Minút
   Published on: 'Publikované dňa'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'pred $ %'
+  Publicationtemplate: 'pred {number} {unit}'
 #& Videos
   Autoplay: Automatické prehrávanie
   Starting soon, please refresh the page to check again: Čoskoro začína, obnovte stránku
@@ -552,7 +551,7 @@ Video:
     video id: ID videa (YouTube)
     buffered: Prednačítané
   External Player:
-    OpenInTemplate: Otvoriť v $
+    OpenInTemplate: Otvoriť v {externalPlayer}
     Unsupported Actions:
       setting a playback rate: nastavenie rýchlosti prehrávania
       reversing playlists: zoznamy videí odzadu
@@ -563,9 +562,9 @@ Video:
         konkrétneho videa v zozname videí (keďtak otvorí video samotné)
       shuffling playlists: premiešavanie zoznamov videí
     playlist: zoznam videí
-    UnsupportedActionTemplate: '$ nepodporuje: %'
+    UnsupportedActionTemplate: '{externalPlayer} nepodporuje: {action}'
     video: video
-    OpeningTemplate: Otvára sa $ v %...
+    OpeningTemplate: Otvára sa {videoOrPlaylist} v {externalPlayer}...
   Premieres on: Premiéruje o
 Videos:
   #& Sort By
@@ -643,7 +642,7 @@ Comments:
   Sort by: Zoradiť podľa
   Pinned by: Pripnuté používateľom
   Show More Replies: Zobraziť viac odpovedí
-  From $channelName: z $channelName
+  From {channelName}: z {channelName}
   And others: a ďalšie
 Up Next: 'Nasledujúci'
 
@@ -713,7 +712,7 @@ Tooltips:
     Remove Video Meta Files: Ak je povolené, FreeTube po zatvorení stránky prezerania
       automaticky odstráni metasúbory vytvorené počas prehrávania videa.
   External Player Settings:
-    DefaultCustomArgumentsTemplate: "(Predvolené: '$')"
+    DefaultCustomArgumentsTemplate: "(Predvolené: '{defaultCustomArguments}')"
     External Player: Po výbere externého prehrávača sa na miniatúre zobrazí ikona
       na otvorenie videa (zoznam videí, ak je podporovaný) v externom prehrávači.
     Custom External Player Executable: V predvolenom nastavení bude FreeTube predpokladať,
@@ -735,14 +734,14 @@ Profile:
   Delete Selected: Zmazať vybrané
   Select None: Zrušiť výber
   Select All: Vybrať všetko
-  $ selected: $ vybraný
+  '{number} selected': '{number} vybraný'
   Other Channels: Ostatné kanály
   Subscription List: Zoznam odberov
-  $ is now the active profile: $ je teraz aktívny profil
+  '{profile} is now the active profile': '{profile} je teraz aktívny profil'
   Your default profile has been changed to your primary profile: Váš predvolený profil
     bol zmenený na hlavný profil
-  Removed $ from your profiles: Odstránený $ spomedzi vašich profilov
-  Your default profile has been set to $: Váš predvolený profil bol nastavený na $
+  Removed {profile} from your profiles: Odstránený {profile} spomedzi vašich profilov
+  Your default profile has been set to {profile}: Váš predvolený profil bol nastavený na {profile}
   Profile has been updated: Profil aktualizovaný
   Profile has been created: Profil vytvorený
   Your profile name cannot be empty: Meno nesmie byť prázdne
@@ -763,10 +762,10 @@ Profile:
   Profile Select: Vyberte profil
   Profile Filter: Filter Profilov
   Profile Settings: Nastavenia profilu
-A new blog is now available, $. Click to view more: Nový príspevok na blogu je k dispozícií,
-  $. Klikni pre viac informácií
+A new blog is now available, {blogTitle}. Click to view more: 'Nový príspevok na blogu je k dispozícií,
+  {blogTitle}. Klikni pre viac informácií'
 Download From Site: Stiahnuť zo stránky
-Version $ is now available!  Click for more details: Je k dispozícií verzia $ ! Klikni
+Version {versionNumber} is now available!  Click for more details: Je k dispozícií verzia {versionNumber} ! Klikni
   pre viac informácií
 Locale Name: Slovenčina
 Playing Next Video Interval: Prehrávanie ďalšieho videa za chvíľu. Kliknutím zrušíte.
@@ -778,8 +777,8 @@ Hashtags have not yet been implemented, try again later: Neznámy typ adresy URL
 Unknown YouTube url type, cannot be opened in app: Neznámy typ adresy URL YouTube,
   v aplikácii sa nedá otvoriť
 Open New Window: Otvoriť Nové Okno
-Default Invidious instance has been set to $: Predvolená Invidious inštancia bola
-  nastavená na $
+Default Invidious instance has been set to {instance}: Predvolená Invidious inštancia bola
+  nastavená na {instance}
 Search Bar:
   Clear Input: Čistý vstup
 Default Invidious instance has been cleared: Predvolená Invidious inštancia bola vymazaná

--- a/static/locales/sl.yaml
+++ b/static/locales/sl.yaml
@@ -30,10 +30,10 @@ Close: 'Zapri'
 Back: 'Nazaj'
 Forward: 'Naprej'
 
-Version $ is now available!  Click for more details: 'Na voljo je različica $!·  Za
+Version {versionNumber} is now available!  Click for more details: 'Na voljo je različica {versionNumber}!·  Za
   več podrobnosti kliknite tukaj'
 Download From Site: 'Prenesi iz spletne strani'
-A new blog is now available, $. Click to view more: 'Na voljo je nov članek, $. Kliknite
+A new blog is now available, {blogTitle}. Click to view more: 'Na voljo je nov članek, {blogTitle}. Kliknite
   tukaj, če ga želite prebrati'
 
 # Search Bar
@@ -398,15 +398,15 @@ Profile:
   Your profile name cannot be empty: 'Ime profila ne sme biti prazno'
   Profile has been created: 'Profil je bil ustvarjen'
   Profile has been updated: 'Profil je bil posodobljen'
-  Your default profile has been set to $: 'Vaš prevzeti profil je bil nastavljen na
-    $'
-  Removed $ from your profiles: 'Profil $ je bil izbrisan'
+  Your default profile has been set to {profile}: 'Vaš prevzeti profil je bil nastavljen na
+    {profile}'
+  Removed {profile} from your profiles: 'Profil {profile} je bil izbrisan'
   Your default profile has been changed to your primary profile: 'Vaš prevzeti profil
     je bil nastavljen na vaš primarni profil'
-  $ is now the active profile: 'Aktivni profil je zdaj $'
+  '{profile} is now the active profile': 'Aktivni profil je zdaj {profile}'
   Subscription List: 'Seznam naročnin'
   Other Channels: 'Drugi kanali'
-  $ selected: '$ je označen'
+  '{number} selected': '{number} je označen'
   Select All: 'Označi vse'
   Select None: 'Ne označi ničesar'
   Delete Selected: 'Izbriši označeno'
@@ -429,7 +429,7 @@ Channel:
   Unsubscribe: 'Prekini naročnino'
   Channel has been removed from your subscriptions: 'Kanal je bil odstranjen iz vaših
     naročnin'
-  Removed subscription from $ other channel(s): 'Naročnina je bila prekinjena v $
+  Removed subscription from {count} other channel(s): 'Naročnina je bila prekinjena v {count}
     kanalih'
   Added channel to your subscriptions: 'Kanal je bil dodan v vaše naročnine'
   Search Channel: 'Preišči kanal'
@@ -524,8 +524,7 @@ Video:
     Ago: 'Nazaj'
     Upcoming: 'Kmalu bo objavljeno'
   Published on: 'Objavljeno dne'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % nazaj'
+  Publicationtemplate: '{number} {unit} nazaj'
 #& Videos
   Audio:
     Best: Najvišja

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -29,10 +29,10 @@ Close: 'Затвори'
 Back: 'Назад'
 Forward: 'Напред'
 
-Version $ is now available!  Click for more details: 'Верзија $ је сада достуна!  Кликните
+Version {versionNumber} is now available!  Click for more details: 'Верзија {versionNumber} је сада достуна!  Кликните
   за више детаља'
 Download From Site: 'Преузми са сајта'
-A new blog is now available, $. Click to view more: 'Нови блог је сада доступан, $.
+A new blog is now available, {blogTitle}. Click to view more: 'Нови блог је сада доступан, {blogTitle}.
   Кликни за приказ више'
 
 # Search Bar
@@ -339,15 +339,15 @@ Profile:
   Your profile name cannot be empty: 'Име профила не може да буде празно'
   Profile has been created: 'Профил је креиран'
   Profile has been updated: 'Профил је ажуриран'
-  Your default profile has been set to $: 'Ваш подразумеван профил је постављен на
-    $'
-  Removed $ from your profiles: 'Уклоњено $ од ваших профила'
+  Your default profile has been set to {profile}: 'Ваш подразумеван профил је постављен на
+    {profile}'
+  Removed {profile} from your profiles: 'Уклоњено {profile} од ваших профила'
   Your default profile has been changed to your primary profile: 'Ваш подразумевани
     профил је промењен на ваш примарни профил'
-  $ is now the active profile: '$ је сада активан профил'
+  '{profile} is now the active profile': '{profile} је сада активан профил'
   Subscription List: 'Листа праћања'
   Other Channels: 'Остали канали'
-  $ selected: '$ одабрано'
+  '{number} selected': '{number} одабрано'
   Select All: 'Све одабрати'
   Select None: 'Скини одабирање'
   Delete Selected: 'Избриши одабрано'
@@ -367,7 +367,7 @@ Channel:
   Subscribe: 'Прати'
   Unsubscribe: 'Не прати више'
   Channel has been removed from your subscriptions: 'Канал је уклоњен из праћања'
-  Removed subscription from $ other channel(s): 'Праћење уклоњен из $ остала канала'
+  Removed subscription from {count} other channel(s): 'Праћење уклоњен из {count} остала канала'
   Added channel to your subscriptions: 'Канал додат у прећења'
   Search Channel: 'Тражи канал'
   Your search results have returned 0 results: 'Резултати претраге вратили су 0 резултата'
@@ -473,7 +473,6 @@ Video:
   Published on: ''
   Streamed on: ''
   Started streaming on: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
 #& Videos
 Videos:

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -29,11 +29,11 @@ Close: 'Stäng'
 Back: 'Tillbaka'
 Forward: 'Framåt'
 
-Version $ is now available!  Click for more details: 'Versionen $ är nu tillgänglig!
+Version {versionNumber} is now available!  Click for more details: 'Versionen {versionNumber} är nu tillgänglig!
   Klicka för mer detaljer'
 Download From Site: 'Ladda ner från sajten'
-A new blog is now available, $. Click to view more: 'En ny bloggpost är nu tillgänglig,
-  $. Klicka för att se mer'
+A new blog is now available, {blogTitle}. Click to view more: 'En ny bloggpost är nu tillgänglig,
+  {blogTitle}. Klicka för att se mer'
 
 # Search Bar
 Search / Go to URL: 'Sök / Gå till URL'
@@ -148,7 +148,7 @@ Settings:
     Current instance will be randomized on startup: Instansen kommer att väljas slumpmässigt
       vid start
     No default instance has been set: Ingen standard instans är vald
-    The currently set default instance is $: Den nuvarande aktiva instansen är $
+    The currently set default instance is {instance}: Den nuvarande aktiva instansen är {instance}
     Current Invidious Instance: Aktiva Invidious Instansen
     External Link Handling:
       No Action: Ingen åtgärd
@@ -440,14 +440,14 @@ Profile:
   Your profile name cannot be empty: 'Ditt profilnamn får inte vara tomt'
   Profile has been created: 'Profil har skapats'
   Profile has been updated: 'Profilen har uppdaterats'
-  Your default profile has been set to $: 'Din standardprofil har ställts in på $'
-  Removed $ from your profiles: 'Borttagen $ från dina profiler'
+  Your default profile has been set to {profile}: 'Din standardprofil har ställts in på {profile}'
+  Removed {profile} from your profiles: 'Borttagen {profile} från dina profiler'
   Your default profile has been changed to your primary profile: 'Din standardprofil
     har ändrats till din primära profil'
-  $ is now the active profile: '$ är nu den aktiva profilen'
+  '{profile} is now the active profile': '{profile} är nu den aktiva profilen'
   Subscription List: 'Prenumerationslista'
   Other Channels: 'Andra kanaler'
-  $ selected: '$ markerad'
+  '{number} selected': '{number} markerad'
   Select All: 'Markera alla'
   Select None: 'Markera inget'
   Delete Selected: 'Ta bort markerad'
@@ -470,7 +470,7 @@ Channel:
   Unsubscribe: 'Avsluta prenumeration'
   Channel has been removed from your subscriptions: 'Kanalen har tagits bort från
     dina prenumerationer'
-  Removed subscription from $ other channel(s): 'Borttagen prenumeration från $ annan
+  Removed subscription from {count} other channel(s): 'Borttagen prenumeration från {count} annan
     kanal(er)'
   Added channel to your subscriptions: 'Kanal tillagd i dina prenumerationer'
   Search Channel: 'Sök i kanal'
@@ -564,8 +564,7 @@ Video:
     Ago: 'Sedan'
     Upcoming: 'Premiärer på'
   Published on: 'Publicerad den'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: 'för $ % sedan'
+  Publicationtemplate: 'för {number} {unit} sedan'
 #& Videos
   Audio:
     Best: Högsta
@@ -603,11 +602,11 @@ Video:
       opening playlists: öppnar spellistor
       setting a playback rate: ställer in en uppspelningshastighet
       starting video at offset: startar video vid offset
-    UnsupportedActionTemplate: $ stöder inte :%
-    OpeningTemplate: Öppnar $ i %...
+    UnsupportedActionTemplate: '{externalPlayer} stöder inte :{action}'
+    OpeningTemplate: Öppnar {videoOrPlaylist} i {externalPlayer}...
     playlist: spellista
     video: video
-    OpenInTemplate: Öppna i $
+    OpenInTemplate: Öppna i {externalPlayer}
 Videos:
   #& Sort By
   Sort By:
@@ -679,7 +678,7 @@ Comments:
   Sort by: Sortera efter
   No more comments available: Det finns inga fler kommentarer
   Show More Replies: Visa fler svar
-  From $channelName: från $channelName
+  From {channelName}: från {channelName}
   And others: och andra
 Up Next: 'Kommer härnäst'
 
@@ -761,8 +760,8 @@ Hashtags have not yet been implemented, try again later: Hashtaggar har inte imp
 Unknown YouTube url type, cannot be opened in app: Okänd YouTube URL, kan inte öppnas
   i programmet
 Default Invidious instance has been cleared: Standard Invidious-instans har rensats
-Default Invidious instance has been set to $: Standard Invidious-instans har ställts
-  in på $
+Default Invidious instance has been set to {instance}: Standard Invidious-instans har ställts
+  in på {instance}
 External link opening has been disabled in the general settings: Öppning av externa
   länkar har inaktiverats i de allmänna inställningarna
 Search Bar:
@@ -775,7 +774,7 @@ Channels:
   Title: Kanallista
   Search bar placeholder: Sök Kanaler
   Unsubscribe: Avprenumerera
-  Unsubscribed: $ blev bortagen från dina prenumerationer
-  Unsubscribe Prompt: Är du säker på att du vill avprenumerera från "$"?
-  Count: $ kanal(er) hittade.
+  Unsubscribed: '{channelName} blev bortagen från dina prenumerationer'
+  Unsubscribe Prompt: Är du säker på att du vill avprenumerera från "{channelName}"?
+  Count: '{number} kanal(er) hittade.'
   Empty: Din kanallista är tom.

--- a/static/locales/tok.yaml
+++ b/static/locales/tok.yaml
@@ -30,10 +30,10 @@ Back: 'tawa monsi'
 Forward: 'tawa sinpin'
 Open New Window: 'open lon sitelin sin'
 
-Version $ is now available!  Click for more details: 'ilo pi nanpa $ li lon! open
+Version {versionNumber} is now available!  Click for more details: 'ilo pi nanpa {versionNumber} li lon! open
   la, sina ken sona mute.'
 Download From Site: 'poki e sitelin ni'
-A new blog is now available, $. Click to view more: 'lipu sin li lon. ona li $. open
+A new blog is now available, {blogTitle}. Click to view more: 'lipu sin li lon. ona li {blogTitle}. open
   la, sina ken lukin mute.'
 Are you sure you want to open this link?: 'sina wile ala wile open e ni?'
 
@@ -137,8 +137,7 @@ Settings:
       Middle: ''
       End: ''
     Current Invidious Instance: ''
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: ''
+    The currently set default instance is {instance}: ''
     No default instance has been set: ''
     Current instance will be randomized on startup: ''
     Set Current Instance as Default: ''
@@ -390,13 +389,13 @@ Profile:
   Your profile name cannot be empty: ''
   Profile has been created: ''
   Profile has been updated: ''
-  Your default profile has been set to $: ''
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: ''
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -413,7 +412,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -517,7 +516,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -530,13 +528,10 @@ Video:
     recap: ''
     filler: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -623,7 +618,7 @@ Comments:
   Replies: ''
   Show More Replies: ''
   Reply: ''
-  From $channelName: ''
+  From {channelName}: ''
   And others: ''
   There are no comments available for this video: ''
   Load More Comments: ''
@@ -651,7 +646,6 @@ Tooltips:
     Custom External Player Executable: ''
     Ignore Warnings: ''
     Custom External Player Arguments: ''
-    # $ is replaced with the default custom arguments for the current player, if defined.
     DefaultCustomArgumentsTemplate: ''
   Subscription Settings:
     Fetch Feeds from RSS: ''
@@ -676,8 +670,7 @@ Playing Next Video: ''
 Playing Previous Video: ''
 Playing Next Video Interval: ''
 Canceled next video autoplay: ''
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: ''
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: ''
 'The playlist has ended.  Enable loop to continue playing': ''
 External link opening has been disabled in the general settings: ''

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -29,10 +29,10 @@ Close: 'Kapat'
 Back: 'Geri'
 Forward: 'İleri'
 
-Version $ is now available!  Click for more details: '$ sürümü çıktı!  Daha fazla
+Version {versionNumber} is now available!  Click for more details: '{versionNumber} sürümü çıktı!  Daha fazla
   ayrıntı için tıklayın'
 Download From Site: 'Siteden indir'
-A new blog is now available, $. Click to view more: 'Yeni blog gönderisi var, $. Daha
+A new blog is now available, {blogTitle}. Click to view more: 'Yeni blog gönderisi var, {blogTitle}. Daha
   fazlasını görüntülemek için tıklayın'
 
 # Search Bar
@@ -150,7 +150,7 @@ Settings:
     Current instance will be randomized on startup: Geçerli örnek başlangıçta rastgele
       olacak
     No default instance has been set: Öntanımlı örnek ayarlanmadı
-    The currently set default instance is $: Şu anda ayarlanan öntanımlı örnek $
+    The currently set default instance is {instance}: Şu anda ayarlanan öntanımlı örnek {instance}
     Current Invidious Instance: Geçerli Invidious Örneği
     External Link Handling:
       No Action: Eylem Yok
@@ -332,7 +332,7 @@ Settings:
     Export Playlists: Oynatma Listelerini Dışa Aktar
     All playlists has been successfully imported: Tüm oynatma listeleri başarıyla
       içe aktarıldı
-    Playlist insufficient data: '"$" oynatma listesi için yetersiz veri, öge atlanıyor'
+    Playlist insufficient data: '"{playlist}" oynatma listesi için yetersiz veri, öge atlanıyor'
     Import Playlists: Oynatma Listelerini İçe Aktar
     All playlists has been successfully exported: Tüm oynatma listeleri başarıyla
       dışa aktarıldı
@@ -521,14 +521,14 @@ Profile:
   Your profile name cannot be empty: 'Profil adı boş bırakılamaz'
   Profile has been created: 'Profil oluşturuldu'
   Profile has been updated: 'Profil güncellendi'
-  Your default profile has been set to $: 'Öntanımlı profiliniz $ olarak ayarlandı'
-  Removed $ from your profiles: '$ Profillerinizden kaldırıldı'
+  Your default profile has been set to {profile}: 'Öntanımlı profiliniz {profile} olarak ayarlandı'
+  Removed {profile} from your profiles: '{profile} Profillerinizden kaldırıldı'
   Your default profile has been changed to your primary profile: 'Öntanımlı profiliniz
     birincil profiliniz olarak değiştirildi'
-  $ is now the active profile: '$ artık etkin profil'
+  '{profile} is now the active profile': '{profile} artık etkin profil'
   Subscription List: 'Abonelik Listesi'
   Other Channels: 'Diğer Kanallar'
-  $ selected: '$ seçildi'
+  '{number} selected': '{number} seçildi'
   Select All: 'Tümünü Seç'
   Select None: 'Hiçbirini Seçme'
   Delete Selected: 'Seçilenleri Sil'
@@ -550,7 +550,7 @@ Channel:
   Subscribe: 'Abone ol'
   Unsubscribe: 'Abonelikten çık'
   Channel has been removed from your subscriptions: 'Kanal aboneliklerinizden kaldırıldı'
-  Removed subscription from $ other channel(s): 'Diğer $ kanallarından abonelik kaldırıldı'
+  Removed subscription from {count} other channel(s): 'Diğer {count} kanallarından abonelik kaldırıldı'
   Added channel to your subscriptions: 'Kanal aboneliklerinize eklendi'
   Search Channel: 'Kanalda ara'
   Your search results have returned 0 results: 'Arama sonuçlarınız 0 sonuç verdi'
@@ -644,8 +644,7 @@ Video:
     Less than a minute: Bir dakikadan az
     In less than a minute: Bir dakikadan kısa sürede
   Published on: 'Yayımlanma tarihi'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % önce'
+  Publicationtemplate: '{number} {unit} önce'
 #& Videos
   Audio:
     Best: En iyi
@@ -685,11 +684,11 @@ Video:
       opening playlists: çalma listelerini açma
       setting a playback rate: oynatma hızı ayarlama
       starting video at offset: belirli bir konumda video başlatma
-    UnsupportedActionTemplate: '$ desteklemiyor: %'
-    OpeningTemplate: $, % içinde açılıyor...
+    UnsupportedActionTemplate: '{externalPlayer} desteklemiyor: {action}'
+    OpeningTemplate: '{videoOrPlaylist}, {externalPlayer} içinde açılıyor...'
     playlist: oynatma listesi
     video: video
-    OpenInTemplate: $ içinde aç
+    OpenInTemplate: '{externalPlayer} içinde aç'
   Premieres on: İlk gösterim tarihi
   Stats:
     volume: Ses Seviyesi
@@ -784,7 +783,7 @@ Comments:
   Sort by: Sıralama ölçütü
   No more comments available: Başka yorum yok
   Show More Replies: Daha Fazla Yanıt Göster
-  From $channelName: $channelName'den
+  From {channelName}: "{channelName}'den"
   And others: ve diğerleri
   Pinned by: Sabitleyen
   Member: Üye
@@ -869,7 +868,7 @@ Tooltips:
     External Player: 'Harici bir oynatıcı seçmek, videoyu (destekleniyorsa oynatma
       listesini) harici oynatıcıda açmak için küçük resimde bir simge görüntüleyecektir.
       Uyarı: Invidious ayarları harici oynatıcıları etkilemez.'
-    DefaultCustomArgumentsTemplate: "(Öntanımlı: '$')"
+    DefaultCustomArgumentsTemplate: "(Öntanımlı: '{defaultCustomArguments}')"
 Playing Next Video Interval: Sonraki video hemen oynatılıyor. İptal etmek için tıklayın.
   | Sonraki video {nextVideoInterval} saniye içinde oynatılıyor. İptal etmek için
   tıklayın. | Sonraki video {nextVideoInterval} saniye içinde oynatılıyor. İptal etmek
@@ -881,7 +880,7 @@ Unknown YouTube url type, cannot be opened in app: Bilinmeyen YouTube URL türü
   açılamıyor
 Open New Window: Yeni Pencere Aç
 Default Invidious instance has been cleared: Öntanımlı Invidious örneği temizlendi
-Default Invidious instance has been set to $: Öntanımlı Invidious örneği $ olarak
+Default Invidious instance has been set to {instance}: Öntanımlı Invidious örneği {instance} olarak
   ayarlandı
 Search Bar:
   Clear Input: Girişi Temizle
@@ -890,16 +889,16 @@ External link opening has been disabled in the general settings: Harici bağlant
 Are you sure you want to open this link?: Bu bağlantıyı açmak istediğinizden emin
   misiniz?
 Downloading canceled: İndirme, kullanıcı tarafından iptal edildi
-Starting download: '"$" indirme işlemi başlatılıyor'
-Downloading has completed: '"$" indirme işlemi tamamlandı'
-Downloading failed: '"$" indirilirken bir sorun oluştu'
+Starting download: '"{videoTitle}" indirme işlemi başlatılıyor'
+Downloading has completed: '"{videoTitle}" indirme işlemi tamamlandı'
+Downloading failed: '"{videoTitle}" indirilirken bir sorun oluştu'
 Download folder does not exist: İndirme dizini "$" mevcut değil. "Klasör sor" moduna
   geri dönülüyor.
-Screenshot Success: Ekran görüntüsü "$" olarak kaydedildi
-Screenshot Error: Ekran görüntüsü başarısız oldu. $
+Screenshot Success: Ekran görüntüsü "{filePath}" olarak kaydedildi
+Screenshot Error: Ekran görüntüsü başarısız oldu. {error}
 New Window: Yeni Pencere
 Age Restricted:
-  This $contentType is age restricted: Bu $ yaş kısıtlamalıdır
+  The currently set default instance is {instance}: Bu {instance} yaş kısıtlamalıdır
   Type:
     Channel: Kanal
     Video: Video
@@ -908,10 +907,10 @@ Channels:
   Channels: Kanallar
   Title: Kanal Listesi
   Search bar placeholder: Kanalları Ara
-  Count: $ kanal bulundu.
+  Count: '{number} kanal bulundu.'
   Unsubscribe: Abonelikten çık
-  Unsubscribed: $ aboneliklerinizden kaldırıldı
-  Unsubscribe Prompt: '"$" aboneliğinden çıkmak istediğinizden emin misiniz?'
+  Unsubscribed: '{channelName} aboneliklerinizden kaldırıldı'
+  Unsubscribe Prompt: '"{channelName}" aboneliğinden çıkmak istediğinizden emin misiniz?'
 Clipboard:
   Copy failed: Panoya kopyalanamadı
   Cannot access clipboard without a secure connection: Güvenli bağlantı olmadan panoya

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -29,10 +29,10 @@ Close: 'Закрити'
 Back: 'Назад'
 Forward: 'Вперед'
 
-Version $ is now available!  Click for more details: 'Доступна нова версія $ ! Натисніть
+Version {versionNumber} is now available!  Click for more details: 'Доступна нова версія {versionNumber} ! Натисніть
   щоб побачити деталі'
 Download From Site: 'Завантажити з сайту'
-A new blog is now available, $. Click to view more: 'Доступний новий блог, $. Натисніть
+A new blog is now available, {blogTitle}. Click to view more: 'Доступний новий блог, {blogTitle}. Натисніть
   щоб побачити більше'
 
 # Search Bar
@@ -155,8 +155,8 @@ Settings:
     Current instance will be randomized on startup: Поточний випадковий екземпляр
       буде обрано під час запуску
     No default instance has been set: Типовий екземпляр не встановлено
-    The currently set default instance is $: Поточний встановлений типовим екземпляр
-      — $
+    The currently set default instance is {instance}: Поточний встановлений типовим екземпляр
+      — {instance}
     Current Invidious Instance: Поточний екземпляр Invidious
     External Link Handling:
       No Action: Без дій
@@ -349,7 +349,7 @@ Settings:
     Unknown data key: 'Невідомий ключ даних'
     How do I import my subscriptions?: 'Як імпортувати свої підписки?'
     Manage Subscriptions: Керування підписками
-    Playlist insufficient data: Недостатньо даних для добірки "$", пропуск елемента
+    Playlist insufficient data: Недостатньо даних для добірки "{playlist}", пропуск елемента
     All playlists has been successfully exported: Усі добірки успішно експортовано
     Import Playlists: Імпорт добірок
     Export Playlists: Експорт добірок
@@ -496,14 +496,14 @@ Profile:
   Your profile name cannot be empty: 'Ім''я профілю не може бути порожнім'
   Profile has been created: 'Профіль створено'
   Profile has been updated: 'Профіль оновлено'
-  Your default profile has been set to $: 'Типовим профілем встановлено $'
-  Removed $ from your profiles: '$ вилучено з профілів'
+  Your default profile has been set to {profile}: 'Типовим профілем встановлено {profile}'
+  Removed {profile} from your profiles: '{profile} вилучено з профілів'
   Your default profile has been changed to your primary profile: 'Ваш типовий профіль
     змінено на основний'
-  $ is now the active profile: '$ активний профіль зараз'
+  '{profile} is now the active profile': '{profile} активний профіль зараз'
   Subscription List: 'Підписки'
   Other Channels: 'Інші канали'
-  $ selected: '$ вибрано'
+  '{number} selected': '{number} вибрано'
   Select All: 'Вибрати все'
   Select None: 'Нічого не вибрано'
   Delete Selected: 'Видалити вибране'
@@ -524,7 +524,7 @@ Channel:
   Subscribe: 'Підписатися'
   Unsubscribe: 'Відписатися'
   Channel has been removed from your subscriptions: 'Канал прибрано з ваших підписок'
-  Removed subscription from $ other channel(s): 'Вилучено підписку з $ інших каналів'
+  Removed subscription from {count} other channel(s): 'Вилучено підписку з {count} інших каналів'
   Added channel to your subscriptions: 'Додано канал до підписок'
   Search Channel: 'Шукати на каналі'
   Your search results have returned 0 results: 'Пошук дав 0 результатів'
@@ -630,8 +630,7 @@ Video:
     Less than a minute: Менш як за хвилину
     In less than a minute: Менше ніж за хвилину
   Published on: 'Опубліковано'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % тому'
+  Publicationtemplate: '{number} {unit} тому'
 #& Videos
   Started streaming on: Почато трансляцію
   Streamed on: Потокове передавання
@@ -659,11 +658,11 @@ Video:
       opening playlists: відкриття добірок
       setting a playback rate: встановлення швидкості відтворення
       starting video at offset: запуск відео зі зміщенням
-    UnsupportedActionTemplate: '$ не підтримує: %'
-    OpeningTemplate: Відкриття $ у %...
+    UnsupportedActionTemplate: '{externalPlayer} не підтримує: {action}'
+    OpeningTemplate: Відкриття {videoOrPlaylist} у {externalPlayer}...
     playlist: добірка
     video: відео
-    OpenInTemplate: Відкрити у $
+    OpenInTemplate: Відкрити у {externalPlayer}
   Premieres on: Прем'єри
   Stats:
     player resolution: Вікно перегляду
@@ -761,7 +760,7 @@ Comments:
   Load More Comments: 'Завантажити більше коментарів'
   No more comments available: 'Більше немає коментарів'
   Show More Replies: Показати інші відповіді
-  From $channelName: від $channelName
+  From {channelName}: від {channelName}
   And others: та інших
   Pinned by: Закріплено
   Member: Учасник
@@ -827,7 +826,7 @@ Tooltips:
     External Player: Якщо обрано зовнішній програвач, з'явиться піктограма для відкриття
       відео (добірка, якщо підтримується) у зовнішньому програвачі, на мініатюрі.
       Увага, налаштування Invidious не застосовуються до сторонніх програвачів.
-    DefaultCustomArgumentsTemplate: "(Типово: '$')"
+    DefaultCustomArgumentsTemplate: "(Типово: '{defaultCustomArguments}')"
 Local API Error (Click to copy): 'Помилка локального API (натисніть, щоб скопіювати)'
 Invidious API Error (Click to copy): 'Помилка Invidious API (натисніть, щоб скопіювати)'
 Falling back to Invidious API: 'Повернення до API Invidious'
@@ -862,36 +861,36 @@ Unknown YouTube url type, cannot be opened in app: Невідомий тип URL
   його не можна відкрити в застосункові
 Open New Window: Відкрити нове вікно
 Default Invidious instance has been cleared: Типовий екземпляр Invidious очищено
-Default Invidious instance has been set to $: Типовим екземпляром Invidious встановлено
-  $
+Default Invidious instance has been set to {instance}: 'Типовим екземпляром Invidious встановлено
+  {instance}'
 Search Bar:
   Clear Input: Очистити поле
 External link opening has been disabled in the general settings: Відкриття зовнішнього
   посилання вимкнено в загальних налаштуваннях
 Are you sure you want to open this link?: Ви впевнені, що хочете відкрити це посилання?
-Downloading failed: Сталася проблема із завантаженням "$"
+Downloading failed: Сталася проблема із завантаженням "{videoTitle}"
 Downloading canceled: Завантаження скасовано користувачем
-Starting download: Починається завантаження "$"
-Downloading has completed: '"$" завершив завантаження'
+Starting download: Починається завантаження "{videoTitle}"
+Downloading has completed: '"{videoTitle}" завершив завантаження'
 Download folder does not exist: Каталог завантаження "$" не існує. Повернення до режиму
   «запитати теку».
-Screenshot Success: Знімок екрана збережено як «$»
-Screenshot Error: Не вдалося зробити знімок екрана. $
+Screenshot Success: Знімок екрана збережено як «{filePath}»
+Screenshot Error: Не вдалося зробити знімок екрана. {error}
 New Window: Нове вікно
 Age Restricted:
-  This $contentType is age restricted: Цей $ має обмеження за віком
+  The currently set default instance is {instance}: Цей {instance} має обмеження за віком
   Type:
     Video: Відео
     Channel: Канал
 Channels:
-  Count: 'Знайдено каналів: $.'
+  Count: 'Знайдено каналів: {number}.'
   Empty: Ваш список каналів наразі порожній.
-  Unsubscribe Prompt: Ви впевнені, що хочете відписатися від «$»?
+  Unsubscribe Prompt: Ви впевнені, що хочете відписатися від «{channelName}»?
   Channels: Канали
   Title: Список каналів
   Unsubscribe: Відписатися
   Search bar placeholder: Пошук каналів
-  Unsubscribed: $ вилучено з ваших підписок
+  Unsubscribed: '{channelName} вилучено з ваших підписок'
 Clipboard:
   Copy failed: Не вдалося скопіювати до буфера обміну
   Cannot access clipboard without a secure connection: Неможливо отримати доступ до

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -31,10 +31,10 @@ Back: 'پیچھے'
 Forward: 'آگے'
 Open New Window: 'نئی ونڈو کھولیں۔'
 
-Version $ is now available!  Click for more details: 'ورژن $ اب دستیاب ہے! کلک کریں۔
+Version {versionNumber} is now available!  Click for more details: 'ورژن $ اب دستیاب ہے! کلک کریں۔
    مزید تفصیلات کے لیے'
 Download From Site: 'سائٹ سے ڈاؤن لوڈ کریں۔'
-A new blog is now available, $. Click to view more: 'ایک نیا بلاگ اب دستیاب ہے، $.
+A new blog is now available, {blogTitle}. Click to view more: 'ایک نیا بلاگ اب دستیاب ہے، {blogTitle}.
    مزید دیکھنے کے لیے کلک کریں۔'
 Are you sure you want to open this link?: 'کیا آپ واقعی اس لنک کو کھولنا چاہتے ہیں؟'
 
@@ -94,10 +94,10 @@ Channels:
   Channels: 'چینلز'
   Title: 'چینل کی فہرست'
   Search bar placeholder: 'چینلز تلاش کریں۔'
-  Count: '$چینل ملا۔'
+  Count: '{number}چینل ملا۔'
   Empty: 'آپ کے چینل کی فہرست فی الحال خالی ہے۔'
   Unsubscribe: 'ان سبسکرائب کریں۔'
-  Unsubscribed: '$ کو آپ کی سبسکرپشنز سے ہٹا دیا گیا ہے۔'
+  Unsubscribed: '{channelName} کو آپ کی سبسکرپشنز سے ہٹا دیا گیا ہے۔'
   Unsubscribe Prompt: 'کیا آپ واقعی "$" سے ان سبسکرائب کرنا چاہتے ہیں؟'
 Trending:
   Trending: ''
@@ -153,8 +153,7 @@ Settings:
       Middle: ''
       End: ''
     Current Invidious Instance: ''
-    # $ is replaced with the default Invidious instance
-    The currently set default instance is $: ''
+    The currently set default instance is {instance}: ''
     No default instance has been set: ''
     Current instance will be randomized on startup: ''
     Set Current Instance as Default: ''
@@ -351,7 +350,7 @@ Settings:
        کامیابی سے درآمد کیا گیا۔'
     All watched history has been successfully exported: 'تمام دیکھی گئی تاریخ رہی ہے۔
        کامیابی سے برآمد'
-    Playlist insufficient data: '"$" پلے لسٹ کے لیے ناکافی ڈیٹا، آئٹم کو چھوڑنا'
+    Playlist insufficient data: '"{playlist}" پلے لسٹ کے لیے ناکافی ڈیٹا، آئٹم کو چھوڑنا'
     All playlists has been successfully imported: 'تمام پلے لسٹ ہو چکی ہیں۔
        کامیابی سے درآمد کیا گیا۔'
     All playlists has been successfully exported: 'تمام پلے لسٹ ہو چکی ہیں۔
@@ -449,13 +448,13 @@ Profile:
   Your profile name cannot be empty: 'آپ کا پروفائل نام خالی نہیں ہو سکتا'
   Profile has been created: 'پروفائل بن گیا ہے۔'
   Profile has been updated: 'پروفائل کو اپ ڈیٹ کر دیا گیا ہے۔'
-  Your default profile has been set to $: 'آپ کا ڈیفالٹ پروفائل $ پر سیٹ کر دیا گیا ہے۔'
-  Removed $ from your profiles: ''
+  Your default profile has been set to {profile}: 'آپ کا ڈیفالٹ پروفائل $ پر سیٹ کر دیا گیا ہے۔'
+  Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
-  $ is now the active profile: ''
+  '{profile} is now the active profile': ''
   Subscription List: ''
   Other Channels: ''
-  $ selected: ''
+  '{number} selected': ''
   Select All: ''
   Select None: ''
   Delete Selected: ''
@@ -475,7 +474,7 @@ Channel:
   Subscribe: ''
   Unsubscribe: ''
   Channel has been removed from your subscriptions: ''
-  Removed subscription from $ other channel(s): ''
+  Removed subscription from {count} other channel(s): ''
   Added channel to your subscriptions: ''
   Search Channel: ''
   Your search results have returned 0 results: ''
@@ -579,7 +578,6 @@ Video:
   Streamed on: ''
   Started streaming on: ''
   translated from English: ''
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
   Publicationtemplate: ''
   Skipped segment: ''
   Sponsor Block category:
@@ -592,13 +590,10 @@ Video:
     recap: ''
     filler: ''
   External Player:
-    # $ is replaced with the external player
     OpenInTemplate: ''
     video: ''
     playlist: ''
-    # $ is replaced with the current context (see video/playlist above) and % the external player setting
     OpeningTemplate: ''
-    # $ is replaced with the external player and % with the unsupported action
     UnsupportedActionTemplate: ''
     Unsupported Actions:
       starting video at offset: ''
@@ -685,7 +680,7 @@ Comments:
   Replies: ''
   Show More Replies: ''
   Reply: ''
-  From $channelName: ''
+  From {channelName}: ''
   And others: ''
   There are no comments available for this video: ''
   Load More Comments: ''
@@ -737,8 +732,7 @@ Tooltips:
        موجودہ کارروائی (مثلاً پلے لسٹ کو تبدیل کرنا، وغیرہ)۔'
     Custom External Player Arguments: کوئی بھی حسب ضرورت کمانڈ لائن آرگومنٹس، جو سیمیکولنز (';') سے الگ کیے گئے ہیں،
        آپ بیرونی کھلاڑی کو منتقل کرنا چاہتے ہیں۔
-    # $ is replaced with the default custom arguments for the current player, if defined.
-    DefaultCustomArgumentsTemplate: '(پہلے سے طے شدہ: ''$'')'
+    DefaultCustomArgumentsTemplate: '(پہلے سے طے شدہ: ''{defaultCustomArguments}'')'
   Subscription Settings:
     Fetch Feeds from RSS: 'فعال ہونے پر، FreeTube اپنے ڈیفالٹ کے بجائے RSS کا استعمال کرے گا۔
        آپ کی سبسکرپشن فیڈ حاصل کرنے کا طریقہ۔ آر ایس ایس تیز ہے اور آئی پی کو بلاک کرنے سے روکتا ہے،
@@ -767,23 +761,21 @@ Playing Next Video: 'اگلا ویڈیو چل رہا ہے۔'
 Playing Previous Video: 'پچھلا ویڈیو چل رہا ہے۔'
 Playing Next Video Interval: 'اگلی ویڈیو بغیر کسی وقت چلائی جا رہی ہے۔ منسوخ کرنے کے لیے کلک کریں۔ | اگلی ویڈیو {nextVideoInterval} سیکنڈ میں چلائی جا رہی ہے۔ منسوخ کرنے کے لیے کلک کریں۔ | اگلی ویڈیو {nextVideoInterval} سیکنڈ میں چلائی جا رہی ہے۔ منسوخ کرنے کے لیے کلک کریں۔'
 Canceled next video autoplay: 'اگلی ویڈیو آٹو پلے منسوخ کر دی گئی۔'
-# $ is replaced with the default Invidious instance
-Default Invidious instance has been set to $: 'ڈیفالٹ Invidious مثال کو $ پر سیٹ کر دیا گیا ہے۔'
+Default Invidious instance has been set to {instance}: 'ڈیفالٹ Invidious مثال کو $ پر سیٹ کر دیا گیا ہے۔'
 Default Invidious instance has been cleared: 'ڈیفالٹ Invidious مثال کو صاف کر دیا گیا ہے۔'
 'The playlist has ended.  Enable loop to continue playing': 'پلے لسٹ ختم ہو گئی ہے۔ فعال
    کھیل جاری رکھنے کے لیے لوپ'
 Age Restricted:
-  # $contentType is replaced with video or channel
-  This $contentType is age restricted: 'یہ $ عمر کی پابندی ہے۔'
+  This {videoOrPlaylist} is age restricted: 'یہ $ عمر کی پابندی ہے۔'
   Type:
     Channel: 'چینل'
     Video: 'ویڈیو'
 External link opening has been disabled in the general settings: 'عام ترتیبات میں بیرونی لنک کھولنے کو غیر فعال کر دیا گیا ہے۔'
-Downloading has completed: '"$" نے ڈاؤن لوڈ مکمل کر لیا ہے۔'
-Starting download: '"$" کا ڈاؤن لوڈ شروع ہو رہا ہے'
-Downloading failed: '"$" کو ڈاؤن لوڈ کرنے میں ایک مسئلہ تھا'
+Downloading has completed: '"{videoTitle}" نے ڈاؤن لوڈ مکمل کر لیا ہے۔'
+Starting download: '"{videoTitle}" کا ڈاؤن لوڈ شروع ہو رہا ہے'
+Downloading failed: '"{videoTitle}" کو ڈاؤن لوڈ کرنے میں ایک مسئلہ تھا'
 Screenshot Success: 'اسکرین شاٹ کو بطور "$" محفوظ کیا گیا'
-Screenshot Error: 'اسکرین شاٹ ناکام ہو گیا۔ $'
+Screenshot Error: 'اسکرین شاٹ ناکام ہو گیا۔ {error}'
 
 Yes: ''
 No: ''

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -31,8 +31,7 @@ Back: 'پیچھے'
 Forward: 'آگے'
 Open New Window: 'نئی ونڈو کھولیں۔'
 
-Version {versionNumber} is now available!  Click for more details: 'ورژن $ اب دستیاب ہے! کلک کریں۔
-   مزید تفصیلات کے لیے'
+Version {versionNumber} is now available!  Click for more details: ''
 Download From Site: 'سائٹ سے ڈاؤن لوڈ کریں۔'
 A new blog is now available, {blogTitle}. Click to view more: 'ایک نیا بلاگ اب دستیاب ہے، {blogTitle}.
    مزید دیکھنے کے لیے کلک کریں۔'
@@ -98,7 +97,7 @@ Channels:
   Empty: 'آپ کے چینل کی فہرست فی الحال خالی ہے۔'
   Unsubscribe: 'ان سبسکرائب کریں۔'
   Unsubscribed: '{channelName} کو آپ کی سبسکرپشنز سے ہٹا دیا گیا ہے۔'
-  Unsubscribe Prompt: 'کیا آپ واقعی "$" سے ان سبسکرائب کرنا چاہتے ہیں؟'
+  Unsubscribe Prompt: ''
 Trending:
   Trending: ''
   Default: ''
@@ -448,7 +447,7 @@ Profile:
   Your profile name cannot be empty: 'آپ کا پروفائل نام خالی نہیں ہو سکتا'
   Profile has been created: 'پروفائل بن گیا ہے۔'
   Profile has been updated: 'پروفائل کو اپ ڈیٹ کر دیا گیا ہے۔'
-  Your default profile has been set to {profile}: 'آپ کا ڈیفالٹ پروفائل $ پر سیٹ کر دیا گیا ہے۔'
+  Your default profile has been set to {profile}: ''
   Removed {profile} from your profiles: ''
   Your default profile has been changed to your primary profile: ''
   '{profile} is now the active profile': ''
@@ -761,12 +760,12 @@ Playing Next Video: 'اگلا ویڈیو چل رہا ہے۔'
 Playing Previous Video: 'پچھلا ویڈیو چل رہا ہے۔'
 Playing Next Video Interval: 'اگلی ویڈیو بغیر کسی وقت چلائی جا رہی ہے۔ منسوخ کرنے کے لیے کلک کریں۔ | اگلی ویڈیو {nextVideoInterval} سیکنڈ میں چلائی جا رہی ہے۔ منسوخ کرنے کے لیے کلک کریں۔ | اگلی ویڈیو {nextVideoInterval} سیکنڈ میں چلائی جا رہی ہے۔ منسوخ کرنے کے لیے کلک کریں۔'
 Canceled next video autoplay: 'اگلی ویڈیو آٹو پلے منسوخ کر دی گئی۔'
-Default Invidious instance has been set to {instance}: 'ڈیفالٹ Invidious مثال کو $ پر سیٹ کر دیا گیا ہے۔'
+Default Invidious instance has been set to {instance}: ''
 Default Invidious instance has been cleared: 'ڈیفالٹ Invidious مثال کو صاف کر دیا گیا ہے۔'
 'The playlist has ended.  Enable loop to continue playing': 'پلے لسٹ ختم ہو گئی ہے۔ فعال
    کھیل جاری رکھنے کے لیے لوپ'
 Age Restricted:
-  This {videoOrPlaylist} is age restricted: 'یہ $ عمر کی پابندی ہے۔'
+  This {videoOrPlaylist} is age restricted: ''
   Type:
     Channel: 'چینل'
     Video: 'ویڈیو'
@@ -774,7 +773,7 @@ External link opening has been disabled in the general settings: 'عام ترت�
 Downloading has completed: '"{videoTitle}" نے ڈاؤن لوڈ مکمل کر لیا ہے۔'
 Starting download: '"{videoTitle}" کا ڈاؤن لوڈ شروع ہو رہا ہے'
 Downloading failed: '"{videoTitle}" کو ڈاؤن لوڈ کرنے میں ایک مسئلہ تھا'
-Screenshot Success: 'اسکرین شاٹ کو بطور "$" محفوظ کیا گیا'
+Screenshot Success: ''
 Screenshot Error: 'اسکرین شاٹ ناکام ہو گیا۔ {error}'
 
 Yes: ''

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -135,8 +135,8 @@ Settings:
     Check for Latest Blog Posts: Check Blog post mới nhất
     Check for Updates: Kiểm tra cập nhật
     Current Invidious Instance: Phiên bản invidious hiện tại
-    The currently set default instance is $: Phiên bản Invidious mặc định hiện được
-      đặt thành $
+    The currently set default instance is {instance}: Phiên bản Invidious mặc định hiện được
+      đặt thành {instance}
     No default instance has been set: Không có phiên bản mặc định nào được đặt
     Current instance will be randomized on startup: Phiên bản hiện tại sẽ được chọn
       ngẫu nhiên khi khởi động
@@ -340,7 +340,7 @@ Settings:
       thêm vào thành công
     All playlists has been successfully exported: Tất cả các danh sách phát đã được
       xuất thành công
-    Playlist insufficient data: Dữ liệu bị thiếu cho danh sách phát "$", bỏ qua mục
+    Playlist insufficient data: Dữ liệu bị thiếu cho danh sách phát "{playlist}", bỏ qua mục
       này
     Export Playlists: Xuất danh sách phát
   Distraction Free Settings:
@@ -510,7 +510,7 @@ Channel:
     Channel Description: 'Miêu tả kênh'
     Featured Channels: 'Kênh đặc sắc'
   Added channel to your subscriptions: Đã thêm kênh vào đăng ký của bạn
-  Removed subscription from $ other channel(s): Đã xóa đăng ký từ $ các kênh khác
+  Removed subscription from {count} other channel(s): Đã xóa đăng ký từ {count} các kênh khác
   Channel has been removed from your subscriptions: Kênh đã được xóa khỏi đăng ký
     của bạn
 Video:
@@ -570,8 +570,7 @@ Video:
     Minutes: Phút
     Minute: Phút
   Published on: 'Phát hành vào'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % trước'
+  Publicationtemplate: '{number} {unit} trước'
 #& Videos
   Video has been removed from your history: Video đã được xóa khỏi lịch sử của bạn
   Video has been marked as watched: Video đánh dấu đã xem
@@ -632,9 +631,9 @@ Video:
       shuffling playlists: xáo trộn danh sách phát
       reversing playlists: đảo ngược danh sách phát
       looping playlists: lập lại danh sách phát
-    OpeningTemplate: Mở $ trong %....
-    UnsupportedActionTemplate: '$ không hổ trợ: %'
-    OpenInTemplate: Mở trong $
+    OpeningTemplate: Mở {videoOrPlaylist} trong {externalPlayer}....
+    UnsupportedActionTemplate: '{externalPlayer} không hổ trợ: {action}'
+    OpenInTemplate: Mở trong {externalPlayer}
     video: video
   Open Channel in Invidious: Mở kênh ưu tiên
   Copy Invidious Channel Link: Sao chép liên kết kênh Invidious
@@ -712,7 +711,7 @@ Comments:
   Sort by: Sắp xếp theo
   There are no more comments for this video: Không có bình luận cho video này
   Member: Thành viên
-  From $channelName: từ $tên kênh
+  From {channelName}: từ {channelName}
   And others: Và những thứ khác
   Pinned by: Được ghim bởi
   Show More Replies: Hiện thêm câu trả lời
@@ -755,15 +754,15 @@ Profile:
   Delete Selected: Xóa đã chọn
   Select None: Chọn không
   Select All: Chọn hết
-  $ selected: $ đã chọn
+  '{number} selected': '{number} đã chọn'
   Other Channels: Các kênh khác
   Subscription List: Danh sách đăng ký
-  $ is now the active profile: $ bây giờ là hoạt động profile
+  '{profile} is now the active profile': '{profile} bây giờ là hoạt động profile'
   Your default profile has been changed to your primary profile: Profile mặc định
     của bạn đã thay đổi thành profile chính
-  Removed $ from your profiles: Đã xóa $ khỏi Profile của bạn
-  Your default profile has been set to $: Profile mặc định của bạn đã được chỉnh về
-    $
+  Removed {profile} from your profiles: Đã xóa {profile} khỏi Profile của bạn
+  Your default profile has been set to {profile}: 'Profile mặc định của bạn đã được chỉnh về
+    {profile}'
   Profile has been updated: Profile đã được cập nhật
   Profile has been created: Profile đã được tạo
   Your profile name cannot be empty: Tên Profile của bạn không được để trống
@@ -784,10 +783,10 @@ Profile:
   Profile Select: Chọn Profile
   Profile Filter: Bộ lọc hồ sơ
   Profile Settings: Cài đặt hồ sơ cá nhân
-A new blog is now available, $. Click to view more: Một blog mới đã có, $. Nhấn để
+A new blog is now available, {blogTitle}. Click to view more: Một blog mới đã có, {blogTitle}. Nhấn để
   xem chi tiết
 Download From Site: Tải từ website
-Version $ is now available!  Click for more details: Phiên bản $ đã có! Click để xem
+Version {versionNumber} is now available!  Click for more details: Phiên bản {versionNumber} đã có! Click để xem
   chi tiết
 Open New Window: Mở cửa sổ mới
 Search Bar:
@@ -801,10 +800,10 @@ Channels:
   Title: Danh sách kênh
   Search bar placeholder: Tìm Kênh
   Empty: Danh sách kênh của bạn hiện đang trống.
-  Unsubscribed: $ đã bị xoá khỏi danh sách kênh đã đăng ký của bạn
-  Unsubscribe Prompt: Bạn có chắc răng bạn muốn huỷ đăng ký kênh "$"?
+  Unsubscribed: '{channelName} đã bị xoá khỏi danh sách kênh đã đăng ký của bạn'
+  Unsubscribe Prompt: Bạn có chắc răng bạn muốn huỷ đăng ký kênh "{channelName}"?
   Unsubscribe: Huỷ đăng ký kênh
-  Count: $kênh đã tìm được.
+  Count: '{number} kênh đã tìm được.'
 Tooltips:
   General Settings:
     Thumbnail Preference: Tất cả các hình thu nhỏ trên FreeTube sẽ được thay thế bằng
@@ -848,7 +847,7 @@ Tooltips:
       Nếu cần, bạn có thể đặt một đường dẫn tuỳ chọn ở đây.
     Ignore Warnings: 'Loại bỏ cảnh báo khi trình phát bên ngoài hiện tại không hỗ
       trợ cho thao tác hiện tại (ví dụ: đảo ngược danh sách phát, v.v.).'
-    DefaultCustomArgumentsTemplate: "(Mặc định: '$')"
+    DefaultCustomArgumentsTemplate: "(Mặc định: '{defaultCustomArguments}')"
     External Player: Chọn một trình phát bên ngoài sẽ hiển thị một biểu tượng để mở
       video (danh sách phát nếu được hỗ trợ) trong trình phát bên ngoài, trên hình
       thu nhỏ của video. Cảnh báo, cài đặt Invidious không ảnh hưởng đến trình phát
@@ -862,7 +861,7 @@ Tooltips:
     Remove Video Meta Files: Khi được bật lên, FreeTube sẽ tự động xóa các tệp meta
       được tạo trong quá trình phát lại video, khi trang xem bị đóng.
 Age Restricted:
-  This $contentType is age restricted: $ này bị giới hạn độ tuổi
+  The currently set default instance is {instance}: '{instance} này bị giới hạn độ tuổi'
   Type:
     Channel: Kênh
     Video: Video
@@ -871,15 +870,15 @@ Hashtags have not yet been implemented, try again later: Thẻ hashtag chưa th�
 Playing Next Video Interval: Phát video tiếp theo ngay lập tức. Nhấn vào để hủy. |
   Phát video tiếp theo sau {nextVideoInterval} giây nữa. Nhấn vào để hủy. | Phát video
   tiếp theo sau {nextVideoInterval} giây. Nhấn vào để hủy.
-Downloading has completed: '"$" đã hoàn tất quá trình tải xuống'
+Downloading has completed: '"{videoTitle}" đã hoàn tất quá trình tải xuống'
 External link opening has been disabled in the general settings: Tính năng mở liên
   kết bên ngoài đã bị tắt trong cài đặt chung
-Downloading failed: Đã xảy ra sự cố trong quá trình tải xuống "$"
+Downloading failed: Đã xảy ra sự cố trong quá trình tải xuống "{videoTitle}"
 Default Invidious instance has been cleared: Phiên bản Invidious mặc định đã bị xóa
-Screenshot Success: Ảnh chụp màn hình đã lưu thành "$"
-Screenshot Error: Chụp màn hình không thành công. $
-Default Invidious instance has been set to $: Phiên bản Invidious mặc định đã được
-  đặt thành $
+Screenshot Success: Ảnh chụp màn hình đã lưu thành "{filePath}"
+Screenshot Error: Chụp màn hình không thành công. {error}
+Default Invidious instance has been set to {instance}: Phiên bản Invidious mặc định đã được
+  đặt thành {instance}
 Unknown YouTube url type, cannot be opened in app: Dạng YouTube URL không xác định,
   không thể mở trong ứng dụng này
-Starting download: Bắt đầu tải xuống "$"
+Starting download: Bắt đầu tải xuống "{videoTitle}"

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -129,7 +129,7 @@ Settings:
     Check for Latest Blog Posts: 检查最新的博客贴
     View all Invidious instance information: 浏览所有Invidious实例
     System Default: 系统默认
-    The currently set default instance is $: 当前设置的默认实例是 $
+    The currently set default instance is {instance}: 当前设置的默认实例是 {instance}
     No default instance has been set: 没有默认实例
     Current instance will be randomized on startup: 当前实例在启动时将会随机化
     Set Current Instance as Default: 将当前实例设为默认
@@ -328,7 +328,7 @@ Settings:
     Manage Subscriptions: 管理订阅
     Import Playlists: 导入播放列表
     Export Playlists: 导出播放列表
-    Playlist insufficient data: '"$" 播放列表数据不足，正在跳过'
+    Playlist insufficient data: '"{playlist}" 播放列表数据不足，正在跳过'
     All playlists has been successfully imported: 已成功导入所有播放列表
     All playlists has been successfully exported: 所有播放列表已成功导出
     Playlist File: 播放列表文件
@@ -475,7 +475,7 @@ Channel:
     About: '关于'
     Channel Description: '频道描述'
     Featured Channels: '列出频道'
-  Removed subscription from $ other channel(s): 从$个其他频道移除订阅
+  Removed subscription from {count} other channel(s): 从{count}个其他频道移除订阅
   Added channel to your subscriptions: 已新增频道至您的订阅
   Channel has been removed from your subscriptions: 频道已从您的订阅中移除
 Video:
@@ -532,8 +532,7 @@ Video:
     Less than a minute: 不到一分钟
     In less than a minute: 不到一分钟
   Published on: '发布于'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % 之前'
+  Publicationtemplate: '{number} {unit} 之前'
 #& Videos
   Video has been removed from your history: 视频已从您的历史记录中移除
   Mark As Watched: 标记为已观看
@@ -583,11 +582,11 @@ Video:
     Bandwidth: 带宽
     Video statistics are not available for legacy videos: 视频统计数据对于 legacy 视频不可用
   External Player:
-    OpenInTemplate: 在 $ 中打开
+    OpenInTemplate: 在 {externalPlayer} 中打开
     video: 视频
     playlist: 播放列表
-    UnsupportedActionTemplate: $ 不支持：%
-    OpeningTemplate: 在 % 中打开 $ …
+    UnsupportedActionTemplate: '{externalPlayer} 不支持：{action}'
+    OpeningTemplate: 在 {externalPlayer} 中打开 {videoOrPlaylist} …
     Unsupported Actions:
       setting a playback rate: 设置播放速率
       opening specific video in a playlist (falling back to opening the video): 打开播放列表中的特定视频
@@ -679,7 +678,7 @@ Comments:
   No more comments available: 没有更多评论
   Show More Replies: 显示更多回复
   Pinned by: 置顶人
-  From $channelName: 来自 $channelName
+  From {channelName}: 来自 {channelName}
   And others: 及其他
   Member: 成员
 Up Next: 'Up Next'
@@ -704,9 +703,9 @@ Yes: '是'
 No: '否'
 Locale Name: 简体中文
 Profile:
-  $ is now the active profile: $现在是使用中的配置文件
-  Removed $ from your profiles: 已从您的配置文件移除$
-  Your default profile has been set to $: 您的默认配置文件已设定为$
+  '{profile} is now the active profile': '{profile}现在是使用中的配置文件'
+  Removed {profile} from your profiles: 已从您的配置文件移除{profile}
+  Your default profile has been set to {profile}: 您的默认配置文件已设定为{profile}
   Your default profile has been changed to your primary profile: 您的默认配置文件已变为您的主配置文件
   Profile has been updated: 配置文件已更新
   Profile has been created: 配置文件已建立
@@ -730,7 +729,7 @@ Profile:
     这不会从其他配置文件中删除频道。
   Add Selected To Profile: 添加选择的到配置文件
   Delete Selected: 删除选择的
-  $ selected: $选择的
+  '{number} selected': '{number}选择的'
   ? This is your primary profile.  Are you sure you want to delete the selected channels?  The
     same channels will be deleted in any profile they are found in.
   : 这是您的主配置文件。 您确定您想删除选择的频道？ 相同的频道中任何找到的配置文件会被删除。
@@ -742,9 +741,9 @@ Profile:
   Profile Settings: 个人资料设置
   Profile Filter: 个人资料筛选器
 The playlist has been reversed: 播放列表已反转
-A new blog is now available, $. Click to view more: 已有新的博客，$。点击以查看更多
+A new blog is now available, {blogTitle}. Click to view more: 已有新的博客，{blogTitle}。点击以查看更多
 Download From Site: 从网站下载
-Version $ is now available!  Click for more details: 版本$已可使用！ 点击以取得更多信息
+Version {versionNumber} is now available!  Click for more details: 版本{versionNumber}已可使用！ 点击以取得更多信息
 This video is unavailable because of missing formats. This can happen due to country unavailability.: 没有这个视频因为缺少格式。这个可能发生由于国家不可用。
 Tooltips:
   Subscription Settings:
@@ -770,7 +769,7 @@ Tooltips:
     External Player: 选择一个外部播放器将在缩略图上显示一个图标，用于在外部播放器中打开视频(播放列表，如果支持)。警告，Invidious 设置不影响外部播放器。
     Custom External Player Executable: 默认情况下，FreeTube 假设选择的外部播放器可以通过 PATH 环境变量找到。如果需要，可以在这里设置自定义路径。
     Ignore Warnings: 当前外部播放器不支持当前操作时(例如，颠倒播放列表文件顺序)，抑制警告。
-    DefaultCustomArgumentsTemplate: "(默认: '$')"
+    DefaultCustomArgumentsTemplate: "(默认: '{defaultCustomArguments}')"
     Custom External Player Arguments: 任何你希望传递给外部播放器的用分号(';')分隔的自定义命令行参数。
   Privacy Settings:
     Remove Video Meta Files: 启用后，当观看页面关闭时，FreeTube 会自动删除在视频播放时创建的元文件。
@@ -782,32 +781,32 @@ Are you sure you want to open this link?: 您确定要打开此链接吗？
 Unknown YouTube url type, cannot be opened in app: 未知的 YouTube url 类型，不能在应用程序中打开
 External link opening has been disabled in the general settings: 外部链接打开在常规设置中被禁用
 Hashtags have not yet been implemented, try again later: 哈希标签功能尚未实现，请稍后再试
-Default Invidious instance has been set to $: 默认的 Invidious 实例已被设置为 $
+Default Invidious instance has been set to {instance}: 默认的 Invidious 实例已被设置为 {instance}
 Playing Next Video Interval: 马上播放下一个视频。单击取消。| {nextVideoInterval} 秒内播放下个视频。单击取消。 |
   {nextVideoInterval} 秒内播放下个视频。单击取消。
 Default Invidious instance has been cleared: 已清除默认的 Invidious 实例
-Downloading failed: 下载“$”出现一个问题
-Downloading has completed: 已完成下载 “$”
-Starting download: 开始下载“$”
+Downloading failed: 下载“{videoTitle}”出现一个问题
+Downloading has completed: 已完成下载 “{videoTitle}”
+Starting download: 开始下载“{videoTitle}”
 Downloading canceled: 用户取消了下载
 Download folder does not exist: 下载目录“$”不存在，退回到 “询问文件夹”模式。
-Screenshot Error: 截屏失败。$
-Screenshot Success: 另存截屏为 “$”
+Screenshot Error: 截屏失败。{error}
+Screenshot Success: 另存截屏为 “{filePath}”
 New Window: 新窗口
 Age Restricted:
   Type:
     Channel: 频道
     Video: 视频
-  This $contentType is age restricted: 此 $ 有年龄限制
+  The currently set default instance is {instance}: 此 {instance} 有年龄限制
 Channels:
   Search bar placeholder: 搜索频道
-  Count: 找到了 $ 个频道。
+  Count: 找到了 {number} 个频道。
   Unsubscribe: 取消订阅
   Channels: 频道
   Title: 频道列表
   Empty: 你的频道列表当前为空。
-  Unsubscribed: 从你的订阅里删除了 $
-  Unsubscribe Prompt: 你确定你要取消订阅 "$" 吗？
+  Unsubscribed: 从你的订阅里删除了 {channelName}
+  Unsubscribe Prompt: 你确定你要取消订阅 "{channelName}" 吗？
 Clipboard:
   Copy failed: 未能复制到剪贴板
   Cannot access clipboard without a secure connection: 没有安全连接无法访问剪贴板

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -134,7 +134,7 @@ Settings:
     Set Current Instance as Default: 設定目前站台為預設值
     Current instance will be randomized on startup: 目前站台將在啟動時隨機選擇
     No default instance has been set: 未設定預設的站台
-    The currently set default instance is $: 目前設定的預設站台為 $
+    The currently set default instance is {instance}: 目前設定的預設站台為 {instance}
     Current Invidious Instance: 目前的 Invidious 站台
     External Link Handling:
       No Action: 無動作
@@ -331,7 +331,7 @@ Settings:
     Import Playlists: 匯入播放清單
     All playlists has been successfully imported: 所有播放清單都已成功匯入
     Export Playlists: 匯出播放清單
-    Playlist insufficient data: 「$」播放清單的資料不足，正在略過項目
+    Playlist insufficient data: 「{playlist}」播放清單的資料不足，正在略過項目
     All playlists has been successfully exported: 所有播放清單都已成功匯出
     Subscription File: 訂閱檔案
     History File: 歷史紀錄檔案
@@ -487,7 +487,7 @@ Channel:
     Channel Description: '頻道說明'
     Featured Channels: '推薦頻道'
   Added channel to your subscriptions: 已新增頻道至您的訂閱
-  Removed subscription from $ other channel(s): 從$個其他頻道移除訂閱
+  Removed subscription from {count} other channel(s): 從{count}個其他頻道移除訂閱
   Channel has been removed from your subscriptions: 頻道已從您的訂閱中移除
 Video:
   Open in YouTube: '在YouTube中開啟'
@@ -543,8 +543,7 @@ Video:
     Less than a minute: 少於一分鐘
     In less than a minute: 不到一分鐘內
   Published on: '發布於'
-  # $ is replaced with the number and % with the unit (days, hours, minutes...)
-  Publicationtemplate: '$ % 前'
+  Publicationtemplate: '{number} {unit} 前'
 #& Videos
   Video has been removed from your history: 影片已從您的觀看紀錄中移除
   Video has been marked as watched: 影片標記為已觀看
@@ -594,11 +593,11 @@ Video:
       opening playlists: 正在開啟播放清單
       setting a playback rate: 正在設定播放速度
       starting video at offset: 在偏移處開始影片
-    UnsupportedActionTemplate: $ 不支援：%
-    OpeningTemplate: 正於 % 中開啟 $……
+    UnsupportedActionTemplate: '{externalPlayer} 不支援：{action}'
+    OpeningTemplate: 正於 {externalPlayer} 中開啟 {videoOrPlaylist}……
     playlist: 播放清單
     video: 視訊
-    OpenInTemplate: 在 $ 中開啟
+    OpenInTemplate: 在 {externalPlayer} 中開啟
   Premieres on: 首映日期
   Stats:
     buffered: 已緩衝
@@ -689,7 +688,7 @@ Comments:
   No more comments available: 沒有更多留言
   Show More Replies: 顯示更多回覆
   And others: 與其他人
-  From $channelName: 來自 $channelName
+  From {channelName}: 來自 {channelName}
   Pinned by: 釘選由
   Member: 成員
 Up Next: '觀看其他類似影片'
@@ -714,10 +713,10 @@ Yes: '是'
 No: '否'
 Locale Name: 繁體中文
 Profile:
-  $ is now the active profile: $現在是作用中的設定檔
+  '{profile} is now the active profile': '{profile}現在是作用中的設定檔'
   Your default profile has been changed to your primary profile: 您的預設設定檔已變更為您的主要設定檔
-  Removed $ from your profiles: 已從您的設定檔移除$
-  Your default profile has been set to $: 您的預設設定檔已設定為$
+  Removed {profile} from your profiles: 已從您的設定檔移除{profile}
+  Your default profile has been set to {profile}: 您的預設設定檔已設定為{profile}
   Profile has been updated: 設定檔已更新
   Profile has been created: 設定檔已建立
   Your profile name cannot be empty: 您的設定檔名稱不能為空
@@ -746,15 +745,15 @@ Profile:
   Delete Selected: 移除選取的
   Select None: 全不選
   Select All: 全選
-  $ selected: $個選取的
+  '{number} selected': '{number}個選取的'
   Other Channels: 其他頻道
   Subscription List: 訂閱清單
   Profile Filter: 設定檔篩選器
   Profile Settings: 設定檔設定
 The playlist has been reversed: 播放清單已反轉
-A new blog is now available, $. Click to view more: 已有新的部落格文章，$。點擊以檢視更多
+A new blog is now available, {blogTitle}. Click to view more: 已有新的部落格文章，{blogTitle}。點擊以檢視更多
 Download From Site: 從網站下載
-Version $ is now available!  Click for more details: 版本更新囉! 最新版本 $ ! 點擊以取得更多資訊
+Version {versionNumber} is now available!  Click for more details: 版本更新囉! 最新版本 {versionNumber} ! 點擊以取得更多資訊
 This video is unavailable because of missing formats. This can happen due to country unavailability.: 沒有這個影片因為缺少格式。這個可能發生由於國家不可用。
 Tooltips:
   Subscription Settings:
@@ -785,7 +784,7 @@ Tooltips:
     Custom External Player Executable: 預設情況下，FreeTube 會假設選定的外部播放程式可以透過 PATH 環境變數找到。如果需要的話，請在此設定自訂路徑。
     External Player: 選擇外部播放程式將會在縮圖上顯示圖示，用來在外部播放程式中開啟影片（若支援的話，播放清單也可以）。警告：Invidious
       設定不會影響外部播放程式。
-    DefaultCustomArgumentsTemplate: （預設：'$'）
+    DefaultCustomArgumentsTemplate: （預設：'{defaultCustomArguments}'）
 Playing Next Video Interval: 馬上播放下一個影片。點擊取消。| 播放下一個影片的時間為{nextVideoInterval}秒。點擊取消。|
   播放下一個影片的時間為{nextVideoInterval}秒。點擊取消。
 More: 更多
@@ -793,19 +792,19 @@ Hashtags have not yet been implemented, try again later: 尚未實作主題標�
 Unknown YouTube url type, cannot be opened in app: 未知的 YouTube url 類型，無法在應用程式開啟
 Open New Window: 開啟新視窗
 Default Invidious instance has been cleared: 預設 Invidious 站台已被清除
-Default Invidious instance has been set to $: 預設 Invidious 站台已被設定為 $
+Default Invidious instance has been set to {instance}: 預設 Invidious 站台已被設定為 {instance}
 Search Bar:
   Clear Input: 清除輸入
 External link opening has been disabled in the general settings: 已在一般設定中停用外部連結開啟
 Are you sure you want to open this link?: 您確定您想要開啟此連結嗎？
-Downloading failed: 下載「$」時發生問題
-Downloading has completed: 「$」已下載結束
-Starting download: 正在開始下載「$」
-Screenshot Success: 已儲存螢幕截圖為 "$"
-Screenshot Error: 螢幕截圖失敗。 $
+Downloading failed: 下載「{videoTitle}」時發生問題
+Downloading has completed: 「{videoTitle}」已下載結束
+Starting download: 正在開始下載「{videoTitle}」
+Screenshot Success: 已儲存螢幕截圖為 "{filePath}"
+Screenshot Error: 螢幕截圖失敗。 {error}
 New Window: 新視窗
 Age Restricted:
-  This $contentType is age restricted: 此 $ 有年齡限制
+  The currently set default instance is {instance}: 此 {instance} 有年齡限制
   Type:
     Channel: 頻道
     Video: 影片
@@ -814,10 +813,10 @@ Channels:
   Title: 頻道清單
   Search bar placeholder: 搜尋頻道
   Unsubscribe: 取消訂閱
-  Count: 找到 $ 個頻道。
+  Count: 找到 {number} 個頻道。
   Empty: 您的頻道清單目前為空。
-  Unsubscribe Prompt: 您確定您想要從「$」取消訂閱嗎？
-  Unsubscribed: $ 已從您的訂閱移除
+  Unsubscribe Prompt: 您確定您想要從「{channelName}」取消訂閱嗎？
+  Unsubscribed: '{channelName} 已從您的訂閱移除'
 Clipboard:
   Copy failed: 複製到剪貼簿失敗
   Cannot access clipboard without a secure connection: 無法在沒有安全連線的情況下存取剪貼簿


### PR DESCRIPTION
# Use named parameters instead of $ and % in localised strings

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
The codeql checks were added in #2650 (see the files tab on that pull request for the warnings).

## Description
This pull reqest aims to fix the two issues reported by codeql: "Incomplete string escaping or encoding" and "Incomplete URL substring sanitization".

I wasn't sure whether I should change all of the language files, as Vue-i18n will happily use the old strings in languages that haven't been updated as, the key didn't change for all of the strings (if the key changes, vue-i18n can't find the translated string and falls back to the en-US one, which doesn't always happen here). I can definitely change all of the strings in the left-to-right languages as part of this pull request if you want me to, I won't be able to do right-to-left languages as the text seems to change entirely when I replace the dollar ($) or percent (%) symbols, so I definitely want to leave those up to the translators on weblate.

## Testing <!-- for code that is not small enough to be easily understandable -->
Ideally check every place where the changed strings show up, only en-US and en_GB will work properly until the other languages are updated. Although that might be too much testing for you so you could just check a couple of strings.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1