### PR TITLE
Implement `getRegionData` in web

### DIFF
--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
@@ -108,13 +109,14 @@ const config = {
     ]
   },
   node: {
-    __dirname: true,
+    __dirname: false,
     __filename: isDevMode,
   },
   plugins: [
     new webpack.DefinePlugin({
       'process.env.PRODUCT_NAME': JSON.stringify(productName),
-      'process.env.IS_ELECTRON': false
+      'process.env.IS_ELECTRON': false,
+      '__dirname': 'window.location.pathname.endsWith("/")?window.location.pathname.substring(0, window.location.pathname.length - 1):window.location.pathname'
     }),
     new webpack.ProvidePlugin({
       process: 'process/browser',
@@ -181,7 +183,8 @@ const processLocalesPlugin = new ProcessLocalesPlugin({
 config.plugins.push(
   processLocalesPlugin,
   new webpack.DefinePlugin({
-    'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames)
+    'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames),
+    'process.env.GEOLOCATION_NAMES': JSON.stringify(fs.readdirSync(path.join(__dirname, '..', 'static', 'geolocations')))
   }),
   new CopyWebpackPlugin({
       patterns: [

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -323,7 +323,7 @@ const stateWithSideEffects = {
       }
 
       i18n.locale = targetLocale
-      dispatch('getRegionData', {
+      await dispatch('getRegionData', {
         locale: targetLocale
       })
     }


### PR DESCRIPTION
# Implement `getRegionData` in web

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `Region for Trending` dropdown doesn't currently populate on web builds, so this PR adds logic to `getRegionData` in order to correct this.

## Screenshots <!-- If appropriate -->
_Before / After:_
<img src="https://user-images.githubusercontent.com/106682128/196487822-b2ed25f2-58b4-4575-a046-c55a9d77f2b8.gif"  width="350" /> <img src="https://user-images.githubusercontent.com/106682128/196487828-8b0b772b-8524-4b75-b181-1f4707d146d5.gif" width="350" />

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn dev:web`
2. Navigate to general settings
3. Click on the `Region for Trending` dropdown to see if it is populated with data

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
This PR also replaces the currently provided `__dirname` in web builds with one which is more accurate. Previously, it was referencing the location of the currently executing file in the source (ex: `src/renderer/components/general-settings` etc.), and now, it should be the path that the web app is currently located on; if the app is hosted at `/freetube/`, the `__dirname` would be `/freetube`.