### PR TITLE
Fix emoji display in the profile selector

### DIFF
--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -28,11 +28,12 @@ export default Vue.extend({
       return this.$store.getters.getDefaultProfile
     },
     activeProfileInitial: function () {
-      return this.activeProfile?.name?.length > 0 ? this.activeProfile.name[0].toUpperCase() : ''
+      // use Array.from, so that emojis don't get split up into individual character codes
+      return this.activeProfile?.name?.length > 0 ? Array.from(this.activeProfile.name)[0].toUpperCase() : ''
     },
     profileInitials: function () {
       return this.profileList.map((profile) => {
-        return profile?.name?.length > 0 ? profile.name[0].toUpperCase() : ''
+        return profile?.name?.length > 0 ? Array.from(profile.name)[0].toUpperCase() : ''
       })
     }
   },


### PR DESCRIPTION
# Fix emoji display in the profile selector

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Closes #2813 
Introduced in #2664

## Description
Turns out that `'string'[0]` extracts the character before parsing emojis, so you end up with the emoji split up into it's individual character codes (same with `'string'.split('')`). Array.from on the other hand creates the array after parsing the emojis.

## Screenshots <!-- If appropriate -->

![before](https://user-images.githubusercontent.com/48293849/199849198-409284b9-0bc8-43e1-976c-11d4557a28fc.jpg) ![after](https://user-images.githubusercontent.com/48293849/199849203-4acdfe73-1823-4065-8c6a-20caa1b3cce0.jpg)

![weird_splitting_behaviour](https://user-images.githubusercontent.com/48293849/199849215-164b7069-f037-47ef-aaed-655d3ada55bc.jpg)

## Testing <!-- for code that is not small enough to be easily understandable -->
Create a profile with an emoji as the first character
Check that the emojis shows up in the profile selector and in the top right when the profile is selected

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1