### PR TITLE
Localise subscriber count on the watch page

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -367,12 +367,10 @@ export default Vue.extend({
           const subCount = result.videoDetails.author.subscriber_count
 
           if (typeof (subCount) !== 'undefined' && !this.hideChannelSubscriptions) {
-            if (subCount >= 1000000) {
-              this.channelSubscriptionCountText = `${subCount / 1000000}M`
-            } else if (subCount >= 10000) {
-              this.channelSubscriptionCountText = `${subCount / 1000}K`
+            if (subCount >= 10000) {
+              this.channelSubscriptionCountText = Intl.NumberFormat([this.currentLocale, 'en'], { notation: 'compact' }).format(subCount)
             } else {
-              this.channelSubscriptionCountText = Intl.NumberFormat(this.currentLocale).format(subCount)
+              this.channelSubscriptionCountText = Intl.NumberFormat([this.currentLocale, 'en']).format(subCount)
             }
           }
 


### PR DESCRIPTION
# Localise subscriber count on the watch page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [x] Feature Implementation

## Description
Currently the subscriber count on the watch page is hardcoded to use the English thousands and millions abreviations. This pull request changes it to be localised in the user's chosen language, with English as a fallback

## Screenshots <!-- If appropriate -->
Before English:
![before_thousand_english](https://user-images.githubusercontent.com/48293849/200418161-63c1023d-ea62-4e54-ba62-6057dd4a0b81.png)
![before_million_english](https://user-images.githubusercontent.com/48293849/200418351-24d6c739-f292-40f9-963a-be49a7ba6144.png)

Before Danish:
![before_thousand_danish](https://user-images.githubusercontent.com/48293849/200418396-862b05ca-b015-443d-90ad-bc390ecf69ad.png)
![before_million_danish](https://user-images.githubusercontent.com/48293849/200418408-9e327e62-6474-4076-b3ca-36f26ef0099d.png)

After Danish:
![after_thousand_danish](https://user-images.githubusercontent.com/48293849/200418442-268eef42-8332-4a4b-af4a-7b02a2323984.png)
![after_million_danish](https://user-images.githubusercontent.com/48293849/200418449-112d3fbf-f5dd-40c9-b9f2-573b991098c5.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Try various languages and check that the language of the unit changes
15M: https://youtu.be/xQMQW4sbXf8
479K: https://youtu.be/oFO92PSvqms

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0