### PR TITLE
Add option to hide the header FreeTube logo

### DIFF
--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -76,6 +76,10 @@ export default Vue.extend({
       return this.$store.getters.getHideLabelsSideBar
     },
 
+    hideHeaderLogo: function () {
+      return this.$store.getters.getHideHeaderLogo
+    },
+
     restartPromptMessage: function () {
       return this.$t('Settings["The app needs to restart for changes to take effect. Restart and apply change?"]')
     },
@@ -154,7 +158,8 @@ export default Vue.extend({
       'updateExpandSideBar',
       'updateUiScale',
       'updateDisableSmoothScrolling',
-      'updateHideLabelsSideBar'
+      'updateHideLabelsSideBar',
+      'updateHideHeaderLogo'
     ])
   }
 })

--- a/src/renderer/components/theme-settings/theme-settings.vue
+++ b/src/renderer/components/theme-settings/theme-settings.vue
@@ -28,6 +28,12 @@
         :default-value="hideLabelsSideBar"
         @change="updateHideLabelsSideBar"
       />
+      <ft-toggle-switch
+        :label="$t('Settings.Theme Settings.Hide FreeTube Header Logo')"
+        :compact="true"
+        :default-value="hideHeaderLogo"
+        @change="updateHideHeaderLogo"
+      />
     </ft-flex-box>
     <ft-flex-box>
       <ft-slider

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -32,6 +32,10 @@ export default Vue.extend({
       return this.$store.getters.getHideSearchBar
     },
 
+    hideHeaderLogo: function () {
+      return this.$store.getters.getHideHeaderLogo
+    },
+
     enableSearchSuggestions: function () {
       return this.$store.getters.getEnableSearchSuggestions
     },

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -51,6 +51,7 @@
         @keydown.enter.prevent="createNewWindow"
       />
       <div
+        v-if="!hideHeaderLogo"
         class="logo"
         role="link"
         tabindex="0"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -198,6 +198,7 @@ const state = {
   hideVideoDescription: false,
   hideLiveChat: false,
   hideLiveStreams: false,
+  hideHeaderLogo: false,
   hidePlaylists: false,
   hidePopularVideos: false,
   hideRecommendedVideos: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -176,6 +176,7 @@ Settings:
     Disable Smooth Scrolling: Disable Smooth Scrolling
     UI Scale: UI Scale
     Hide Side Bar Labels: Hide Side Bar Labels
+    Hide FreeTube Header Logo: Hide FreeTube Header Logo
     Base Theme:
       Base Theme: Base Theme
       Black: Black


### PR DESCRIPTION
# Option to hide the header FreeTube logo

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #2488

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds a new toggle setting under Theme Settings to hide the FreeTube's logo on the header.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![Screenshot_20221125_125601](https://user-images.githubusercontent.com/52256539/203981508-97aa3436-5780-43e0-afcb-5418deb3b1e9.png)
The new setting.

![Screenshot_20221125_125621](https://user-images.githubusercontent.com/52256539/203981526-2f554eab-9add-4621-bee8-8f489aea9590.png)
When the toggle is on, the logo is hidden.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** --
- **FreeTube version:** 0.18.0

## Additional context
<!-- Add any other context about the pull request here. -->
I wasn't quite sure where exactly to put the setting, but Theme Settings felt the most right. Let me know if I should move it somewhere else.