### PR TITLE
Fixing the logic for `isExternalLink`

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -320,7 +320,7 @@ export default Vue.extend({
     },
 
     openAllLinksExternally: function () {
-      const isExternalLink = (event) => event.target.tagName === 'A' && event.target.href.startsWith('http')
+      const isExternalLink = (event) => event.target.tagName === 'A' && !event.target.href.startsWith(window.location.origin)
 
       document.addEventListener('click', (event) => {
         if (isExternalLink(event)) {


### PR DESCRIPTION


# Fixing the logic for `isExternalLink`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
This PR intends to fix an issue which was causing the link around the video title in `ft-list-video` to trigger `openExternalLink` erroneously. This problem occurs because the link surrounding the title in `ft-list-video` does not contain a `span` element, and all other internal links seem to contain some sort of element, so the `event.target.tagName === 'A'` condition had been catching all of the the internal links without even needing the check for `http`. 

The check for `http` at the beginning of a link doesn't work is because it uses the `.href` property of the link element which is computed using the real attribute value `#/watch/{someVideoId}` and the current window location. The result is a link that looks like `http://localhost:9080/#/watch/{someVideoId}` which is technically internal but also starts with `http`. Therefore, a better way to classify links might be to check if the link is the same origin as the current window. If the link points to the same origin as window, it will be internal.

## Screenshots <!-- If appropriate -->
_Before:_
![before-change-is-external-min](https://user-images.githubusercontent.com/106682128/194678958-75e824ad-b0df-4ded-b645-221633e4609d.gif)
_After:_
![after-change-is-external](https://user-images.githubusercontent.com/106682128/194678938-bd11effd-6d06-4b3e-af41-1d6435f690ee.gif)
## Testing <!-- for code that is not small enough to be easily understandable -->
This change can be tested by clicking on the title of a video contained within the `ft-list-video` component.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
This could also be achieved by using the original condition with `el.getAttribute('href')` instead of `el.href`.
