### PR TITLE
Improve accessibility of FreeTube input elements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,10 +26,11 @@ module.exports = {
     'eslint:recommended',
     'plugin:vue/recommended',
     'standard'
+    // 'plugin:vuejs-accessibility/recommended' // uncomment once issues are fixed
   ],
 
   // https://eslint.org/docs/user-guide/configuring#configuring-plugins
-  plugins: ['vue'],
+  plugins: ['vue', 'vuejs-accessibility'],
 
   rules: {
     'space-before-function-paren': 'off',
@@ -40,6 +41,12 @@ module.exports = {
     'no-undef': 'warn',
     'vue/no-template-key': 'warn',
     'vue/no-useless-template-attributes': 'off',
-    'vue/multi-word-component-names': 'off'
+    'vue/multi-word-component-names': 'off',
+    'vuejs-accessibility/no-onchange': 'off',
+    'vuejs-accessibility/label-has-for': ['error', {
+      required: {
+        some: ['nesting', 'id']
+      }
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "autolinker": "^4.0.0",
     "browserify": "^17.0.0",
     "electron-context-menu": "^3.5.0",
+    "eslint-plugin-vuejs-accessibility": "^1.2.0",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
     "lodash.debounce": "^4.0.8",

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -20,12 +20,14 @@
           v-if="showUpdatesBanner"
           class="banner"
           :message="updateBannerMessage"
+          role="link"
           @click="handleUpdateBannerClick"
         />
         <ft-notification-banner
           v-if="showBlogBanner"
           class="banner"
           :message="blogBannerMessage"
+          role="link"
           @click="handleNewBlogBannerClick"
         />
       </div>
@@ -46,11 +48,9 @@
 
     <ft-prompt
       v-if="showReleaseNotes"
+      :label="changeLogTitle"
       @click="showReleaseNotes = !showReleaseNotes"
     >
-      <h2>
-        {{ changeLogTitle }}
-      </h2>
       <span
         id="changeLogText"
         v-html="updateChangelog"
@@ -59,6 +59,10 @@
         <ft-button
           :label="$t('Download From Site')"
           @click="openDownloadsPage"
+        />
+        <ft-button
+          :label="$t('Close')"
+          @click="showReleaseNotes = !showReleaseNotes"
         />
       </ft-flex-box>
     </ft-prompt>

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { removeWhitespace } from '../../helpers/accessibility'
 
 export default Vue.extend({
   name: 'FtIconButton',
@@ -59,6 +60,7 @@ export default Vue.extend({
     }
   },
   methods: {
+    removeWhitespace,
     // used by the share menu
     hideDropdown: function () {
       this.dropdownShown = false

--- a/src/renderer/components/ft-icon-button/ft-icon-button.sass
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.sass
@@ -86,7 +86,7 @@
     cursor: pointer
     transition: background 0.2s ease-out
 
-    &:hover
+    &:hover, &:focus
       background-color: var(--side-nav-hover-color)
       transition: background 0.2s ease-in
 

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -12,8 +12,12 @@
         padding: padding + 'px',
         fontSize: size + 'px'
       }"
+      tabindex="0"
+      role="button"
       @click="handleIconClick"
       @mousedown="handleIconMouseDown"
+      @keydown.enter.prevent="handleIconClick"
+      @keydown.space.prevent="handleIconClick"
     />
     <div
       v-show="dropdownShown"
@@ -33,12 +37,19 @@
         <ul
           v-if="dropdownOptions.length > 0"
           class="list"
+          role="listbox"
+          aria-expanded="false"
         >
           <li
             v-for="(option, index) in dropdownOptions"
+            :id="removeWhitespace(title + '-' + index)"
             :key="index"
+            role="option"
+            aria-selected="false"
+            tabindex="-1"
             :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
-            @click="handleDropdownClick({url: option.value, index: index})"
+            @click="handleDropdownClick({url: option.value, index: index}, $event)"
+            @keydown="handleDropdownClick({url: option.value, index: index}, $event)"
           >
             {{ option.type === 'divider' ? '' : option.label }}
           </li>

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events -->
 <template>
   <div
     class="ft-input-component"
@@ -69,6 +70,7 @@
         @mouseenter="searchState.isPointerInList = true"
         @mouseleave="searchState.isPointerInList = false"
       >
+        <!-- eslint-disable vuejs-accessibility/click-events-have-key-events -->
         <li
           v-for="(list, index) in visibleDataList"
           :key="index"
@@ -78,6 +80,7 @@
         >
           {{ list }}
         </li>
+        <!-- skipped -->
       </ul>
     </div>
   </div>

--- a/src/renderer/components/ft-list-dropdown/ft-list-dropdown.css
+++ b/src/renderer/components/ft-list-dropdown/ft-list-dropdown.css
@@ -1,11 +1,11 @@
-.dropDown {
+.dropdown {
   position: relative;
   text-align: center;
   text-transform: uppercase;
   margin: 0 5px;
 }
 
-.dropDown ul {
+.dropdown ul {
     display: none;
     position: absolute;
     list-style: none;
@@ -15,19 +15,19 @@
     z-index: 100;
 }
 
-.dropDown ul li {
+.dropdown ul li.buttonOption {
     width: 100%;
     float: none;
     box-sizing: border-box;
 }
 
-.dropDown:hover ul {
-    display: block;
+.dropdown:hover ul, .dropdown:focus-within ul {
+  display: block;
 }
 
-.dropDown ul li a {
-    text-decoration: none;
-    color: inherit;
+.dropdown ul li a {
+  text-decoration: none;
+  color: inherit;
 }
 
 .buttonTitle {
@@ -60,7 +60,7 @@
   transition: background 0.2s ease-out;
 }
 
-.buttonOption:hover {
+.buttonOption:hover, .buttonOption:focus {
   background-color: var(--side-nav-hover-color);
   -moz-transition: background 0.2s ease-in;
   -o-transition: background 0.2s ease-in;

--- a/src/renderer/components/ft-list-dropdown/ft-list-dropdown.js
+++ b/src/renderer/components/ft-list-dropdown/ft-list-dropdown.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-
+import { removeWhitespace, handleDropdownKeyboardEvent } from '../../helpers/accessibility'
 export default Vue.extend({
   name: 'FtListDropdown',
   props: {
@@ -30,6 +30,37 @@ export default Vue.extend({
   computed: {
     listType: function () {
       return this.$store.getters.getListType
+    }
+  },
+  methods: {
+    removeWhitespace,
+    handleIconKeyPress(event) {
+      if (event instanceof KeyboardEvent) {
+        if (event.key === 'Tab') {
+          return
+        }
+
+        event.preventDefault()
+
+        if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'ArrowDown') {
+          return
+        }
+      }
+
+      const firstOption = document.getElementById('buttonOption0')
+      firstOption.setAttribute('tabIndex', 1)
+      firstOption.focus()
+    },
+    handleDropdownClick: function(index, event) {
+      if (!handleDropdownKeyboardEvent(event, event?.target)) {
+        return
+      }
+
+      const unspacedTitle = removeWhitespace(this.title)
+      const allOptions = document.querySelector(`#${unspacedTitle} + ul`)
+      allOptions.setAttribute('tabindex', '-1')
+      event.target.setAttribute('tabindex', '0')
+      this.$emit('click', this.labelValues[index])
     }
   }
 })

--- a/src/renderer/components/ft-list-dropdown/ft-list-dropdown.vue
+++ b/src/renderer/components/ft-list-dropdown/ft-list-dropdown.vue
@@ -1,6 +1,12 @@
 <template>
-  <div class="dropDown">
-    <div class="buttonTitle">
+  <div class="dropdown">
+    <div
+      :id="removeWhitespace(title)"
+      class="buttonTitle"
+      tabindex="0"
+      role="listbox"
+      @keypress="handleIconKeyPress($event)"
+    >
       {{ title }}
       <font-awesome-icon
         class="angleDownIcon"
@@ -10,9 +16,14 @@
     <ul>
       <li
         v-for="(label, index) in labelNames"
+        :id="'buttonOption' + index"
         :key="index"
         class="buttonOption"
-        @click="$emit('click', labelValues[index])"
+        role="option"
+        tabindex="-1"
+        aria-selected="false"
+        @click="handleDropdownClick(index, $event)"
+        @keydown="handleDropdownClick(index, $event)"
       >
         {{ label }}
       </li>

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.css
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.css
@@ -14,6 +14,10 @@
   cursor: pointer;
 }
 
+.ftNotificationBanner:focus {
+  box-shadow: 20px 20px 20px rgba(0,0,0,.1);
+}
+
 .message {
   margin-right: 25px;
   cursor: pointer;

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.js
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.js
@@ -18,8 +18,7 @@ export default Vue.extend({
       this.$emit('click', response)
     },
 
-    handleClose: function (event) {
-      event.stopPropagation()
+    handleClose: function () {
       this.handleClick(false)
     }
   }

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.vue
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.vue
@@ -1,7 +1,13 @@
 <template>
   <div
     class="ftNotificationBanner"
+    tabindex="0"
+    role="link"
+    :title="message"
+    :aria-describedby="message"
     @click="handleClick(true)"
+    @keydown.enter.prevent="handleClick(true)"
+    @keydown.space.prevent="handleClick(true)"
   >
     <div
       class="message"
@@ -15,7 +21,10 @@
     <font-awesome-icon
       class="bannerIcon"
       :icon="['fas', 'times']"
-      @click="handleClose"
+      tabindex="0"
+      :title="$t('Close Banner')"
+      @click.stop="handleClose"
+      @keydown.enter.stop.prevent="handleClose"
     />
   </div>
 </template>

--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
+import { removeWhitespace } from '../../helpers/accessibility'
 
 export default Vue.extend({
   name: 'FtPrompt',
@@ -26,11 +27,20 @@ export default Vue.extend({
     optionValues: {
       type: Array,
       default: () => { return [] }
+
     }
   },
+  mounted: function () {
+    setTimeout(() => {
+      document.querySelector('.prompt')
+        .querySelectorAll('button')[0]
+        .focus()
+    })
+  },
   methods: {
+    removeWhitespace,
     handleHide: function (event) {
-      if (event.target.className === 'prompt') {
+      if (event.target.getAttribute('role') === 'button' || event.target.className === 'prompt') {
         this.$emit('click', null)
       }
     }

--- a/src/renderer/components/ft-prompt/ft-prompt.vue
+++ b/src/renderer/components/ft-prompt/ft-prompt.vue
@@ -1,11 +1,19 @@
 <template>
   <div
     class="prompt"
+    tabindex="-1"
     @click="handleHide"
+    @keydown.enter="handleHide"
   >
-    <ft-card class="promptCard">
+    <ft-card
+      class="promptCard"
+      :aria-labelledby="'dialog-' + removeWhitespace(label)"
+    >
       <slot>
-        <h2 class="center">
+        <h2
+          :id="'dialog-' + removeWhitespace(label)"
+          class="center"
+        >
           {{ label }}
         </h2>
         <p

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -88,7 +88,6 @@
   font-size: 18px;
   font-weight: normal;
   position: absolute;
-  pointer-events: none;
   left: 0;
   top: 10px;
   transition: 0.2s ease all;

--- a/src/renderer/components/ft-select/ft-select.js
+++ b/src/renderer/components/ft-select/ft-select.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import FtTooltip from '../ft-tooltip/ft-tooltip.vue'
-
+import { removeWhitespace } from '../../helpers/accessibility'
 export default Vue.extend({
   name: 'FtSelect',
   components: {
@@ -31,5 +31,8 @@ export default Vue.extend({
       type: Boolean,
       default: false
     }
+  },
+  methods: {
+    removeWhitespace
   }
 })

--- a/src/renderer/components/ft-select/ft-select.vue
+++ b/src/renderer/components/ft-select/ft-select.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="select">
     <select
+      :id="removeWhitespace(placeholder)"
       class="select-text"
       :class="{disabled: disabled}"
       :value="value"
+      :name="removeWhitespace(placeholder)"
       :disabled="disabled"
       @change="$emit('change', $event.target.value)"
     >
@@ -23,6 +25,7 @@
     <span class="select-bar" />
     <label
       class="select-label"
+      :for="removeWhitespace(placeholder)"
       :hidden="disabled"
     >
       {{ placeholder }}

--- a/src/renderer/components/ft-toast/ft-toast.vue
+++ b/src/renderer/components/ft-toast/ft-toast.vue
@@ -5,7 +5,11 @@
       :key="'toast-' + index"
       class="toast"
       :class="{ closed: !toast.isOpen, open: toast.isOpen }"
+      tabindex="0"
+      role="status"
       @click="performAction(index)"
+      @keydown.enter.prevent="performAction(index)"
+      @keydown.space.prevent="performAction(index)"
     >
       <p class="message">
         {{ toast.message }}

--- a/src/renderer/helpers/accessibility.js
+++ b/src/renderer/helpers/accessibility.js
@@ -1,0 +1,44 @@
+export function handleDropdownKeyboardEvent(event, target, afterElement) {
+  if (!event || !(event instanceof KeyboardEvent)) {
+    return true
+  }
+
+  let nextElement = null
+  if (event.key === 'Tab') {
+    if (afterElement) {
+      afterElement.tabindex = 0
+      afterElement.focus()
+    }
+    return false
+  } if (event.key === 'ArrowUp') {
+    nextElement = target.previousElementSibling ?? target.parentNode.lastElementChild
+
+    if (nextElement.classList.contains('listItemDivider')) {
+      nextElement = nextElement.previousElementSibling
+    }
+  } else if (event.key === 'ArrowDown') {
+    nextElement = target.nextElementSibling ?? target.parentNode.firstElementChild
+
+    if (nextElement.classList.contains('listItemDivider')) {
+      nextElement = nextElement.nextElementSibling
+    }
+  } else if (event.key === 'Home') {
+    nextElement = target.parentNode.firstElementChild
+  } else if (event.key === 'End') {
+    nextElement = target.parentNode.lastElementChild
+  }
+
+  event.preventDefault()
+
+  if (nextElement) {
+    target.setAttribute('tabindex', '-1')
+    nextElement.setAttribute('tabindex', '0')
+    nextElement.focus()
+  }
+
+  return event.key === 'Enter' || event.key === ' '
+}
+
+export function removeWhitespace(attribute) {
+  return attribute.replace(/\s/g, '')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,6 +1977,11 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-query@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.2.tgz#0b8a744295271861e1d933f8feca13f9b70cfdc1"
+  integrity sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -3586,6 +3591,11 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+emoji-regex@^10.0.0:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.2.1.tgz#a41c330d957191efd3d9dfe6e1e8e1e9ab048b3f"
+  integrity sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -3849,6 +3859,15 @@ eslint-plugin-vue@^9.6.0:
     semver "^7.3.5"
     vue-eslint-parser "^9.0.1"
     xml-name-validator "^4.0.0"
+
+eslint-plugin-vuejs-accessibility@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-1.2.0.tgz#b7304bc8dfe4fad930c5d95cd51a2e0979225bda"
+  integrity sha512-wF7kT22lS2VOmIpDeI65bnFFKFgESEEpI+CWKr43mdfDRywA4sCk7cKhtZsvfbPOtKO0GDlnpFxZbOIGsFn7IQ==
+  dependencies:
+    aria-query "^5.0.0"
+    emoji-regex "^10.0.0"
+    vue-eslint-parser "^9.0.1"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
# Improve accessibility of FreeTube input elements


## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Implements part of #1525 (removes jquery)

## Description
Makes generic ft-(input) items more accessible. Future PRs will tackle more components.

## Testing 
FtDropdown:
- Find a Playlist
- Tab to the "Share" bar (clicking on the description then clicking tab might be easier)
- Click enter on the "Share"
- Click enter on copy link

FtNotificationBanner:
- modify version in package.json to a previous version (0.16.0)(verify that check for app updates is enabled in the setting as well)
- Tab to notification banner
- Click enter
- (Repeat but instead of clicking enter, tab to the close button then click enter)

FtPrompt:
- go to data settings
- click "Export Subscriptions"
- click tab then click enter

FtIconButon
- navigate to a video
- tab to the share button
- click enter
- tab to different options in list
- click enter

FtSelect
- go to settings
- go to download settings
- tab to "Download Behavior"
- click arrow keys up/down
- see that value changes
- click enter
- list of values opens up

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.17.2

## Additional context
Co-Authored-By: Jason <84899178+jasonhenriquez@users.noreply.github.com>
