### PR TITLE
Fix double focus on the sidebar channels

### DIFF
--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -69,7 +69,6 @@
 .navOption .navLabel {
   margin-left: 40px;
   overflow: hidden;
-  margin-left: 40px;
   word-break: break-word;
 }
 
@@ -90,6 +89,7 @@
 }
 
 .channelLink {
+  display: block;
   color: inherit;
   text-decoration: inherit;
 }
@@ -97,6 +97,7 @@
 .channelThumbnail {
   border-radius: 50%;
   width: 35px;
+  vertical-align: middle;
 }
 
 .closed {

--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -76,9 +76,6 @@ export default Vue.extend({
   methods: {
     navigate: function (route) {
       this.$router.push('/' + route)
-    },
-    goToChannel: function (id) {
-      this.$router.push({ path: `/channel/${id}` })
     }
   }
 })

--- a/src/renderer/components/side-nav/side-nav.vue
+++ b/src/renderer/components/side-nav/side-nav.vue
@@ -218,36 +218,29 @@
       <div
         v-if="!hideActiveSubscriptions"
       >
-        <div
+        <router-link
           v-for="(channel, index) in activeSubscriptions"
           :key="index"
-          class="navChannel mobileHidden"
+          :to="`/channel/${channel.id}`"
+          class="navChannel channelLink mobileHidden"
           :title="channel.name"
           role="button"
-          tabindex="0"
-          @keydown.enter.prevent="goToChannel(channel.id)"
-          @click="goToChannel(channel.id)"
         >
-          <router-link
-            :to="`/channel/${channel.id}`"
-            class="channelLink"
+          <div
+            class="thumbnailContainer"
           >
-            <div
-              class="thumbnailContainer"
+            <img
+              class="channelThumbnail"
+              :src="channel.thumbnail"
             >
-              <img
-                class="channelThumbnail"
-                :src="channel.thumbnail"
-              >
-            </div>
-            <p
-              v-if="isOpen"
-              class="navLabel"
-            >
-              {{ channel.name }}
-            </p>
-          </router-link>
-        </div>
+          </div>
+          <p
+            v-if="isOpen"
+            class="navLabel"
+          >
+            {{ channel.name }}
+          </p>
+        </router-link>
       </div>
     </div>
   </ft-flex-box>


### PR DESCRIPTION
# Fix double focus on the sidebar channels

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently there are two focusable and clickable elements which could be confusing for people tabbing through them. This pull request removes the div with the event handlers, instead just relying on the router-link element.

You might want to make the github diff not show whitespace differences while reviewing this PR.

## Screenshots <!-- If appropriate -->
**Before with the sidebar compacted:**
![before-collapsed-outer](https://user-images.githubusercontent.com/48293849/196757832-183586ff-5f16-422f-a427-c0fadcf068de.jpg) ![before-collapsed-inner](https://user-images.githubusercontent.com/48293849/196757845-f8035458-e4ab-4d70-b0f9-0f485169de77.jpg)

**Before with the sidebar expanded:**
![before-expanded-outer](https://user-images.githubusercontent.com/48293849/196758138-7ec0804a-46ef-434d-8a19-5d9956ca0a53.jpg) ![before-expanded-inner](https://user-images.githubusercontent.com/48293849/196758330-b3cb0735-c6a6-49f6-91b5-617dfa4c0d1f.jpg)

**After:**
![after-collapsed](https://user-images.githubusercontent.com/48293849/196758410-7a32e39d-3f8c-4037-b19c-b1e30a6b3d3a.jpg) ![after-expanded](https://user-images.githubusercontent.com/48293849/196758439-1f2be5fa-7bb5-4fac-bb40-446ed0f587e3.jpg)

## Testing <!-- for code that is not small enough to be easily understandable -->
Clicking on the channels
Tabbing through them
Selecting them by pressing enter

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1