### PR TITLE
Use the available space better in the player and theme settings

### DIFF
--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -45,18 +45,6 @@
           :tooltip="$t('Tooltips.Player Settings.Scroll Playback Rate Over Video Player')"
           @change="updateVideoPlaybackRateMouseScroll"
         />
-        <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Display Play Button In Video Player')"
-          :compact="true"
-          :default-value="displayVideoPlayButton"
-          @change="updateDisplayVideoPlayButton"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Enter Fullscreen on Display Rotate')"
-          :compact="true"
-          :default-value="enterFullscreenOnDisplayRotate"
-          @change="updateEnterFullscreenOnDisplayRotate"
-        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch
@@ -77,6 +65,18 @@
           :disabled="hideRecommendedVideos"
           :default-value="playNextVideo"
           @change="updatePlayNextVideo"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Display Play Button In Video Player')"
+          :compact="true"
+          :default-value="displayVideoPlayButton"
+          @change="updateDisplayVideoPlayButton"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Enter Fullscreen on Display Rotate')"
+          :compact="true"
+          :default-value="enterFullscreenOnDisplayRotate"
+          @change="updateEnterFullscreenOnDisplayRotate"
         />
       </div>
     </div>

--- a/src/renderer/components/theme-settings/theme-settings.vue
+++ b/src/renderer/components/theme-settings/theme-settings.vue
@@ -5,22 +5,26 @@
     <ft-flex-box>
       <ft-toggle-switch
         :label="$t('Settings.Theme Settings.Match Top Bar with Main Color')"
+        :compact="true"
         :default-value="barColor"
         @change="updateBarColor"
       />
       <ft-toggle-switch
         :label="$t('Settings.Theme Settings.Expand Side Bar by Default')"
+        :compact="true"
         :default-value="expandSideBar"
         @change="handleExpandSideBar"
       />
       <ft-toggle-switch
         v-if="usingElectron"
         :label="$t('Settings.Theme Settings.Disable Smooth Scrolling')"
+        :compact="true"
         :default-value="disableSmoothScrollingToggleValue"
         @change="handleRestartPrompt"
       />
       <ft-toggle-switch
         :label="$t('Settings.Theme Settings.Hide Side Bar Labels')"
+        :compact="true"
         :default-value="hideLabelsSideBar"
         @change="updateHideLabelsSideBar"
       />


### PR DESCRIPTION
# Use the available space better in the player and theme settings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This pull request make the switches in the theme settings compact and rearranges the switches in the player settings so they aren't all in the left column.

## Screenshots <!-- If appropriate -->
Theme settings:
![before-theme-settings](https://user-images.githubusercontent.com/48293849/201398588-d78d85ee-3d06-4cf7-9503-3d7662603995.png)
![after-theme-settings](https://user-images.githubusercontent.com/48293849/201398599-19e9b011-9c86-4acc-a543-245f0bc9d73a.png)

Player settings:
![before-player-settings](https://user-images.githubusercontent.com/48293849/201398696-b0477823-0531-41af-8b69-90508f98b7c2.png)
![after-player-settings](https://user-images.githubusercontent.com/48293849/201398700-0e346fe4-7684-4003-a0b2-20800f32255d.png)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0