### PR TITLE
Reducing overflow in the vjs video player

### DIFF
--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2192,3 +2192,13 @@ video::-webkit-media-text-track-display {
     height: 100%;
   }
 }
+
+@media screen and (max-width: 680px) {
+  .vjs-control.vjs-disabled.vjs-picture-in-picture-control,
+  .vjs-control.vjs-button.vjs-button-fullwindow {
+    display: none;
+  }
+  .vjs-full-window .video-js.vjs-full-screen .vjs-control.vjs-button.vjs-button-fullwindow {
+    display: initial;
+  }
+}


### PR DESCRIPTION
# Reducing overflow in the vjs video player

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The vjs controls overflow the window when the window is small. This PR hides some of the vjs controls under certain conditions in order to help with this overflow issue. When the window is less than `680px` width, it hides the `picture and picture` button (when it is disabled), and the `full window` button (when vjs is not currently in the `full window mode`). 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
_Before/After:_ (in web)
<img src="https://user-images.githubusercontent.com/106682128/194671254-d774ed4c-e518-4d9a-984b-bf5fba49ec78.png" width="300" /> <img src="https://user-images.githubusercontent.com/106682128/194671259-56f1fef7-8cc2-476c-ba11-ea1d1d538ae6.png" width="300" />
_Before/After:_ (in electron)
<img src="https://user-images.githubusercontent.com/106682128/194671261-f7611ba5-2bc7-49c2-99bb-7f922d30385e.png" width="300" /> <img src="https://user-images.githubusercontent.com/106682128/194671267-fd5619a8-d166-453e-815d-913e7b274ea3.png" width="300" />

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
I personally feel like the `full window` button is superfluous when the screen width is below 680px due to existing media queries.

In my fork, this overflow was reduced by hiding the timestamp when the width is less than 680px; however, I feel like it makes more sense to show the timestamp and to hide these other buttons which might not be useful or be enabled at all.

I am open to modifying this PR to change which controls are shown / hidden, and I would also be open to exploring options which involve moving these controls to a different part of the screen instead of hiding them outright if that would make more sense. My main goal in making this PR is to reduce the overflow in the vjs-player when the window is narrow.