### PR TITLE
Add shortcut: Home key to go to beginning of video

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1840,6 +1840,11 @@ export default Vue.extend({
             event.preventDefault()
             this.changeDurationBySeconds(this.defaultSkipInterval * this.player.playbackRate())
             break
+          case 'Home': {
+            event.preventDefault()
+            this.player.currentTime(0)
+            break
+          }
           case 'I':
           case 'i':
             event.preventDefault()


### PR DESCRIPTION
# Add Home shortcut

## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Relates to (but does not close) https://github.com/FreeTubeApp/FreeTube/issues/2138

## Description
Adds an alternate hotkey for going to the beginning of the current video. (Existing hotkey is the `0` key, for going to the 0% point of the video (`1` for 10%, etc.))

## Screenshots

None

## Testing

I have tested it manually. I did not find a test suite or side-by-side `.spec.js` files or anything.

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux
- **OS Version:** Kernel version 5.10.52
- **FreeTube version:** Development branch, as of commit a6b86fac9c100f191a5a19880f3ccad39eac5e05

## Additional context

None needed
