### PR TITLE
Make more UI elements middle clickable

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -135,10 +135,6 @@ export default Vue.extend({
           query: playlistInfo
         }
       )
-    },
-
-    goToChannel: function () {
-      this.$router.push({ path: `/channel/${this.channelId}` })
     }
   }
 })

--- a/src/renderer/components/playlist-info/playlist-info.sass
+++ b/src/renderer/components/playlist-info/playlist-info.sass
@@ -31,9 +31,8 @@
   align-items: center
   gap: 8px
   height: 40px
-
-  /* Indicates the box can be clicked to navigate */
-  cursor: pointer
+  text-decoration: none
+  color: inherit
 
 .channelThumbnail
   width: 40px

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -29,9 +29,9 @@
 
     <hr>
 
-    <div
+    <router-link
       class="playlistChannel"
-      @click="goToChannel"
+      :to="`/channel/${channelId}`"
     >
       <img
         class="channelThumbnail"
@@ -42,7 +42,7 @@
       >
         {{ channelName }}
       </h3>
-    </div>
+    </router-link>
 
     <br>
 

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.js
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.js
@@ -32,7 +32,7 @@ export default Vue.extend({
   methods: {
     navigate: function (route) {
       this.openMoreOptions = false
-      this.$emit('navigate', route)
+      this.$router.push('/' + route)
     }
   }
 })

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -40,7 +40,6 @@
 .navOption, .navChannel {
   position: relative;
   padding: 5px;
-  cursor: pointer;
   min-height: 35px;
 }
 
@@ -88,7 +87,7 @@
   transform: translateY(-50%);
 }
 
-.channelLink {
+.navOption, .channelLink {
   display: block;
   color: inherit;
   text-decoration: inherit;

--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -75,10 +75,5 @@ export default Vue.extend({
         hiddenLabels: this.hideText
       }
     }
-  },
-  methods: {
-    navigate: function (route) {
-      this.$router.push('/' + route)
-    }
   }
 })

--- a/src/renderer/components/side-nav/side-nav.vue
+++ b/src/renderer/components/side-nav/side-nav.vue
@@ -8,12 +8,11 @@
       class="inner"
       :class="applyHiddenLabels"
     >
-      <div
+      <router-link
         class="navOption topNavOption mobileShow "
         role="button"
-        tabindex="0"
+        to="/subscriptions"
         :title="$t('Subscriptions.Subscriptions')"
-        @click="navigate('subscriptions')"
       >
         <div
           class="thumbnailContainer"
@@ -31,14 +30,12 @@
         >
           {{ $t("Subscriptions.Subscriptions") }}
         </p>
-      </div>
-      <div
+      </router-link>
+      <router-link
         class="navOption mobileHidden"
         role="button"
-        tabindex="0"
+        to="/subscribedchannels"
         :title="$t('Channels.Channels')"
-        @click="navigate('subscribedchannels')"
-        @keydown.enter.prevent="navigate('subscribedchannels')"
       >
         <div
           class="thumbnailContainer"
@@ -56,15 +53,13 @@
         >
           {{ $t("Channels.Channels") }}
         </p>
-      </div>
-      <div
+      </router-link>
+      <router-link
         v-if="!hideTrendingVideos"
         class="navOption mobileHidden"
         role="button"
-        tabindex="0"
+        to="/trending"
         :title="$t('Trending.Trending')"
-        @click="navigate('trending')"
-        @keydown.enter.prevent="navigate('trending')"
       >
         <div
           class="thumbnailContainer"
@@ -82,15 +77,13 @@
         >
           {{ $t("Trending.Trending") }}
         </p>
-      </div>
-      <div
+      </router-link>
+      <router-link
         v-if="!hidePopularVideos && (backendFallback || backendPreference === 'invidious')"
         class="navOption mobileHidden"
         role="button"
-        tabindex="0"
+        to="/popular"
         :title="$t('Most Popular')"
-        @click="navigate('popular')"
-        @keydown.enter.prevent="navigate('popular')"
       >
         <div
           class="thumbnailContainer"
@@ -108,15 +101,13 @@
         >
           {{ $t("Most Popular") }}
         </p>
-      </div>
-      <div
+      </router-link>
+      <router-link
         v-if="!hidePlaylists"
         class="navOption mobileShow"
         role="button"
-        tabindex="0"
+        to="/userplaylists"
         :title="$t('Playlists')"
-        @click="navigate('userplaylists')"
-        @keydown.enter.prevent="navigate('userplaylists')"
       >
         <div
           class="thumbnailContainer"
@@ -134,17 +125,13 @@
         >
           {{ $t("Playlists") }}
         </p>
-      </div>
-      <side-nav-more-options
-        @navigate="navigate"
-      />
-      <div
+      </router-link>
+      <side-nav-more-options />
+      <router-link
         class="navOption mobileShow"
         role="button"
-        tabindex="0"
+        to="/history"
         :title="$t('History.History')"
-        @click="navigate('history')"
-        @keydown.enter.prevent="navigate('history')"
       >
         <div
           class="thumbnailContainer"
@@ -162,15 +149,13 @@
         >
           {{ $t("History.History") }}
         </p>
-      </div>
+      </router-link>
       <hr>
-      <div
+      <router-link
         class="navOption mobileShow"
         role="button"
-        tabindex="0"
+        to="/settings"
         :title="$t('Settings.Settings')"
-        @click="navigate('settings')"
-        @keydown.enter.prevent="navigate('settings')"
       >
         <div
           class="thumbnailContainer"
@@ -188,14 +173,12 @@
         >
           {{ $t('Settings.Settings') }}
         </p>
-      </div>
-      <div
+      </router-link>
+      <router-link
         class="navOption mobileHidden"
         role="button"
-        tabindex="0"
+        to="/about"
         :title="$t('About.About')"
-        @click="navigate('about')"
-        @keydown.enter.prevent="navigate('about')"
       >
         <div
           class="thumbnailContainer"
@@ -213,7 +196,7 @@
         >
           {{ $t("About.About") }}
         </p>
-      </div>
+      </router-link>
       <hr>
       <div
         v-if="!hideActiveSubscriptions"


### PR DESCRIPTION
# Make more UI elements middle clickable

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
Partially addresses #2094

## Description
This pull request make it possible to middle click on the buttons in the side menu and the playlist author on the playlist page to open then in a new window. Additonally this also makes the "Open in a new window" context menu option show up.

## Testing <!-- for code that is not small enough to be easily understandable -->
Middle click on the buttons in the side menu and the channel name on the playlist page.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0