### PR TITLE
Migrate search suggestions to youtubei.js

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -126,10 +126,19 @@ const config = {
       filename: isDevMode ? '[name].css' : '[name].[contenthash].css',
       chunkFilename: isDevMode ? '[id].css' : '[id].[contenthash].css',
     }),
+    // ignore linkedom's unnecessary broken canvas import, as youtubei.js only uses linkedom to generate DASH manifests
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^canvas$/
+    })
   ],
   resolve: {
     alias: {
-      vue$: 'vue/dist/vue.common.js'
+      vue$: 'vue/dist/vue.common.js',
+
+      // defaults to the prebundled browser version which causes webpack to error with:
+      // "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted"
+      // webpack likes to bundle the dependencies itself, could really have a better error message though
+      'youtubei.js$': 'youtubei.js/dist/browser.js',
     },
     extensions: ['.js', '.vue']
   },

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -26,6 +26,7 @@ const config = {
   },
   externals: {
     electron: '{}',
+    'youtubei.js': '{}',
     ytpl: '{}',
     ytsr: '{}'
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtube-suggest": "^1.2.0",
+    "youtubei.js": "^2.3.3",
     "yt-channel-info": "^3.2.1",
     "yt-dash-manifest-generator": "1.1.0",
     "ytdl-core": "https://github.com/absidue/node-ytdl-core#fix-likes-extraction",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^2.3.3",
+    "youtubei.js": "^2.5.0",
     "yt-channel-info": "^3.2.1",
     "yt-dash-manifest-generator": "1.1.0",
     "ytdl-core": "https://github.com/absidue/node-ytdl-core#fix-likes-extraction",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -162,6 +162,16 @@ function runApp() {
       })
     })
 
