### PR TITLE
Escape special characters in channel names in ompl export

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -620,19 +620,20 @@ export default Vue.extend({
       }
 
       let opmlData = '<opml version="1.1"><body><outline text="YouTube Subscriptions" title="YouTube Subscriptions">'
-      const endingOpmlString = '</outline></body></opml>'
-
-      let count = 0
 
       this.profileList[0].subscriptions.forEach((channel) => {
-        const channelOpmlString = `<outline text="${channel.name}" title="${channel.name}" type="rss" xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}"/>`
-        count++
-        opmlData += channelOpmlString
+        const escapedName = channel.name
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&apos;')
 
-        if (count === this.profileList[0].subscriptions.length) {
-          opmlData += endingOpmlString
-        }
+        const channelOpmlString = `<outline text="${escapedName}" title="${escapedName}" type="rss" xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}"/>`
+        opmlData += channelOpmlString
       })
+
+      opmlData += '</outline></body></opml>'
 
       const response = await showSaveDialog(options)
       if (response.canceled || response.filePath === '') {


### PR DESCRIPTION
# Escape special characters in channel names in ompl export

## Pull Request Type

- [x] Bugfix

## Related issue
noticed in https://github.com/FreeTubeApp/FreeTube/pull/2769#issuecomment-1292254844

## Description
Escape special characters in the channel names during the XML exports, so that the output is valid XML.

## Screenshots <!-- If appropriate -->
formatted versions of the before and after output
before:
```xml
<opml version="1.1">
    <body>
        <outline text="YouTube Subscriptions" title="YouTube Subscriptions">
            <outline text="House & Garden" title="House & Garden" type="rss" xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=UCBEqJ-MfSIxKM5mgwVB3ZDg"/>
        </outline>
    </body>
</opml>
```

after:
```xml
<opml version="1.1">
    <body>
        <outline text="YouTube Subscriptions" title="YouTube Subscriptions">
            <outline text="House &amp; Garden" title="House &amp; Garden" type="rss" xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=UCBEqJ-MfSIxKM5mgwVB3ZDg"/>
        </outline>
    </body>
</opml>
```

## Testing <!-- for code that is not small enough to be easily understandable -->
Channels with special characters in their names like [House & Garden](https://www.youtube.com/channel/UCBEqJ-MfSIxKM5mgwVB3ZDg), others can be found by searching for `&` in the search box and set the type filter to channels.

Subscribe to those channels and then export your subscriptions.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0