### PR TITLE
Switch workflows from npm to yarn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
-        runtime: 
+        runtime:
           - linux-x64
           - linux-armv7l
           - linux-arm64
@@ -29,7 +29,7 @@ jobs:
 
         - runtime: linux-armv7l
           os: ubuntu-latest
-          
+
         - runtime: linux-arm64
           os: ubuntu-latest
 
@@ -38,7 +38,7 @@ jobs:
 
 #        - runtime: osx-arm64
 #          os: macOS-latest
-          
+
         - runtime: win-x64
           os: windows-latest
 
@@ -54,8 +54,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
-    - run: npm run ci
-    - run: npm run lint
+    - run: yarn run ci
+    - run: yarn run lint
     - name: Get Version Number
       uses: nyaayaya/package-version@v1
       with:
@@ -92,20 +92,20 @@ jobs:
 
 
     - name: Install libarchive-tools
-      if: startsWith(matrix.os, 'ubuntu') 
+      if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt -y install libarchive-tools; echo "Version Number ${{ toJson(job) }} ${{ toJson(needs) }}"
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')
-      run: npm run build --if-present
+      run: yarn run build --if-present
 
     - name: Build ARMv7l with Node.js ${{ matrix.node-version}}
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      run: npm run build:arm32 --if-present
-      
+      run: yarn run build:arm32 --if-present
+
     - name: Build ARM64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'arm64')
-      run: npm run build:arm64 --if-present
+      run: yarn run build:arm64 --if-present
 
     - name: Upload Linux .zip x64 Artifact
       uses: actions/upload-artifact@v3
@@ -162,7 +162,7 @@ jobs:
       with:
         name: freetube_${{ steps.versionNumber.outputs.result }}_armv7l.deb
         path: build/freetube_${{ steps.versionNumber.outputs.result }}_armv7l.deb
-        
+
     - name: Upload .deb ARM64 Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
@@ -197,7 +197,7 @@ jobs:
       with:
         name: freetube_${{ steps.versionNumber.outputs.result }}_amd64.rpm
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.x86_64.rpm
-        
+
     # rpm are not built for armv7l
 
     - name: Upload .rpm ARM64 Artifact
@@ -220,7 +220,7 @@ jobs:
       with:
         name: freetube_${{ steps.versionNumber.outputs.result }}_alpine_armv7l.apk
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.apk
-        
+
     - name: Upload Alpine .apk ARM64 Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
@@ -248,14 +248,14 @@ jobs:
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-setup-x64.exe
         path: build/freetube Setup ${{ steps.versionNumber.outputs.result }}.exe
-        
+
     - name: Upload Windows arm64 .exe Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-setup-arm64.exe
         path: build/freetube Setup ${{ steps.versionNumber.outputs.result }}.exe
-        
+
     - name: Upload Windows x64 .zip Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
@@ -283,7 +283,7 @@ jobs:
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-win-arm64-portable.7z
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64-win.7z
-        
+
     - name: Upload Windows x64 Portable Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
@@ -297,21 +297,21 @@ jobs:
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-portable-arm64.exe
         path: build/freetube ${{ steps.versionNumber.outputs.result }}.exe
-        
+
     - name: Upload Mac x64 .dmg Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
       with:
         name: freetube-${{ steps.versionNumber.outputs.result }}-mac-x64.dmg
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.dmg
-        
+
 #    - name: Upload Mac arm64 .dmg Artifact
 #      uses: actions/upload-artifact@v3
 #      if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-arm64')
 #      with:
 #        name: freetube-${{ steps.versionNumber.outputs.result }}-mac-arm64.dmg
 #        path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.dmg
-        
+
     - name: Upload Mac x64 .zip Artifact
       uses: actions/upload-artifact@v3
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,5 +23,5 @@ jobs:
       with:
         node-version: 16.x
         cache: "yarn"
-    - run: npm run ci
-    - run: npm run lint
+    - run: yarn run ci
+    - run: yarn run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x]
-        runtime: 
+        runtime:
           - linux-x64
           - linux-armv7l
           - linux-arm64
@@ -29,19 +29,19 @@ jobs:
 
         - runtime: linux-armv7l
           os: ubuntu-latest
-        
+
         - runtime: linux-arm64
           os: ubuntu-latest
 
         - runtime: osx-x64
           os: macOS-latest
-          
+
 #        - runtime: osx-arm64
 #          os: macOS-latest
