### PR TITLE
Fix possible to do both actions in video player by scrolling

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -729,6 +729,11 @@ export default Vue.extend({
     },
 
     mouseScrollSkip: function (event) {
+      // Avoid doing both
+      if ((event.ctrlKey || event.metaKey) && this.videoPlaybackRateMouseScroll) {
+        return
+      }
+
       // ensure that the mouse is over the player
       if (event.target && (event.target.matches('.vjs-tech') || event.target.matches('.ftVideoPlayer'))) {
         event.preventDefault()


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Fixes https://github.com/FreeTubeApp/FreeTube/pull/2418#issuecomment-1363016201

## Description
Fix possible to do both actions in video player by scrolling

"Scroll playback rate over video player" and "Skip by Scrolling Over Video Player"

## Screenshots <!-- If appropriate -->
![image](https://user-images.githubusercontent.com/1018543/209420985-72cce842-23c9-4f6a-97be-8e8315d983d7.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Enable both "Scroll playback rate over video player" and "Skip by Scrolling Over Video Player"
- Watch random video (long enough)
- Scroll & Ctrl/Cmd + scroll to see how playback rate & video progress changes

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2 
- **FreeTube version:** d38827dc0a6ef85915afd3fce4e0dfdafb9e2cd0

## Additional context
<!-- Add any other context about the pull request here. -->