+    // make InnerTube request work with the fetch function
+    // InnerTube rejects requests if the referer isn't YouTube or empty
+    const innertubeRequestFilter = { urls: ['https://www.youtube.com/youtubei/*'] }
+
+    session.defaultSession.webRequest.onBeforeSendHeaders(innertubeRequestFilter, ({ requestHeaders }, callback) => {
+      requestHeaders.referer = 'https://www.youtube.com'
+      // eslint-disable-next-line node/no-callback-literal
+      callback({ requestHeaders })
+    })
+
     if (replaceHttpCache) {
       // in-memory image cache
 

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -24,7 +24,8 @@ export default Vue.extend({
       searchFilterValueChanged: false,
       historyIndex: 1,
       isForwardOrBack: false,
-      searchSuggestionsDataList: []
+      searchSuggestionsDataList: [],
+      lastSuggestionQuery: ''
     }
   },
   computed: {
@@ -208,7 +209,11 @@ export default Vue.extend({
 
     getSearchSuggestionsDebounce: function (query) {
       if (this.enableSearchSuggestions) {
-        this.debounceSearchResults(query)
+        const trimmedQuery = query.trim()
+        if (trimmedQuery !== this.lastSuggestionQuery) {
+          this.lastSuggestionQuery = trimmedQuery
+          this.debounceSearchResults(trimmedQuery)
+        }
       }
     },
 

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -4,10 +4,10 @@ import FtInput from '../ft-input/ft-input.vue'
 import FtSearchFilters from '../ft-search-filters/ft-search-filters.vue'
 import FtProfileSelector from '../ft-profile-selector/ft-profile-selector.vue'
 import debounce from 'lodash.debounce'
-import ytSuggest from 'youtube-suggest'
 
 import { IpcChannels } from '../../../constants'
 import { openInternalPath, showToast } from '../../helpers/utils'
+import { clearYTSearchSuggestionsSession, getYTSearchSuggestions } from '../../helpers/api/local'
 
 export default Vue.extend({
   name: 'TopNav',
@@ -110,6 +110,8 @@ export default Vue.extend({
       } else {
         this.searchInput.blur()
       }
+
+      clearYTSearchSuggestionsSession()
 
       this.getYoutubeUrlInfo(query).then((result) => {
         switch (result.urlType) {
@@ -227,7 +229,7 @@ export default Vue.extend({
         return
       }
 
-      ytSuggest(query).then((results) => {
+      getYTSearchSuggestions(query).then((results) => {
         this.searchSuggestionsDataList = results
       })
     },

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -7,7 +7,7 @@ import debounce from 'lodash.debounce'
 
 import { IpcChannels } from '../../../constants'
 import { openInternalPath, showToast } from '../../helpers/utils'
-import { clearYTSearchSuggestionsSession, getYTSearchSuggestions } from '../../helpers/api/local'
+import { clearLocalSearchSuggestionsSession, getLocalSearchSuggestions } from '../../helpers/api/local'
 
 export default Vue.extend({
   name: 'TopNav',
@@ -111,7 +111,7 @@ export default Vue.extend({
         this.searchInput.blur()
       }
 
-      clearYTSearchSuggestionsSession()
+      clearLocalSearchSuggestionsSession()
 
       this.getYoutubeUrlInfo(query).then((result) => {
         switch (result.urlType) {
@@ -229,7 +229,7 @@ export default Vue.extend({
         return
       }
 
-      getYTSearchSuggestions(query).then((results) => {
+      getLocalSearchSuggestions(query).then((results) => {
         this.searchSuggestionsDataList = results
       })
     },

--- a/src/renderer/helpers/api/PlayerCache.js
+++ b/src/renderer/helpers/api/PlayerCache.js
@@ -1,0 +1,41 @@
+import { access, mkdir, readFile, unlink, writeFile } from 'fs/promises'
+import { resolve } from 'path'
+
+// based off https://github.com/LuanRT/YouTube.js/blob/6caa679df6ddc77d25be02dcb7355b722ab268aa/src/utils/Cache.ts
+// avoids errors caused by the fully dynamic `fs` and `pathh` module imports that youtubei.js's UniversalCache does
+export class PlayerCache {
+  constructor(cacheDirectory) {
+    this.cacheDirectory = cacheDirectory
+  }
+
+  async get(key) {
+    const filePath = resolve(this.cacheDirectory, key)
+
+    try {
+      const contents = await readFile(filePath)
+      return contents.buffer
+    } catch (e) {
+      if (e?.code === 'ENOENT') {
+        return undefined
+      }
+      throw e
+    }
+  }
+
+  async set(key, value) {
+    await mkdir(this.cacheDirectory, { recursive: true })
+
+    const filePath = resolve(this.cacheDirectory, key)
+    await writeFile(filePath, new Uint8Array(value))
+  }
+
+  async remove(key) {
+    const filePath = resolve(this.cacheDirectory, key)
+
+    // only try to delete the file if it exists, access() throws an exception if the file doesn't exist
+    try {
+      await access(filePath)
+      await unlink(filePath)
+    } catch { }
+  }
+}

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,19 +1,19 @@
 import { Innertube } from 'youtubei.js'
 
-let searchSuggestionsInnerTube = null
+let searchSuggestionsSession = null
 
-export async function getYTSearchSuggestions(query) {
+export async function getLocalSearchSuggestions(query) {
   // reuse innertube instance to keep the search suggestions snappy
-  if (searchSuggestionsInnerTube === null) {
-    searchSuggestionsInnerTube = await Innertube.create({
+  if (searchSuggestionsSession === null) {
+    searchSuggestionsSession = await Innertube.create({
       // use browser fetch
       fetch: (input, init) => fetch(input, init)
     })
   }
 
-  return await searchSuggestionsInnerTube.getSearchSuggestions(query)
+  return await searchSuggestionsSession.getSearchSuggestions(query)
 }
 
-export function clearYTSearchSuggestionsSession() {
-  searchSuggestionsInnerTube = null
+export function clearLocalSearchSuggestionsSession() {
+  searchSuggestionsSession = null
 }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,0 +1,19 @@
+import { Innertube } from 'youtubei.js'
+
+let searchSuggestionsInnerTube = null
+
+export async function getYTSearchSuggestions(query) {
+  // reuse innertube instance to keep the search suggestions snappy
+  if (searchSuggestionsInnerTube === null) {
+    searchSuggestionsInnerTube = await Innertube.create({
+      // use browser fetch
+      fetch: (input, init) => fetch(input, init)
+    })
+  }
+
+  return await searchSuggestionsInnerTube.getSearchSuggestions(query)
+}
+
+export function clearYTSearchSuggestionsSession() {
+  searchSuggestionsInnerTube = null
+}

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,14 +1,53 @@
-import { Innertube } from 'youtubei.js'
+import { Innertube, Session } from 'youtubei.js'
+import { PlayerCache } from './PlayerCache'
+import { join } from 'path'
+
+import store from '../../store/index'
+
+/**
+ * Creates a lightweight Innertube instance, which is faster to create or
+ * an instance that can decode the streaming URLs, which is slower to create
+ * the lightweight one only needs a single web request to create the new session
+ * the full one needs 3 (or 2 if the player is cached) web requests to create:
+ * 1. the request for the session
+ * 2. fetch a page that contains a link to the player
+ * 3. if the player isn't cached, it is downloaded and transformed
+ * @param {boolean} withPlayer set to true to get an Innertube instance that can decode the streaming URLs
+ * @returns the Innertube instance
+ */
+async function createInnertube(withPlayer = false) {
+  if (withPlayer) {
+    const userData = await store.dispatch('getUserDataPath')
+
+    return await Innertube.create({
+      // use browser fetch
+      fetch: (input, init) => fetch(input, init),
+      cache: new PlayerCache(join(userData, 'player_cache'))
+    })
+  } else {
+    // from https://github.com/LuanRT/YouTube.js/pull/240
+    const sessionData = await Session.getSessionData()
+
+    const session = new Session(
+      sessionData.context,
+      sessionData.api_key,
+      sessionData.api_version,
+      sessionData.account_index,
+      undefined, // player
+      undefined, // cookies
+      (input, init) => fetch(input, init) // use browser fetch
+    )
+
+    return new Innertube(session)
+  }
+}
 
 let searchSuggestionsSession = null
 
 export async function getLocalSearchSuggestions(query) {
   // reuse innertube instance to keep the search suggestions snappy
   if (searchSuggestionsSession === null) {
-    searchSuggestionsSession = await Innertube.create({
-      // use browser fetch
-      fetch: (input, init) => fetch(input, init)
-    })
+    searchSuggestionsSession = await createInnertube()
   }
 
   return await searchSuggestionsSession.getSearchSuggestions(query)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,6 +1228,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@protobuf-ts/runtime@^2.7.0":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.8.1.tgz#e88f89650ab29c3eba0afebe32b9f3552f35fc85"
+  integrity sha512-D9M5hSumYCovIfNllt7N6ODh4q+LrjiMWtNETvooaf+a2XheZJ7kgjFlsFghti0CFWwtA//of4JXQfw9hU+cCw==
+
 "@seald-io/binary-search-tree@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@seald-io/binary-search-tree/-/binary-search-tree-1.0.2.tgz#9f0e5cec5e0acf97f1b495f2f6d3476ddb6a94ed"
@@ -2487,6 +2492,13 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -3005,6 +3017,17 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-tree@^1.1.2, css-tree@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
@@ -3013,7 +3036,7 @@ css-tree@^1.1.2, css-tree@^1.1.3:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@^6.0.1:
+css-what@^6.0.1, css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
@@ -3078,6 +3101,11 @@ csso@^4.2.0:
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
+
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
 
 csstype@^3.1.0:
   version "3.1.1"
@@ -3307,6 +3335,15 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
@@ -3317,7 +3354,7 @@ domain-browser@^1.2.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
   integrity sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -3329,6 +3366,13 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+domhandler@^5.0.1, domhandler@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
@@ -3337,6 +3381,15 @@ domutils@^2.5.2, domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -3527,6 +3580,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.2.0, entities@^4.3.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -4596,6 +4654,11 @@ html-entities@^2.3.2:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
   integrity sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==
 
+html-escaper@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
+  integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
+
 html-minifier-terser@^6.0.2:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#bfc818934cc07918f6b3669f5774ecdfd48f32ab"
@@ -4634,6 +4697,16 @@ htmlparser2@^6.1.0:
     domhandler "^4.0.0"
     domutils "^2.5.2"
     entities "^2.0.0"
+
+htmlparser2@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
+  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    entities "^4.3.0"
 
 http-cache-semantics@^4.0.0:
   version "4.1.0"
@@ -5168,6 +5241,13 @@ jest-worker@^29.1.2:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jintr@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/jintr/-/jintr-0.3.1.tgz#0ab49390a187d77dc5f2c19580c644d70a94528a"
+  integrity sha512-AUcq8fKL4BE9jDx8TizZmJ9UOvk1CHKFW0nQcWaOaqk9tkLS9S10fNmusTWGEYTncn7U43nXrCbhYko/ylqrSg==
+  dependencies:
+    acorn "^8.8.0"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5389,6 +5469,17 @@ lilconfig@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
+
+linkedom@^0.14.12:
+  version "0.14.19"
+  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.14.19.tgz#a8e9b91af26d5c631b5b3d21614cef1db8a56fb7"
+  integrity sha512-sFNkQZlKBWpEaAcbsDIghTLE0hHbyvS6dZuM7IH+KTM09GaQ772PtDZAuFlN0oFgyAjUj8XS9FpoWSLmBjl8MA==
+  dependencies:
+    css-select "^5.1.0"
+    cssom "^0.5.0"
+    html-escaper "^3.0.3"
+    htmlparser2 "^8.0.1"
+    uhyphen "^0.1.0"
 
 load-json-file@^4.0.0:
   version "4.0.0"
@@ -5859,13 +5950,6 @@ node-addon-api@^1.6.3:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
-
-node-fetch@^2.6.0:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-forge@^1:
   version "1.3.1"
@@ -7288,11 +7372,6 @@ smart-buffer@^4.0.2, smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-smol-jsonp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/smol-jsonp/-/smol-jsonp-1.0.0.tgz#b662c932a193f1a5c6bb1dcdaaddcd4e2007f7df"
-  integrity sha512-EwM2cKsq87A9cCKiAwfp7kVSRtAT01M/3HXaO3tYxP+pnEZ5zVYsxLdTnPjJVVIeK9O2zkV0QbWuwlHEUQNdOA==
-
 sockjs@^0.3.24:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
@@ -7483,6 +7562,11 @@ stream-splicer@^2.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.2"
+
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -7755,11 +7839,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
-
 tree-kill@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -7844,6 +7923,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
+uhyphen@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/uhyphen/-/uhyphen-0.1.0.tgz#3cc22afa790daa802b9f6789f3583108d5b4a08c"
+  integrity sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw==
+
 umd@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.3.tgz#aa9fe653c42b9097678489c01000acb69f0b26cf"
@@ -7874,6 +7958,13 @@ underscore@1.13.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
+
+undici@^5.7.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.12.0.tgz#c758ffa704fbcd40d506e4948860ccaf4099f531"
+  integrity sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==
+  dependencies:
+    busboy "^1.6.0"
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -8216,11 +8307,6 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
-
 webpack-cli@^4.10.0:
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
@@ -8341,14 +8427,6 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -8489,13 +8567,15 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-youtube-suggest@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/youtube-suggest/-/youtube-suggest-1.2.0.tgz#5f1b445c2b71bfc8a4c89af99775b02cd827e77d"
-  integrity sha512-/ItW6204M+OOHaO4k5DYJGHH+UZjkaKNb7rtAWQaA6zeJvUu3tbveAsm+xTGH+8VfyT/LoAhN9/yOQajduDCJA==
+youtubei.js@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.3.3.tgz#49c727c12e7c4e9caa7da1987bc09810bde5ab67"
+  integrity sha512-6pYPZMN2sMfIBb33nRgtlIhgj0DD1GNRf9jZXiJYxqXntt8RCa9T7N3WvuTbImJA5GgNA6RwAW5VI0uhh0jF4w==
   dependencies:
-    node-fetch "^2.6.0"
-    smol-jsonp "^1.0.0"
+    "@protobuf-ts/runtime" "^2.7.0"
+    jintr "^0.3.1"
+    linkedom "^0.14.12"
+    undici "^5.7.0"
 
 yt-channel-info@^3.2.1:
   version "3.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8567,10 +8567,10 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-youtubei.js@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.3.3.tgz#49c727c12e7c4e9caa7da1987bc09810bde5ab67"
-  integrity sha512-6pYPZMN2sMfIBb33nRgtlIhgj0DD1GNRf9jZXiJYxqXntt8RCa9T7N3WvuTbImJA5GgNA6RwAW5VI0uhh0jF4w==
+youtubei.js@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.5.0.tgz#bd209a8b1edccc106ef0d77c6a619f3e3085913a"
+  integrity sha512-RnRXF4+HESqpJQ1FIWXZ/6M+0Sdt8OndTTD0yYex+zWR+7YOBRrWcXRuKSsWgw3v3ctuzW7TJ8+t/s/8/ImFHw==
   dependencies:
     "@protobuf-ts/runtime" "^2.7.0"
     jintr "^0.3.1"


### PR DESCRIPTION
# Migrate search suggestions to youtubei.js

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This is the first step in migrating over to youtubei.js (https://github.com/LuanRT/YouTube.js), as discussed I decided to start with the search suggestions as those are the easiest to do.

The full Innertube instance creation is only needed when you want to decode streaming URLs, so for us that is only needed on the watch page, all other parts of FreeTube don't need it, so we can just create new sessions without needing to fetch the player, for most of FreeTube. This approach should keep FreeTube quick.

**I had to do some shenanigans in the webpack config to get the library to work:**

1. The youtubei.js package is distributed in 3 different versions, only the last one works for our use case:
    - `bundle/browser.js`: browser ready bundle with all of it's dependencies already bundled in (webpack likes to do it's own bundling of dependencies, which is why it errored), this is what webpack picks by default as it's listed in the browser field in their package.json
    - `dist/index.js`: node version, this is the one that overwrites the global fetch function, as most versions of node don't have fetch anyway so it's fine in 99% of situations. It's bad for us though, as that means that none of the fetch calls that FreeTube makes (update check, RSS subscriptions, SponsorBlock) show up in the devtools anymore.
    - `dist/browser.js`: browser version but not prebundled, so it doesn't make webpack complain and it doesn't overwrite the fetch function, so I can make the library use the browser fetch function, which means that it will respect the proxy settings (no need for the {http,https,socks}-proxy-agent dependencies once we fully migrate, as we configure the proxy in electron's settings at startup, the browser fetch function routes everything through the proxy)

2. One of youtubei.js' dependencies linkedom, has an optional dependency on `canvas`, which it tries to import in a try-catch. Webpack doesn't care about the optional nature of the dependency and complains about it being missing. I decided to use the IgnorePlugin to ignore it instead of adding it, as it is a native dependency and failed to build on my machine, additionally youtubei.js only uses linkedom to generate DASH manifests, so it definitely doesn't need the canvas dependency.

Sadly due to webpack not being able to tree shake classes and only having partial support for tree shaking commonjs, this PR blows up the `renderer.js` file by 0.87MB and increases the release build time by 3-6 seconds on my machine. In the future we might be able to improve this by switching to a more modern bundler such as vite. For the electron build that's fine, as electron itself is still massive and the web build isn't affected. The bundle size will go down slightly again once we migrate over other parts of FreeTube, getting rid of the dependencies that they currently use.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/204135077-5a6debb0-4716-4239-96e5-67729212c344.png)
![after](https://user-images.githubusercontent.com/48293849/204135080-fff52ab3-c366-4183-8d0e-d68fc8c61d9d.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Use the search field as usually and check that the search suggestions show up.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0