### PR TITLE
Pass playlist

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -31,7 +31,6 @@ export default Vue.extend({
       reversePlaylist: false,
       channelName: '',
       channelId: '',
-      channelThumbnail: '',
       playlistTitle: '',
       playlistItems: [],
       randomizedPlaylistItems: []
@@ -251,9 +250,7 @@ export default Vue.extend({
       this.setCachedPlaylist(null)
 
       this.playlistTitle = cachedPlaylist.title
-      this.videoCount = cachedPlaylist.videoCount
       this.channelName = cachedPlaylist.channelName
-      this.channelThumbnail = cachedPlaylist.channelThumbnail
       this.channelId = cachedPlaylist.channelId
 
       if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious' || cachedPlaylist.continuationData === null) {
@@ -286,9 +283,7 @@ export default Vue.extend({
         let playlist = await getLocalPlaylist(this.playlistId)
 
         this.playlistTitle = playlist.info.title
-        this.videoCount = playlist.info.total_items
         this.channelName = playlist.info.author?.name
-        this.channelThumbnail = playlist.info.author?.best_thumbnail?.url
         this.channelId = playlist.info.author?.id
 
         const videos = playlist.items.map(parseLocalPlaylistVideo)
@@ -328,9 +323,7 @@ export default Vue.extend({
 
       this.invidiousGetPlaylistInfo(payload).then((result) => {
         this.playlistTitle = result.title
-        this.videoCount = result.videoCount
         this.channelName = result.author
-        this.channelThumbnail = result.authorThumbnails[2].url
         this.channelId = result.authorId
         this.playlistItems = this.playlistItems.concat(result.videos)
 

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -22,6 +22,7 @@ const state = {
     gaming: null,
     movies: null
   },
+  cachedPlaylist: null,
   showProgressBar: false,
   progressBarPercentage: 0,
   regionNames: [],
@@ -58,6 +59,10 @@ const getters = {
 
   getTrendingCache () {
     return state.trendingCache
+  },
+
+  getCachedPlaylist() {
+    return state.cachedPlaylist
   },
 
   getSearchSettings () {
@@ -687,6 +692,10 @@ const mutations = {
 
   setTrendingCache (state, { value, page }) {
     state.trendingCache[page] = value
+  },
+
+  setCachedPlaylist(state, value) {
+    state.cachedPlaylist = value
   },
 
   setSearchSortBy (state, value) {

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -25,9 +25,7 @@ export default Vue.extend({
       this.setCachedPlaylist({
         id: this.playlistId,
         title: this.infoData.title,
-        videoCount: this.infoData.videoCount,
         channelName: this.infoData.channelName,
-        channelThumbnail: this.infoData.channelThumbnail,
         channelId: this.infoData.channelId,
         items: this.playlistItems,
         continuationData: this.continuationData

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { mapActions } from 'vuex'
+import { mapActions, mapMutations } from 'vuex'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import PlaylistInfo from '../../components/playlist-info/playlist-info.vue'
@@ -19,6 +19,21 @@ export default Vue.extend({
     'ft-list-video': FtListVideo,
     'ft-flex-box': FtFlexBox,
     'ft-button': FtButton
+  },
+  beforeRouteLeave(to, from, next) {
+    if (!this.isLoading && to.path.startsWith('/watch') && to.query.playlistId === this.playlistId) {
+      this.setCachedPlaylist({
+        id: this.playlistId,
+        title: this.infoData.title,
+        videoCount: this.infoData.videoCount,
+        channelName: this.infoData.channelName,
+        channelThumbnail: this.infoData.channelThumbnail,
+        channelId: this.infoData.channelId,
+        items: this.playlistItems,
+        continuationData: this.continuationData
+      })
+    }
+    next()
   },
   data: function () {
     return {
@@ -185,6 +200,10 @@ export default Vue.extend({
     ...mapActions([
       'invidiousGetPlaylistInfo',
       'updateSubscriptionDetails'
+    ]),
+
+    ...mapMutations([
+      'setCachedPlaylist'
     ])
   }
 })


### PR DESCRIPTION
# Pass playlist data from playlist page to watch page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
Currently when you start playling a video in a playlist from the playlist page, the watch page fetches the playlist information again. With this PR the watch page can reuse the playlist information that was already fetched on the playlist page, this prevents unnecessary network activity and also speeds up the loading of the playlist component on the watch page, as it has less to do. If the playlist has extra pages that haven't been fetched yet, the watch page will fetch those.

The watch page will of course still need to fetch everything itself if you come from a different page.

I also got rid of some unused properties, as I noticed them while implementing the changes mentioned above.

## Testing <!-- for code that is not small enough to be easily understandable -->

**Single page playlist**
https://www.youtube.com/playlist?list=PL4fGSI1pDJn6puJdseH2Rt9sMvt9E2M4i

**Playlist with lots of pages**
1. Don't load anymore pages on the playlist page, should be slow on the watch page but slightly faster than before
2. Click "Load more" a few times on the playlist page before playing a video, the playlist view on the watch page should load significantly faster
https://www.youtube.com/playlist?list=PLbMjU_TVMIFvmkQ871iUvE5gy5ezXc6hE

**Jump directly to the watch page, without visiting the playlist page first**
https://youtu.be/Uq9gPaIzbe8?list=PL4fGSI1pDJn6puJdseH2Rt9sMvt9E2M4i

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0