### PR TITLE
Add video numbering to playlists

### DIFF
--- a/src/renderer/views/Playlist/Playlist.css
+++ b/src/renderer/views/Playlist/Playlist.css
@@ -23,7 +23,18 @@
   width: 60%;
 }
 
-@media only screen and (max-width: 800px) {
+.playlistItem {
+  display: grid;
+  grid-template-columns: max-content auto;
+  column-gap: 8px;
+  align-items: center;
+}
+
+.videoIndex {
+  color: var(--tertiary-text-color);
+}
+
+@media only screen and (max-width: 850px) {
   .routerView {
     flex-direction: column;
   }

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -15,15 +15,24 @@
       v-if="!isLoading"
       class="playlistItems"
     >
-      <ft-list-video
+      <div
         v-for="(item, index) in playlistItems"
         :key="index"
-        :data="item"
-        :playlist-id="playlistId"
-        :playlist-index="index"
-        appearance="result"
-        force-list-type="list"
-      />
+        class="playlistItem"
+      >
+        <p
+          class="videoIndex"
+        >
+          {{ index + 1 }}
+        </p>
+        <ft-list-video
+          :data="item"
+          :playlist-id="playlistId"
+          :playlist-index="index"
+          appearance="result"
+          force-list-type="list"
+        />
+      </div>
     </ft-card>
   </div>
 </template>


### PR DESCRIPTION
# Add video numbering to playlists

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
related to #2725

## Description
This pull request adds numbers next to the videos on the playlist view.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/199803116-47fe79bf-af51-4fe0-bf99-ba117898bf3b.jpg)

![video_numbers](https://user-images.githubusercontent.com/48293849/199803126-7ba5abf7-fb43-482a-a2ae-16d425be8c95.jpg)

## Testing <!-- for code that is not small enough to be easily understandable -->
[https://www.youtube.com/playlist?list=PLw-VjHDlEOguL2K_NwIl_tYcs9_FSt5v_](https://www.youtube.com/playlist?list=PLw-VjHDlEOguL2K_NwIl_tYcs9_FSt5v_)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1

## Additional context
The video thumbnails should really shrink in narrow windows instead of staying so large, not in the scope of this PR though.