### PR TITLE
Make the save as and open file dialogs blocking

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -433,21 +433,27 @@ function runApp() {
     return app.getPath('pictures')
   })
 
-  ipcMain.handle(IpcChannels.SHOW_OPEN_DIALOG, async (_, options) => {
+  ipcMain.handle(IpcChannels.SHOW_OPEN_DIALOG, async ({ sender }, options) => {
+    const senderWindow = findSenderWindow(sender)
+    if (senderWindow) {
+      return await dialog.showOpenDialog(senderWindow, options)
+    }
     return await dialog.showOpenDialog(options)
   })
 
-  ipcMain.handle(IpcChannels.SHOW_SAVE_DIALOG, async (event, { options, useModal }) => {
-    if (useModal) {
-      const senderWindow = BrowserWindow.getAllWindows().find((window) => {
-        return window.webContents.id === event.sender.id
-      })
-      if (senderWindow) {
-        return await dialog.showSaveDialog(senderWindow, options)
-      }
+  ipcMain.handle(IpcChannels.SHOW_SAVE_DIALOG, async ({ sender }, options) => {
+    const senderWindow = findSenderWindow(sender)
+    if (senderWindow) {
+      return await dialog.showSaveDialog(senderWindow, options)
     }
     return await dialog.showSaveDialog(options)
   })
+
+  function findSenderWindow(sender) {
+    return BrowserWindow.getAllWindows().find((window) => {
+      return window.webContents.id === sender.id
+    })
+  }
 
   ipcMain.on(IpcChannels.STOP_POWER_SAVE_BLOCKER, (_, id) => {
     powerSaveBlocker.stop(id)

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -543,7 +543,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -626,7 +626,7 @@ export default Vue.extend({
         return object
       })
 
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -678,7 +678,7 @@ export default Vue.extend({
         }
       })
 
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -724,7 +724,7 @@ export default Vue.extend({
         exportText += `${channel.id},${channelUrl},${channelName}\n`
       })
       exportText += '\n'
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -777,7 +777,7 @@ export default Vue.extend({
         newPipeObject.subscriptions.push(subscription)
       })
 
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -893,7 +893,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -1062,7 +1062,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showSaveDialog({ options })
+      const response = await this.showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1383,7 +1383,7 @@ export default Vue.extend({
           ]
         }
 
-        const response = await this.showSaveDialog({ options, useModal: true })
+        const response = await this.showSaveDialog(options)
         if (wasPlaying) {
           this.player.play()
         }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -371,10 +371,10 @@ const actions = {
     return await invokeIRC(context, IpcChannels.SHOW_OPEN_DIALOG, webCbk, options)
   },
 
-  async showSaveDialog (context, { options, useModal = false }) {
+  async showSaveDialog (context, options) {
     // TODO: implement showSaveDialog web compatible callback
     const webCbk = () => null
-    return await invokeIRC(context, IpcChannels.SHOW_SAVE_DIALOG, webCbk, { options, useModal })
+    return await invokeIRC(context, IpcChannels.SHOW_SAVE_DIALOG, webCbk, options)
   },
 
   async getUserDataPath (context) {


### PR DESCRIPTION
# Make the save as and open file dialogs blocking

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the Save as... and Open file... dialogs are non-blocking, which means you can switch back to the FreeTube window and open as many of those dialogs as you want or navigate to a different page, causing unexpected behaviour when you select a file.
As we aren't Discord, I decided to fix that bug, so that when one of those dialogs is open, you have to deal with it before you can return to FreeTube.

## Testing <!-- for code that is not small enough to be easily understandable -->
The easiest place to test this is in the data import and export settings, by opening on of those dialogs and then attempting to click into the FreeTube window. On Windows the dialog window will flash for a short moment. It should stop you from going back to the FreeTube window until you cancel or select a file to open/save to.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1