### PR TITLE
Parse channel handles in video descriptions

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -904,8 +904,14 @@ export default Vue.extend({
       } else {
         // Some YouTube URLs don't have the urlEndpoint so we handle them here
 
-        const path = part.navigationEndpoint.commandMetadata.webCommandMetadata.url
-        return `https://www.youtube.com${path}`
+        const { browseEndpoint, commandMetadata: { webCommandMetadata } } = part.navigationEndpoint
+        // channel handle
+        if (webCommandMetadata.webPageType === 'WEB_PAGE_TYPE_CHANNEL' && part.text.startsWith('@')) {
+          return `<a href="https://www.youtube.com/channel/${browseEndpoint.browseId}">${part.text}</a>`
+        } else {
+          const path = webCommandMetadata.url
+          return `https://www.youtube.com${path}`
+        }
       }
     },
 


### PR DESCRIPTION
# Parse channel handles in video descriptions

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
Currently links to users channels are displayed with the channel ID, even if the original description contains the channel handle. As channel handles are YouTube main username system now, I think it makes sense to display the channel handles in the description if they are available. The actual link still uses the channel ID, so it functions identically to before, it just looks prettier .

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/210062368-a94ebb29-344c-4639-9556-790c63c001c9.png)
![after](https://user-images.githubusercontent.com/48293849/210062377-69b5c76a-a535-46dd-b0ad-9d11ced27337.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
https://youtu.be/QtwEO9aDhHw

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0