### PR TITLE
Fix watch-video-info overflow for live streams

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -263,7 +263,8 @@ export default Vue.extend({
       const date = new Date(this.published)
       const locale = this.currentLocale.replace('_', '-')
       const localeDateString = new Intl.DateTimeFormat([locale, 'en'], { dateStyle: 'medium' }).format(date)
-      return `${localeDateString}`
+      // replace spaces with no break spaces to make the date act as a single entity while wrapping
+      return `${localeDateString}`.replace(/ /g, '\u00A0')
     },
 
     publishedString() {

--- a/src/renderer/components/watch-video-info/watch-video-info.sass
+++ b/src/renderer/components/watch-video-info/watch-video-info.sass
@@ -1,6 +1,6 @@
 .watchVideoInfo
   display: grid
-  grid-template-columns: auto max-content
+  grid-template-columns: auto minmax(min-content, 1fr)
   column-gap: 15px
   padding: 16px
 


### PR DESCRIPTION
# Fix watch-video-info overflow for live streams

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Introduced in #2751

## Description
Live streams have a much longer published date string than normal videos ("Started streaming on <date>" vs "Published on <date>" ), so it was causing layout problems.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/198827483-ab6bbfed-6efa-4eda-bba0-50c554eba6ff.jpg)

![after](https://user-images.githubusercontent.com/48293849/198827489-a6467057-c10a-4c2e-946f-130cf22b5286.jpg)

## Testing <!-- for code that is not small enough to be easily understandable -->
Find a live stream on https://www.youtube.com/live and resize the window while watching it.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1