### PR TITLE
Move `Dialog` funtions to `utils/helpers`

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -10,7 +10,7 @@ import { MAIN_PROFILE_ID } from '../../../constants'
 
 import { opmlToJSON } from 'opml-to-json'
 import ytch from 'yt-channel-info'
-import { calculateColorLuminance, copyToClipboard, getRandomColor, showToast } from '../../helpers/utils'
+import { calculateColorLuminance, copyToClipboard, getRandomColor, readFileFromDialog, showToast, writeFileFromDialog } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'DataSettings',
@@ -103,7 +103,7 @@ export default Vue.extend({
       }
       let textDecode
       try {
-        textDecode = await this.readFileFromDialog({ response })
+        textDecode = await readFileFromDialog(response)
       } catch (err) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
         showToast(`${message}: ${err}`)
@@ -509,7 +509,7 @@ export default Vue.extend({
         return
       }
       try {
-        await this.writeFileFromDialog({ response, content: subscriptionsDb })
+        await writeFileFromDialog(response, subscriptionsDb)
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
         showToast(`${message}: ${writeErr}`)
@@ -575,7 +575,7 @@ export default Vue.extend({
       }
 
       try {
-        await this.writeFileFromDialog({ response, content: JSON.stringify(subscriptionsObject) })
+        await writeFileFromDialog(response, JSON.stringify(subscriptionsObject))
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
@@ -620,7 +620,7 @@ export default Vue.extend({
       }
 
       try {
-        await this.writeFileFromDialog({ response, content: opmlData })
+        await writeFileFromDialog(response, opmlData)
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
@@ -659,7 +659,7 @@ export default Vue.extend({
       }
 
       try {
-        await this.writeFileFromDialog({ response, content: exportText })
+        await writeFileFromDialog(response, exportText)
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
@@ -705,7 +705,7 @@ export default Vue.extend({
         return
       }
       try {
-        await this.writeFileFromDialog({ response, content: JSON.stringify(newPipeObject) })
+        await writeFileFromDialog(response, JSON.stringify(newPipeObject))
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
@@ -731,7 +731,7 @@ export default Vue.extend({
       }
       let textDecode
       try {
-        textDecode = await this.readFileFromDialog({ response })
+        textDecode = await readFileFromDialog(response)
       } catch (err) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
         showToast(`${message}: ${err}`)
@@ -806,7 +806,7 @@ export default Vue.extend({
       }
 
       try {
-        await this.writeFileFromDialog({ response, content: historyDb })
+        await writeFileFromDialog(response, historyDb)
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
@@ -831,7 +831,7 @@ export default Vue.extend({
       }
       let data
       try {
-        data = await this.readFileFromDialog({ response })
+        data = await readFileFromDialog(response)
       } catch (err) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
         showToast(`${message}: ${err}`)
@@ -948,7 +948,7 @@ export default Vue.extend({
         return
       }
       try {
-        await this.writeFileFromDialog({ response, content: JSON.stringify(this.allPlaylists) })
+        await writeFileFromDialog(response, JSON.stringify(this.allPlaylists))
       } catch (writeErr) {
         const message = this.$t('Settings.Data Settings.Unable to write file')
         showToast(`${message}: ${writeErr}`)
@@ -1101,9 +1101,7 @@ export default Vue.extend({
       'updateHistory',
       'compactHistory',
       'showOpenDialog',
-      'readFileFromDialog',
       'showSaveDialog',
-      'writeFileFromDialog',
       'getUserDataPath',
       'addPlaylist',
       'addVideo'

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -10,7 +10,7 @@ import { MAIN_PROFILE_ID } from '../../../constants'
 
 import { opmlToJSON } from 'opml-to-json'
 import ytch from 'yt-channel-info'
-import { calculateColorLuminance, copyToClipboard, getRandomColor, readFileFromDialog, showToast, writeFileFromDialog } from '../../helpers/utils'
+import { calculateColorLuminance, copyToClipboard, getRandomColor, readFileFromDialog, showOpenDialog, showSaveDialog, showToast, writeFileFromDialog } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'DataSettings',
@@ -97,7 +97,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showOpenDialog(options)
+      const response = await showOpenDialog(options)
       if (response.canceled || response.filePaths?.length === 0) {
         return
       }
@@ -503,7 +503,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -568,7 +568,7 @@ export default Vue.extend({
         return object
       })
 
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -613,7 +613,7 @@ export default Vue.extend({
         }
       })
 
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -652,7 +652,7 @@ export default Vue.extend({
         exportText += `${channel.id},${channelUrl},${channelName}\n`
       })
       exportText += '\n'
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -699,7 +699,7 @@ export default Vue.extend({
         newPipeObject.subscriptions.push(subscription)
       })
 
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -725,7 +725,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showOpenDialog(options)
+      const response = await showOpenDialog(options)
       if (response.canceled || response.filePaths?.length === 0) {
         return
       }
@@ -799,7 +799,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -825,7 +825,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showOpenDialog(options)
+      const response = await showOpenDialog(options)
       if (response.canceled || response.filePaths?.length === 0) {
         return
       }
@@ -942,7 +942,7 @@ export default Vue.extend({
         ]
       }
 
-      const response = await this.showSaveDialog(options)
+      const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {
         // User canceled the save dialog
         return
@@ -1100,8 +1100,6 @@ export default Vue.extend({
       'updateShowProgressBar',
       'updateHistory',
       'compactHistory',
-      'showOpenDialog',
-      'showSaveDialog',
       'getUserDataPath',
       'addPlaylist',
       'addVideo'


### PR DESCRIPTION
# Move `Dialog` funtions to `utils/helpers`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [X] Other

## Description
The functions pertaining to file pickers don't touch the state.

```javascript
  // line 346 of src/store/modules/utils.js
  async showSaveDialog (context, options) {
    const webCbk = async () => {
         // ...
    }
    // These functions technically pass the context into this function.
    return await invokeIRC(context, IpcChannels.SHOW_SAVE_DIALOG, webCbk, options)
  }
```
```javascript
// line 107 of src/store/modules/utils.js
async function invokeIRC(context, IRCtype, webCbk, payload = null) {
  // However, context is completely unused here.
  let response = null
  if (process.env.IS_ELECTRON) {
    const { ipcRenderer } = require('electron')
    response = await ipcRenderer.invoke(IRCtype, payload)
  } else if (webCbk) {
    response = await webCbk()
  }

  return response
}
```
I believe it makes sense to move them out of `src/store/modules/utils.js` and into `src/helpers/utils.js`.

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1

## Additional context
If there is a scenario which could occur in the future which would involve the `invokeIRC` needing to modify state; it might make  sense to only move the `writeFileFromDialog` and `readFileFromDialog` functions.

