### PR TITLE
fix linting error in ft-input-tags.vue

### DIFF
--- a/src/renderer/components/ft-input-tags/ft-input-tags.vue
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.vue
@@ -20,7 +20,10 @@
           v-for="tag in tagList"
           :key="tag.id"
         >
-          <label>{{ tag }}</label>
+          <label
+            :for="tag.id"
+          >
+            {{ tag }}</label>
           <font-awesome-icon
             :icon="['fas', 'fa-times']"
             class="removeTagButton"


### PR DESCRIPTION
# fix linting error in ft-input-tags.vue

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Linting is currently failing after #2849

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I don't quite understand why the lint error was not caught on the auto running checks on PR's.
Either way here is a fix for the linting error currently on the development branch.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
```
```

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
