### PR TITLE
Filtering out invidious instances that don't support the API

### DIFF
--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -24,7 +24,7 @@ const actions = {
       const response = await fetch(requestUrl)
       const json = await response.json()
       instances = json.filter((instance) => {
-        if (instance[0].includes('.onion') || instance[0].includes('.i2p')) {
+        if (instance[0].includes('.onion') || instance[0].includes('.i2p') || !instance[1].api || (!process.env.IS_ELECTRON && !instance[1].cors)) {
           return false
         } else {
           return true


### PR DESCRIPTION

# Filtering out invidious instances that don't support the API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Currently, when filtering invidious instances, there isn't any check for if an invidious instance supports API calls. The result is that, occasionally, the selected invidious instance is one that doesn't support the API whatsoever.  For instance, if the selected instance is set to `https://yewtu.be/` or `https://invidious.snopyta.org/`, all invidious API calls will fail, and that won't change until the user selects another instance or the app is restarted.

This PR aims to address this issue by adding two extra conditions to the invidious instances filter:
- Does this instance support the API?
- Does this instance support CORS? (This is only checked when `IS_ELECTRON` is `false`.)

## Screenshots <!-- If appropriate -->
_Before / After:_
<img src="https://user-images.githubusercontent.com/106682128/195461302-35381f0e-0000-49ef-a56c-c27e5f660d91.png"  width="300" /> <img src="https://user-images.githubusercontent.com/106682128/195461309-9e7e74ae-04ed-4e65-924c-8dd172dc81a0.png" width="300" />

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1
