### PR TITLE
Fix incorrect selector (meant to be multiple targets not nested)

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -137,26 +137,26 @@
   --logo-text: url("../../_icons/textCatppuccinMochaLightSmall.png");
 }
 
-.mainRed
-.mainPink
-.mainPurple
-.mainDeepPurple
-.mainIndigo
-.mainBlue
-.mainLightBlue
-.mainCyan
-.mainTeal
+.mainRed,
+.mainPink,
+.mainPurple,
+.mainDeepPurple,
+.mainIndigo,
+.mainBlue,
+.mainLightBlue,
+.mainCyan,
+.mainTeal,
 .mainGreen {
   --text-with-main-color: #FFFFFF;
   --logo-icon-bar-color: url("../../_icons/iconWhite.png");
   --logo-text-bar-color: url("../../_icons/textWhite.png");
 }
 
-.mainLightGreen
-.mainLime
-.mainYellow
-.mainAmber
-.mainOrange
+.mainLightGreen,
+.mainLime,
+.mainYellow,
+.mainAmber,
+.mainOrange,
 .mainDeepOrange {
   --text-with-main-color: #000000;
   --logo-icon-bar-color: url("../../_icons/iconBlackSmall.png");
@@ -421,24 +421,24 @@
   --primary-color-active: #8d98e4;
 }
 
-.secRed
-.secPink
-.secPurple
-.secDeepPurple
-.secIndigo
-.secBlue
-.secLightBlue
-.secCyan
-.secTeal
+.secRed,
+.secPink,
+.secPurple,
+.secDeepPurple,
+.secIndigo,
+.secBlue,
+.secLightBlue,
+.secCyan,
+.secTeal,
 .secGreen {
   --text-with-accent-color: #FFFFFF;
 }
 
-.secLightGreen
-.secLime
-.secYellow
-.secAmber
-.secOrange
+.secLightGreen,
+.secLime,
+.secYellow,
+.secAmber,
+.secOrange,
 .secDeepOrange {
   --text-with-accent-color: #000000;
 }


### PR DESCRIPTION
# Fix incorrect selector (meant to be multiple targets not nested)

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Introduced by #2868

## Description
```css
/* Expected */
theme1,
theme2 {
  --var-1: #000;
}

/* Actual */
theme1
theme2 {
  --var-1: #000;
}
```

## Screenshots <!-- If appropriate -->
Trying to fix filter changed indicator (broken without this PR)
![image](https://user-images.githubusercontent.com/1018543/207490733-722cb218-824a-40e0-8899-5505973a5fc3.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Update any search criteria & look for indicator in screenshot

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.1
- **FreeTube version:** 29f5e38623d02f2e19a0d396aa615fbebf3d1238

## Additional context
Why no one discover it for so long ._.
