### PR TITLE
Remove stale label when PR gets closed by stale workflow or when PR gets merged

### DIFF
--- a/.github/workflows/remove-outdated-labels.yml
+++ b/.github/workflows/remove-outdated-labels.yml
@@ -19,6 +19,7 @@ jobs:
             PR: changes requested
             PR: merge conflicts / rebase needed
             PR/Issue: dependent
+            PR: stale
 
   remove-closed-pr-labels:
     name: Remove closed pull request labels


### PR DESCRIPTION
# Remove stale label when PR gets closed by stale workflow

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix?

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Title says it all. I forgot to add these lines to the workflow when stale workflow got introduced