### PR TITLE
Improve display of long channel names on subscribed channel page

### DIFF
--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.css
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.css
@@ -47,6 +47,8 @@
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
+  overflow-wrap: break-word;
+  width: 100%;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
# Title

Improve display of long channel names on subscribed channel page
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #2524

## Description
Long channel names with no spaces or dashes would never wrap or overflow due to unspecified css width.  I have amended the css so that these rules are effective, and also added overflow-wrap so that more of the title is displayed.

## Screenshots 

Before: (title edited in profiles.db to force issue)

![image](https://user-images.githubusercontent.com/698207/208947302-00db29eb-fe2f-4164-aa45-a9f5f7c9c0b6.png)

After:

![image](https://user-images.githubusercontent.com/698207/208947191-c0021a77-9da0-4547-bbb3-1b07d97c2442.png)

As you can see, Dave2d looks pleased with the results.

## Testing

I have checked the rendering in the subscribed channels page.

## Desktop
- POP OS
- 22.04
-  0.18.0

## Additional context

None