### PR TITLE
Only show the load more comments button when necessary

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -192,7 +192,7 @@
       </h3>
     </div>
     <h4
-      v-if="commentData.length > 0 && !isLoading && showComments"
+      v-if="commentData.length > 0 && !isLoading && showComments && nextPageToken"
       class="getMoreComments"
       @click="getMoreComments"
     >


### PR DESCRIPTION
# Only show the load more comments button when necessary

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #2894

## Description
Only show the "Load More Comments" button if there are more comments available, otherwise hide it.

## Testing <!-- for code that is not small enough to be easily understandable -->
Video from the issue with only one page of comments: https://youtu.be/rKOkJqUWnPM
LTT video with lots of comments: https://youtu.be/OHKKcd3sx2c

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0