### PR TITLE
Fix docs link in the data settings section

### DIFF
--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -21,14 +21,11 @@
       />
     </ft-flex-box>
     <ft-flex-box>
-      <a
-        class="center"
-        href="https://docs.freetubeapp.io/usage/importing-subscriptions/"
-      >
-        <p>
+      <p>
+        <a href="https://docs.freetubeapp.io/usage/importing-subscriptions/">
           {{ $t("Settings.Data Settings.How do I import my subscriptions?") }}
-        </p>
-      </a>
+        </a>
+      </p>
     </ft-flex-box>
     <ft-flex-box>
       <ft-button


### PR DESCRIPTION
# Fix docs link in the data settings section

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #2975 

## Description
Not sure what exactly was going wrong, if I had to guess, somehow the click was being attributed to the `p` element, so that our click handler for `a` elements wasn't getting triggered.

## Testing <!-- for code that is not small enough to be easily understandable -->
Click on the link, it should respect the users "External Link Handling" setting.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0