### PR TITLE
Add Release drafter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,8 @@
 <!-- Please remove what is not applicable! -->
 - [ ] Bugfix
 - [ ] Feature Implementation
+- [ ] New Build
+- [ ] I am a New Contributor
 - [ ] Documentation
 - [ ] Other
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 - [ ] I am a New Contributor
 
 ## Pull Request Type
-<!-- Please select what type of pull request this is: [x] -->
+<!-- Please select what type of pull request this is (select one only): [x] -->
 - [ ] Bugfix
 - [ ] Feature Implementation
 - [ ] Documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@
 
 ## Pull Request Type
 <!-- Please select what type of pull request this is: [x] -->
-<!-- Please remove what is not applicable! -->
 - [ ] Bugfix
 - [ ] Feature Implementation
 - [ ] New Build

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,13 @@
 
 <!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines: https://github.com/FreeTubeApp/FreeTube/blob/development/CONTRIBUTING.md -->
 <!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
+<!-- Please select if this is applicable to u: [x] -->
+- [ ] I am a New Contributor
 
 ## Pull Request Type
 <!-- Please select what type of pull request this is: [x] -->
 - [ ] Bugfix
 - [ ] Feature Implementation
-- [ ] I am a New Contributor
 - [ ] Documentation
 - [ ] Other
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 # Title
 
-<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
+<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines: https://github.com/FreeTubeApp/FreeTube/blob/development/CONTRIBUTING.md -->
 <!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
 
 ## Pull Request Type
 <!-- Please select what type of pull request this is: [x] -->
+<!-- Please remove what is not applicable! -->
 - [ ] Bugfix
 - [ ] Feature Implementation
 - [ ] Documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@
 <!-- Please select what type of pull request this is: [x] -->
 - [ ] Bugfix
 - [ ] Feature Implementation
-- [ ] New Build
 - [ ] I am a New Contributor
 - [ ] Documentation
 - [ ] Other

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,34 @@
+name-template: 'Release v0.x.x Beta'
+tag-template: 'v0.x.x-beta'
+categories:
+  - title: 'Features'
+    labels:
+      - 'PR: enhancement'
+  - title: 'Fixes'
+    labels:
+      - 'PR: bug'
+  - title: 'Changes'
+    labels:
+      - 'PR: change'
+  - title: 'Dependencies'
+    labels:
+      - 'PR: dependencies'
+  - title: 'New Builds'
+    labels:
+      - 'PR: new build'
+  - title: 'New Contributors'
+    labels:
+      - 'PR: new contributor'    
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+template: |
+  ## PR MERGED WITHOUT LABEL
+  $CHANGES
+prerelease: true
+autolabeler:
+  - label: 'PR: bug'
+    body:
+      - 'Bugfix'
+  - label: 'PR: enhancement'
+    body:
+      - 'Feature Implementation'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,9 +13,6 @@ categories:
   - title: 'Dependencies'
     labels:
       - 'PR: dependencies'
-  - title: 'New Builds'
-    labels:
-      - 'PR: new build'
   - title: 'New Contributors'
     labels:
       - 'PR: new contributor'    
@@ -35,9 +32,6 @@ autolabeler:
   - label: 'PR: change'
     body:
       - ''
-  - label: 'PR: new build'
-    body:
-      - '- [x] New Build'
   - label: 'PR: new contributor'
     body:
       - '- [x] I am a New Contributor'  

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,16 +28,16 @@ prerelease: true
 autolabeler:
   - label: 'PR: enhancement'
     body:
-      - 'Feature Implementation'
+      - '- [x] Feature Implementation'
   - label: 'PR: bug'
     body:
-      - 'Bugfix'
+      - '- [x] Bugfix'
   - label: 'PR: change'
     body:
       - ''
   - label: 'PR: new build'
     body:
-      - 'New Build'
+      - '- [x] New Build'
   - label: 'PR: new contributor'
     body:
-      - 'I am a New Contributor'  
+      - '- [x] I am a New Contributor'  

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,9 +26,18 @@ template: |
   $CHANGES
 prerelease: true
 autolabeler:
-  - label: 'PR: bug'
-    body:
-      - 'Bugfix'
   - label: 'PR: enhancement'
     body:
       - 'Feature Implementation'
+  - label: 'PR: bug'
+    body:
+      - 'Bugfix'
+  - label: 'PR: change'
+    body:
+      - ''
+  - label: 'PR: new build'
+    body:
+      - 'New Build'
+  - label: 'PR: new contributor'
+    body:
+      - 'I am a New Contributor'  

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,41 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - development
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "development"
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,16 +26,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
-
       # Drafts your next Release notes as Pull Requests are merged into "development"
       - uses: release-drafter/release-drafter@v5
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Add Release drafter

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Other - Automation

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This will make the life of Preston allot easier. The workflow auto generates release draft notes based on merged PR's and the PR labels. 

Workflow in use:
Somebody fills in the PR template -> Selects applicable keywords in the `Pull Request Type` section -> Opens/Creates the PR -> labels gets added based on keywords -> PR gets merged -> PR gets added to draft notes in a category based on the labels 

See example draft notes in https://github.com/FreeTubeApp/Test-Repo/releases just dont mind on the mess i made

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

1. Open PR in https://github.com/FreeTubeApp/Test-Repo/
2. Use keywords or not
3. Merge PR
4. See notes getting added to the right category in the notes

## Additional context
<!-- Add any other context about the pull request here. -->
Need help/feedback/advice with:
- Coming up with a good keyword to trigger the `PR: change` label to get added to the PR!
- So i made a dependencies header in the notes because i think it is also important to list them when we do a release (if u think otherwise let me know!). This will mean that everytime one of the files listed in https://github.com/FreeTubeApp/FreeTube/blob/development/.github/labeler.yml#L17 gets changed it will add the `PR: dependencies` label like in https://github.com/FreeTubeApp/FreeTube/pull/2729 or in https://github.com/FreeTubeApp/FreeTube/pull/2804. The workflow would add this to the dependencies catogory in the notes which seems strange to me. So what i propose is to remove the `PR: dependencies` lines in https://github.com/FreeTubeApp/FreeTube/blob/development/.github/labeler.yml and add them to this workflow. The only thing the contributor has to do is to select in the PR template if the PR is related to a dependency. Another upside to using this method is that the we dont hit an edge case we've seen in a few PRs where the bot removes a the dependencies label in https://github.com/FreeTubeApp/FreeTube/pull/2766 or https://github.com/FreeTubeApp/FreeTube/pull/2791

Also some important things to note:
- Labels cant be removed after a PR has been merged because the workflow will throw them out of the category and into the unlabeled bucket
- PR's cant get merged while Preston is editing the draft to make it more friendly to read. It will overwrite the text to default.