### PR TITLE
Fix fetching the comments from invidious

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -104,14 +104,7 @@ export default Vue.extend({
         case 'invidious':
           this.isLoading = true
           this.commentData = []
-          this.getCommentDataInvidious({
-            resource: 'comments',
-            id: this.id,
-            params: {
-              continuation: this.nextPageToken,
-              sort_by: this.sortNewest ? 'new' : 'top'
-            }
-          })
+          this.getCommentDataInvidious()
           break
       }
     },
@@ -128,14 +121,7 @@ export default Vue.extend({
           })
           break
         case 'invidious':
-          this.getCommentDataInvidious({
-            resource: 'comments',
-            id: this.id,
-            params: {
-              continuation: this.nextPageToken,
-              sort_by: this.sortNewest ? 'new' : 'top'
-            }
-          })
+          this.getCommentDataInvidious()
           break
       }
     },
@@ -184,14 +170,7 @@ export default Vue.extend({
         })
         if (this.backendFallback && this.backendPreference === 'local') {
           showToast(this.$t('Falling back to Invidious API'))
-          this.getCommentDataInvidious({
-            resource: 'comments',
-            id: this.id,
-            params: {
-              continuation: this.nextPageToken,
-              sort_by: this.sortNewest ? 'new' : 'top'
-            }
-          })
+          this.getCommentDataInvidious()
         } else {
           this.isLoading = false
         }
@@ -211,14 +190,7 @@ export default Vue.extend({
         })
         if (this.backendFallback && this.backendPreference === 'local') {
           showToast(this.$t('Falling back to Invidious API'))
-          this.getCommentDataInvidious({
-            resource: 'comments',
-            id: this.id,
-            params: {
-              continuation: this.nextPageToken,
-              sort_by: this.sortNewest ? 'new' : 'top'
-            }
-          })
+          this.getCommentDataInvidious()
         } else {
           this.isLoading = false
         }
@@ -274,7 +246,16 @@ export default Vue.extend({
       }
     },
 
-    getCommentDataInvidious: function (payload) {
+    getCommentDataInvidious: function () {
+      const payload = {
+        resource: 'comments',
+        id: this.id,
+        params: {
+          continuation: this.nextPageToken ?? '',
+          sort_by: this.sortNewest ? 'new' : 'top'
+        }
+      }
+
       this.invidiousAPICall(payload).then((response) => {
         const commentData = response.comments.map((comment) => {
           comment.showReplies = false


### PR DESCRIPTION
# Fix fetching the comments from invidious

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Reported in the general channel on Matrix

## Description
This PR fixes fetching the comments under videos from Invidious, Invidious doesn't like the continuation parameter being null or undefined and returns 404 errors, it's happy if we set it to an empty string though.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Change your preferred API backend to Invidious
2. Open a video
3. Click the load comments button

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1