### PR TITLE
Add Distraction Free Settings -> Hide Upcoming Premieres

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -49,6 +49,9 @@ export default Vue.extend({
     hideLiveStreams: function() {
       return this.$store.getters.getHideLiveStreams
     },
+    hideUpcomingPremieres: function () {
+      return this.$store.getters.getHideUpcomingPremieres
+    },
     hideSharingActions: function () {
       return this.$store.getters.getHideSharingActions
     },
@@ -84,6 +87,7 @@ export default Vue.extend({
       'updateHideVideoDescription',
       'updateHideComments',
       'updateHideLiveStreams',
+      'updateHideUpcomingPremieres',
       'updateHideSharingActions',
       'updateHideChapters'
     ])

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -91,6 +91,12 @@
           @change="updateHideLiveStreams"
         />
         <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Upcoming Premieres')"
+          :compact="true"
+          :default-value="hideUpcomingPremieres"
+          @change="updateHideUpcomingPremieres"
+        />
+        <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Hide Comments')"
           :compact="true"
           :default-value="hideComments"

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
@@ -36,11 +36,38 @@ export default Vue.extend({
   computed: {
     hideLiveStreams: function() {
       return this.$store.getters.getHideLiveStreams
+    },
+    hideUpcomingPremieres: function () {
+      return this.$store.getters.getHideUpcomingPremieres
     }
   },
   methods: {
     onVisibilityChanged: function (visible) {
       this.visible = visible
+    },
+
+    showResult: function (data) {
+      if (!data.type) {
+        return false
+      }
+      if (data.type === 'video') {
+        if (this.hideLiveStreams && (data.liveNow || data.lengthSeconds == null)) {
+          // hide livestreams
+          return false
+        }
+
+        if (this.hideUpcomingPremieres &&
+            // Observed for premieres in Local API Channels.
+            (data.durationText === 'PREMIERE' ||
+             // viewCount is our only method of detecting premieres in RSS
+             // data without sending an additional request.
+             // If we ever get a better flag, use it here instead.
+             (data.isRSS && data.viewCount === '0'))) {
+          // hide upcoming
+          return false
+        }
+      }
+      return true
     }
   }
 })

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="data.type !== undefined && (data.type === 'video' ? ((!data.liveNow && (data.lengthSeconds != null)) || (!hideLiveStreams)) : true)"
+    v-if="showResult(data)"
     v-observe-visibility="firstScreen ? false : {
       callback: onVisibilityChanged,
       once: true,

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -223,6 +223,10 @@ export default Vue.extend({
       return this.$store.getters.getHideLiveStreams
     },
 
+    hideUpcomingPremieres: function () {
+      return this.$store.getters.getHideUpcomingPremieres
+    },
+
     hideVideoViews: function () {
       return this.$store.getters.getHideVideoViews
     },

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -205,6 +205,7 @@ const state = {
   hideSharingActions: false,
   hideTrendingVideos: false,
   hideUnsubscribeButton: false,
+  hideUpcomingPremieres: false,
   hideVideoLikesAndDislikes: false,
   hideVideoViews: false,
   hideWatchedSubs: false,

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -42,6 +42,11 @@ export default Vue.extend({
     hideLiveStreams: function() {
       return this.$store.getters.getHideLiveStreams
     },
+
+    hideUpcomingPremieres: function () {
+      return this.$store.getters.getHideUpcomingPremieres
+    },
+
     showFamilyFriendlyOnly: function() {
       return this.$store.getters.getShowFamilyFriendlyOnly
     }
@@ -149,7 +154,7 @@ export default Vue.extend({
             const publishDate = video.uploadedAt
             let videoDuration = video.duration
             const videoId = video.id
-            if (videoDuration !== null && videoDuration !== '' && videoDuration !== 'LIVE' && videoDuration !== 'UPCOMING') {
+            if (videoDuration !== null && videoDuration !== '' && videoDuration !== 'LIVE' && videoDuration !== 'UPCOMING' && videoDuration !== 'PREMIERE') {
               videoDuration = calculateLengthInSeconds(video.duration)
             }
             dataToShow.push(
@@ -169,7 +174,7 @@ export default Vue.extend({
                 liveNow: video.isLive || videoDuration === 'LIVE',
                 paid: false,
                 premium: false,
-                isUpcoming: videoDuration === 'UPCOMING',
+                isUpcoming: videoDuration === 'UPCOMING' || videoDuration === 'PREMIERE',
                 timeText: videoDuration
               }
             )

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -88,6 +88,11 @@ export default Vue.extend({
     hideLiveStreams: function() {
       return this.$store.getters.getHideLiveStreams
     },
+
+    hideUpcomingPremieres: function () {
+      return this.$store.getters.getHideUpcomingPremieres
+    },
+
     fetchSubscriptionsAutomatically: function() {
       return this.$store.getters.getFetchSubscriptionsAutomatically
     }
@@ -193,6 +198,18 @@ export default Vue.extend({
           if (this.hideLiveStreams) {
             videoList = videoList.filter(item => {
               return (!item.liveNow && !item.isUpcoming)
+            })
+          }
+          if (this.hideUpcomingPremieres) {
+            videoList = videoList.filter(item => {
+              if (item.isRSS) {
+                // viewCount is our only method of detecting premieres in RSS
+                // data without sending an additional request.
+                // If we ever get a better flag, use it here instead.
+                return item.viewCount !== '0'
+              }
+              // Observed for premieres in Local API Subscriptions.
+              return item.durationText !== 'PREMIERE'
             })
           }
           const profileSubscriptions = {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -322,6 +322,7 @@ Settings:
     Hide Video Description: Hide Video Description
     Hide Comments: Hide Comments
     Hide Live Streams: Hide Live Streams
+    Hide Upcoming Premieres: Hide Upcoming Premieres
     Hide Sharing Actions: Hide Sharing Actions
     Hide Chapters: Hide Chapters
   Data Settings:

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -391,6 +391,7 @@ Settings:
     Hide Comments: Hide comments
     Hide Video Description: Hide video description
     Hide Live Streams: Hide live streams
+    Hide Upcoming Premieres: Hide Upcoming Premieres
     Hide Sharing Actions: Hide sharing actions
     Hide Chapters: Hide chapters
   The app needs to restart for changes to take effect. Restart and apply change?: The


### PR DESCRIPTION
# Add Distraction Free Settings → Hide Upcoming Premieres

## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #507
see also #1070, #2755

## Description
Add a new boolean setting to Distraction Free: "Hide Upcoming Premieres."

When enabled, removes non-live future premieres from subscription and channel pages.

YT-side data unpredictably flips some streams that get "waiting" viewers from premieres into live streams and back. The live streams introduced can be removed by also enabling the "Hide Live Streams" setting.

Seeking feedback: Due to the weird shapeshifting streams issue above, and in order to avoid adding yet another setting, IMO there's a good argument for combining this new option with "Hide Live Streams" and having one switch do both. If you want one on, you probably want the other. I definitely need both myself. Made it a separate switch for now but happy to make the change if maintainers think combining makes sense.

## Screenshots

### New setting
![prem_new_setting](https://user-images.githubusercontent.com/704580/201117555-aaa3009a-71f6-4cd9-905c-5eec651b7504.png)

### An affected video
![prem_vid_info](https://user-images.githubusercontent.com/704580/201117707-44d0011d-fa81-4631-b9f0-e8092411dd7b.png)

### Setting OFF

The first item is our target.

![prem_before](https://user-images.githubusercontent.com/704580/201117808-b4177e82-9552-4e09-a9dd-684196d9f93a.png)

### Setting ON

And it's gone.

![prem_after](https://user-images.githubusercontent.com/704580/201118034-b79d6d35-074a-4aa6-9acf-4cfa5774c94a.png)

## Testing

I've tested the new setting using `npm run dev` against Local API (no fallback) due to Invidious API not cooperating at present, with Fetch Feeds from RSS both OFF and ON.

For a quick test:
1. Find a channel with a non-live upcoming premiere video. Subscribe to the channel.
2. With the setting OFF, verify that the target video appears in Subscriptions.
3. Turn the setting ON.
4. Return to Subscriptions and reload.
5. Verify that the target video no longer appears.

I've tested Subscriptions, Channel and Search pages. If you see areas where I'm not removing videos as appropriate please let me know.

## Desktop
- **OS:** NixOS
- **OS Version:** 22.05
- **FreeTube version:** 3f7a2cf

## Additional context
This PR conflicts with #2849 and the later merge will need rebasing/fixing. I'm borrowing their excellent showResult() addition to ft-list-lazy-wrapper.js since it's easier to work with than the previous v-if one-liner.