### PR TITLE
Fix project board workflow

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -4,7 +4,7 @@ name: Project Board Automation
 
 on:
   issues:
-    types: [labeled, unlabeled, closed, deleted]
+    types: [closed, deleted, reopened, opened]
 
 jobs:
   assign-issues-to-projects:
@@ -14,37 +14,57 @@ jobs:
     # For bug reports
       - name: New bug issue
         uses: alex-page/github-project-automation-plus@v0.8.1
-        if: github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'bug')
+        if: contains(github.event.issue.labels.*.name, 'bug') && github.event.action == 'opened'
         with:
           project: Bug Reports
           column: To assign
           repo-token: ${{ secrets.PUSH_TOKEN }}
           action: update
-
-      - name: Bug label removed
+          
+      - name: Bug issue closed
         uses: alex-page/github-project-automation-plus@v0.8.1
-        if: github.event.action == 'unlabeled' || github.event.action == 'closed' || github.event.action == 'deleted'
+        if: github.event.action == 'closed' || github.event.action == 'deleted'
         with:
           action: delete
           project: Bug Reports
           column: To assign
           repo-token: ${{ secrets.PUSH_TOKEN }}
+          
+      - name: Bug issue reopened
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        if: contains(github.event.issue.labels.*.name, 'bug') && github.event.action == 'reopened'
+        with:
+          project: Bug Reports
+          column: To assign
+          repo-token: ${{ secrets.PUSH_TOKEN }}
+          action: update
 
       # For feature requests
       - name: New feature issue
         uses: alex-page/github-project-automation-plus@v0.8.1
-        if: github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'enhancement')
+        if: contains(github.event.issue.labels.*.name, 'enhancement') && github.event.action == 'opened'
         with:
           project: Feature Requests
           column: To assign
           repo-token: ${{ secrets.PUSH_TOKEN }}
           action: update
 
-      - name: Feature request label removed
+      - name: Feature request issue closed
         uses: alex-page/github-project-automation-plus@v0.8.1
-        if: github.event.action == 'unlabeled' || github.event.action == 'closed' || github.event.action == 'deleted'
+        if: github.event.action == 'closed' || github.event.action == 'deleted'
         with:
           action: delete
           project: Feature Requests
           column: To assign
           repo-token: ${{ secrets.PUSH_TOKEN }}
+          
+      - name: Feature request issue reopened
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        if: contains(github.event.issue.labels.*.name, 'enhancement') && github.event.action == 'reopened'
+        with:
+          project: Feature Requests
+          column: To assign
+          repo-token: ${{ secrets.PUSH_TOKEN }}
+          action: update
+
+


### PR DESCRIPTION
# Fix project board workflow

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
raised in https://github.com/FreeTubeApp/FreeTube/issues/2436#issuecomment-1272358737 by @linuxgirl22 confirmed in https://github.com/FreeTubeApp/FreeTube/issues/1623

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
There were several issues with this workflow:

1. When adding or removing a random label this workflow would delete this issue from the project board or add this issue to the project board.
2. When issue gets closed it removes the issue from the project board but when an issue gets reopened it didnt add the issue back to the project board
3. This workflow also move issues from bucket X to the to assign bucket under certain edge cases when adding labels / removing labels

Nr 1/3. fixed by removing the `labeled` and `unlabeled` logic more info on why i did this in 'Additional context'
Nr 2. fixed by adding some adding some code that would check if the issue has been reopened

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

1. Open up issue in https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/issues/new/choose
2. See that issue gets added to project board
3. Close issue
4. See issue gets removed from project board
5. Reopen issue
6. See that issue gets added back to project board

## Additional context
<!-- Add any other context about the pull request here. -->
Okay so the original workflow was intended with the following rationale. When u remove the bug label, it means that the issue needs to get removed from the bug project board. This rationale was valid in the early development stages of FT. There were no dedicated bug and feature request templates. Questions and discussion were opened up as issues instead of in dedicated discussion section like we have now. So chances were very high that someone asked a question when the bug label was applied. In this case u would remove the bug label and add the question label.

Rationale for edited workflow is that we will never remove the bug label because we have dedicated issue templates. If an user makes an error by picking the bug template instead of the feature request template, we should request them to create the issue in the correct template instead of just replacing the label.

Hope it all makes sense :)