### PR TITLE
Implenting `showSaveDialog` in web

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -574,17 +574,14 @@ export default Vue.extend({
         return
       }
 
-      const filePath = response.filePath
-
-      fs.writeFile(filePath, JSON.stringify(subscriptionsObject), (writeErr) => {
-        if (writeErr) {
-          const message = this.$t('Settings.Data Settings.Unable to write file')
-          showToast(`${message}: ${writeErr}`)
-          return
-        }
-
-        showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
-      })
+      try {
+        await this.writeFileFromDialog({ response, content: JSON.stringify(subscriptionsObject) })
+      } catch (writeErr) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${writeErr}`)
+        return
+      }
+      showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
     },
 
     exportOpmlYouTubeSubscriptions: async function () {

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -487,9 +487,9 @@ export default Vue.extend({
     },
 
     exportFreeTubeSubscriptions: async function () {
-      await this.compactProfiles()
-      const userData = await this.getUserDataPath()
-      const subscriptionsDb = `${userData}/profiles.db`
+      const subscriptionsDb = this.profileList.map((profile) => {
+        return JSON.stringify(profile)
+      }).join('\n') + '\n'// a trailing line is expected
       const date = new Date().toISOString().split('T')[0]
       const exportFileName = 'freetube-subscriptions-' + date + '.db'
 
@@ -508,26 +508,14 @@ export default Vue.extend({
         // User canceled the save dialog
         return
       }
-
-      const filePath = response.filePath
-
-      fs.readFile(subscriptionsDb, (readErr, data) => {
-        if (readErr) {
-          const message = this.$t('Settings.Data Settings.Unable to read file')
-          showToast(`${message}: ${readErr}`)
-          return
-        }
-
-        fs.writeFile(filePath, data, (writeErr) => {
-          if (writeErr) {
-            const message = this.$t('Settings.Data Settings.Unable to write file')
-            showToast(`${message}: ${writeErr}`)
-            return
-          }
-
-          showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
-        })
-      })
+      try {
+        await this.writeFileFromDialog({ response, content: subscriptionsDb })
+      } catch (writeErr) {
+        const message = this.$t('Settings.Data Settings.Unable to read file')
+        showToast(`${message}: ${writeErr}`)
+        return
+      }
+      showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
     },
 
     exportYouTubeSubscriptions: async function () {
@@ -1143,6 +1131,7 @@ export default Vue.extend({
       'showOpenDialog',
       'readFileFromDialog',
       'showSaveDialog',
+      'writeFileFromDialog',
       'getUserDataPath',
       'addPlaylist',
       'addVideo',

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -953,7 +953,7 @@ export default Vue.extend({
         showToast(`${message}: ${writeErr}`)
         return
       }
-      showToast(`${this.$t('Settings.Data Settings.All playlists has been successfully exported')} also ${JSON.stringify(response)}`)
+      showToast(`${this.$t('Settings.Data Settings.All playlists has been successfully exported')}`)
     },
 
     convertOldFreeTubeFormatToNew(oldData) {

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -8,12 +8,9 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtPrompt from '../ft-prompt/ft-prompt.vue'
 import { MAIN_PROFILE_ID } from '../../../constants'
 
-import fs from 'fs'
 import { opmlToJSON } from 'opml-to-json'
 import ytch from 'yt-channel-info'
 import { calculateColorLuminance, getRandomColor, showToast } from '../../helpers/utils'
-
-// FIXME: Missing web logic branching
 
 export default Vue.extend({
   name: 'DataSettings',

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -619,17 +619,14 @@ export default Vue.extend({
         return
       }
 
-      const filePath = response.filePath
-
-      fs.writeFile(filePath, opmlData, (writeErr) => {
-        if (writeErr) {
-          const message = this.$t('Settings.Data Settings.Unable to write file')
-          showToast(`${message}: ${writeErr}`)
-          return
-        }
-
-        showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
-      })
+      try {
+        await this.writeFileFromDialog({ response, content: opmlData })
+      } catch (writeErr) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${writeErr}`)
+        return
+      }
+      showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
     },
 
     exportCsvYouTubeSubscriptions: async function () {
@@ -661,16 +658,14 @@ export default Vue.extend({
         return
       }
 
-      const filePath = response.filePath
-      fs.writeFile(filePath, exportText, (writeErr) => {
-        if (writeErr) {
-          const message = this.$t('Settings.Data Settings.Unable to write file')
-          showToast(`${message}: ${writeErr}`)
-          return
-        }
-
-        showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
-      })
+      try {
+        await this.writeFileFromDialog({ response, content: exportText })
+      } catch (writeErr) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${writeErr}`)
+        return
+      }
+      showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
     },
 
     exportNewPipeSubscriptions: async function () {
@@ -709,18 +704,14 @@ export default Vue.extend({
         // User canceled the save dialog
         return
       }
-
-      const filePath = response.filePath
-
-      fs.writeFile(filePath, JSON.stringify(newPipeObject), (writeErr) => {
-        if (writeErr) {
-          const message = this.$t('Settings.Data Settings.Unable to write file')
-          showToast(`${message}: ${writeErr}`)
-          return
-        }
-
-        showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
-      })
+      try {
+        await this.writeFileFromDialog({ response, content: JSON.stringify(newPipeObject) })
+      } catch (writeErr) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${writeErr}`)
+        return
+      }
+      showToast(this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
     },
 
     importHistory: async function () {

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -811,6 +811,7 @@ export default Vue.extend({
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
       }
+      showToast(this.$t('Settings.Data Settings.All watched history has been successfully exported'))
     },
 
     importPlaylists: async function () {

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -949,18 +949,14 @@ export default Vue.extend({
         // User canceled the save dialog
         return
       }
-
-      const filePath = response.filePath
-
-      fs.writeFile(filePath, JSON.stringify(this.allPlaylists), (writeErr) => {
-        if (writeErr) {
-          const message = this.$t('Settings.Data Settings.Unable to write file')
-          showToast(`${message}: ${writeErr}`)
-          return
-        }
-
-        showToast(this.$t('Settings.Data Settings.All playlists has been successfully exported'))
-      })
+      try {
+        await this.writeFileFromDialog({ response, content: JSON.stringify(this.allPlaylists) })
+      } catch (writeErr) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${writeErr}`)
+        return
+      }
+      showToast(`${this.$t('Settings.Data Settings.All playlists has been successfully exported')} also ${JSON.stringify(response)}`)
     },
 
     convertOldFreeTubeFormatToNew(oldData) {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -370,8 +370,7 @@ const actions = {
       } else {
         // If the native filesystem api is not available,
         const { filePath } = response
-        const fileNameArray = filePath.split('/')
-        const filename = fileNameArray[fileNameArray.length - 1]
+        const filename = filePath.split('/').at(-1)
         const a = document.createElement('a')
         const url = URL.createObjectURL(new Blob([content], { type: 'application/octet-stream' }))
         a.setAttribute('href', url)
@@ -385,7 +384,19 @@ const actions = {
     const webCbk = async () => {
       // If the native filesystem api is available
       if ('showSaveFilePicker' in window) {
-        return { canceled: false, handle: await window.showSaveFilePicker({ suggestedName: options.defaultPath, types: options.filters?.extensions?.map((extension) => { return { accept: extension } }) }) }
+        return {
+          canceled: false,
+          handle: await window.showSaveFilePicker({
+            suggestedName: options.defaultPath.split('/').at(-1),
+            types: options?.filters[0]?.extensions?.map((extension) => {
+              return {
+                accept: {
+                  'application/octet-stream': '.' + extension
+                }
+              }
+            })
+          })
+        }
       } else {
         return { canceled: false, filePath: options.defaultPath }
       }

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -345,8 +345,14 @@ const actions = {
   },
 
   async showSaveDialog (context, options) {
-    // TODO: implement showSaveDialog web compatible callback
-    const webCbk = () => null
+    const webCbk = async () => {
+      // If the native filesystem api is available
+      if ('showSaveFilePicker' in window) {
+        return { canceled: false, handle: await window.showSaveFilePicker({ suggestedName: options.defaultPath, types: options.filters?.extensions?.map((extension) => { return { accept: extension } }) }) }
+      } else {
+        return { canceled: false, filePath: options.defaultPath }
+      }
+    }
     return await invokeIRC(context, IpcChannels.SHOW_SAVE_DIALOG, webCbk, options)
   },
 

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -344,6 +344,43 @@ const actions = {
     return await invokeIRC(context, IpcChannels.SHOW_OPEN_DIALOG, webCbk, options)
   },
 
+  /**
+   * Write to a file picked out from the `showSaveDialog` picker
+   * @param {Object} response the response from `showSaveDialog`
+   * @param {String} content the content to be written to the file selected by the dialog
+   */
+  async writeFileFromDialog (context, { response, content }) {
+    if (process.env.IS_ELECTRON) {
+      return await new Promise((resolve, reject) => {
+        const { filePath } = response
+        fs.writeFile(filePath, content, (error) => {
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
+        })
+      })
+    } else {
+      if ('showOpenFilePicker' in window) {
+        const { handle } = response
+        const writableStream = await handle.createWritable()
+        await writableStream.write(content)
+        await writableStream.close()
+      } else {
+        // If the native filesystem api is not available,
+        const { filePath } = response
+        const fileNameArray = filePath.split('/')
+        const filename = fileNameArray[fileNameArray.length - 1]
+        const a = document.createElement('a')
+        const url = URL.createObjectURL(new Blob([content], { type: 'application/octet-stream' }))
+        a.setAttribute('href', url)
+        a.setAttribute('download', encodeURI(filename))
+        a.click()
+      }
+    }
+  },
+
   async showSaveDialog (context, options) {
     const webCbk = async () => {
       // If the native filesystem api is available


### PR DESCRIPTION
# Implenting `showSaveDialog` in web

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR implements the `showSaveDialog` web callback. When the native filesystem API is available, it will utilize it to show a file picker, but when it is not available, it will fall-back to the default downloads folder. This also introduces a new function called `writeFileFromDialog` which works similarly to `readFileFromDialog` except that it writes files instead of reading them. The introduction of this function allows the `fs` module to be abstracted entirely out of `data-settings`.

## Screenshots <!-- If appropriate -->
_Exporting all of the different subscription types when the native filesystem api is not available:_
![subpscrptions-export-after-no-native-web-api](https://user-images.githubusercontent.com/106682128/196301753-28a5a57a-5d6a-4abe-b15a-1397ba5efbb9.gif)
_Exporting history when the native filesystem api is not available:_
![history-export-after](https://user-images.githubusercontent.com/106682128/196302548-b612856e-015f-4f3c-b744-c494630c23d0.gif)
_Exporting playlists when the native filesystem api is not available:_
![playlist-export-after-no-native-api](https://user-images.githubusercontent.com/106682128/196302563-fb1891c7-20ce-444d-8f74-ef8ca5fdb829.gif)
_Exporting all of the different subscription types when the native filesystem api is avaiable:_
![subscription-export-after-native-api](https://user-images.githubusercontent.com/106682128/196301915-f737ddd2-ff67-4125-b7f9-a04d910d5fe2.gif)
_Exporting history when the native filesystem api is available:_
![history-export-after-native-api](https://user-images.githubusercontent.com/106682128/196303133-3a72eab2-af26-421b-b348-c5889df87b44.gif)
_Exporting playlists when the native filesystem api is available:_
![playlist-export-after-native-api](https://user-images.githubusercontent.com/106682128/196303154-18b21b54-4d3c-419a-a00c-a2550bdf9501.gif)
_Importing the exported subscriptions back into 0.17.1_
(FreeTube DB)
![freetube-subscription-import-after-native-api](https://user-images.githubusercontent.com/106682128/196303294-5b6887d8-fd11-49cd-9916-f728857188cb.gif)
(Youtube CSV)
![youtube-csv-subscription-import-after-native-api](https://user-images.githubusercontent.com/106682128/196303480-deb72546-9cf4-455a-a6dd-d5bc9a576915.gif)
This error can be reproduced by trying to export and import these same subscriptions in this format, so this demonstrates that it works exactly like it does already in 0.17.1.
![demonstrating-discrepancy-with-csv-on0 17 1](https://user-images.githubusercontent.com/106682128/196303605-6eb7847e-5594-4259-a045-4f9b54099de8.gif)


(Youtube JSON)
![youtubejson-subscription-import-after-native-api](https://user-images.githubusercontent.com/106682128/196303307-2f27c9ff-8365-479a-97ca-a907d765726c.gif)
(OPML)
![opml-subscription-import-after-native-api](https://user-images.githubusercontent.com/106682128/196303313-7765563b-475b-401b-b5c4-2f8f8ec6f673.gif)
(NewPipe)
![newpipe-json-subscription-import-after-native-api](https://user-images.githubusercontent.com/106682128/196303321-602e162a-ed3f-4de5-bb27-8e724083b5fe.gif)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn pack:web`
2. Navigate to the `dist/web` folder
3. Serve the directory with something like `node-static` or `http-server`
4. Navigate to `Data Settings`
5. Attempt to export some data
6. Import that exported data back into 0.17.1 or upstream

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
This PR also technically modifies the way that FreeTube subscriptions and history are exported. Previously, these functions would call `fs.readFile` to read the existing `history.db` and `profiles.db`; however, this is not possible in web builds, so I modified the functions to use the profile and history data already in memory. This solution should be more platform agnostic.
