### PR TITLE
Improving touch input by bringing in `videojs-mobile-ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "video.js": "7.18.1",
     "videojs-contrib-quality-levels": "^2.1.0",
     "videojs-http-source-selector": "^1.1.6",
+    "videojs-mobile-ui": "^0.8.0",
     "videojs-overlay": "^2.1.4",
     "videojs-vtt-thumbnails-freetube": "0.0.15",
     "vue": "^2.7.10",

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -111,6 +111,7 @@ export default Vue.extend({
       statsModal: null,
       showStatsModal: false,
       statsModalEventName: 'updateStats',
+      usingTouch: false,
       dataSetup: {
         fluid: true,
         nativeTextTracks: false,
@@ -484,6 +485,7 @@ export default Vue.extend({
             this.transformAndInsertCaptions()
           }
           this.toggleScreenshotButton()
+          this.usingTouch = this.$refs.video.parentNode.querySelector('.vjs-touch-overlay') !== null
         })
 
         this.player.on('ended', () => {

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -11,7 +11,8 @@ import 'videojs-overlay/dist/videojs-overlay.css'
 import 'videojs-vtt-thumbnails-freetube'
 import 'videojs-contrib-quality-levels'
 import 'videojs-http-source-selector'
-
+import 'videojs-mobile-ui'
+import 'videojs-mobile-ui/dist/videojs-mobile-ui.css'
 import { IpcChannels } from '../../../constants'
 import { sponsorBlockSkipSegments } from '../../helpers/sponsorblock'
 import { calculateColorLuminance } from '../../helpers/utils'
@@ -362,6 +363,21 @@ export default Vue.extend({
               allowSeeksWithinUnsafeLiveWindow: true,
               handlePartialData: true
             }
+          }
+        })
+        // TODO : map actual settings to this object
+        this.player.mobileUi({
+          fullscreen: {
+            enterOnRotate: true,
+            exitOnRotate: true,
+            lockOnRotate: true,
+            iOS: false
+          },
+          touchControls: {
+            seekSeconds: 10,
+            tapTimeout: 300,
+            disableOnEnd: false,
+            disabled: false
           }
         })
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -370,7 +370,7 @@ export default Vue.extend({
             enterOnRotate: true,
             exitOnRotate: true,
             lockOnRotate: true,
-            forceForTesting: this.hasUserTouched
+            forceForTesting: true
           },
           touchControls: {
             seekSeconds: this.defaultSkipInterval,

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -369,7 +369,11 @@ export default Vue.extend({
           fullscreen: {
             enterOnRotate: true,
             exitOnRotate: true,
-            lockOnRotate: true,
+            lockOnRotate: false,
+            // Without this flag, the mobile UI will only activate
+            // if videojs detects it is in Android or iOS
+            // With this flag, the mobile ui could theoretically
+            // work on any device that has a touch input.
             forceForTesting: true
           },
           touchControls: {
@@ -485,7 +489,6 @@ export default Vue.extend({
             this.transformAndInsertCaptions()
           }
           this.toggleScreenshotButton()
-          this.usingTouch = this.$refs.video.parentNode.querySelector('.vjs-touch-overlay') !== null
         })
 
         this.player.on('ended', () => {

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -106,13 +106,11 @@ export default Vue.extend({
       activeAdaptiveFormats: [],
       mouseTimeout: null,
       touchTimeout: null,
-      lastTouchTime: null,
       playerStats: null,
       statsModal: null,
       showStatsModal: false,
       statsModalEventName: 'updateStats',
       usingTouch: false,
-      hasUserTouched: false,
       dataSetup: {
         fluid: true,
         nativeTextTracks: false,
@@ -487,8 +485,7 @@ export default Vue.extend({
             this.transformAndInsertCaptions()
           }
           this.toggleScreenshotButton()
-          const touchOverlay = this.$refs.video.parentNode.querySelector('.vjs-touch-overlay')
-          this.usingTouch = touchOverlay !== null
+          this.usingTouch = this.$refs.video.parentNode.querySelector('.vjs-touch-overlay') !== null
         })
 
         this.player.on('ended', () => {

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -112,6 +112,7 @@ export default Vue.extend({
       showStatsModal: false,
       statsModalEventName: 'updateStats',
       usingTouch: false,
+      hasUserTouched: false,
       dataSetup: {
         fluid: true,
         nativeTextTracks: false,
@@ -370,7 +371,8 @@ export default Vue.extend({
           fullscreen: {
             enterOnRotate: true,
             exitOnRotate: true,
-            lockOnRotate: true
+            lockOnRotate: true,
+            forceForTesting: this.hasUserTouched
           },
           touchControls: {
             seekSeconds: this.defaultSkipInterval,
@@ -485,7 +487,8 @@ export default Vue.extend({
             this.transformAndInsertCaptions()
           }
           this.toggleScreenshotButton()
-          this.usingTouch = this.$refs.video.parentNode.querySelector('.vjs-touch-overlay') !== null
+          const touchOverlay = this.$refs.video.parentNode.querySelector('.vjs-touch-overlay')
+          this.usingTouch = touchOverlay !== null
         })
 
         this.player.on('ended', () => {
@@ -1706,23 +1709,14 @@ export default Vue.extend({
       }
     },
 
-    handleTouchStart: function (event) {
-      this.touchPauseTimeout = setTimeout(() => {
-        this.togglePlayPause()
-      }, 1000)
-
-      const touchTime = new Date()
-
-      if (this.lastTouchTime !== null && (touchTime.getTime() - this.lastTouchTime.getTime()) < 250) {
-        this.toggleFullscreen()
-      }
-
-      this.lastTouchTime = touchTime
+    handleTouchStart: function () {
+      this.usingTouch = true
     },
 
-    handleTouchEnd: function (event) {
-      clearTimeout(this.touchPauseTimeout)
+    handleMouseOver: function () {
+      this.usingTouch = false
     },
+
     toggleShowStatsModal: function() {
       if (this.format !== 'dash') {
         this.showToast({

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1718,6 +1718,8 @@ export default Vue.extend({
     },
 
     handleMouseOver: function () {
+      // This addresses a discrepancy that only seems to occur in the mobile version of firefox
+      if (navigator.userAgent.search('Firefox') !== -1 && (videojs.browser.IS_ANDROID || videojs.browser.IS_IOS)) { return }
       this.usingTouch = false
     },
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -292,6 +292,10 @@ export default Vue.extend({
 
     screenshotFolder: function() {
       return this.$store.getters.getScreenshotFolderPath
+    },
+
+    wrapperClass: function () {
+      return `relative ${this.usingTouch ? 'vjs-using-touch' : ''}`
     }
   },
   watch: {
@@ -369,13 +373,13 @@ export default Vue.extend({
           fullscreen: {
             enterOnRotate: true,
             exitOnRotate: true,
-            lockOnRotate: false,
-            // Without this flag, the mobile UI will only activate
-            // if videojs detects it is in Android or iOS
-            // With this flag, the mobile ui could theoretically
-            // work on any device that has a touch input.
-            forceForTesting: true
+            lockOnRotate: false
           },
+          // Without this flag, the mobile UI will only activate
+          // if videojs detects it is in Android or iOS
+          // With this flag, the mobile ui could theoretically
+          // work on any device that has a touch input.
+          forceForTesting: true,
           touchControls: {
             seekSeconds: this.defaultSkipInterval,
             tapTimeout: 300

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -377,7 +377,7 @@ export default Vue.extend({
           },
           // Without this flag, the mobile UI will only activate
           // if videojs detects it is in Android or iOS
-          // With this flag, the mobile ui could theoretically
+          // With this flag, the mobile UI could theoretically
           // work on any device that has a touch input.
           forceForTesting: true,
           touchControls: {

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -378,7 +378,7 @@ export default Vue.extend({
           // Without this flag, the mobile UI will only activate
           // if videojs detects it is in Android or iOS
           // With this flag, the mobile UI could theoretically
-          // work on any device that has a touch input.
+          // work on any device that has a touch input
           forceForTesting: true,
           touchControls: {
             seekSeconds: this.defaultSkipInterval,

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -365,19 +365,15 @@ export default Vue.extend({
             }
           }
         })
-        // TODO : map actual settings to this object
         this.player.mobileUi({
           fullscreen: {
             enterOnRotate: true,
             exitOnRotate: true,
-            lockOnRotate: true,
-            iOS: false
+            lockOnRotate: true
           },
           touchControls: {
-            seekSeconds: 10,
-            tapTimeout: 300,
-            disableOnEnd: false,
-            disabled: false
+            seekSeconds: this.defaultSkipInterval,
+            tapTimeout: 300
           }
         })
 

--- a/src/renderer/components/ft-video-player/ft-video-player.vue
+++ b/src/renderer/components/ft-video-player/ft-video-player.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     :class="`relative ${usingTouch ? 'vjs-using-touch': ''}`"
+    @mouseover="handleMouseOver"
   >
     <video
       ref="video"
@@ -11,7 +12,6 @@
       :data-setup="JSON.stringify(dataSetup)"
       crossorigin="anonymous"
       @touchstart="handleTouchStart"
-      @touchend="handleTouchEnd"
     >
       <source
         v-for="(source, index) in activeSourceList"

--- a/src/renderer/components/ft-video-player/ft-video-player.vue
+++ b/src/renderer/components/ft-video-player/ft-video-player.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="`relative ${usingTouch ? 'vjs-using-touch': ''}`"
+    :class="wrapperClass"
     @mouseover="handleMouseOver"
   >
     <video

--- a/src/renderer/components/ft-video-player/ft-video-player.vue
+++ b/src/renderer/components/ft-video-player/ft-video-player.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="relative">
+  <div
+    :class="`relative ${usingTouch ? 'touch': ''}`"
+  >
     <video
       ref="video"
       class="ftVideoPlayer video-js vjs-default-skin dark"

--- a/src/renderer/components/ft-video-player/ft-video-player.vue
+++ b/src/renderer/components/ft-video-player/ft-video-player.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="`relative ${usingTouch ? 'touch': ''}`"
+    :class="`relative ${usingTouch ? 'vjs-using-touch': ''}`"
   >
     <video
       ref="video"

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1848,7 +1848,7 @@ video::-webkit-media-text-track-display {
     display: block
 }
 
-.video-js .vjs-load-progress div,.vjs-seeking .vjs-big-play-button,.vjs-waiting .vjs-big-play-button,.touch .vjs-big-play-button {
+.video-js .vjs-load-progress div,.vjs-seeking .vjs-big-play-button,.vjs-waiting .vjs-big-play-button,.vjs-using-touch .vjs-big-play-button {
     display: none!important
 }
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2216,8 +2216,8 @@ video::-webkit-media-text-track-display {
   text-shadow: 0 0 25px rgb(0 0 0 / 50%), 0 0 10px rgb(0 0 0 / 50%), 2px 2px 8px rgb(206 89 55 / 0%);
   color: white;
   font-size: 18vw;
-  display:flex;
-  flex-direction:row;
+  display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
   background-image: none !important;

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2226,3 +2226,8 @@ video::-webkit-media-text-track-display {
 .video-js .vjs-touch-overlay .vjs-play-control.vjs-paused .vjs-icon-placeholder:before {
   content: "\f101" !important;
 }
+
+.video-js .vjs-touch-overlay.skip {
+  -webkit-filter: drop-shadow(0px 0px 4px black);
+  filter: drop-shadow(0px 0px 4px black);
+}

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1848,7 +1848,7 @@ video::-webkit-media-text-track-display {
     display: block
 }
 
-.video-js .vjs-load-progress div,.vjs-seeking .vjs-big-play-button,.vjs-waiting .vjs-big-play-button {
+.video-js .vjs-load-progress div,.vjs-seeking .vjs-big-play-button,.vjs-waiting .vjs-big-play-button,.touch .vjs-big-play-button {
     display: none!important
 }
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2203,7 +2203,7 @@ video::-webkit-media-text-track-display {
   }
 }
 
-.video-js.vjs-touch-enabled .vjs-touch-overlay {
+.videoPlayer .video-js .vjs-touch-overlay {
   display: none;
 }
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2225,5 +2225,4 @@ video::-webkit-media-text-track-display {
 
 .video-js .vjs-touch-overlay .vjs-play-control.vjs-paused .vjs-icon-placeholder:before {
   content: "\f101" !important;
-  background-image: none;
 }

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -2202,3 +2202,28 @@ video::-webkit-media-text-track-display {
     display: initial;
   }
 }
+
+.video-js.vjs-touch-enabled .vjs-touch-overlay {
+  display: none;
+}
+
+.vjs-using-touch .video-js.vjs-touch-enabled .vjs-touch-overlay {
+  display: block;
+}
+
+.video-js .vjs-touch-overlay .vjs-play-control .vjs-icon-placeholder:before {
+  content: "\f103" !important;
+  text-shadow: 0 0 25px rgb(0 0 0 / 50%), 0 0 10px rgb(0 0 0 / 50%), 2px 2px 8px rgb(206 89 55 / 0%);
+  color: white;
+  font-size: 18vw;
+  display:flex;
+  flex-direction:row;
+  align-items: center;
+  justify-content: center;
+  background-image: none !important;
+}
+
+.video-js .vjs-touch-overlay .vjs-play-control.vjs-paused .vjs-icon-placeholder:before {
+  content: "\f101" !important;
+  background-image: none;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8165,6 +8165,13 @@ videojs-http-source-selector@^1.1.6:
     video.js "^7.0.0"
     videojs-contrib-quality-levels "^2.0.4"
 
+videojs-mobile-ui@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/videojs-mobile-ui/-/videojs-mobile-ui-0.8.0.tgz#40a1c6f9302071b9bbe95937c934114600916ac5"
+  integrity sha512-Jd+u/ctjUkbZlT1cAA0umTu0LQwSZSFG+02cJxShuwq27B6rfrRALETK/gsuTc7U27lB9fbwcF7HBMaNxW62nA==
+  dependencies:
+    global "^4.4.0"
+
 videojs-overlay@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/videojs-overlay/-/videojs-overlay-2.1.5.tgz#763b9d89dff87c32d94e9a873451a5fb25f02c8e"


### PR DESCRIPTION
# Improving touch input by bringing in `videojs-mobile-ui`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
MarmadileManteater#56

## Description
This PR aims to improve the touch input on the video player by adding in the [videojs-mobile-ui](https://github.com/mister-ben/videojs-mobile-ui) plugin. This plugin adds the ability to double tap on the left or right side of the video in order to rewind or fast forward. It also adds in its' own `pause / play` button which responds more naturally to touch input, and it puts the window into fullscreen mode when it detects a rotation from portait to landscape. 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img src="https://user-images.githubusercontent.com/106682128/195624879-4baa8691-2ffc-4ca1-be26-b5266ff97534.gif" width="200" /> <img src="https://user-images.githubusercontent.com/106682128/195625066-8f8152df-b81e-4e9f-9e1c-13650d09e6f0.gif" width="200" />
<img src="https://user-images.githubusercontent.com/106682128/195624911-bbe26ff4-8b70-4297-8ac0-d76bc6fa29e2.gif"  width="300" />
<img src="https://user-images.githubusercontent.com/106682128/195624928-4cca07c3-4a45-43dc-af90-b7e67a41a84f.gif"  width="400" />

## Testing <!-- for code that is not small enough to be easily understandable -->
This can be tested in the web build by using the touch simulation available in Chrome and Firefox.
Theoretically, this implementation should also work in Electron, but the touch simulation doesn't seem to work in Electron (afaik), so I have no idea how to test this in Electron without a touch screen device that can run Electron apps.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
I added `v0.8.0` of `videojs-mobile-ui`. This is technically the beta version. My reason for not using the latest `v0.7.0` is because it contains a bug. `v0.7.0` references `videojs` as a dependency, instead of a dev-dependency. The result is that `v0.7.0` loads a second version of `videojs`  which is not the one FreeTube uses, and this causes the plugin to fail to load. This bug is fixed in `v0.8.0`.

The `videojs-mobile-ui` plugin, by default, only works if videojs detects it is running in Android or iOS. This is why I enabled the `forceForTesting` flag. Instead of letting `videojs-mobile-ui` try to detect if touch input should be used, I added logic to show the touch input when a touch event occurs and to hide the touch input as soon as a mouseover event occurs. The result is that the touch controls should be able to load on any device that has a touch screen even if it isn't Android or iOS, and they won't load show up at all if the user doesn't use any touch input.

A lot of the options available in the `.mobileUi` method seem like good candidates for new settings: `fullscreen.enterOnRotate`, `fullscreen.exitOnRotate`,  and `fullscreen.lockOnRotate`. I could understand wanting them enabled on some devices and disabled on others. 