### PR TITLE
Fixes wording of video video statistics

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -21,7 +21,7 @@ function runApp() {
     showCopyImageAddress: true,
     prepend: (defaultActions, parameters, browserWindow) => [
       {
-        label: 'Show Video Statistics',
+        label: 'Show / Hide Video Statistics',
         visible: parameters.mediaType === 'video',
         click: () => {
           browserWindow.webContents.send('showVideoStatistics')


### PR DESCRIPTION
# Fixes wording of video video statistics

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix?
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #2277 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Like mentioned in the issue the wording is a bit off

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

1. Right click on player

## Desktop
<!-- Please complete the following information-->
- **OS:**  Windows 10
- **OS Version:** 21H2
- **FreeTube version:** bleeding edge
