### PR TITLE
exempt some labels from stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,3 +19,5 @@ jobs:
           days-before-pr-close: 14
           stale-issue-label: 'U: stale'
           stale-pr-label: 'PR: stale'
+          exempt-pr-labels: 'PR: waiting for review'
+          exempt-issue-labels: 'enhancement'


### PR DESCRIPTION
# exempt some labels from stale workflow

## Pull Request Type
- [x] Other - workflow

## Description
I don't feel that the stale workflow should apply to feature requests or PRs that are waiting for review

## Testing 
Tested in the FreeTube test repo

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0

## Additional context
Let me know if you agree/disagree with the changes 😃 
