### PR TITLE
Fix empty likes by switching to absidue's fork of ytdl-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "youtube-suggest": "^1.2.0",
     "yt-channel-info": "^3.2.1",
     "yt-dash-manifest-generator": "1.1.0",
-    "ytdl-core": "^4.11.2",
+    "ytdl-core": "https://github.com/absidue/node-ytdl-core#fix-likes-extraction",
     "ytpl": "^2.3.0",
     "ytsr": "^3.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8652,6 +8652,14 @@ ytdl-core@^4.11.2:
     miniget "^4.2.2"
     sax "^1.1.3"
 
+"ytdl-core@https://github.com/absidue/node-ytdl-core#fix-likes-extraction":
+  version "0.0.0-development"
+  resolved "https://github.com/absidue/node-ytdl-core#937d589cbe5f69f3153a7db12bf529c92a620800"
+  dependencies:
+    m3u8stream "^0.8.6"
+    miniget "^4.2.2"
+    sax "^1.1.3"
+
 ytpl@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/ytpl/-/ytpl-2.3.0.tgz#74633b6e582e22ff03e409dfb65d200c1a4ca0d2"


### PR DESCRIPTION
# Fix empty likes by switching to absidue's fork of ytdl-core

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently FreeTube doesn't show any likes on videos, this is due to a layout change on YouTube's end which broke the extraction of them in ytdl-core. I have created a PR on the ytdl-core repo to fix the issue. Historically we've had terrible experiences with PRs getting merged upstream (as in they haven't been merged), so I'm temporarily switching over to my branch with the fix, until it's merged or fixed upstream.

## Testing <!-- for code that is not small enough to be easily understandable -->
The like count should show up under videos instead of being empty

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0