### PR TITLE
Migrate the trending page to YouTube.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@fortawesome/vue-fontawesome": "^2.0.9",
     "@freetube/youtube-chat": "^1.1.2",
     "@freetube/yt-comment-scraper": "^6.2.0",
-    "@freetube/yt-trending-scraper": "^3.1.1",
     "@silvermine/videojs-quality-selector": "^1.2.5",
     "autolinker": "^4.0.0",
     "browserify": "^17.0.0",

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -2,7 +2,7 @@ import { Innertube, Session } from 'youtubei.js'
 import { join } from 'path'
 
 import { PlayerCache } from './PlayerCache'
-import { getUserDataPath } from '../utils'
+import { extractNumberFromString, getUserDataPath } from '../utils'
 
 /**
  * Creates a lightweight Innertube instance, which is faster to create or
@@ -12,21 +12,24 @@ import { getUserDataPath } from '../utils'
  * 1. the request for the session
  * 2. fetch a page that contains a link to the player
  * 3. if the player isn't cached, it is downloaded and transformed
- * @param {boolean} withPlayer set to true to get an Innertube instance that can decode the streaming URLs
+ * @param {object} options
+ * @param {boolean} options.withPlayer set to true to get an Innertube instance that can decode the streaming URLs
+ * @param {string|undefined} options.location the geolocation to pass to YouTube get different content
  * @returns the Innertube instance
  */
-async function createInnertube(withPlayer = false) {
-  if (withPlayer) {
+async function createInnertube(options = { withPlayer: false, location: undefined }) {
+  if (options.withPlayer) {
     const userData = await getUserDataPath()
 
     return await Innertube.create({
       // use browser fetch
+      location: options.location,
       fetch: (input, init) => fetch(input, init),
       cache: new PlayerCache(join(userData, 'player_cache'))
     })
   } else {
     // from https://github.com/LuanRT/YouTube.js/pull/240
-    const sessionData = await Session.getSessionData()
+    const sessionData = await Session.getSessionData(undefined, options.location)
 
     const session = new Session(
       sessionData.context,
@@ -62,6 +65,11 @@ export async function getLocalPlaylist(id) {
   return await innertube.getPlaylist(id)
 }
 
+export async function getLocalTrending(location) {
+  const innertube = await createInnertube({ location })
+  return await innertube.getTrending()
+}
+
 /**
  * @typedef {import('youtubei.js/dist/src/parser/classes/PlaylistVideo').default} PlaylistVideo
  */
@@ -76,5 +84,27 @@ export function parseLocalPlaylistVideo(video) {
     author: video.author.name,
     authorId: video.author.id,
     lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds
+  }
+}
+
+/**
+ * @typedef {import('youtubei.js/dist/src/parser/classes/Video').default} Video
+ */
+
+/**
+ * @param {Video} video
+ */
+export function parseLocalListVideo(video) {
+  return {
+    type: 'video',
+    videoId: video.id,
+    title: video.title.text,
+    author: video.author.name,
+    authorId: video.author.id,
+    description: video.description,
+    viewCount: extractNumberFromString(video.view_count.text),
+    publishedText: video.published.text,
+    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
+    liveNow: video.is_live
   }
 }

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -3,7 +3,7 @@ import { mapActions } from 'vuex'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
-import { calculateLengthInSeconds } from '@freetube/yt-trending-scraper/src/HtmlParser'
+import { timeToSeconds } from 'youtubei.js/dist/src/utils/Utils'
 import { copyToClipboard, searchFiltersMatch, showToast } from '../../helpers/utils'
 
 export default Vue.extend({
@@ -155,7 +155,7 @@ export default Vue.extend({
             let videoDuration = video.duration
             const videoId = video.id
             if (videoDuration !== null && videoDuration !== '' && videoDuration !== 'LIVE' && videoDuration !== 'UPCOMING' && videoDuration !== 'PREMIERE') {
-              videoDuration = calculateLengthInSeconds(video.duration)
+              videoDuration = timeToSeconds(video.duration)
             }
             dataToShow.push(
               {

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -6,8 +6,8 @@ import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 
-import { scrapeTrendingPage } from '@freetube/yt-trending-scraper'
 import { copyToClipboard, showToast } from '../../helpers/utils'
+import { getLocalTrending, parseLocalListVideo } from '../../helpers/api/local'
 
 export default Vue.extend({
   name: 'Trending',
@@ -22,7 +22,8 @@ export default Vue.extend({
     return {
       isLoading: false,
       shownResults: [],
-      currentTab: 'default'
+      currentTab: 'default',
+      trendingInstance: null
     }
   },
   computed: {
@@ -77,27 +78,35 @@ export default Vue.extend({
       }
     },
 
-    getTrendingInfoLocal: function () {
+    getTrendingInfoLocal: async function () {
       this.isLoading = true
 
-      const param = {
-        parseCreatorOnRise: false,
-        page: this.currentTab,
-        geoLocation: this.region
-      }
+      try {
+        let trendingInstance
 
-      scrapeTrendingPage(param).then((result) => {
-        const returnData = result.filter((item) => {
-          return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
-        })
+        if (this.trendingInstance !== null) {
+          trendingInstance = this.trendingInstance
+        } else {
+          trendingInstance = await getLocalTrending(this.region)
+        }
 
-        this.shownResults = returnData
+        // youtubei.js's tab names are localised, so we need to use the index to get tab name that youtubei.js expects
+        const tabIndex = ['default', 'music', 'gaming', 'movies'].indexOf(this.currentTab)
+        const results = await trendingInstance.getTabByName(trendingInstance.tabs[tabIndex])
+
+        const parsedVideos = results.videos
+          .filter((video) => video.type === 'Video')
+          .map(parseLocalListVideo)
+
+        this.shownResults = parsedVideos
         this.isLoading = false
-        this.$store.commit('setTrendingCache', { value: returnData, page: this.currentTab })
+        this.trendingInstance = results
+
+        this.$store.commit('setTrendingCache', { value: parsedVideos, page: this.currentTab })
         setTimeout(() => {
           this.$refs[this.currentTab].focus()
         })
-      }).catch((err) => {
+      } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
         showToast(`${errorMessage}: ${err}`, 10000, () => {
@@ -109,7 +118,7 @@ export default Vue.extend({
         } else {
           this.isLoading = false
         }
-      })
+      }
     },
 
     getTrendingInfoCache: function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1060,13 +1060,6 @@
   dependencies:
     axios "^0.27.2"
 
-"@freetube/yt-trending-scraper@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@freetube/yt-trending-scraper/-/yt-trending-scraper-3.1.1.tgz#82d11ac3dad3ea25bc0f30d68e315364e9977046"
-  integrity sha512-qgWFLefcKiLfJmETtEeDVuv9MQ50JFwkGlR3NITDG/SzdrhTFBizG5Ggs34sub6UQd6M6Ib8HxI/lgtKYqN7qA==
-  dependencies:
-    axios "^0.27.2"
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"


### PR DESCRIPTION
# Migrate the trending page to YouTube.js

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This pull request changes the local API backend of the trending page from @freetube/yt-trending-scraper to YouTube.js.

This removes the need for the @freetube/yt-trending-scraper dependency. Yay! 😄

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the different trending tabs work

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0