### PR TITLE
Convert Invidious comment `publishText` to locale

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -273,8 +273,9 @@ export default Vue.extend({
           }
 
           comment.replies = []
-
-          comment.time = comment.publishedText
+          comment.time = toLocalePublicationString({
+            publishText: comment.publishedText
+          })
 
           return comment
         })


### PR DESCRIPTION
# Convert Invidious comment `publishText` to locale

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `toLocalePublicationString` function is currently only being called on comments retrieved from the local API. This PR adds a call to that function inside of `getCommentDataInvidious` in order to format the publish text retrieved from the Invidious API to the current locale.

## Screenshots <!-- If appropriate -->
_Before:_
![before](https://user-images.githubusercontent.com/106682128/197331595-108d5448-5c25-4438-bd9e-c53d57c79a4d.png)
_After:_
![after](https://user-images.githubusercontent.com/106682128/197331599-5b2033bb-22b6-4f31-bcec-772547ece069.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Change your locale preference to something that is not English
2. Change your API backend preference to `Invidious`
3. Check the comments on any video to see what the publish text says

**Desktop (please complete the following information):**
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1
