### PR TITLE
Increase dependebot PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     labels:
       - "PR: waiting for review"
       - "PR: dependencies"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Increase dependebot PR limit to 10

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Other - Automation

## Description
Even after the recent dependency updates we still have a lot of outdated dependencies (see screenshot below), increasing the PR limit from the default of 5 to 10, should hopefully make a bigger dent in that list, in the future.

## Screenshots <!-- If appropriate -->
![dependencies](https://user-images.githubusercontent.com/48293849/205708039-39106edc-8f2e-49ac-b4c1-6e6d4be11cc1.png)