### PR TITLE
Fix CTRL+clicking on the channel name on the watch page

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -331,10 +331,6 @@ export default Vue.extend({
       })
     },
 
-    goToChannel: function () {
-      this.$router.push({ path: `/channel/${this.channelId}` })
-    },
-
     toggleSave: function () {
       if (this.inFavoritesPlaylist) {
         this.removeFromPlaylist()

--- a/src/renderer/components/watch-video-info/watch-video-info.sass
+++ b/src/renderer/components/watch-video-info/watch-video-info.sass
@@ -26,6 +26,9 @@
     cursor: pointer
     position: relative
     top: -2px
+    display: block
+    color: inherit
+    text-decoration: inherit
 
   .subscribeButton
     margin-top: 6px
@@ -86,7 +89,3 @@
     :deep(.iconDropdown)
       left: calc(50% - 20px)
       right: auto
-
-.channelLink
-  color: inherit
-  text-decoration: inherit

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -19,21 +19,15 @@
               <img
                 :src="channelThumbnail"
                 class="channelThumbnail"
-                @click="goToChannel"
               >
             </router-link>
           </div>
           <div>
             <router-link
               :to="`/channel/${channelId}`"
-              class="channelLink"
+              class="channelName"
             >
-              <div
-                class="channelName"
-                @click="goToChannel"
-              >
-                {{ channelName }}
-              </div>
+              {{ channelName }}
             </router-link>
             <ft-button
               v-if="!hideUnsubscribeButton"


### PR DESCRIPTION
# Fix <kbd>CTRL</kbd>+clicking on the channel name on the watch page

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #2707

## Description
This pull request fixes opening the channel page in a new window by <kbd>CTRL</kbd>+clicking on the name or the icon on the watch page. The issue was cause by duplicate listeners, removing the click event handlers, makes them work like normal links in FreeTube.

## Testing <!-- for code that is not small enough to be easily understandable -->
Open a video, then <kbd>CTRL</kbd>+click on the channel name or icon, it should open the channel in a new window, without affecting the current window.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1