### PR TITLE
Fix styling of the comment author text

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -34,7 +34,6 @@
   height: 60px;
   border-radius: 200px 200px 200px 200px;
   -webkit-border-radius: 200px 200px 200px 200px;
-  cursor: pointer;
 }
 
 .commentAuthorWrapper {
@@ -53,7 +52,8 @@
 }
 
 .commentAuthor {
-  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
 }
 
 .commentText {

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -77,18 +77,15 @@
         <p
           class="commentAuthorWrapper"
         >
-          <span
+          <router-link
             class="commentAuthor"
             :class="{
               commentOwner: comment.isOwner
             }"
+            :to="`/channel/${comment.authorLink}`"
           >
-            <router-link
-              :to="`/channel/${comment.authorLink}`"
-            >
-              {{ comment.author }}
-            </router-link>
-          </span>
+            {{ comment.author }}
+          </router-link>
           <img
             v-if="comment.isMember"
             :src="comment.memberIconUrl"


### PR DESCRIPTION
# Fix styling of the comment author text

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
#2986

## Description
This changes the styling of the comment author text to look like normal text instead of links.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/210071761-4f187c9d-e9b2-4b80-8f4e-2630adc63e4d.png)
![after](https://user-images.githubusercontent.com/48293849/210071768-f9ea05db-4b26-4999-925d-df82ff32485e.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Look at the comments on videos e.g. https://youtu.be/S0zpKHvEKXc

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0