### PR TITLE
Improve responsiveness of `Hide Videos From Channels`

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.css
+++ b/src/renderer/components/distraction-settings/distraction-settings.css
@@ -1,0 +1,5 @@
+@media only screen and (max-width: 800px) {
+  br.hide-on-mobile {
+    display: none;
+  }
+}

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -104,7 +104,7 @@
         />
       </div>
     </div>
-    <br>
+    <br class="hide-on-mobile" />
     <ft-flex-box>
       <ft-input-tags
         :label="$t('Settings.Distraction Free Settings.Hide Channels')"
@@ -119,3 +119,4 @@
 </template>
 
 <script src="./distraction-settings.js" />
+<style src="./distraction-settings.css" />

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -48,3 +48,8 @@
   margin-top: 10px;
 }
 
+@media(max-width: 532px) {
+  .ft-input-tags-component {
+    width: 100%;
+  }
+}

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -5,6 +5,7 @@
   border-radius: 5px;
   display: block;
   width: 60%;
+  margin-top: 2em;
 }
 
 .ft-tag-box ul {
@@ -48,7 +49,8 @@
   margin-top: 10px;
 }
 
-@media(max-width: 532px) {
+
+@media only screen and (max-width: 576px) {
   .ft-input-tags-component {
     width: 100%;
   }

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -5,7 +5,6 @@
   border-radius: 5px;
   display: block;
   width: 60%;
-  margin-top: 2em;
 }
 
 .ft-tag-box ul {
@@ -48,7 +47,6 @@
 :deep(.ft-input-component .ft-input) {
   margin-top: 10px;
 }
-
 
 @media only screen and (max-width: 576px) {
   .ft-input-tags-component {

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -114,6 +114,10 @@
   color: #EEEEEE;
 }
 
+.inputWrapper {
+  position: relative;
+}
+
 .inputAction {
   position: absolute;
   margin: 0 3px;
@@ -134,7 +138,7 @@
 
 .inputAction.withLabel {
   /* If showLabel defined, re-centralize the input button*/
-  top: 34px;
+  top: 14px;
 }
 
 

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -122,7 +122,7 @@
   position: absolute;
   margin: 0 3px;
   padding: 10px;
-  top: 5px;
+  top: -8px;
   right: 0;
   border-radius: 100%;
   color: var(--primary-text-color);
@@ -136,18 +136,9 @@
   cursor: pointer;
 }
 
-.inputAction.withLabel {
-  /* If showLabel defined, re-centralize the input button*/
-  top: 14px;
-}
-
 
 .search ::-webkit-calendar-picker-indicator {
   display: none;
-}
-
-.search .inputAction {
-  top: 12px;
 }
 
 .forceTextColor .inputAction {

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -38,32 +38,33 @@
       @keydown.space.prevent="handleClearTextClick"
       @keydown.enter.prevent="handleClearTextClick"
     />
-    <input
-      :id="id"
-      ref="input"
-      v-model="inputData"
-      :list="idDataList"
-      class="ft-input"
-      :type="inputType"
-      :placeholder="placeholder"
-      :disabled="disabled"
-      :spellcheck="spellcheck"
-      @input="e => handleInput(e.target.value)"
-      @focus="handleFocus"
-      @blur="handleInputBlur"
-      @keydown="handleKeyDown"
-    >
-    <font-awesome-icon
-      v-if="showActionButton"
-      :icon="actionButtonIconName"
-      class="inputAction"
-      :class="{
-        enabled: inputDataPresent,
-        withLabel: showLabel
-      }"
-      @click="handleClick"
-    />
-
+    <div class="inputWrapper">
+      <input
+        :id="id"
+        ref="input"
+        v-model="inputData"
+        :list="idDataList"
+        class="ft-input"
+        :type="inputType"
+        :placeholder="placeholder"
+        :disabled="disabled"
+        :spellcheck="spellcheck"
+        @input="e => handleInput(e.target.value)"
+        @focus="handleFocus"
+        @blur="handleInputBlur"
+        @keydown="handleKeyDown"
+      >
+      <font-awesome-icon
+        v-if="showActionButton"
+        :icon="actionButtonIconName"
+        class="inputAction"
+        :class="{
+          enabled: inputDataPresent,
+          withLabel: showLabel
+        }"
+        @click="handleClick"
+      />
+    </div>
     <div class="options">
       <ul
         v-if="inputData !== '' && visibleDataList.length > 0 && searchState.showOptions"

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -38,7 +38,7 @@
       @keydown.space.prevent="handleClearTextClick"
       @keydown.enter.prevent="handleClearTextClick"
     />
-    <div class="inputWrapper">
+    <span class="inputWrapper">
       <input
         :id="id"
         ref="input"
@@ -64,7 +64,7 @@
         }"
         @click="handleClick"
       />
-    </div>
+    </span>
     <div class="options">
       <ul
         v-if="inputData !== '' && visibleDataList.length > 0 && searchState.showOptions"


### PR DESCRIPTION
# Improve responsiveness of `Hide Videos From Channels` section in Settings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
This PR aims to improve the mobile responsiveness of the `Hide Videos From Channels` input by adjusting the alignment of the action button and adjusting the whitespace surrounding the section.

Currently, the action icon is absolutely positioned within the relative `ft-input-component`. The `ft-input-component` contains a `label` which is displayed before the `input` element, and this can cause the icon to become misaligned if the label is taller than the `top` position of the icon. This PR aims to fix this by adding a relatively positioned wrapper around just the `input` and action icon. This should ensure that the action icon remains in line with the input even if the height of the label changes due to text wrapping.

Additionally, there is a lot of space between the `Hide Videos From Channel` section and the above section on small displays, so this PR aims to address this by hiding the line break in-between these sections with a media query. It may make more sense to use a margin/padding which changes based on a media query instead of hiding and showing the existing line-break.

## Screenshots <!-- If appropriate -->
_(the below screenshots are from a 412px wide window)_
| _before:_ | _after:_ |
| :---: | :---: |
|<img src="https://user-images.githubusercontent.com/106682128/209483117-cd0dfe13-77a9-4358-bf62-4ee1d5bb7b12.png" width="300" />|<img src="https://user-images.githubusercontent.com/106682128/209483118-b9a11667-0fa4-4810-80db-2b539235ba11.png" width="300" />|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn dev`
2. Open the `Settings` view
3. Navigate to `Distraction Free Settings`
4. Reduce the width of the window to something below `576px`
5. Make sure that the `Hide Videos From Channels` section doesn't contain any overflow

_It would also make sense to do a run through of all other `ft-input`s which display an action icon._

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0

## Additional context
This can also be tested in a web build; however, there is currently an issue with the web build which is resolved by FreeTubeApp/FreeTube#2991. I went ahead and tested this PR in the web build by adding the additional fallback for `fs/promises` to the `web` webpack config which is present in that PR, and it seems to work fine. 

I am unsure if the break-point I used is the best one to use. I tried to pick a pretty standard break-point, but I am aware that FreeTube uses a lot of non-standard breakpoints, so it might make more sense for this to use one of the already existing breakpoints in FT.
