### PR TITLE
Only show Select All context menu item in text fields

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -21,6 +21,7 @@ function runApp() {
     showSearchWithGoogle: false,
     showSaveImageAs: true,
     showCopyImageAddress: true,
+    showSelectAll: false,
     prepend: (defaultActions, parameters, browserWindow) => [
       {
         label: 'Show / Hide Video Statistics',
@@ -34,6 +35,15 @@ function runApp() {
         visible: parameters.linkURL.includes((new URL(browserWindow.webContents.getURL())).origin),
         click: () => {
           createWindow({ replaceMainWindow: false, windowStartupUrl: parameters.linkURL, showWindowNow: true })
+        }
+      },
+      // Only show select all in text fields
+      {
+        label: 'Select All',
+        enabled: parameters.editFlags.canSelectAll,
+        visible: parameters.isEditable,
+        click: () => {
+          browserWindow.webContents.selectAll()
         }
       }
     ]


### PR DESCRIPTION
# Only show Select All context menu item in text fields

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Description
Currently the Select All context menu item is shown all the time. This pull request makes it so that the option is only shown for text fields. If the text field is empty the Select All item will be greyed out and enabled if the text field contains text.

## Screenshots <!-- If appropriate -->
Before:
![before_1](https://user-images.githubusercontent.com/48293849/200196731-569525ce-0de6-4988-a809-70ae6f9a0134.png)
![before_2](https://user-images.githubusercontent.com/48293849/200196732-ca7d0cb0-134c-4659-93e5-b8cc7e8db285.png)

After:
![after_1](https://user-images.githubusercontent.com/48293849/200196737-0914e015-56af-49e3-9e97-4ba0cc81d1f9.jpg)
![after_2](https://user-images.githubusercontent.com/48293849/200196739-591f6113-83a5-4d30-812b-e5367650b0e1.jpg) ![after_3](https://user-images.githubusercontent.com/48293849/200196741-0134359d-fd1b-4b12-bcb5-a9204e1e153f.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Invoke the context menu in random places around FreeTube
Invoke the context menu on an empty text field
Invoke the context menu on a non empty text field

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0