### PR TITLE
Use path.sep instead of working out the directory separator ourselves

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1390,10 +1390,9 @@ export default Vue.extend({
         return
       }
 
-      const dirChar = process.platform === 'win32' ? '\\' : '/'
       let subDir = ''
-      if (filename.indexOf(dirChar) !== -1) {
-        const lastIndex = filename.lastIndexOf(dirChar)
+      if (filename.indexOf(path.sep) !== -1) {
+        const lastIndex = filename.lastIndexOf(path.sep)
         subDir = filename.substring(0, lastIndex)
         filename = filename.substring(lastIndex + 1)
       }


### PR DESCRIPTION
# Use path.sep instead of working out the directory separator ourselves

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
Node's path module has a `sep` property that contains the platform specific directory separator, we can use that instead of working it out ourselves.

I know this doesn't seem great for the web build, however the screenshot code in general is not web friendly yet, for the web build we should probably just replace both separator characters, but that can be decided once we make the screenshot stuff web friendly.

## Testing <!-- for code that is not small enough to be easily understandable -->
Take screenshots on videos.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0