### PR TITLE
Make the auto merge workflow compatible with draft PRs

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -1,7 +1,7 @@
 name: Auto Merge PR
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, auto_merge_disabled]
+    types: [opened, synchronize, reopened, auto_merge_disabled, ready_for_review]
 
 jobs:
   build:
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Auto Merge PR
-      if: contains(${{ github.event.pull_request.base.ref }}, 'development') || contains(${{ github.event.pull_request.base.ref }}, 'RC')
+      if: github.event.pull_request.draft == false && (contains(${{ github.event.pull_request.base.ref }}, 'development') || contains(${{ github.event.pull_request.base.ref }}, 'RC'))
       run: |
         echo ${{ secrets.PUSH_TOKEN }} >> auth.txt
         gh auth login --with-token < auth.txt


### PR DESCRIPTION
# Make the auto merge workflow compatible with draft PRs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Noticed in #2855

## Description
Currently the auto merge workflow fails when a PR is set to draft and it doesn't run when the PR is changed from draft to ready to review.