### PR TITLE
fix duplicate workflow trigger

### DIFF
--- a/.github/workflows/autoLabelDuplicate.yml
+++ b/.github/workflows/autoLabelDuplicate.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: Amwam/issue-comment-action@v1.3.1
         with:
-          keywords: '["duplicate of"]'
+          keywords: '["duplicate of #", "duplicate of https://github.com/FreeTubeApp/FreeTube/issues/"]'
           labels: '["U: duplicate"]'
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# fix duplicate workflow trigger

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/issues/2801#issuecomment-1303254361 and https://github.com/FreeTubeApp/FreeTube/pull/2812#issuecomment-1302652772

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
In both issue and PR workflow gets triggerd because all keywords are used but the there was no intend to mark them as duplicate. To make the workflow somewhat more robust i added some code.