### PR TITLE
change occurrence of `this.showToast` to `showToast`

### DIFF
--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -321,7 +321,7 @@ export default Vue.extend({
             return this.getChannelVideosLocalScraper(channel, failedAttempts + 1)
           case 1:
             if (this.backendFallback) {
-              this.showToast(this.$t('Falling back to Invidious API'))
+              showToast(this.$t('Falling back to Invidious API'))
               return this.getChannelVideosInvidiousRSS(channel, failedAttempts + 1)
             } else {
               return []
@@ -398,7 +398,7 @@ export default Vue.extend({
             return this.getChannelVideosInvidiousScraper(channel, failedAttempts + 1)
           case 1:
             if (this.backendFallback) {
-              this.showToast(this.$t('Falling back to the local API'))
+              showToast(this.$t('Falling back to the local API'))
               return this.getChannelVideosLocalRSS(channel, failedAttempts + 1)
             } else {
               return []


### PR DESCRIPTION
# change occurrence  of `this.showToast` to `showToast`

## Pull Request Type
- [x] Bugfix

## Description
The this keyword was not removed from these two occurrences of showToast

## Testing 
I think disconnecting your wifi while having local backend as main preference with fallback might allow you to test it but it's such a small change that I don't think it needs to be tested 

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.17.1

