### PR TITLE
Prevent default event for shortcut

### DIFF
--- a/src/renderer/views/Popular/Popular.js
+++ b/src/renderer/views/Popular/Popular.js
@@ -69,6 +69,7 @@ export default Vue.extend({
       switch (event.key) {
         case 'r':
         case 'R':
+          event.preventDefault()
           if (!this.isLoading) {
             this.fetchPopularInfo()
           }

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -484,6 +484,7 @@ export default Vue.extend({
       switch (event.key) {
         case 'r':
         case 'R':
+          event.preventDefault()
           if (!this.isLoading) {
             this.getSubscriptions()
           }

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -188,6 +188,7 @@ export default Vue.extend({
       switch (event.key) {
         case 'r':
         case 'R':
+          event.preventDefault()
           if (!this.isLoading) {
             this.getTrendingInfo()
           }


### PR DESCRIPTION

# Prevent default event for shortcut

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
no related issue

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds `event.preventDefault()` to the shortcuts added in https://github.com/FreeTubeApp/FreeTube/pull/2689.
This fixes an issue where pressing shortcut also caused sidebar to expand/close when hamburger button was last element clicked.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
no visible difference
## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
1. Go to Subscription page
2. Press the hamburger menu to expand/close the sidebar.
3. Press the any alpha character key such as the `A` key 
4. See that the menu expands or closes. (Is this intended?)
5. Press the `R` key 
6. See that nothing happens to the menu.

## Desktop
<!-- Please complete the following information-->

- **OS:** Arch Linux
- **OS Version:** 5.19.13-arch1-1
- **FreeTube version:** 0.17.1

## Additional context
<!-- Add any other context about the pull request here. -->
I don't really know why the sidebar behaves that way or if it's something to be fixed.