### PR TITLE
Add setting to toggle `Enter fullscreen on rotate`

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -193,6 +193,10 @@ export default Vue.extend({
       return this.$store.getters.getDisplayVideoPlayButton
     },
 
+    enterFullscreenOnDisplayRotate: function() {
+      return this.$store.getters.getEnterFullscreenOnDisplayRotate
+    },
+
     sponsorSkips: function () {
       const sponsorCats = ['sponsor',
         'selfpromo',
@@ -363,8 +367,8 @@ export default Vue.extend({
         })
         this.player.mobileUi({
           fullscreen: {
-            enterOnRotate: true,
-            exitOnRotate: true,
+            enterOnRotate: this.enterFullscreenOnDisplayRotate,
+            exitOnRotate: this.enterFullscreenOnDisplayRotate,
             lockOnRotate: false
           },
           // Without this flag, the mobile UI will only activate

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -132,6 +132,10 @@ export default Vue.extend({
       return this.$store.getters.getDisplayVideoPlayButton
     },
 
+    enterFullscreenOnDisplayRotate: function () {
+      return this.$store.getters.getEnterFullscreenOnDisplayRotate
+    },
+
     maxVideoPlaybackRate: function () {
       return parseInt(this.$store.getters.getMaxVideoPlaybackRate)
     },
@@ -270,6 +274,7 @@ export default Vue.extend({
       'updateVideoVolumeMouseScroll',
       'updateVideoPlaybackRateMouseScroll',
       'updateDisplayVideoPlayButton',
+      'updateEnterFullscreenOnDisplayRotate',
       'updateMaxVideoPlaybackRate',
       'updateVideoPlaybackRateInterval',
       'updateEnableScreenshot',

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -51,6 +51,12 @@
           :default-value="displayVideoPlayButton"
           @change="updateDisplayVideoPlayButton"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Enter Fullscreen on Display Rotate')"
+          :compact="true"
+          :default-value="enterFullscreenOnDisplayRotate"
+          @change="updateEnterFullscreenOnDisplayRotate"
+        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -183,6 +183,7 @@ const state = {
   displayVideoPlayButton: true,
   enableSearchSuggestions: true,
   enableSubtitles: true,
+  enterFullscreenOnDisplayRotate: false,
   externalLinkHandling: '',
   externalPlayer: '',
   externalPlayerExecutable: '',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -237,6 +237,7 @@ Settings:
     Scroll Volume Over Video Player: Scroll Volume Over Video Player
     Scroll Playback Rate Over Video Player: Scroll Playback Rate Over Video Player
     Display Play Button In Video Player: Display Play Button In Video Player
+    Enter Fullscreen on Display Rotate: Enter Fullscreen on Display Rotate
     Next Video Interval: Next Video Interval
     Fast-Forward / Rewind Interval: Fast-Forward / Rewind Interval
     Default Volume: Default Volume

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -247,6 +247,7 @@ Settings:
     Playlist Next Video Interval: Playlist Next Video Interval
     Next Video Interval: Next video interval
     Display Play Button In Video Player: Display play button in video player
+    Enter Fullscreen on Display Rotate: Enter fullscreen on display rotate
     Fast-Forward / Rewind Interval: Fast-forward / rewind interval
     Scroll Playback Rate Over Video Player: Scroll playback rate over video player
     Video Playback Rate Interval: Video playback rate interval


### PR DESCRIPTION
# Add setting to toggle `Enter fullscreen on rotate`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes FreetubeApp/FreeTube#2806

## Description
This PR adds a new setting called `Enter fullscreen on display rotate`. This setting defaults to `false`, and this should prevent the video from entering fullscreen when dragged across multi-monitor setups with portrait and landscape displays because AFAIK there is no scenario where someone would have multiple monitors and want to have this setting on.

## Screenshots <!-- If appropriate -->
_before:_
![before](https://user-images.githubusercontent.com/106682128/199638650-ee761d93-92c9-4292-af7b-1a275da51cf0.gif)
_after:_
![after](https://user-images.githubusercontent.com/106682128/199638695-03bb5ce3-776a-4c15-9438-e497b703a314.gif)

## Testing <!-- for code that is not small enough to be easily understandable -->
This can be tested on dual monitor setups with one portrait and one landscape display.
1. Play a video
2. Attempt to drag it from your portrait monitor to your landscape monitor
3. Make sure it doesn't enter full screen mode unexpectedly

It would also probably be worth testing that the setting works when enabled:
1. Enable `Enter fullscreen on rotate` under `Player Settings`
2. Attempt to drag it from your portrait monitor to your landscape monitor
3. Make sure it does enter fullscreen

Or, I guess if you are really trying to be thorough about it:

1. `yarn dev:web`
2. Access your IP address at port `9080` from a browser on a phone or tablet
3. Enable `Enter fullscreen on rotate` under `Player Settings`
4. Play a video
5. Tap the video to ensure `videojs-mobile-ui` is active and working
6. Attempt to rotate the display from portrait to landscape while a video is playing
7. Make sure that the video enters fullscreen

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0