-          
+
         - runtime: win-x64
           os: windows-latest
-          
+
         - runtime: win-arm64
           os: windows-latest
 
@@ -54,8 +54,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
-    - run: npm run ci
-    - run: npm run lint
+    - run: yarn run ci
+    - run: yarn run lint
 
     - name: Get Version Number
       uses: nyaayaya/package-version@v1
@@ -65,15 +65,15 @@ jobs:
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')
-      run: npm run build --if-present
+      run: yarn run build --if-present
 
     - name: Build ARMv7l with Node.js ${{ matrix.node-version}}
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      run: npm run build:arm32 --if-present
-      
+      run: yarn run build:arm32 --if-present
+
     - name: Build ARM64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'arm64')
-      run: npm run build:arm64 --if-present
+      run: yarn run build:arm64 --if-present
 
     - name: Upload AppImage x64 Release
       uses: actions/upload-release-asset@v1
@@ -173,7 +173,7 @@ jobs:
         asset_name: freetube_${{ env.PACKAGE_VERSION }}_armv7l.deb
         asset_path: build/freetube_${{ env.PACKAGE_VERSION }}_armv7l.deb
         asset_content_type: application/vnd.debian.binary-package
-        
+
     - name: Upload Linux .deb ARM64 Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
@@ -195,7 +195,7 @@ jobs:
         asset_name: freetube_${{ env.PACKAGE_VERSION }}_amd64.rpm
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}.x86_64.rpm
         asset_content_type: application/x-rpm
-        
+
      # rpm are not built for armv7l
 
     - name: Upload Linux .rpm ARM64 Release
@@ -274,7 +274,7 @@ jobs:
         asset_name: freetube-${{ env.PACKAGE_VERSION }}-win-arm64-portable.7z
         asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64-win.7z
         asset_content_type: application/x-7z-compressed
-        
+
     - name: Upload Windows x64 portable Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
@@ -296,7 +296,7 @@ jobs:
         asset_name: freetube-${{ env.PACKAGE_VERSION }}-win-arm64-portable.exe
         asset_path: build/FreeTube ${{ env.PACKAGE_VERSION }}.exe
         asset_content_type: application/x-ms-dos-executable
-        
+
     - name: Upload Mac x64 .dmg Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
@@ -318,7 +318,7 @@ jobs:
 #        asset_name: freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg
 #        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64.dmg
 #        asset_content_type: application/x-apple-diskimage
-        
+
     - name: Upload Mac x64 .zip Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
@@ -351,4 +351,4 @@ jobs:
 #        asset_name: freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.zip
 #        asset_path: build/freetube-${{ env.PACKAGE_VERSION }}-arm64-mac.zip
 #        asset_content_type: application/x-apple-diskimage
-    
+

--- a/package.json
+++ b/package.json
@@ -38,12 +38,11 @@
     "pack:renderer": "webpack --mode=production --node-env=production --config _scripts/webpack.renderer.config.js",
     "pack:web": "webpack --mode=production --node-env=production --config _scripts/webpack.web.config.js",
     "pack:workers": "webpack --mode=production --node-env=production --config _scripts/webpack.workers.config.js",
-    "postinstall": "npm run rebuild:electron",
+    "postinstall": "yarn run --silent rebuild:electron",
     "prettier": "prettier --write \"{src,_scripts}/**/*.{js,vue}\"",
     "rebuild:electron": "electron-builder install-app-deps",
-    "rebuild:node": "npm rebuild",
     "release": "run-s test build",
-    "ci": "yarn install --frozen-lockfile"
+    "ci": "yarn install --silent --frozen-lockfile"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.0",


### PR DESCRIPTION
# Switch workflows from npm to yarn

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [x] Feature Implementation

## Description
This pull request replaces the remaining uses of npm in the workflows, with yarn, which is quicker. I also changed the package.json file to use yarn, I had to add the `--silent` argument to prevent the inner yarn command from outputting it's duration (could be confusing if you don't know why there are two durations). Got rid of the `rebuild:node` target as that isn't used anymore and doesn't work.

## Screenshots <!-- If appropriate -->
before and after:
![yarn-install](https://user-images.githubusercontent.com/48293849/196790491-36ea27b9-cef1-402e-91b6-095e14447cdc.jpg)

## Testing <!-- for code that is not small enough to be easily understandable -->
All of the commands that i changed work locally, so they should work on GitHub actions too.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1