### PR TITLE
Make getVideoParamsFromUrl and showExternalPlayerUnsupportedActionToast helpers

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -486,3 +486,71 @@ export function extractNumberFromString(str) {
     return NaN
   }
 }
+
+export function showExternalPlayerUnsupportedActionToast(externalPlayer, actionName) {
+  const action = i18n.t(`Video.External Player.Unsupported Actions.${actionName}`)
+  const message = i18n.t('Video.External Player.UnsupportedActionTemplate', { externalPlayer, action })
+  showToast(message)
+}
+
+export function getVideoParamsFromUrl(url) {
+  /** @type {URL} */
+  let urlObject
+  const paramsObject = { videoId: null, timestamp: null, playlistId: null }
+  try {
+    urlObject = new URL(url)
+  } catch (e) {
+    return paramsObject
+  }
+
+  function extractParams(videoId) {
+    paramsObject.videoId = videoId
+    paramsObject.timestamp = urlObject.searchParams.get('t')
+  }
+
+  const extractors = [
+    // anything with /watch?v=
+    function () {
+      if (urlObject.pathname === '/watch' && urlObject.searchParams.has('v')) {
+        extractParams(urlObject.searchParams.get('v'))
+        paramsObject.playlistId = urlObject.searchParams.get('list')
+        return paramsObject
+      }
+    },
+    // youtu.be
+    function () {
+      if (urlObject.host === 'youtu.be' && urlObject.pathname.match(/^\/[A-Za-z0-9_-]+$/)) {
+        extractParams(urlObject.pathname.slice(1))
+        return paramsObject
+      }
+    },
+    // youtube.com/embed
+    function () {
+      if (urlObject.pathname.match(/^\/embed\/[A-Za-z0-9_-]+$/)) {
+        const urlTail = urlObject.pathname.replace('/embed/', '')
+        if (urlTail === 'videoseries') {
+          paramsObject.playlistId = urlObject.searchParams.get('list')
+        } else {
+          extractParams(urlTail)
+        }
+        return paramsObject
+      }
+    },
+    // youtube.com/shorts
+    function () {
+      if (urlObject.pathname.match(/^\/shorts\/[A-Za-z0-9_-]+$/)) {
+        extractParams(urlObject.pathname.replace('/shorts/', ''))
+        return paramsObject
+      }
+    },
+    // cloudtube
+    function () {
+      if (urlObject.host.match(/^cadence\.(gq|moe)$/) && urlObject.pathname.match(/^\/cloudtube\/video\/[A-Za-z0-9_-]+$/)) {
+        extractParams(urlObject.pathname.slice('/cloudtube/video/'.length))
+        return paramsObject
+      }
+    }
+  ]
+
+  return extractors.reduce((a, c) => a || c(), null) || paramsObject
+}


### PR DESCRIPTION
# Make getVideoParamsFromUrl and showExternalPlayerUnsupportedActionToast helpers

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
This pull request moves the `getVideoParamsFromUrl` and `showExternalPlayerUnsupportedActionToast` functions out of the store and into the utils helper file. These are the last two functions in the utils store that don't require access to the store.

## Testing
### getVideoParamsFromUrl
Use the main search bar to search and enter URLs

### showExternalPlayerUnsupportedActionToast
According to [static/external-player-map.json](https://github.com/FreeTubeApp/FreeTube/blob/development/static/external-player-map.json) none of the external players that we support, have support for reversing playlists. So to check that the toast still shows up, you can open a playlist, then on the watch page reverse it and open it in an external player.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0