### PR TITLE
Themes css deduplication

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -343,130 +343,107 @@
   --logo-text-bar-color: url("../../_icons/textDraculaDarkSmall.png");
 }
 
+.mainCatppuccinMochaRosewater,
+.mainCatppuccinMochaFlamingo,
+.mainCatppuccinMochaPink,
+.mainCatppuccinMochaMauve,
+.mainCatppuccinMochaRed,
+.mainCatppuccinMochaMaroon,
+.mainCatppuccinMochaPeach,
+.mainCatppuccinMochaYellow,
+.mainCatppuccinMochaGreen,
+.mainCatppuccinMochaTeal,
+.mainCatppuccinMochaSky,
+.mainCatppuccinMochaSapphire,
+.mainCatppuccinMochaBlue,
+.mainCatppuccinMochaLavender {
+  --text-with-main-color: #1e1e2e;
+  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
+  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
+}
+
 .mainCatppuccinMochaRosewater {
   --primary-color: #f5e0dc;
   --primary-color-hover: #fceeec;
   --primary-color-active: #e1c8c3;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaFlamingo {
   --primary-color: #f2cdcd;
   --primary-color-hover: #f2e1e1;
   --primary-color-active: #ddb7b7;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaPink {
   --primary-color: #f5c2e7;
   --primary-color-hover: #f3d2ea;
   --primary-color-active: #dca3cd;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaMauve {
   --primary-color: #cba6f7;
   --primary-color-hover: #d4b7f8;
   --primary-color-active: #b38fdf;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaRed {
   --primary-color: #f38ba8;
   --primary-color-hover: #f0a4b9;
   --primary-color-active: #de7693;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaMaroon {
   --primary-color: #eba0ac;
   --primary-color-hover: #eabbc3;
   --primary-color-active: #d68895;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaPeach {
   --primary-color: #fab387;
   --primary-color-hover: #f7c7a9;
   --primary-color-active: #e1996d;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaYellow {
   --primary-color: #f9e2af;
   --primary-color-hover: #feeecd;
   --primary-color-active: #dec48d;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaGreen {
   --primary-color: #a6e3a1;
   --primary-color-hover: #bfebbb;
   --primary-color-active: #86c780;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaTeal {
   --primary-color: #94e2d5;
   --primary-color-hover: #aceae0;
   --primary-color-active: #6fc5b7;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaSky {
   --primary-color: #89dceb;
   --primary-color-hover: #a3e4f0;
   --primary-color-active: #68bcca;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaSapphire {
   --primary-color: #74c7ec;
   --primary-color-hover: #93d1ed;
   --primary-color-active: #59a9cf;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaBlue {
   --primary-color: #89b4fa;
   --primary-color-hover: #a6c8ff;
   --primary-color-active: #6593df;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .mainCatppuccinMochaLavender {
   --primary-color: #b4befe;
   --primary-color-hover: #c9d0ff;
   --primary-color-active: #8d98e4;
-  --text-with-main-color: #1e1e2e;
-  --logo-icon-bar-color: url("../../_icons/iconCatppuccinMochaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textCatppuccinMochaDarkSmall.png");
 }
 
 .secRed {
@@ -768,13 +745,29 @@
   --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
+.secCatppuccinMochaRosewater,
+.secCatppuccinMochaFlamingo,
+.secCatppuccinMochaPink,
+.secCatppuccinMochaMauve,
+.secCatppuccinMochaRed,
+.secCatppuccinMochaMaroon,
+.secCatppuccinMochaPeach,
+.secCatppuccinMochaYellow,
+.secCatppuccinMochaGreen,
+.secCatppuccinMochaTeal,
+.secCatppuccinMochaSky,
+.secCatppuccinMochaSapphire,
+.secCatppuccinMochaBlue,
+.secCatppuccinMochaLavender {
+  --text-with-accent-color: #1e1e2e;
+}
+
 .secCatppuccinMochaRosewater {
   --accent-color: #f5e0dc;
   --accent-color-hover: #fceeec;
   --accent-color-active: #e1c8c3;
   --accent-color-light: #F8EAE7;
   --accent-color-visited: #D3A197;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(245,224,220,0.04);
   --accent-color-opacity2: rgba(245,224,220,0.12);
   --accent-color-opacity3: rgba(245,224,220,0.16);
@@ -787,7 +780,6 @@
   --accent-color-active: #ddb7b7;
   --accent-color-light: #F7DFDF;
   --accent-color-visited: #cf9898;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(242,205,205,0.04);
   --accent-color-opacity2: rgba(242,205,205,0.12);
   --accent-color-opacity3: rgba(242,205,205,0.16);
@@ -800,7 +792,6 @@
   --accent-color-active: #dca3cd;
   --accent-color-light: #f4dbed;
   --accent-color-visited: #d28fc0;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(245,194,231,0.04);
   --accent-color-opacity2: rgba(245,194,231,0.12);
   --accent-color-opacity3: rgba(245,194,231,0.16);
@@ -813,7 +804,6 @@
   --accent-color-active: #b38fdf;
   --accent-color-light: #D6B9F9;
   --accent-color-visited: #A171DA;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(203,166,247,0.04);
   --accent-color-opacity2: rgba(203,166,247,0.12);
   --accent-color-opacity3: rgba(203,166,247,0.16);
@@ -826,7 +816,6 @@
   --accent-color-active: #de7693;
   --accent-color-light: #F5A3BA;
   --accent-color-visited: #D56C89;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(243,139,168,0.04);
   --accent-color-opacity2: rgba(243,139,168,0.12);
   --accent-color-opacity3: rgba(243,139,168,0.16);
@@ -839,7 +828,6 @@
   --accent-color-active: #d68895;
   --accent-color-light: #F0B7C0;
   --accent-color-visited: #C86A79;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(235,160,172,0.04);
   --accent-color-opacity2: rgba(235,160,172,0.12);
   --accent-color-opacity3: rgba(235,160,172,0.16);
@@ -852,7 +840,6 @@
   --accent-color-active: #e1996d;
   --accent-color-light: #FBC4A2;
   --accent-color-visited: #D78A5B;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(250,179,135,0.04);
   --accent-color-opacity2: rgba(250,179,135,0.12);
   --accent-color-opacity3: rgba(250,179,135,0.16);
@@ -865,7 +852,6 @@
   --accent-color-active: #dec48d;
   --accent-color-light: #FBECCB;
   --accent-color-visited: #D5B05D;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(249,226,175,0.04);
   --accent-color-opacity2: rgba(249,226,175,0.12);
   --accent-color-opacity3: rgba(249,226,175,0.16);
@@ -878,7 +864,6 @@
   --accent-color-active: #86c780;
   --accent-color-light: #BCEAB8;
   --accent-color-visited: #6ED166;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(166,227,161,0.04);
   --accent-color-opacity2: rgba(166,227,161,0.12);
   --accent-color-opacity3: rgba(166,227,161,0.16);
@@ -891,7 +876,6 @@
   --accent-color-active: #6fc5b7;
   --accent-color-light: #AFE9DF;
   --accent-color-visited: #5CCCB9;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(148,226,213,0.04);
   --accent-color-opacity2: rgba(148,226,213,0.12);
   --accent-color-opacity3: rgba(148,226,213,0.16);
@@ -904,7 +888,6 @@
   --accent-color-active: #68bcca;
   --accent-color-light: #9FE3EF;
   --accent-color-visited: #64C2D3;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(137,220,235,0.04);
   --accent-color-opacity2: rgba(137,220,235,0.12);
   --accent-color-opacity3: rgba(137,220,235,0.16);
@@ -917,7 +900,6 @@
   --accent-color-active: #59a9cf;
   --accent-color-light: #93D4F0;
   --accent-color-visited: #6AB6D7;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(116,199,236,0.04);
   --accent-color-opacity2: rgba(116,199,236,0.12);
   --accent-color-opacity3: rgba(116,199,236,0.16);
@@ -930,7 +912,6 @@
   --accent-color-active: #6593df;
   --accent-color-light: #A7C7FB;
   --accent-color-visited: #739CDD;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(137,220,235,0.04);
   --accent-color-opacity2: rgba(137,220,235,0.12);
   --accent-color-opacity3: rgba(137,220,235,0.16);
@@ -943,7 +924,6 @@
   --accent-color-active: #8d98e4;
   --accent-color-light: #D2D8FE;
   --accent-color-visited: #96A1E9;
-  --text-with-accent-color: #1e1e2e;
   --accent-color-opacity1: rgba(180,190,254,0.04);
   --accent-color-opacity2: rgba(180,190,254,0.12);
   --accent-color-opacity3: rgba(180,190,254,0.16);

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -1,13 +1,45 @@
+.system[data-system-theme*='light'], .light,
+.system[data-system-theme*='dark'], .dark,
+.black,
+.gray,
+.dracula,
+.catppuccinMocha {
+  --primary-input-color: rgba(0, 0, 0, 0.50);
+}
+
+.system[data-system-theme*='light'], .light,
+.system[data-system-theme*='dark'], .dark,
+.black,
+.gray {
+  --logo-icon: url("../../_icons/iconColorSmall.png");
+  --logo-text: url("../../_icons/textColorSmall.png");
+}
+
+.system[data-system-theme*='light'], .light,
+.system[data-system-theme*='dark'], .dark,
+.black,
+.dracula,
+.catppuccinMocha {
+  --link-color: var(--accent-color);
+  --link-visited-color: var(--accent-color-visited);
+  --instance-menu-color: var(--search-bar-color);
+}
+
+.system[data-system-theme*='dark'], .dark,
+.black,
+.gray,
+.dracula,
+.catppuccinMocha {
+  --primary-shadow-color: rgba(0, 0, 0, 0.75);
+}
+
 .system[data-system-theme*='light'], .light {
   --primary-text-color: #212121;
   --secondary-text-color: #424242;
   --tertiary-text-color: #757575;
-  --primary-input-color: rgba(0, 0, 0, 0.50);
   --primary-shadow-color: rgba(232, 232, 232, 1);
   --title-color: #3f7ac6;
   --bg-color: #f1f1f1;
-  --link-color: var(--accent-color);
-  --link-visited-color: var(--accent-color-visited);
   --favorite-icon-color: #FFD600;
   --card-bg-color: #FFFFFF;
   --secondary-card-bg-color: #eeeeee;
@@ -17,21 +49,14 @@
   --side-nav-hover-color: #e0e0e0;
   --side-nav-active-color: #757575;
   --search-bar-color: #f5f5f5;
-  --instance-menu-color: var(--search-bar-color);
-  --logo-icon: url("../../_icons/iconColorSmall.png");
-  --logo-text: url("../../_icons/textColorSmall.png");
 }
 
 .system[data-system-theme*='dark'], .dark {
   --primary-text-color: #EEEEEE;
   --secondary-text-color: #ddd;
   --tertiary-text-color: #999;
-  --primary-input-color: rgba(0, 0, 0, 0.50);
-  --primary-shadow-color: rgba(0, 0, 0, 0.75);
   --title-color: #EEEEEE;
   --bg-color: #212121;
-  --link-color: var(--accent-color);
-  --link-visited-color: var(--accent-color-visited);
   --favorite-icon-color: #FFEA00;
   --card-bg-color: #303030;
   --secondary-card-bg-color: rgba(0, 0, 0, 0.75);
@@ -41,21 +66,14 @@
   --side-nav-hover-color: #212121;
   --side-nav-active-color: #303030;
   --search-bar-color: #262626;
-  --instance-menu-color: var(--search-bar-color);
-  --logo-icon: url("../../_icons/iconColorSmall.png");
-  --logo-text: url("../../_icons/textColorSmall.png");
 }
 
 .black {
     --primary-text-color: #EEEEEE;
     --secondary-text-color: #ddd;
     --tertiary-text-color: #EEEEEE;
-    --primary-input-color: rgba(0, 0, 0, 0.50);
-    --primary-shadow-color: rgba(0, 0, 0, 0.75);
     --title-color: #EEEEEEE;
     --bg-color: #000000;
-    --link-color: var(--accent-color);
-    --link-visited-color: var(--accent-color-visited);
     --favorite-icon-color: #FFEA00;
     --card-bg-color: #000000;
     --secondary-card-bg-color: rgba(0, 0, 0, 0.75);
@@ -65,17 +83,12 @@
     --side-nav-hover-color: #212121;
     --side-nav-active-color: #303030;
     --search-bar-color: #262626;
-    --instance-menu-color: var(--search-bar-color);
-    --logo-icon: url("../../_icons/iconColorSmall.png");
-    --logo-text: url("../../_icons/textColorSmall.png");
 }
 
 .gray {
   --primary-text-color: #EEEEEE;
   --secondary-text-color: #E0E0E0;
   --tertiary-text-color: #F5F5F5;
-  --primary-input-color: rgba(0, 0, 0, 0.50);
-  --primary-shadow-color: rgba(0, 0, 0, 0.75);
   --title-color: #EEEEEE;
   --bg-color: #212121;
   --card-bg-color: #303030;
@@ -84,20 +97,14 @@
   --side-nav-hover-color: #212121;
   --side-nav-active-color: #303030;
   --search-bar-color: #212121;
-  --logo-icon: url("../../_icons/iconColorSmall.png");
-  --logo-text: url("../../_icons/textColorSmall.png");
 }
 
 .dracula {
   --primary-text-color: #F8F8F2;
   --secondary-text-color: #c6cee6;
   --tertiary-text-color: #e5e8f3;
-  --primary-input-color: rgba(0, 0, 0, 0.50);
-  --primary-shadow-color: rgba(0, 0, 0, 0.75);
   --title-color: #BD93F9;
   --bg-color: #282A36;
-  --link-color: var(--accent-color);
-  --link-visited-color: var(--accent-color-visited);
   --favorite-icon-color: #F1FA8C;
   --card-bg-color: #33353F;
   --secondary-card-bg-color: #282A36;
@@ -107,7 +114,6 @@
   --side-nav-hover-color: #57596B;
   --side-nav-active-color: #3D4051;
   --search-bar-color: #3E3F4A;
-  --instance-menu-color: var(--search-bar-color);
   --logo-icon: url("../../_icons/iconDraculaLightSmall.png");
   --logo-text: url("../../_icons/textDraculaLightSmall.png");
 }
@@ -116,12 +122,8 @@
   --primary-text-color: #cdd6f4;
   --secondary-text-color: #bac2de;
   --tertiary-text-color: #a6adc8;
-  --primary-input-color: rgba(0, 0, 0, 0.50);
-  --primary-shadow-color: rgba(0, 0, 0, 0.75);
   --title-color: var(--accent-color);
   --bg-color: #1e1e2e;
-  --link-color: var(--accent-color);
-  --link-visited-color: var(--accent-color-visited);
   --favorite-icon-color: #f9e2af;
   --card-bg-color: #181825;
   --secondary-card-bg-color: #1e1e2e;
@@ -131,7 +133,6 @@
   --side-nav-hover-color: #11111b;
   --side-nav-active-color: #11111b;
   --search-bar-color: #313244;
-  --instance-menu-color: var(--search-bar-color);
   --logo-icon: url("../../_icons/iconCatppuccinMochaLightSmall.png");
   --logo-text: url("../../_icons/textCatppuccinMochaLightSmall.png");
 }

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -137,148 +137,126 @@
   --logo-text: url("../../_icons/textCatppuccinMochaLightSmall.png");
 }
 
