### PR TITLE
Fix insecure coookie error

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -265,9 +265,7 @@ function runApp() {
 
     // Set CONSENT cookie on reasonable domains
     const consentCookieDomains = [
-      'http://www.youtube.com',
       'https://www.youtube.com',
-      'http://youtube.com',
       'https://youtube.com'
     ]
     consentCookieDomains.forEach(url => {


### PR DESCRIPTION
# Fix insecure coookie error

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
A couple of time users have asked whether these errors are what is causing their unrelated issue. As we make all of the requests to YouTube over HTTPS I don't think we need to set the cookies for HTTP anymore, this also gets rid of the errors.

## Screenshots <!-- If appropriate -->
![insecure-cookies-errors](https://user-images.githubusercontent.com/48293849/209437655-dac8bd95-fd59-4493-a68a-ccd54ec994ac.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Uncomment this line in `_script/dev-runner.js` to make the logs from electron show up in your terminal:
```diff
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -56,7 +56,7 @@ async function restartElectron() {
-    // { stdio: 'inherit' } // required for logs to actually appear in the stdout
+    { stdio: 'inherit' } // required for logs to actually appear in the stdout
```
then `yarn dev`

alternatively you can build a release build with `yarn build` and then run it from a terminal.

You should no longer see the errors about the insecure cookies popping up.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0