### PR TITLE
Replace lodash.isequal with simple comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.isequal": "^4.5.0",
     "marked": "^4.1.1",
     "nedb-promises": "^6.2.1",
     "opml-to-json": "^1.0.1",

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -480,3 +480,10 @@ export function formatDurationAsTimestamp(lengthSeconds) {
 
   return timestamp
 }
+
+export function searchFiltersMatch(filtersA, filtersB) {
+  return filtersA?.sortBy === filtersB?.sortBy &&
+    filtersA?.time === filtersB?.time &&
+    filtersA?.type === filtersB?.type &&
+    filtersA?.duration === filtersB?.duration
+}

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -1,10 +1,15 @@
-import IsEqual from 'lodash.isequal'
 import fs from 'fs'
 import path from 'path'
 import i18n from '../../i18n/index'
 
 import { IpcChannels } from '../../../constants'
-import { createWebURL, openExternalLink, showSaveDialog, showToast } from '../../helpers/utils'
+import {
+  createWebURL,
+  openExternalLink,
+  searchFiltersMatch,
+  showSaveDialog,
+  showToast
+} from '../../helpers/utils'
 
 const state = {
   isSideNavOpen: false,
@@ -753,7 +758,7 @@ const mutations = {
 
   addToSessionSearchHistory (state, payload) {
     const sameSearch = state.sessionSearchHistory.findIndex((search) => {
-      return search.query === payload.query && IsEqual(payload.searchSettings, search.searchSettings)
+      return search.query === payload.query && searchFiltersMatch(payload.searchSettings, search.searchSettings)
     })
 
     if (sameSearch !== -1) {

--- a/src/renderer/store/modules/ytdl.js
+++ b/src/renderer/store/modules/ytdl.js
@@ -2,12 +2,12 @@ import ytdl from 'ytdl-core'
 import ytsr from 'ytsr'
 import ytpl from 'ytpl'
 
-import IsEqual from 'lodash.isequal'
 import { SocksProxyAgent } from 'socks-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { HttpProxyAgent } from 'http-proxy-agent'
 
 import i18n from '../../i18n/index'
+import { searchFiltersMatch } from '../../helpers/utils'
 
 const state = {
   isYtSearchRunning: false
@@ -79,7 +79,7 @@ const actions = {
 
       commit('toggleIsYtSearchRunning')
 
-      if (!IsEqual(defaultFilters, rootState.utils.searchSettings)) {
+      if (!searchFiltersMatch(defaultFilters, rootState.utils.searchSettings)) {
         dispatch('ytSearchGetFilters', payload).then((filter) => {
           if (typeof (payload.options.nextpageRef) === 'undefined' && filter !== payload.query) {
             payload.options.nextpageRef = filter

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -1,11 +1,10 @@
 import Vue from 'vue'
 import { mapActions } from 'vuex'
-import IsEqual from 'lodash.isequal'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import { calculateLengthInSeconds } from '@freetube/yt-trending-scraper/src/HtmlParser'
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { copyToClipboard, searchFiltersMatch, showToast } from '../../helpers/utils'
 
 export default Vue.extend({
   name: 'Search',
@@ -93,7 +92,7 @@ export default Vue.extend({
   methods: {
     checkSearchCache: function (payload) {
       const sameSearch = this.sessionSearchHistory.filter((search) => {
-        return search.query === payload.query && IsEqual(payload.searchSettings, search.searchSettings)
+        return search.query === payload.query && searchFiltersMatch(payload.searchSettings, search.searchSettings)
       })
 
       this.shownResults = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,11 +5526,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"


### PR DESCRIPTION
# Replace lodash.isequal with simple comparison

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
Replaces the 10KB lodash.isequal dependency with this small comparison which gets the job done too.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Search for something
2. Change the search filters
3. Press the search button again
4. FreeTube will perform another search

1. Search for something
2. Change the search filters
3. Change them back
4. Press the search button again
5. FreeTube won't do another search with the same query and same filters

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.17.1