### PR TITLE
Remove unused property from the invidious store

### DIFF
--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -2,15 +2,10 @@ import fs from 'fs'
 
 const state = {
   currentInvidiousInstance: '',
-  invidiousInstancesList: null,
-  isGetChannelInfoRunning: false
+  invidiousInstancesList: null
 }
 
 const getters = {
-  getIsGetChannelInfoRunning(state) {
-    return state.isGetChannelInfoRunning
-  },
-
   getCurrentInvidiousInstance(state) {
     return state.currentInvidiousInstance
   },
@@ -88,8 +83,6 @@ const actions = {
 
   invidiousGetChannelInfo({ commit, dispatch }, channelId) {
     return new Promise((resolve, reject) => {
-      commit('toggleIsGetChannelInfoRunning')
-
       const payload = {
         resource: 'channels',
         id: channelId,
@@ -100,7 +93,6 @@ const actions = {
         resolve(response)
       }).catch((xhr) => {
         console.error(xhr)
-        commit('toggleIsGetChannelInfoRunning')
         reject(xhr)
       })
     })
@@ -112,7 +104,6 @@ const actions = {
         resolve(response)
       }).catch((xhr) => {
         console.error(xhr)
-        commit('toggleIsGetChannelInfoRunning')
         reject(xhr)
       })
     })
@@ -137,10 +128,6 @@ const actions = {
 }
 
 const mutations = {
-  toggleIsGetChannelInfoRunning(state) {
-    state.isGetChannelInfoRunning = !state.isGetChannelInfoRunning
-  },
-
   setCurrentInvidiousInstance(state, value) {
     state.currentInvidiousInstance = value
   },


### PR DESCRIPTION
# Remove unused property from the invidious store

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Cleanup

## Description
This pull request removes the unused `isGetChannelInfoRunning` property from the invidious store. I couldn't find any other references to that property so it doesn't seem worth keeping it around.

Technically in vuex 3 it's all one big store, the concept of separate stores only exists in Pinia.

## Testing <!-- for code that is not small enough to be easily understandable -->
Channel pages and fetching subscriptions still work fine.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1