### PR TITLE
fix error when searching

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -197,14 +197,13 @@ export default Vue.extend({
     handleKeyDown: function (event) {
       if (this.visibleDataList.length === 0) { return }
       if (event.key === 'Enter') {
-        this.inputData = this.visibleDataList[this.searchState.selectedOption]
         // Update Input box value if enter key was pressed and option selected
         if (this.searchState.selectedOption !== -1) {
           this.searchState.showOptions = false
           event.preventDefault()
           this.inputData = this.visibleDataList[this.searchState.selectedOption]
-          this.handleClick()
         }
+        this.handleClick()
       } else {
         this.searchState.showOptions = true
         const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp'


### PR DESCRIPTION
# Fix error when searching

## Pull Request Type
- [x] Bugfix

## Description
Error introduced in #2943 
If you click enter without selecting an option in the list then an error will occur

## Testing 
Write something in search bar, click enter without hovering over any of the options

## Desktop
- **OS:** Windws
- **OS Version:** 11
- **FreeTube version:** 0.18.0
