### PR TITLE
Adding filePaths to the web file picker response

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -323,7 +323,7 @@ const actions = {
         }
         fileInput.onchange = () => {
           const files = Array.from(fileInput.files)
-          resolve({ canceled: false, files })
+          resolve({ canceled: false, files, filePaths: files.map(({ name }) => { return name }) })
           delete fileInput.onchange
         }
         const listenForEnd = () => {


### PR DESCRIPTION

# Adding `filePaths` to the web file picker response

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
`filePaths` is now used to decide which subscriptions type to parse, so this PR adds `filePaths` to the response object for `showOpenDialog` when in web builds. 

## Screenshots <!-- If appropriate -->
_Before:_
![before](https://user-images.githubusercontent.com/106682128/196276497-029bcfb0-63cd-401f-add5-768a86dcb156.gif)
_After:_
![after](https://user-images.githubusercontent.com/106682128/196276515-3b51edef-266e-4dbe-ac8d-704b0a1bf25f.gif)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn pack:web`
2. Navigate to `dist/web`
3. Use a one line server like `node-static` or `http-server`
4. Navigate to the Data Settings in FreeTube
5. Attempt to import a subscription file of any kind

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
This property was excluded previously because it was unused outside of when `IS_ELECTRON` was `true`.