### PR TITLE
Fix chapter marker placement

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -657,7 +657,7 @@ export default Vue.extend({
 
       markerDiv.title = chapter.title
       markerDiv.className = 'chapterMarker'
-      markerDiv.style.marginLeft = (chapter.startSeconds / this.lengthSeconds) * 100 - 0.5 + '%'
+      markerDiv.style.marginLeft = `calc(${(chapter.startSeconds / this.lengthSeconds) * 100}% - 1px)`
 
       this.player.el().querySelector('.vjs-progress-holder').appendChild(markerDiv)
     },


### PR DESCRIPTION
# Fix chapter marker placement

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
This pull request lines the chapter markers up with the start of the chapters.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/202848869-69133ed9-9b72-4e49-94f7-23511103faa9.png)
![after](https://user-images.githubusercontent.com/48293849/202848870-809bd53d-d770-4db0-8d9a-0e8292586e86.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
https://youtu.be/k-6yc1dA--0

Use the chapters list to seek to various chapters and check that the markers line up with the start of the chapters.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0