### PR TITLE
Remove select-on-focus from ft-input

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -45,10 +45,6 @@ export default Vue.extend({
       type: Boolean,
       default: false
     },
-    selectOnFocus: {
-      type: Boolean,
-      default: false
-    },
     disabled: {
       type: Boolean,
       default: false
@@ -262,9 +258,6 @@ export default Vue.extend({
 
     handleFocus: function(e) {
       this.searchState.showOptions = true
-      if (this.selectOnFocus) {
-        e.target.select()
-      }
     },
 
     updateVisibleDataList: function () {

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -80,7 +80,6 @@
           :placeholder="$t('Search / Go to URL')"
           class="searchInput"
           :is-search="true"
-          :select-on-focus="true"
           :data-list="searchSuggestionsDataList"
           :spellcheck="false"
           :show-clear-text-button="true"

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -74,7 +74,7 @@
 }
 
 .channelSearch {
-  width: 200px;
+  width: 220px;
   align-self: flex-end;
 }
 

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -96,7 +96,7 @@
           </div>
           <ft-input
             :placeholder="$t('Channel.Search Channel')"
-            :select-on-focus="true"
+            :show-clear-text-button="true"
             class="channelSearch"
             @click="newSearch"
           />


### PR DESCRIPTION
# Title

Remove select-on-focus behaviour from ft-input as this has been superceded by show-clear-text-button.
 
# Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #2622
## Description

This removes the select-on-focus property, and uses of that property from ft-input.  Where select-on-focus was used we now use the show-clear-text-button property instead to display a clear text button.  This is less surprising from a UX point of view.

I have also enlarged the search box on the channel page so that the placeholder is not truncated now that the clear text button is shown.


## Screenshots 

None.

## Testing

I have tested this PR manually by viewing the pages where I have changed the input control (top nav, search within channels page) to ensure they render correctly and no errors are observed in the console.  I have verified that the text is no longer selected when you click into the search bar, and that the clear text button removes the text from the search box.

## Desktop
<!-- Please complete the following information-->
- Pop OS
-  22.04
- 0.18.0

## Additional context

None