### PR TITLE
Migrate playlists on the watch page to YouTube.js

### DIFF
--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -64,7 +64,7 @@ const config = {
     '!node_modules/**/*',
 
     // renderer
-    'node_modules/{miniget,ytpl,ytsr}/**/*',
+    'node_modules/{miniget,ytsr}/**/*',
 
     '!**/README.md',
     '!**/*.js.map',

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -28,10 +28,10 @@ const config = {
     path: path.join(__dirname, '../dist'),
     filename: '[name].js',
   },
-  // webpack spits out errors while inlining ytpl and ytsr as
+  // webpack spits out errors while inlining ytsr as
   // they dynamically import their package.json file to extract the bug report URL
   // the error: "Critical dependency: the request of a dependency is an expression"
-  externals: ['ytpl', 'ytsr'],
+  externals: ['ytsr'],
   module: {
     rules: [
       {

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -27,7 +27,6 @@ const config = {
   externals: {
     electron: '{}',
     'youtubei.js': '{}',
-    ytpl: '{}',
     ytsr: '{}'
   },
   module: {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "yt-channel-info": "^3.2.1",
     "yt-dash-manifest-generator": "1.1.0",
     "ytdl-core": "https://github.com/absidue/node-ytdl-core#fix-likes-extraction",
-    "ytpl": "^2.3.0",
     "ytsr": "^3.8.0"
   },
   "devDependencies": {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -4,6 +4,7 @@ import FtLoader from '../ft-loader/ft-loader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtListVideo from '../ft-list-video/ft-list-video.vue'
 import { copyToClipboard, showToast } from '../../helpers/utils'
+import { getLocalPlaylist, parseLocalPlaylistVideo } from '../../helpers/api/local'
 
 export default Vue.extend({
   name: 'WatchVideoPlaylist',
@@ -249,36 +250,31 @@ export default Vue.extend({
       }
     },
 
-    getPlaylistInformationLocal: function () {
+    getPlaylistInformationLocal: async function () {
       this.isLoading = true
 
-      this.ytGetPlaylistInfo(this.playlistId).then((result) => {
-        this.playlistTitle = result.title
-        this.playlistItems = result.items
-        this.videoCount = result.estimatedItemCount
-        this.channelName = result.author.name
-        this.channelThumbnail = result.author.bestAvatar.url
-        this.channelId = result.author.channelID
+      try {
+        let playlist = await getLocalPlaylist(this.playlistId)
 
-        this.playlistItems = result.items.filter((video) => {
-          return !(video.title === '[Private video]' || video.title === '[Deleted video]')
-        }).map((video) => {
-          if (typeof video.author !== 'undefined') {
-            const channelName = video.author.name
-            const channelId = video.author.channelID
-            video.author = channelName
-            video.authorId = channelId
-          } else {
-            video.author = ''
-            video.authorId = ''
-          }
-          video.videoId = video.id
-          video.lengthSeconds = video.duration
-          return video
-        })
+        this.playlistTitle = playlist.info.title
+        this.videoCount = playlist.info.total_items
+        this.channelName = playlist.info.author?.name
+        this.channelThumbnail = playlist.info.author?.best_thumbnail?.url
+        this.channelId = playlist.info.author?.id
+
+        const videos = playlist.items.map(parseLocalPlaylistVideo)
+
+        while (playlist.has_continuation) {
+          playlist = await playlist.getContinuation()
+
+          const parsedVideos = playlist.items.map(parseLocalPlaylistVideo)
+          videos.push(...parsedVideos)
+        }
+
+        this.playlistItems = videos
 
         this.isLoading = false
-      }).catch((err) => {
+      } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
         showToast(`${errorMessage}: ${err}`, 10000, () => {
@@ -290,7 +286,7 @@ export default Vue.extend({
         } else {
           this.isLoading = false
         }
-      })
+      }
     },
 
     getPlaylistInformationInvidious: function () {
@@ -347,7 +343,6 @@ export default Vue.extend({
     },
 
     ...mapActions([
-      'ytGetPlaylistInfo',
       'invidiousGetPlaylistInfo'
     ])
   }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -61,3 +61,20 @@ export async function getLocalPlaylist(id) {
   const innertube = await createInnertube()
   return await innertube.getPlaylist(id)
 }
+
+/**
+ * @typedef {import('youtubei.js/dist/src/parser/classes/PlaylistVideo').default} PlaylistVideo
+ */
+
+/**
+ * @param {PlaylistVideo} video
+ */
+export function parseLocalPlaylistVideo(video) {
+  return {
+    videoId: video.id,
+    title: video.title.text,
+    author: video.author.name,
+    authorId: video.author.id,
+    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds
+  }
+}

--- a/src/renderer/store/modules/ytdl.js
+++ b/src/renderer/store/modules/ytdl.js
@@ -1,12 +1,10 @@
 import ytdl from 'ytdl-core'
 import ytsr from 'ytsr'
-import ytpl from 'ytpl'
 
 import { SocksProxyAgent } from 'socks-proxy-agent'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import { HttpProxyAgent } from 'http-proxy-agent'
 
-import i18n from '../../i18n/index'
 import { searchFiltersMatch } from '../../helpers/utils'
 
 const state = {
@@ -190,32 +188,6 @@ const actions = {
 
     return new Promise((resolve, reject) => {
       resolve(filterUrl)
-    })
-  },
-
-  ytGetPlaylistInfo ({ rootState }, playlistId) {
-    return new Promise((resolve, reject) => {
-      let agent = null
-      const settings = rootState.settings
-
-      if (settings.useProxy) {
-        agent = createProxyAgent(settings.proxyProtocol, settings.proxyHostname, settings.proxyPort)
-      }
-      let locale = i18n.locale.replace('_', '-')
-
-      if (locale === 'nn') {
-        locale = 'no'
-      }
-
-      ytpl(playlistId, {
-        hl: locale,
-        limit: Infinity,
-        requestOptions: { agent }
-      }).then((result) => {
-        resolve(result)
-      }).catch((err) => {
-        reject(err)
-      })
     })
   },
 

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -7,7 +7,7 @@ import FtListVideo from '../../components/ft-list-video/ft-list-video.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
 import i18n from '../../i18n/index'
-import { getLocalPlaylist } from '../../helpers/api/local'
+import { getLocalPlaylist, parseLocalPlaylistVideo } from '../../helpers/api/local'
 import { extractNumberFromString } from '../../helpers/utils'
 
 export default Vue.extend({
@@ -90,7 +90,7 @@ export default Vue.extend({
           channelId: this.infoData.channelId
         })
 
-        this.playlistItems = result.items.map(this.parseVideoLocal)
+        this.playlistItems = result.items.map(parseLocalPlaylistVideo)
 
         if (result.has_continuation) {
           this.continuationData = result
@@ -106,16 +106,6 @@ export default Vue.extend({
           this.isLoading = false
         }
       })
-    },
-
-    parseVideoLocal: function (video) {
-      return {
-        videoId: video.id,
-        title: video.title.text,
-        author: video.author.name,
-        authorId: video.author.id,
-        lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds
-      }
     },
 
     getPlaylistInvidious: function () {
@@ -179,7 +169,7 @@ export default Vue.extend({
       this.isLoadingMore = true
 
       this.continuationData.getContinuation().then((result) => {
-        const parsedVideos = result.items.map(this.parseVideoLocal)
+        const parsedVideos = result.items.map(parseLocalPlaylistVideo)
         this.playlistItems = this.playlistItems.concat(parsedVideos)
 
         if (result.has_continuation) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8710,13 +8710,6 @@ ytdl-core@^3.2.2:
     miniget "^4.2.2"
     sax "^1.1.3"
 
-ytpl@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/ytpl/-/ytpl-2.3.0.tgz#74633b6e582e22ff03e409dfb65d200c1a4ca0d2"
-  integrity sha512-Cfw2rxq3PFK6qgWr2Z8gsRefVahEzbn9XEuiJldqdXHE6GhO7kTfEvbZKdfXing1SmgW635uJ/UL2g8r0fvu2Q==
-  dependencies:
-    miniget "^4.2.2"
-
 ytsr@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ytsr/-/ytsr-3.8.0.tgz#49a8e5dc413f41515fc3d79d93ee3e073d10e772"


### PR DESCRIPTION
# Migrate playlists on the watch page to YouTube.js

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This pull request migrates the playlists view on the watch page to YouTube.js, this removes the need for the ytpl dependency, as the playlist page was migrated in an earlier PR. Yay! 😄

Like the previous implementation this will paginate through the entire playlist, which means the playlist view is slow to load for lots of videos, however the benefits of having all videos there outweigh the wait. In the future we might want to introduce a timeout and then just show the videos that have been fetched up until then.

## Testing <!-- for code that is not small enough to be easily understandable -->
playlist with 100 videos, only a single page
https://www.youtube.com/playlist?list=PL4fGSI1pDJn6puJdseH2Rt9sMvt9E2M4i

playlist with 872 videos, multiple pages
https://www.youtube.com/playlist?list=PLbMjU_TVMIFvmkQ871iUvE5gy5ezXc6hE

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0