### PR TITLE
Import the product name instead of using a define for it

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -1,9 +1,6 @@
 const path = require('path')
-const webpack = require('webpack')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const JsonMinimizerPlugin = require('json-minimizer-webpack-plugin')
-
-const { productName } = require('../package.json')
 
 const isDevMode = process.env.NODE_ENV === 'development'
 
@@ -36,11 +33,7 @@ const config = {
     __dirname: isDevMode,
     __filename: isDevMode
   },
-  plugins: [
-    new webpack.DefinePlugin({
-      'process.env.PRODUCT_NAME': JSON.stringify(productName),
-    }),
-  ],
+  plugins: [],
   output: {
     filename: '[name].js',
     libraryTarget: 'commonjs2',

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -6,8 +6,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const ProcessLocalesPlugin = require('./ProcessLocalesPlugin')
 
-const { productName } = require('../package.json')
-
 const isDevMode = process.env.NODE_ENV === 'development'
 
 const config = {
@@ -110,7 +108,6 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.PRODUCT_NAME': JSON.stringify(productName),
       'process.env.IS_ELECTRON': true
     }),
     new HtmlWebpackPlugin({

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -9,8 +9,6 @@ const JsonMinimizerPlugin = require('json-minimizer-webpack-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const ProcessLocalesPlugin = require('./ProcessLocalesPlugin')
 
-const { productName } = require('../package.json')
-
 const isDevMode = process.env.NODE_ENV === 'development'
 
 const config = {
@@ -114,7 +112,6 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.PRODUCT_NAME': JSON.stringify(productName),
       'process.env.IS_ELECTRON': false
     }),
     new webpack.ProvidePlugin({

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -76,10 +76,10 @@ export default Vue.extend({
       if (this.$route.meta.title !== 'Channel' && this.$route.meta.title !== 'Watch') {
         let title =
         this.$route.meta.path === '/home'
-          ? process.env.PRODUCT_NAME
-          : `${this.$t(this.$route.meta.title)} - ${process.env.PRODUCT_NAME}`
+          ? packageDetails.productName
+          : `${this.$t(this.$route.meta.title)} - ${packageDetails.productName}`
         if (!title) {
-          title = process.env.PRODUCT_NAME
+          title = packageDetails.productName
         }
         return title
       } else {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -16,6 +16,7 @@ import autolinker from 'autolinker'
 import { MAIN_PROFILE_ID } from '../../../constants'
 import i18n from '../../i18n/index'
 import { copyToClipboard, showToast } from '../../helpers/utils'
+import packageDetails from '../../../../package.json'
 
 export default Vue.extend({
   name: 'Search',
@@ -273,7 +274,7 @@ export default Vue.extend({
         this.idType = 1
         this.channelName = channelName
         this.isFamilyFriendly = response.isFamilyFriendly
-        document.title = `${this.channelName} - ${process.env.PRODUCT_NAME}`
+        document.title = `${this.channelName} - ${packageDetails.productName}`
         if (this.hideChannelSubscriptions || response.subscriberCount === 0) {
           this.subCount = null
         } else {
@@ -373,7 +374,7 @@ export default Vue.extend({
         const channelName = response.author
         const channelId = response.authorId
         this.channelName = channelName
-        document.title = `${this.channelName} - ${process.env.PRODUCT_NAME}`
+        document.title = `${this.channelName} - ${packageDetails.productName}`
         this.id = channelId
         this.isFamilyFriendly = response.isFamilyFriendly
         if (this.hideChannelSubscriptions) {


### PR DESCRIPTION
# Import the product name instead of using a define for it

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
Currently we import the version from the package.json file but we use a define for the product name. This PR makes getting information from the package.json file more consistent, by importing the product name as well, instead of using a define for it.

## Testing <!-- for code that is not small enough to be easily understandable -->
Navigate around FreeTube and check that the window title is set correctly to `{page} - FreeTube` and on the watch page `{video title} - FreeTube`

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0