+.mainRed
+.mainPink
+.mainPurple
+.mainDeepPurple
+.mainIndigo
+.mainBlue
+.mainLightBlue
+.mainCyan
+.mainTeal
+.mainGreen {
+  --text-with-main-color: #FFFFFF;
+  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
+  --logo-text-bar-color: url("../../_icons/textWhite.png");
+}
+
+.mainLightGreen
+.mainLime
+.mainYellow
+.mainAmber
+.mainOrange
+.mainDeepOrange {
+  --text-with-main-color: #000000;
+  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
+  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
+}
+
 .mainRed {
   --primary-color: #f44336;
   --primary-color-hover: #e53935;
   --primary-color-active: #c62828;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainPink {
   --primary-color: #E91E63;
   --primary-color-hover: #D81B60;
   --primary-color-active: #AD1457;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainPurple {
   --primary-color: #9C27B0;
   --primary-color-hover: #8E24AA;
   --primary-color-active: #6A1B9A;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainDeepPurple {
   --primary-color: #673AB7;
   --primary-color-hover: #5E35B1;
   --primary-color-active: #4527A0;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainIndigo {
   --primary-color: #3F51B5;
   --primary-color-hover: #3949AB;
   --primary-color-active: #283593;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainBlue {
   --primary-color: #2196F3;
   --primary-color-hover: #1E88E5;
   --primary-color-active: #1565C0;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainLightBlue {
   --primary-color: #03A9F4;
   --primary-color-hover: #039BE5;
   --primary-color-active: #0277BD;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainCyan {
   --primary-color: #00BCD4;
   --primary-color-hover: #00ACC1;
   --primary-color-active: #00838F;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainTeal {
   --primary-color: #009688;
   --primary-color-hover: #00897B;
   --primary-color-active: #00695C;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainGreen {
   --primary-color: #4CAF50;
   --primary-color-hover: #43A047;
   --primary-color-active: #2E7D32;
-  --text-with-main-color: #FFFFFF;
-  --logo-icon-bar-color: url("../../_icons/iconWhite.png");
-  --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
 .mainLightGreen {
   --primary-color: #8BC34A;
   --primary-color-hover: #7CB342;
   --primary-color-active: #558B2F;
-  --text-with-main-color: #000000;
-  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
-  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
 .mainLime {
   --primary-color: #CDDC39;
   --primary-color-hover: #C0CA33;
   --primary-color-active: #9E9D24;
-  --text-with-main-color: #000000;
-  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
-  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
 .mainYellow {
   --primary-color: #FFEB3B;
   --primary-color-hover: #FDD835;
   --primary-color-active: #F9A825;
-  --text-with-main-color: #000000;
-  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
-  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
 .mainAmber {
   --primary-color: #FFC107;
   --primary-color-hover: #FFB300;
   --primary-color-active: #FF8F00;
-  --text-with-main-color: #000000;
-  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
-  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
 .mainOrange {
   --primary-color: #FF9800;
   --primary-color-hover: #FB8C00;
   --primary-color-active: #EF6C00;
-  --text-with-main-color: #000000;
-  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
-  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
 .mainDeepOrange {
   --primary-color: #FF5722;
   --primary-color-hover: #F4511E;
   --primary-color-active: #D84315;
-  --text-with-main-color: #000000;
-  --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
-  --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
 .mainDraculaCyan,
@@ -443,13 +421,34 @@
   --primary-color-active: #8d98e4;
 }
 
+.secRed
+.secPink
+.secPurple
+.secDeepPurple
+.secIndigo
+.secBlue
+.secLightBlue
+.secCyan
+.secTeal
+.secGreen {
+  --text-with-accent-color: #FFFFFF;
+}
+
+.secLightGreen
+.secLime
+.secYellow
+.secAmber
+.secOrange
+.secDeepOrange {
+  --text-with-accent-color: #000000;
+}
+
 .secRed {
   --accent-color: #f44336;
   --accent-color-hover: #e53935;
   --accent-color-active: #c62828;
   --accent-color-light: #ef9a9a;
   --accent-color-visited: #b71c1c;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(244,67,54,0.04);
   --accent-color-opacity2: rgba(244,67,54,0.12);
   --accent-color-opacity3: rgba(244,67,54,0.16);
@@ -462,7 +461,6 @@
   --accent-color-active: #AD1457;
   --accent-color-light: #F48FB1;
   --accent-color-visited: #880E4F;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(233,30,99,0.04);
   --accent-color-opacity2: rgba(233,30,99,0.12);
   --accent-color-opacity3: rgba(233,30,99,0.16);
@@ -475,7 +473,6 @@
   --accent-color-active: #6A1B9A;
   --accent-color-light: #CE93D8;
   --accent-color-visited: #4A148C;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(156,39,176,0.04);
   --accent-color-opacity2: rgba(156,39,176,0.12);
   --accent-color-opacity3: rgba(156,39,176,0.16);
@@ -488,7 +485,6 @@
   --accent-color-active: #4527A0;
   --accent-color-light: #B39DDB;
   --accent-color-visited: #311B92;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(103,58,183,0.04);
   --accent-color-opacity2: rgba(103,58,183,0.12);
   --accent-color-opacity3: rgba(103,58,183,0.16);
@@ -501,7 +497,6 @@
   --accent-color-active: #283593;
   --accent-color-light: #9FA8DA;
   --accent-color-visited: #1A237E;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(63,81,181,0.04);
   --accent-color-opacity2: rgba(63,81,181,0.12);
   --accent-color-opacity3: rgba(63,81,181,0.16);
@@ -514,7 +509,6 @@
   --accent-color-active: #1565C0;
   --accent-color-light: #90CAF9;
   --accent-color-visited: #0D47A1;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(33,150,243,0.04);
   --accent-color-opacity2: rgba(33,150,243,0.12);
   --accent-color-opacity3: rgba(33,150,243,0.16);
@@ -527,7 +521,6 @@
   --accent-color-active: #0277BD;
   --accent-color-light: #81D4FA;
   --accent-color-visited: #01579B;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(3,169,244,0.04);
   --accent-color-opacity2: rgba(3,169,244,0.12);
   --accent-color-opacity3: rgba(3,169,244,0.16);
@@ -540,7 +533,6 @@
   --accent-color-active: #00838F;
   --accent-color-light: #80DEEA;
   --accent-color-visited: #006064;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(0,188,212,0.04);
   --accent-color-opacity2: rgba(0,188,212,0.12);
   --accent-color-opacity3: rgba(0,188,212,0.16);
@@ -553,7 +545,6 @@
   --accent-color-active: #00695C;
   --accent-color-light: #80CBC4;
   --accent-color-visited: #004D40;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(0,150,136,0.04);
   --accent-color-opacity2: rgba(0,150,136,0.12);
   --accent-color-opacity3: rgba(0,150,136,0.16);
@@ -566,7 +557,6 @@
   --accent-color-active: #2E7D32;
   --accent-color-light: #A5D6A7;
   --accent-color-visited: #1B5E20;
-  --text-with-accent-color: #FFFFFF;
   --accent-color-opacity1: rgba(76,175,80,0.04);
   --accent-color-opacity2: rgba(76,175,80,0.12);
   --accent-color-opacity3: rgba(76,175,80,0.16);
@@ -579,7 +569,6 @@
   --accent-color-active: #558B2F;
   --accent-color-light: #C5E1A5;
   --accent-color-visited: #33691E;
-  --text-with-accent-color: #000000;
   --accent-color-opacity1: rgba(139,195,74,0.04);
   --accent-color-opacity2: rgba(139,195,74,0.12);
   --accent-color-opacity3: rgba(139,195,74,0.16);
@@ -592,7 +581,6 @@
   --accent-color-active: #9E9D24;
   --accent-color-light: #E6EE9C;
   --accent-color-visited: #827717;
-  --text-with-accent-color: #000000;
   --accent-color-opacity1: rgba(205,220,57,0.04);
   --accent-color-opacity2: rgba(205,220,57,0.12);
   --accent-color-opacity3: rgba(205,220,57,0.16);
@@ -605,7 +593,6 @@
   --accent-color-active: #F9A825;
   --accent-color-light: #FFF59D;
   --accent-color-visited: #F57F17;
-  --text-with-accent-color: #000000;
   --accent-color-opacity1: rgba(255,235,59,0.04);
   --accent-color-opacity2: rgba(255,235,59,0.12);
   --accent-color-opacity3: rgba(255,235,59,0.16);
@@ -618,7 +605,6 @@
   --accent-color-active: #FF8F00;
   --accent-color-light: #FFE082;
   --accent-color-visited: #FF6F00;
-  --text-with-accent-color: #000000;
   --accent-color-opacity1: rgba(255,193,7,0.04);
   --accent-color-opacity2: rgba(255,193,7,0.12);
   --accent-color-opacity3: rgba(255,193,7,0.16);
@@ -631,7 +617,6 @@
   --accent-color-active: #EF6C00;
   --accent-color-light: #FFCC80;
   --accent-color-visited: #E65100;
-  --text-with-accent-color: #000000;
   --accent-color-opacity1: rgba(255,152,0,0.04);
   --accent-color-opacity2: rgba(255,152,0,0.12);
   --accent-color-opacity3: rgba(255,152,0,0.16);
@@ -644,7 +629,6 @@
   --accent-color-active: #D84315;
   --accent-color-light: #FFAB91;
   --accent-color-visited: #BF360C;
-  --text-with-accent-color: #000000;
   --accent-color-opacity1: rgba(255,87,34,0.04);
   --accent-color-opacity2: rgba(255,87,34,0.12);
   --accent-color-opacity3: rgba(255,87,34,0.16);

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -280,67 +280,63 @@
   --logo-text-bar-color: url("../../_icons/textBlackSmall.png");
 }
 
+.mainDraculaCyan,
+.mainDraculaGreen,
+.mainDraculaOrange,
+.mainDraculaYellow {
+  --text-with-main-color: #282A36;
+  --logo-icon-bar-color: url("../../_icons/iconDraculaDarkSmall.png");
+  --logo-text-bar-color: url("../../_icons/textDraculaDarkSmall.png");
+}
+
+.mainDraculaPink,
+.mainDraculaPurple,
+.mainDraculaRed {
+  --text-with-main-color: #F8F8F2;
+  --logo-icon-bar-color: url("../../_icons/iconDraculaLightSmall.png");
+  --logo-text-bar-color: url("../../_icons/textDraculaLightSmall.png");
+}
+
 .mainDraculaCyan {
   --primary-color: #8BE9FD;
   --primary-color-hover: #97EBFD;
   --primary-color-active: #7DD2E4;
-  --text-with-main-color: #282A36;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaDarkSmall.png");
 }
 
 .mainDraculaGreen {
   --primary-color: #50FA7B;
   --primary-color-hover: #62FB88;
   --primary-color-active: #48E16F;
-  --text-with-main-color: #282A36;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaDarkSmall.png");
 }
 
 .mainDraculaOrange {
   --primary-color: #FFB86C;
   --primary-color-hover: #FFBF7B;
   --primary-color-active: #E6A661;
-  --text-with-main-color: #282A36;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaDarkSmall.png");
 }
 
 .mainDraculaPink {
   --primary-color: #FF79C6;
   --primary-color-hover: #FF86CC;
   --primary-color-active: #E66DB2;
-  --text-with-main-color: #F8F8F2;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaLightSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaLightSmall.png");
 }
 
 .mainDraculaPurple {
   --primary-color: #BD93F9;
   --primary-color-hover: #C49EFA;
   --primary-color-active: #AA84E0;
-  --text-with-main-color: #F8F8F2;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaLightSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaLightSmall.png");
 }
 
 .mainDraculaRed {
   --primary-color: #FF5555;
   --primary-color-hover: #FF6666;
   --primary-color-active: #E64D4D;
-  --text-with-main-color: #F8F8F2;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaLightSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaLightSmall.png");
 }
 
 .mainDraculaYellow {
   --primary-color: #F1FA8C;
   --primary-color-hover: #F2FB98;
   --primary-color-active: #D9E17E;
-  --text-with-main-color: #282A36;
-  --logo-icon-bar-color: url("../../_icons/iconDraculaDarkSmall.png");
-  --logo-text-bar-color: url("../../_icons/textDraculaDarkSmall.png");
 }
 
 .mainCatppuccinMochaRosewater,
@@ -654,17 +650,39 @@
   --accent-color-opacity4: rgba(255,87,34,0.24);
 }
 
+.secDraculaCyan,
+.secDraculaGreen,
+.secDraculaOrange,
+.secDraculaYellow {
+  --text-with-accent-color: #212121;
+}
+
+.secDraculaPink,
+.secDraculaPurple,
+.secDraculaRed {
+  --text-with-accent-color: #F8F8F2;
+}
+
+.secDraculaCyan,
+.secDraculaGreen,
+.secDraculaOrange,
+.secDraculaPink,
+.secDraculaPurple,
+.secDraculaRed,
+.secDraculaYellow {
+  --accent-color-opacity1: rgba(98, 114, 164, 0.04);
+  --accent-color-opacity2: rgba(98, 114, 164, 0.12);
+  --accent-color-opacity3: rgba(98, 114, 164, 0.16);
+  --accent-color-opacity4: rgba(98, 114, 164, 0.24);
+}
+
 .secDraculaCyan {
   --accent-color: #8BE9FD;
   --accent-color-hover: #97EBFD;
   --accent-color-active: #7DD2E4;
   --accent-color-light: #A2EDFD;
   --accent-color-visited: #6FBACA;
-  --text-with-accent-color: #212121;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
+
 }
 
 .secDraculaGreen {
@@ -673,11 +691,6 @@
   --accent-color-active: #48E16F;
   --accent-color-light: #73FB95;
   --accent-color-visited: #40C862;
-  --text-with-accent-color: #212121;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
 .secDraculaOrange {
@@ -686,11 +699,6 @@
   --accent-color-active: #E6A661;
   --accent-color-light: #FFC689;
   --accent-color-visited: #CC9356;
-  --text-with-accent-color: #212121;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
 .secDraculaPink {
@@ -699,11 +707,6 @@
   --accent-color-active: #E66DB2;
   --accent-color-light: #FF94D1;
   --accent-color-visited: #CC619E;
-  --text-with-accent-color: #F8F8F2;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
 .secDraculaPurple {
@@ -712,11 +715,6 @@
   --accent-color-active: #AA84E0;
   --accent-color-light: #CAA9FA;
   --accent-color-visited: #9776C7;
-  --text-with-accent-color: #F8F8F2;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
 .secDraculaRed {
@@ -725,11 +723,6 @@
   --accent-color-active: #E64D4D;
   --accent-color-light: #FF7777;
   --accent-color-visited: #CC4444;
-  --text-with-accent-color: #F8F8F2;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
 .secDraculaYellow {
@@ -738,11 +731,6 @@
   --accent-color-active: #D9E17E;
   --accent-color-light: #F4FBA3;
   --accent-color-visited: #C1C870;
-  --text-with-accent-color: #212121;
-  --accent-color-opacity1: rgba(98,114,164,0.04);
-  --accent-color-opacity2: rgba(98,114,164,0.12);
-  --accent-color-opacity3: rgba(98,114,164,0.16);
-  --accent-color-opacity4: rgba(98,114,164,0.24);
 }
 
 .secCatppuccinMochaRosewater,


### PR DESCRIPTION
# Themes css deduplication

## Pull Request Type

- [x] Other - Cleanup

## Description
Just deduplicates some of the CSS rules, that way the output is 6KB smaller. You probably want to review this commit by commit, instead of looking at it all in one go.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/201755094-34402f49-f64f-4b2f-a5ed-fb2f201965a6.png)
![after](https://user-images.githubusercontent.com/48293849/201755099-61a53c38-87ca-4ef6-a40f-427dd2d5866b.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the colours still work, you don't need to test all of them if you don't want to.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0