### PR TITLE
Only show prompt close button when it is needed

### DIFF
--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -48,6 +48,7 @@
       :label="$t('Settings.Data Settings.Select Export Type')"
       :option-names="exportSubscriptionsPromptNames"
       :option-values="subscriptionsPromptValues"
+      :show-close="true"
       @click="exportSubscriptions"
     />
   </ft-settings-section>

--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -27,6 +27,10 @@ export default Vue.extend({
     optionValues: {
       type: Array,
       default: () => { return [] }
+    },
+    showClose: {
+      type: Boolean,
+      default: false
     }
   },
   data: function () {

--- a/src/renderer/components/ft-prompt/ft-prompt.vue
+++ b/src/renderer/components/ft-prompt/ft-prompt.vue
@@ -34,6 +34,7 @@
             @click="$emit('click', optionValues[index])"
           />
           <ft-button
+            v-if="showClose"
             :id="'prompt-' + sanitizedLabel + '-close'"
             :label="$t('Close')"
             tabindex="0"


### PR DESCRIPTION
# Only show prompt close button when it is needed

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the close button is shown for all prompts, even if they already provide a way of closing it without taking an action or making changes. This pull request changes that, so it is only shown in the export type prompt.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/209534569-8360e33d-9c85-46fc-b234-b314ef18db9e.png)
![after](https://user-images.githubusercontent.com/48293849/209534574-5669a7dc-eab4-4c38-81cf-0676a634d13c.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Try out various prompts in FreeTube and make sure that they don't need the close button.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0