### PR TITLE
Add ft-input enter listener the vue way

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -103,8 +103,6 @@ export default Vue.extend({
     this.id = this._uid
     this.inputData = this.value
     this.updateVisibleDataList()
-
-    setTimeout(this.addListener, 200)
   },
   methods: {
     handleClick: function (e) {
@@ -132,11 +130,10 @@ export default Vue.extend({
       this.handleActionIconChange()
       this.updateVisibleDataList()
 
-      const inputElement = document.getElementById(this.id)
-      inputElement.value = ''
+      this.$refs.input.value = ''
 
       // Focus on input element after text is clear for better UX
-      inputElement.focus()
+      this.$refs.input.focus()
 
       this.$emit('clear')
     },
@@ -187,18 +184,6 @@ export default Vue.extend({
         this.actionButtonIconName = ['fas', 'search']
         // Rethrow exception
         throw ex
-      }
-    },
-
-    addListener: function () {
-      const inputElement = document.getElementById(this.id)
-
-      if (inputElement !== null) {
-        inputElement.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter') {
-            this.handleClick(event)
-          }
-        })
       }
     },
 

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -50,6 +50,7 @@
       @focus="handleFocus"
       @blur="handleInputBlur"
       @keydown="handleKeyDown"
+      @keydown.enter="handleClick"
     >
     <font-awesome-icon
       v-if="showActionButton"


### PR DESCRIPTION
# Add ft-input enter listener the vue way

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Cleanup

## Description
The current implementation uses setTimeout to add the listener and has a theoretical race condition, in which it would not add the listener at all. This PR moves away from the setTimeout approach and instead makes vue manage the event handler, which avoids the race condition and also makes our code simpler.

I also replaced the getElementById calls with vue refs (the ref was already there).

## Testing <!-- for code that is not small enough to be easily understandable -->
Enter some search queries into the search bar and press enter, it should still do the search.
Check that the clear button still works.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0