### PR TITLE
Remove the npm only --if-present arg from the workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,15 +97,15 @@ jobs:
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')
-      run: yarn run build --if-present
+      run: yarn run build
 
     - name: Build ARMv7l with Node.js ${{ matrix.node-version}}
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      run: yarn run build:arm32 --if-present
+      run: yarn run build:arm32
 
     - name: Build ARM64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'arm64')
-      run: yarn run build:arm64 --if-present
+      run: yarn run build:arm64
 
     - name: Upload Linux .zip x64 Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,15 @@ jobs:
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')
-      run: yarn run build --if-present
+      run: yarn run build
 
     - name: Build ARMv7l with Node.js ${{ matrix.node-version}}
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      run: yarn run build:arm32 --if-present
+      run: yarn run build:arm32
 
     - name: Build ARM64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'arm64')
-      run: yarn run build:arm64 --if-present
+      run: yarn run build:arm64
 
     - name: Upload AppImage x64 Release
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
# Remove the npm only --if-present arg from the workflows

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Issue introduced in #2750

## Description
Fix the workflows that I broke recently by removing the npm only --if-present arg.

## Testing <!-- for code that is not small enough to be easily understandable -->
the commands work without --if-present on my local machine

## Desktop
GitHub Actions