### PR TITLE
Fix enter on input doesn't work with empty visible data list

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -195,7 +195,6 @@ export default Vue.extend({
     },
 
     handleKeyDown: function (event) {
-      if (this.visibleDataList.length === 0) { return }
       if (event.key === 'Enter') {
         // Update Input box value if enter key was pressed and option selected
         if (this.searchState.selectedOption !== -1) {
@@ -204,27 +203,31 @@ export default Vue.extend({
           this.inputData = this.visibleDataList[this.searchState.selectedOption]
         }
         this.handleClick()
-      } else {
-        this.searchState.showOptions = true
-        const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp'
-        if (isArrow) {
-          if (event.key === 'ArrowDown') {
-            this.searchState.selectedOption = (this.searchState.selectedOption + 1) % this.visibleDataList.length
-          } else if (event.key === 'ArrowUp') {
-            if (this.searchState.selectedOption < 1) {
-              this.searchState.selectedOption = this.visibleDataList.length - 1
-            } else {
-              this.searchState.selectedOption--
-            }
+        // Early return
+        return
+      }
+
+      if (this.visibleDataList.length === 0) { return }
+
+      this.searchState.showOptions = true
+      const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp'
+      if (isArrow) {
+        if (event.key === 'ArrowDown') {
+          this.searchState.selectedOption = (this.searchState.selectedOption + 1) % this.visibleDataList.length
+        } else if (event.key === 'ArrowUp') {
+          if (this.searchState.selectedOption < 1) {
+            this.searchState.selectedOption = this.visibleDataList.length - 1
+          } else {
+            this.searchState.selectedOption--
           }
-          if (this.searchState.selectedOption < 0) {
-            this.searchState.selectedOption = this.visibleDataList.length
-          } else if (this.searchState.selectedOption > this.visibleDataList.length - 1) {
-            this.searchState.selectedOption = 0
-          }
-        } else {
-          this.searchState.selectedOption = -1
         }
+        if (this.searchState.selectedOption < 0) {
+          this.searchState.selectedOption = this.visibleDataList.length
+        } else if (this.searchState.selectedOption > this.visibleDataList.length - 1) {
+          this.searchState.selectedOption = 0
+        }
+      } else {
+        this.searchState.selectedOption = -1
       }
     },
 


### PR DESCRIPTION
# Fix enter on input doesn't work with empty visible data list

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Addresses https://github.com/FreeTubeApp/FreeTube/pull/2960#issuecomment-1351000234

## Description
Since `keydown.enter` event handler is moved in https://github.com/FreeTubeApp/FreeTube/pull/2943 to `handleKeyDown`
It's affected by `if (this.visibleDataList.length === 0) { return }` so that enter does nothing without a "visible data list"

This PR move that statement to NOT run for pressing enter

## Screenshots <!-- If appropriate -->
![image](https://user-images.githubusercontent.com/1018543/207763244-e536a368-a575-4c53-8a06-848dae25be02.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Enter something into top nav that doesn't produce suggestion(e.g. `asdasdasdasdasdasdasdasd`)
- Press enter

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 12.6.1
- **FreeTube version:** 083ae0e622d4fd90d42f23969a5b8ed612229383

## Additional context
<!-- Add any other context about the pull request here. -->
