### PR TITLE
Exempt some labels from stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,3 +19,5 @@ jobs:
           days-before-pr-close: 14
           stale-issue-label: 'U: stale'
           stale-pr-label: 'PR: stale'
+          exempt-pr-labels: 'PR: WIP'
+          exempt-issue-labels: 'U: skip-stale'


### PR DESCRIPTION
# Exempt some labels from stale workflow

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Other - Workflow

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Based on https://github.com/FreeTubeApp/FreeTube/pull/2812

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Stale workflow shouldnt run when labels are applied.

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
@ChunkyProgrammer tested this in the test repo with #2812 