### PR TITLE
Centralize map used for parsing invidious comments

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -240,6 +240,37 @@ export default Vue.extend({
       }
     },
 
+    parseInvidiousCommentData: function (response) {
+      return response.comments.map((comment) => {
+        comment.showReplies = false
+        comment.authorLink = comment.authorId
+        comment.authorThumb = comment.authorThumbnails[1].url.replace('https://yt3.ggpht.com', `${this.currentInvidiousInstance}/ggpht/`)
+        if (this.hideCommentLikes) {
+          comment.likes = null
+        } else {
+          comment.likes = comment.likeCount
+        }
+        comment.text = autolinker.link(comment.content.replace(/(<(?!br>)([^>]+)>)/ig, ''))
+        comment.dataType = 'invidious'
+        comment.isOwner = comment.authorIsChannelOwner
+
+        if (typeof (comment.replies) !== 'undefined' && typeof (comment.replies.replyCount) !== 'undefined') {
+          comment.numReplies = comment.replies.replyCount
+          comment.replyContinuation = comment.replies.continuation
+        } else {
+          comment.numReplies = 0
+          comment.replyContinuation = ''
+        }
+
+        comment.replies = []
+        comment.time = toLocalePublicationString({
+          publishText: comment.publishedText
+        })
+
+        return comment
+      })
+    },
+
     getCommentDataInvidious: function () {
       const payload = {
         resource: 'comments',
@@ -251,34 +282,7 @@ export default Vue.extend({
       }
 
       this.invidiousAPICall(payload).then((response) => {
-        const commentData = response.comments.map((comment) => {
-          comment.showReplies = false
-          comment.authorLink = comment.authorId
-          comment.authorThumb = comment.authorThumbnails[1].url.replace('https://yt3.ggpht.com', `${this.currentInvidiousInstance}/ggpht/`)
-          if (this.hideCommentLikes) {
-            comment.likes = null
-          } else {
-            comment.likes = comment.likeCount
-          }
-          comment.text = autolinker.link(comment.content.replace(/(<(?!br>)([^>]+)>)/ig, ''))
-          comment.dataType = 'invidious'
-          comment.isOwner = comment.authorIsChannelOwner
-
-          if (typeof (comment.replies) !== 'undefined' && typeof (comment.replies.replyCount) !== 'undefined') {
-            comment.numReplies = comment.replies.replyCount
-            comment.replyContinuation = comment.replies.continuation
-          } else {
-            comment.numReplies = 0
-            comment.replyContinuation = ''
-          }
-
-          comment.replies = []
-          comment.time = toLocalePublicationString({
-            publishText: comment.publishedText
-          })
-
-          return comment
-        })
+        const commentData = this.parseInvidiousCommentData(response)
 
         this.commentData = this.commentData.concat(commentData)
         this.nextPageToken = response.continuation
@@ -310,24 +314,7 @@ export default Vue.extend({
       }
 
       this.invidiousAPICall(payload).then((response) => {
-        const commentData = response.comments.map((comment) => {
-          comment.showReplies = false
-          comment.authorLink = comment.authorId
-          comment.authorThumb = comment.authorThumbnails[1].url.replace('https://yt3.ggpht.com', `${this.currentInvidiousInstance}/ggpht/`)
-          if (this.hideCommentLikes) {
-            comment.likes = null
-          } else {
-            comment.likes = comment.likeCount
-          }
-          comment.text = autolinker.link(comment.content.replace(/(<(?!br>)([^>]+)>)/ig, ''))
-          comment.time = comment.publishedText
-          comment.dataType = 'invidious'
-          comment.numReplies = 0
-          comment.replyContinuation = ''
-          comment.replies = []
-
-          return comment
-        })
+        const commentData = this.parseInvidiousCommentData(response)
 
         this.commentData[index].replies = commentData
         this.commentData[index].showReplies = true


### PR DESCRIPTION
# Centralize map used for parsing invidious comments

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
When I added `toLocalePublicationString` to the invidious comments, I missed that this function should also probably be called on comment replies; however, this brought my attention to the fact that there are two maps which do virtually the same thing which could be simplified into one `parseInvidiousCommentData` function similar to how the local API comments work.

This PR aims to fix the locale date string inconsistency between replies and top level comments that come from the Invidious API.

## Screenshots <!-- If appropriate -->
_Before:_
![before](https://user-images.githubusercontent.com/106682128/198575503-cec5f894-ea3a-4b42-a752-feb9b852d4ae.png)
_After:_
![after](https://user-images.githubusercontent.com/106682128/198575512-fa838553-3a9d-402b-807e-e2b526c0c399.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn dev`
2. Make sure your locale preference is set to something that is not English
3. Check a comment reply to see if the date string is in your selected locale

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.17.1
