### PR TITLE
Hide `Most Popular` if invidious is disabled

### DIFF
--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.js
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.js
@@ -8,6 +8,12 @@ export default Vue.extend({
     }
   },
   computed: {
+    backendFallback: function () {
+      return this.$store.getters.getBackendFallback
+    },
+    backendPreference: function () {
+      return this.$store.getters.getBackendPreference
+    },
     hidePopularVideos: function () {
       return this.$store.getters.getHidePopularVideos
     },

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
@@ -64,7 +64,7 @@
         </p>
       </div>
       <div
-        v-if="!hidePopularVideos"
+        v-if="!hidePopularVideos && (backendFallback || backendPreference === 'invidious')"
         class="navOption"
         :title="$t('Most Popular')"
         @click="navigate('popular')"

--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -12,6 +12,9 @@ export default Vue.extend({
     isOpen: function () {
       return this.$store.getters.getIsSideNavOpen
     },
+    backendFallback: function () {
+      return this.$store.getters.getBackendFallback
+    },
     backendPreference: function () {
       return this.$store.getters.getBackendPreference
     },

--- a/src/renderer/components/side-nav/side-nav.vue
+++ b/src/renderer/components/side-nav/side-nav.vue
@@ -84,7 +84,7 @@
         </p>
       </div>
       <div
-        v-if="!hidePopularVideos"
+        v-if="!hidePopularVideos && (backendFallback || backendPreference === 'invidious')"
         class="navOption mobileHidden"
         role="button"
         tabindex="0"


### PR DESCRIPTION
# Hide `Most Popular` if invidious is disabled

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Hide `Most Popular` if invidious is disabled (not primary api/fallback)


## Testing 
- change primary api to local without fallback
- dont see most popular
- change primary api to local with fallback
- see `most popular`
- change primary api to invidious
- see `most popular`


## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.17.1

