### PR TITLE
Clear cached subscription videos when removing all subscriptions

### DIFF
--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -106,6 +106,13 @@ export default Vue.extend({
             this.removeProfile(profile._id)
           }
         })
+
+        this.updateAllSubscriptionsList([])
+        this.updateProfileSubscriptions({
+          activeProfile: MAIN_PROFILE_ID,
+          videoList: [],
+          errorChannels: []
+        })
       }
     },
 
@@ -117,7 +124,9 @@ export default Vue.extend({
       'clearSessionSearchHistory',
       'updateProfile',
       'removeProfile',
-      'updateActiveProfile'
+      'updateActiveProfile',
+      'updateAllSubscriptionsList',
+      'updateProfileSubscriptions'
     ])
   }
 })


### PR DESCRIPTION
# Clear cached subscription videos when removing all subscriptions

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently when you remove all subscriptions and profiles, the cached subscription videos, stay in the subscriptions tab, this PR fixes this by clearing that cache when all subscriptions and profiles are removed.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Import your subscriptions/subscribe to a few channels
2. Select the all channels profile
3. Refresh your subscriptions
4. In the privacy settings click "Remove All Subscriptions / Profiles"
5. Switch to the subscripitons tab, it should be empty

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0