### PR TITLE
Copy in-app links as YouTube links

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,6 +1,7 @@
 import {
   app, BrowserWindow, dialog, Menu, ipcMain,
-  powerSaveBlocker, screen, session, shell, nativeTheme, net, protocol
+  powerSaveBlocker, screen, session, shell,
+  nativeTheme, net, protocol, clipboard
 } from 'electron'
 import path from 'path'
 import cp from 'child_process'
@@ -22,6 +23,7 @@ function runApp() {
     showSaveImageAs: true,
     showCopyImageAddress: true,
     showSelectAll: false,
+    showCopyLink: false,
     prepend: (defaultActions, parameters, browserWindow) => [
       {
         label: 'Show / Hide Video Statistics',
@@ -47,7 +49,81 @@ function runApp() {
           browserWindow.webContents.selectAll()
         }
       }
-    ]
+    ],
+    // only show the copy link entry for external links and the /playlist, /channel and /watch in-app URLs
+    // the /playlist, /channel and /watch in-app URLs get transformed to their equivalent YouTube URLs
+    append: (defaultActions, parameters, browserWindow) => {
+      let visible = false
+      const isInAppUrl = parameters.linkURL.split('#')[0] === browserWindow.webContents.getURL().split('#')[0]
+
+      if (parameters.linkURL.length > 0) {
+        if (isInAppUrl) {
+          const path = parameters.linkURL.split('#')[1]
+
+          if (path) {
+            visible = ['/playlist', '/channel', '/watch'].some(p => path.startsWith(p))
+          }
+        } else {
+          visible = true
+        }
+      }
+
+      return [{
+        label: 'Copy Lin&k',
+        visible: visible,
+        click: () => {
+          let url = parameters.linkURL
+
+          if (isInAppUrl) {
+            const [path, query] = url.split('#')[1].split('?')
+            const [route, id] = path.split('/').filter(p => p)
+
+            switch (route) {
+              case 'playlist':
+                url = `https://youtube.com/playlist?list=${id}`
+                break
+              case 'channel':
+                url = `https://www.youtube.com/channel/${id}`
+                break
+              case 'watch': {
+                url = `https://youtu.be/${id}`
+
+                if (query) {
+                  const params = new URLSearchParams(query)
+                  const newParams = new URLSearchParams()
+                  let hasParams = false
+
+                  if (params.has('playlistId')) {
+                    newParams.set('list', params.get('playlistId'))
+                    hasParams = true
+                  }
+
+                  if (params.has('timestamp')) {
+                    newParams.set('t', params.get('timestamp'))
+                    hasParams = true
+                  }
+
+                  if (hasParams) {
+                    url += '?' + newParams.toString()
+                  }
+                }
+
+                break
+              }
+            }
+          }
+
+          if (parameters.linkText) {
+            clipboard.write({
+              bookmark: parameters.linkText,
+              text: url
+            })
+          } else {
+            clipboard.writeText(url)
+          }
+        }
+      }]
+    }
   })
 
   // disable electron warning


### PR DESCRIPTION
# Copy in-app links as YouTube links


## Pull Request Type

- [x] Feature Implementation

## Related issue
closes  #2479

## Description
Currently all links in FreeTube, in-app and external ones, have the "Copy Link" context menu entry. This PR changes it to only show up on external links and certain in-app ones, to make it useful on the in-app ones it also transforms them into their YouTube equivalents. This means that you can copy the link to a video just by right clicking on it in the search results.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Right click on menu items in the side bar, "Copy Link" should only show up for the list of subscribed channels
2. Right click on videos, channels and playlists in channels, search results, playlists, up next and trending
3. Right click on channel name and image on the watch and playlist pages

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0