### PR TITLE
Fix for `Region for Trending` dropdown not populating

### DIFF
--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -387,9 +387,14 @@ Object.assign(customGetters, {
 const customActions = {
   grabUserSettings: async ({ commit, dispatch, getters }) => {
     try {
-      const userSettings = await DBSettingHandlers.find()
+      // Assigning default settings for settings that have side effects
+      const userSettings = Object.entries(Object.assign({},
+        Object.fromEntries(Object.entries(stateWithSideEffects).map(([_id, { defaultValue }]) => { return [_id, defaultValue] })),
+        Object.fromEntries((await DBSettingHandlers.find()).map(({ _id, value }) => { return [_id, value] })))
+      )
+
       for (const setting of userSettings) {
-        const { _id, value } = setting
+        const [_id, value] = setting
         if (getters.settingHasSideEffects(_id)) {
           dispatch(defaultSideEffectsTriggerId(_id), value)
         }


### PR DESCRIPTION

# Fix for `Region for Trending` dropdown not populating

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
FreetubeApp#1644

## Description
This PR aims to fix an issue with the `Region for Trending` dropdown not populating with data before the user changes the `currentLocale`.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
_Before:_
<img src="https://user-images.githubusercontent.com/106682128/196230183-023a2b3a-aa39-487e-a5cb-1f843bc8e904.gif" />
_After:_
<img src="https://user-images.githubusercontent.com/106682128/196230229-a0416559-2b32-491c-9690-be1d5833806b.gif" />


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Delete your `settings.db` file _(I believe it is located in the `Electron` roaming directory when debugging)_
2. Start FreeTube
3. Check the `Region for Trending` dropdown in settings


**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional Information
An alternative solution might be to add an additional call to `getRegionData` somewhere; however, it may be difficult to tell if `getRegionData` has already been called recently without introducing a race condition. That could cause `getRegionData` to be called twice in a row. The reason I went with this solution was because this issue goes away when all of the side effects are evaluated on app mounted.
