### PR TITLE
Make replaceFilenameForbiddenChars a helper

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -422,3 +422,36 @@ export function searchFiltersMatch(filtersA, filtersB) {
     filtersA?.type === filtersB?.type &&
     filtersA?.duration === filtersB?.duration
 }
+
+export function replaceFilenameForbiddenChars(filenameOriginal) {
+  let filenameNew = filenameOriginal
+  let forbiddenChars = {}
+  switch (process.platform) {
+    case 'win32':
+      forbiddenChars = {
+        '<': '＜', // U+FF1C
+        '>': '＞', // U+FF1E
+        ':': '：', // U+FF1A
+        '"': '＂', // U+FF02
+        '/': '／', // U+FF0F
+        '\\': '＼', // U+FF3C
+        '|': '｜', // U+FF5C
+        '?': '？', // U+FF1F
+        '*': '＊' // U+FF0A
+      }
+      break
+    case 'darwin':
+      forbiddenChars = { '/': '／', ':': '：' }
+      break
+    case 'linux':
+      forbiddenChars = { '/': '／' }
+      break
+    default:
+      break
+  }
+
+  for (const forbiddenChar in forbiddenChars) {
+    filenameNew = filenameNew.replaceAll(forbiddenChar, forbiddenChars[forbiddenChar])
+  }
+  return filenameNew
+}

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -6,6 +6,7 @@ import { IpcChannels } from '../../../constants'
 import {
   createWebURL,
   openExternalLink,
+  replaceFilenameForbiddenChars,
   searchFiltersMatch,
   showSaveDialog,
   showToast
@@ -122,46 +123,13 @@ async function invokeIRC(context, IRCtype, webCbk, payload = null) {
 }
 
 const actions = {
-  replaceFilenameForbiddenChars(_, filenameOriginal) {
-    let filenameNew = filenameOriginal
-    let forbiddenChars = {}
-    switch (process.platform) {
-      case 'win32':
-        forbiddenChars = {
-          '<': '＜', // U+FF1C
-          '>': '＞', // U+FF1E
-          ':': '：', // U+FF1A
-          '"': '＂', // U+FF02
-          '/': '／', // U+FF0F
-          '\\': '＼', // U+FF3C
-          '|': '｜', // U+FF5C
-          '?': '？', // U+FF1F
-          '*': '＊' // U+FF0A
-        }
-        break
-      case 'darwin':
-        forbiddenChars = { '/': '／', ':': '：' }
-        break
-      case 'linux':
-        forbiddenChars = { '/': '／' }
-        break
-      default:
-        break
-    }
-
-    for (const forbiddenChar in forbiddenChars) {
-      filenameNew = filenameNew.replaceAll(forbiddenChar, forbiddenChars[forbiddenChar])
-    }
-    return filenameNew
-  },
-
-  async downloadMedia({ rootState, dispatch }, { url, title, extension, fallingBackPath }) {
+  async downloadMedia({ rootState }, { url, title, extension, fallingBackPath }) {
     if (!process.env.IS_ELECTRON) {
       openExternalLink(url)
       return
     }
 
-    const fileName = `${await dispatch('replaceFilenameForbiddenChars', title)}.${extension}`
+    const fileName = `${replaceFilenameForbiddenChars(title)}.${extension}`
     const errorMessage = i18n.t('Downloading failed', { videoTitle: title })
     let folderPath = rootState.settings.downloadFolderPath
 


### PR DESCRIPTION
# Make replaceFilenameForbiddenChars a helper

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
The benefits are that we get rid of one unnecessary use of await, the function can now be dead code eliminated in web builds and it also gets rid of one place where a polyfill would be needed in the web build. We will need to replace more local API modules with YouTube.js and check other places in FreeTube, before we can get rid of polyfills entirely, this is a start though.

## Testing <!-- for code that is not small enough to be easily understandable -->
Set the download behaviour to "Download in app" and download this video https://youtu.be/O16lQlK7bkw, the slash in the title should be replaced by a similar looking unicode character, the same as before.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0