### PR TITLE
Fix clear button covered by new input wrapper

### DIFF
--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -38,10 +38,12 @@
 
 .clearInputTextButton {
   position: absolute;
-  margin: 0 3px;
-  padding: 10px;
   top: 5px;
   left: 0;
+  /* To be higher than `.inputWrapper` */
+  z-index: 1;
+  margin: 0 3px;
+  padding: 10px;
   border-radius: 100%;
   color: var(--primary-text-color);
   opacity: 0;

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -85,7 +85,6 @@
   width: 100%;
   padding: 1rem;
   border: none;
-  background: transparent;
   margin-bottom: 10px;
   font-size: 16px;
   height: 45px;
@@ -190,7 +189,7 @@
 
 .list li {
   display: block;
-  padding: 0px 15px;
+  padding: 0 15px;
   line-height: 2rem;
 }
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/2994#issuecomment-1367853471

## Description
Fix clear button covered by new input wrapper

## Screenshots <!-- If appropriate -->
![image](https://user-images.githubusercontent.com/1018543/210124129-0e4a4e0e-0c30-4900-b6af-29d2eee2f145.png)
![image](https://user-images.githubusercontent.com/1018543/210124146-b968c541-c489-4475-9b31-866fb101662e.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Ensure top nav search input clear button can be functioned (clicked) & styled correctly
- Following Testing in https://github.com/FreeTubeApp/FreeTube/pull/2994

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** 8a30e322517099f3f86f2643aa0f074078fa9ac1

## Additional context
<!-- Add any other context about the pull request here. -->
