### PR TITLE
Update workflow node version to LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         runtime:
           - linux-x64
           - linux-armv7l

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,10 +18,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
         cache: "yarn"
     - run: yarn run ci
     - run: yarn run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         runtime:
           - linux-x64
           - linux-armv7l


### PR DESCRIPTION
# Update workflow node version to LTS

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [x] Other

## Description
16 and 19 reach EOL in 2023 while 18 reaches EOL in 2025
https://github.com/nodejs/release#release-schedule

## Testing
I use this version of node on my local machine

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
