### PR TITLE
Move colours from the store to the utils helper

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -11,7 +11,7 @@ import { MAIN_PROFILE_ID } from '../../../constants'
 import fs from 'fs'
 import { opmlToJSON } from 'opml-to-json'
 import ytch from 'yt-channel-info'
-import { calculateColorLuminance } from '../../helpers/utils'
+import { calculateColorLuminance, getRandomColor } from '../../helpers/utils'
 
 // FIXME: Missing web logic branching
 
@@ -129,7 +129,7 @@ export default Vue.extend({
       })
     },
 
-    importFreeTubeSubscriptions: async function (textDecode) {
+    importFreeTubeSubscriptions: function (textDecode) {
       textDecode = textDecode.split('\n')
       textDecode.pop()
       textDecode = textDecode.map(data => JSON.parse(data))
@@ -137,7 +137,7 @@ export default Vue.extend({
       const firstEntry = textDecode[0]
       if (firstEntry.channelId && firstEntry.channelName && firstEntry.channelThumbnail && firstEntry._id && firstEntry.profile) {
         // Old FreeTube subscriptions format detected, so convert it to the new one:
-        textDecode = await this.convertOldFreeTubeFormatToNew(textDecode)
+        textDecode = this.convertOldFreeTubeFormatToNew(textDecode)
       }
 
       textDecode.forEach((profileData) => {
@@ -1085,14 +1085,14 @@ export default Vue.extend({
       })
     },
 
-    async convertOldFreeTubeFormatToNew(oldData) {
+    convertOldFreeTubeFormatToNew(oldData) {
       const convertedData = []
       for (const channel of oldData) {
         const listOfProfilesAlreadyAdded = []
         for (const profile of channel.profile) {
           let index = convertedData.findIndex(p => p.name === profile.value)
           if (index === -1) { // profile doesn't exist yet
-            const randomBgColor = await this.getRandomColor()
+            const randomBgColor = getRandomColor()
             const contrastyTextColor = calculateColorLuminance(randomBgColor)
             convertedData.push({
               name: profile.value,
@@ -1241,7 +1241,6 @@ export default Vue.extend({
       'updateHistory',
       'compactHistory',
       'showToast',
-      'getRandomColor',
       'showOpenDialog',
       'readFileFromDialog',
       'showSaveDialog',

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -6,7 +6,7 @@ import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtInput from '../../components/ft-input/ft-input.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
 import { MAIN_PROFILE_ID } from '../../../constants'
-import { calculateColorLuminance } from '../../helpers/utils'
+import { calculateColorLuminance, colorValues } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'FtProfileEdit',
@@ -46,7 +46,7 @@ export default Vue.extend({
       return this.profileId === MAIN_PROFILE_ID
     },
     colorValues: function () {
-      return this.$store.getters.getColorValues
+      return colorValues
     },
     profileInitial: function () {
       return this?.profileName?.length > 0 ? Array.from(this.profileName)[0].toUpperCase() : ''

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import { mapActions } from 'vuex'
+import { colorNames } from '../../helpers/utils'
 import FtSelect from '../ft-select/ft-select.vue'
 
 export default Vue.extend({
@@ -27,11 +28,11 @@ export default Vue.extend({
   },
   computed: {
     colorValues: function () {
-      return this.$store.getters.getColorNames
+      return colorNames
     },
 
     colorNames: function () {
-      return this.colorValues.map(colorVal => {
+      return colorNames.map(colorVal => {
         // add spaces before capital letters
         const colorName = colorVal.replace(/([A-Z])/g, ' $1').trim()
         return this.$t(`Settings.Theme Settings.Main Color Theme.${colorName}`)

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -14,7 +14,7 @@ import 'videojs-http-source-selector'
 
 import { IpcChannels } from '../../../constants'
 import { sponsorBlockSkipSegments } from '../../helpers/sponsorblock'
-import { calculateColorLuminance } from '../../helpers/utils'
+import { calculateColorLuminance, colorNames, colorValues } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'FtVideoPlayer',
@@ -1181,8 +1181,6 @@ export default Vue.extend({
 
       if (!this.player.loop()) {
         const currentTheme = this.$store.state.settings.mainColor
-        const colorNames = this.$store.state.utils.colorNames
-        const colorValues = this.$store.state.utils.colorValues
 
         const nameIndex = colorNames.findIndex((color) => {
           return color === currentTheme

--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -7,6 +7,7 @@ import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtSlider from '../ft-slider/ft-slider.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtPrompt from '../ft-prompt/ft-prompt.vue'
+import { colorNames } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'ThemeSettings',
@@ -100,11 +101,11 @@ export default Vue.extend({
     },
 
     colorValues: function () {
-      return this.$store.getters.getColorNames
+      return colorNames
     },
 
     colorNames: function () {
-      return this.colorValues.map(colorVal => {
+      return colorNames.map(colorVal => {
         // add spaces before capital letters
         const colorName = colorVal.replace(/([A-Z])/g, ' $1').trim()
         return this.$t(`Settings.Theme Settings.Main Color Theme.${colorName}`)

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -1,5 +1,4 @@
 import Vue from 'vue'
-import { mapActions } from 'vuex'
 import FtLoader from '../ft-loader/ft-loader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtButton from '../ft-button/ft-button.vue'
@@ -7,6 +6,7 @@ import FtListVideo from '../ft-list-video/ft-list-video.vue'
 
 import autolinker from 'autolinker'
 import { LiveChat } from '@freetube/youtube-chat'
+import { getRandomColorClass } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'WatchVideoLiveChat',
@@ -178,30 +178,26 @@ export default Vue.extend({
       this.comments.push(comment)
 
       if (typeof (comment.superchat) !== 'undefined') {
-        this.getRandomColorClass().then((data) => {
-          comment.superchat.colorClass = data
+        comment.superchat.colorClass = getRandomColorClass()
 
-          this.superChatComments.unshift(comment)
+        this.superChatComments.unshift(comment)
 
-          setTimeout(() => {
-            this.removeFromSuperChat(comment.id)
-          }, 120000)
-        })
+        setTimeout(() => {
+          this.removeFromSuperChat(comment.id)
+        }, 120000)
       }
 
       if (comment.author.name[0] === 'Ge' || comment.author.name[0] === 'Ne') {
-        this.getRandomColorClass().then((data) => {
-          comment.superChat = {
-            amount: '$5.00',
-            colorClass: data
-          }
+        comment.superChat = {
+          amount: '$5.00',
+          colorClass: getRandomColorClass()
+        }
 
-          this.superChatComments.unshift(comment)
+        this.superChatComments.unshift(comment)
 
-          setTimeout(() => {
-            this.removeFromSuperChat(comment.id)
-          }, 120000)
-        })
+        setTimeout(() => {
+          this.removeFromSuperChat(comment.id)
+        }, 120000)
       }
 
       if (this.stayAtBottom) {
@@ -260,10 +256,6 @@ export default Vue.extend({
     preventDefault: function (event) {
       event.stopPropagation()
       event.preventDefault()
-    },
-
-    ...mapActions([
-      'getRandomColorClass'
-    ])
+    }
   }
 })

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1,3 +1,93 @@
+export const colorNames = [
+  'Red',
+  'Pink',
+  'Purple',
+  'DeepPurple',
+  'Indigo',
+  'Blue',
+  'LightBlue',
+  'Cyan',
+  'Teal',
+  'Green',
+  'LightGreen',
+  'Lime',
+  'Yellow',
+  'Amber',
+  'Orange',
+  'DeepOrange',
+  'DraculaCyan',
+  'DraculaGreen',
+  'DraculaOrange',
+  'DraculaPink',
+  'DraculaPurple',
+  'DraculaRed',
+  'DraculaYellow',
+  'CatppuccinMochaRosewater',
+  'CatppuccinMochaFlamingo',
+  'CatppuccinMochaPink',
+  'CatppuccinMochaMauve',
+  'CatppuccinMochaRed',
+  'CatppuccinMochaMaroon',
+  'CatppuccinMochaPeach',
+  'CatppuccinMochaYellow',
+  'CatppuccinMochaGreen',
+  'CatppuccinMochaTeal',
+  'CatppuccinMochaSky',
+  'CatppuccinMochaSapphire',
+  'CatppuccinMochaBlue',
+  'CatppuccinMochaLavender'
+]
+
+export const colorValues = [
+  '#d50000',
+  '#C51162',
+  '#AA00FF',
+  '#6200EA',
+  '#304FFE',
+  '#2962FF',
+  '#0091EA',
+  '#00B8D4',
+  '#00BFA5',
+  '#00C853',
+  '#64DD17',
+  '#AEEA00',
+  '#FFD600',
+  '#FFAB00',
+  '#FF6D00',
+  '#DD2C00',
+  '#8BE9FD',
+  '#50FA7B',
+  '#FFB86C',
+  '#FF79C6',
+  '#BD93F9',
+  '#FF5555',
+  '#F1FA8C',
+  '#F5E0DC',
+  '#F2CDCD',
+  '#F5C2E7',
+  '#CBA6F7',
+  '#F38BA8',
+  '#EBA0AC',
+  '#FAB387',
+  '#F9E2AF',
+  '#A6E3A1',
+  '#94E2D5',
+  '#89DCEB',
+  '#74C7EC',
+  '#89B4FA',
+  '#B4BEFE'
+]
+
+export function getRandomColorClass() {
+  const randomInt = Math.floor(Math.random() * colorNames.length)
+  return 'main' + colorNames[randomInt]
+}
+
+export function getRandomColor() {
+  const randomInt = Math.floor(Math.random() * colorValues.length)
+  return colorValues[randomInt]
+}
+
 export function calculateColorLuminance(colorValue) {
   const cutHex = colorValue.substring(1, 7)
   const colorValueR = parseInt(cutHex.substring(0, 2), 16)

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -1,6 +1,6 @@
 import { MAIN_PROFILE_ID } from '../../../constants'
 import { DBProfileHandlers } from '../../../datastores/handlers/index'
-import { calculateColorLuminance } from '../../helpers/utils'
+import { calculateColorLuminance, getRandomColor } from '../../helpers/utils'
 
 const state = {
   profileList: [{
@@ -40,7 +40,7 @@ function profileSort(a, b) {
 }
 
 const actions = {
-  async grabAllProfiles({ rootState, dispatch, commit }, defaultName = null) {
+  async grabAllProfiles({ rootState, commit }, defaultName = null) {
     let profiles
     try {
       profiles = await DBProfileHandlers.find()
@@ -53,7 +53,7 @@ const actions = {
 
     if (profiles.length === 0) {
       // Create a default profile and persist it
-      const randomColor = await dispatch('getRandomColor')
+      const randomColor = getRandomColor()
       const textColor = calculateColorLuminance(randomColor)
       const defaultProfile = {
         _id: MAIN_PROFILE_ID,

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -27,85 +27,6 @@ const state = {
     type: 'all',
     duration: ''
   },
-  colorNames: [
-    'Red',
-    'Pink',
-    'Purple',
-    'DeepPurple',
-    'Indigo',
-    'Blue',
-    'LightBlue',
-    'Cyan',
-    'Teal',
-    'Green',
-    'LightGreen',
-    'Lime',
-    'Yellow',
-    'Amber',
-    'Orange',
-    'DeepOrange',
-    'DraculaCyan',
-    'DraculaGreen',
-    'DraculaOrange',
-    'DraculaPink',
-    'DraculaPurple',
-    'DraculaRed',
-    'DraculaYellow',
-    'CatppuccinMochaRosewater',
-    'CatppuccinMochaFlamingo',
-    'CatppuccinMochaPink',
-    'CatppuccinMochaMauve',
-    'CatppuccinMochaRed',
-    'CatppuccinMochaMaroon',
-    'CatppuccinMochaPeach',
-    'CatppuccinMochaYellow',
-    'CatppuccinMochaGreen',
-    'CatppuccinMochaTeal',
-    'CatppuccinMochaSky',
-    'CatppuccinMochaSapphire',
-    'CatppuccinMochaBlue',
-    'CatppuccinMochaLavender'
-
-  ],
-  colorValues: [
-    '#d50000',
-    '#C51162',
-    '#AA00FF',
-    '#6200EA',
-    '#304FFE',
-    '#2962FF',
-    '#0091EA',
-    '#00B8D4',
-    '#00BFA5',
-    '#00C853',
-    '#64DD17',
-    '#AEEA00',
-    '#FFD600',
-    '#FFAB00',
-    '#FF6D00',
-    '#DD2C00',
-    '#8BE9FD',
-    '#50FA7B',
-    '#FFB86C',
-    '#FF79C6',
-    '#BD93F9',
-    '#FF5555',
-    '#F1FA8C',
-    '#F5E0DC',
-    '#F2CDCD',
-    '#F5C2E7',
-    '#CBA6F7',
-    '#F38BA8',
-    '#EBA0AC',
-    '#FAB387',
-    '#F9E2AF',
-    '#A6E3A1',
-    '#94E2D5',
-    '#89DCEB',
-    '#74C7EC',
-    '#89B4FA',
-    '#B4BEFE'
-  ],
   externalPlayerNames: [],
   externalPlayerNameTranslationKeys: [],
   externalPlayerValues: [],
@@ -135,14 +56,6 @@ const getters = {
 
   getSearchSettings () {
     return state.searchSettings
-  },
-
-  getColorNames () {
-    return state.colorNames
-  },
-
-  getColorValues () {
-    return state.colorValues
   },
 
   getShowProgressBar () {
@@ -532,16 +445,6 @@ const actions = {
 
   updateShowProgressBar ({ commit }, value) {
     commit('setShowProgressBar', value)
-  },
-
-  getRandomColorClass () {
-    const randomInt = Math.floor(Math.random() * state.colorNames.length)
-    return 'main' + state.colorNames[randomInt]
-  },
-
-  getRandomColor () {
-    const randomInt = Math.floor(Math.random() * state.colorValues.length)
-    return state.colorValues[randomInt]
   },
 
   getRegionData ({ commit }, payload) {

--- a/src/renderer/views/ProfileEdit/ProfileEdit.js
+++ b/src/renderer/views/ProfileEdit/ProfileEdit.js
@@ -5,7 +5,7 @@ import FtProfileEdit from '../../components/ft-profile-edit/ft-profile-edit.vue'
 import FtProfileChannelList from '../../components/ft-profile-channel-list/ft-profile-channel-list.vue'
 import FtProfileFilterChannelsList from '../../components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.vue'
 import { MAIN_PROFILE_ID } from '../../../constants'
-import { calculateColorLuminance } from '../../helpers/utils'
+import { calculateColorLuminance, getRandomColor } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'ProfileEdit',
@@ -53,14 +53,14 @@ export default Vue.extend({
       deep: true
     }
   },
-  mounted: async function () {
+  mounted: function () {
     const profileType = this.$route.name
 
     this.deletePromptLabel = `${this.$t('Profile.Are you sure you want to delete this profile?')} ${this.$t('Profile["All subscriptions will also be deleted."]')}`
 
     if (profileType === 'newProfile') {
       this.isNew = true
-      const bgColor = await this.getRandomColor()
+      const bgColor = getRandomColor()
       const textColor = calculateColorLuminance(bgColor)
       this.profile = {
         name: '',
@@ -88,8 +88,7 @@ export default Vue.extend({
   },
   methods: {
     ...mapActions([
-      'showToast',
-      'getRandomColor'
+      'showToast'
     ])
   }
 })


### PR DESCRIPTION
# Move colours from the store to the utils helper

## Pull Request Type

- [x] Refactor

## Description
This pull request move the colorNames and colorValues arrays out of the store, as they don't change at runtime. I also moved the getRandomColor and getRandomColorClass functions out of the store, as they just need access to the colorNames and colorValues arrays.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Colours are listed in the theming and sponsorblock settings
- The colourful cirlces are shown when editing a profile
- A random colour is auto selected when you create a new profile

Very unlikely that you'll be able to find a livestream with superchats
- Superchats get a random colour as the background.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1