### PR TITLE
Fix "Open in new window" context menu action in release builds

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -31,7 +31,7 @@ function runApp() {
       },
       {
         label: 'Open in a New Window',
-        visible: parameters.linkURL.includes((new URL(browserWindow.webContents.getURL())).origin),
+        visible: parameters.linkURL.startsWith(browserWindow.webContents.getURL()),
         click: () => {
           createWindow({ replaceMainWindow: false, windowStartupUrl: parameters.linkURL, showWindowNow: true })
         }


### PR DESCRIPTION
# Fix "Open in new window" context menu action in release builds

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Partially addresses #2832

## Description
In the release builds, all files are accessed using the `file:` protocol, including the index.html file. Interestingly how the `new URL()` class handles file URLs differs depending on the implementation. In node the `origin` field is `null`, in Firefox it's a string with null in it `"null"` and in Chromium it's `file:///`. In release builds, the current implementation was checking if the linkURL contained `null`, which it never did, so it always hid the context menu entry.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn build`
2. run the built release build
3. right click on links and check that the Open in New Window context menu entry shows up

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0