### PR TITLE
Cleanup webpack aliases

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -34,8 +34,7 @@ const config = {
   },
   node: {
     __dirname: isDevMode,
-    __filename: isDevMode,
-    global: isDevMode,
+    __filename: isDevMode
   },
   plugins: [
     new webpack.DefinePlugin({
@@ -46,13 +45,6 @@ const config = {
     filename: '[name].js',
     libraryTarget: 'commonjs2',
     path: path.join(__dirname, '../dist'),
-  },
-  resolve: {
-    extensions: ['.js', '.json'],
-    alias: {
-      '@': path.join(__dirname, '../src/'),
-      src: path.join(__dirname, '../src/'),
-    },
   },
   target: 'electron-main',
 }

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -106,8 +106,7 @@ const config = {
   },
   node: {
     __dirname: isDevMode,
-    __filename: isDevMode,
-    global: isDevMode,
+    __filename: isDevMode
   },
   plugins: [
     new webpack.DefinePlugin({
@@ -130,14 +129,9 @@ const config = {
   ],
   resolve: {
     alias: {
-      vue$: 'vue/dist/vue.common.js',
-      '@': path.join(__dirname, '../src/'),
-      src: path.join(__dirname, '../src/'),
-      icons: path.join(__dirname, '../_icons/'),
-      images: path.join(__dirname, '../src/renderer/assets/img/'),
-      static: path.join(__dirname, '../static/'),
+      vue$: 'vue/dist/vue.common.js'
     },
-    extensions: ['.js', '.vue', '.json'],
+    extensions: ['.js', '.vue']
   },
   target: 'electron-renderer',
 }

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -135,12 +135,7 @@ const config = {
   ],
   resolve: {
     alias: {
-      '@': path.join(__dirname, '../src/renderer'),
-      vue$: 'vue/dist/vue.esm.js',
-      src: path.join(__dirname, '../src/'),
-      icons: path.join(__dirname, '../_icons/'),
-      images: path.join(__dirname, '../src/renderer/assets/img/'),
-      static: path.join(__dirname, '../static/'),
+      vue$: 'vue/dist/vue.esm.js'
     },
     fallback: {
       buffer: require.resolve('buffer/'),
@@ -157,7 +152,7 @@ const config = {
       vm: require.resolve('vm-browserify'),
       zlib: require.resolve('browserify-zlib')
     },
-    extensions: ['.js', '.vue', '.json', '.css'],
+    extensions: ['.js', '.vue']
   },
   target: 'web',
 }

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -18,7 +18,7 @@
 }
 
 .channelBannerContainer.default {
-  background-image: url("images/defaultBanner.png");
+  background-image: url("../../assets/img/defaultBanner.png");
   background-repeat: repeat;
   background-size: contain;
 }


### PR DESCRIPTION
# Cleanup webpack aliases

## Pull Request Type

- [x] Feature Implementation

## Description
Most of the resolve aliases we have setup in the webpack configuration files go unused, this PR aims to get rid of all of the unused ones. The `image` alias was used in a single place, so that was easy to fix. I've kept the vue one around so that we still import the specific vue framework files that we want.

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn dev` and `yarn build` check that there are no build errors and then check that you don't see any missing images while FreeTube is running

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0