### PR TITLE
Cleanup the web webpack config

### DIFF
--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -35,17 +35,7 @@ const config = {
       },
       {
         test: /\.vue$/,
-        use: {
-          loader: 'vue-loader',
-          options: {
-            extractCSS: true,
-            loaders: {
-              sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax=1',
-              scss: 'vue-style-loader!css-loader!sass-loader',
-              less: 'vue-style-loader!css-loader!less-loader',
-            },
-          },
-        },
+        loader: 'vue-loader'
       },
       {
         test: /\.s(c|a)ss$/,

--- a/package.json
+++ b/package.json
@@ -113,12 +113,10 @@
     "rimraf": "^3.0.2",
     "sass": "^1.54.9",
     "sass-loader": "^13.0.2",
-    "style-loader": "^3.2.1",
     "tree-kill": "1.2.2",
     "vue-devtools": "^5.1.4",
     "vue-eslint-parser": "^9.1.0",
     "vue-loader": "^15.10.0",
-    "vue-style-loader": "^4.1.3",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7807,11 +7807,6 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-style-loader@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
-  integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
-
 stylehacks@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.1.0.tgz#a40066490ca0caca04e96c6b02153ddc39913520"
@@ -8450,7 +8445,7 @@ vue-router@^3.6.5:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.6.5.tgz#95847d52b9a7e3f1361cb605c8e6441f202afad8"
   integrity sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==
 
-vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
+vue-style-loader@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.3.tgz#6d55863a51fa757ab24e89d9371465072aa7bc35"
   integrity sha512-sFuh0xfbtpRlKfm39ss/ikqs9AbKCoXZBpHeVZ8Tx650o0k0q/YCM7FRvigtxpACezfq6af+a7JeqVTWvncqDg==


### PR DESCRIPTION
# Cleanup the web webpack config

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Cleanup

## Description
We've been using vue-loader for the electron renderer without specifying an options for a while now without any issues. This pull request updates the webpack config for the web build to do the same. This doesn't change the build output as vue-loader already has a dependency on vue-style-loder and uses it internally, which also means we can get rid of the explicit vue-style-loader dependency in our package.json. I also got rid of the unused style-loader dependency (vue-style-loader is vue's fork of style-loader).

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn pack:web`

I used `git diff --no-index dist dist2` to compare the dist/web directory with and without these changes and the output was identical.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1