### PR TITLE
Fix no sources error on the watch page

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -43,7 +43,7 @@ export default Vue.extend({
   },
   data: function () {
     return {
-      isLoading: false,
+      isLoading: true,
       firstLoad: true,
       useTheatreMode: false,
       showDashPlayer: true,


### PR DESCRIPTION
# Fix no sources error on the watch page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
When you open the watch page, an error pops up in the console `No sources available`, but it appears harmless as the video clearly starts playing when it's loaded. Still I thought I would track it down.

The ft-player and other components on the watch page have `v-if="!isLoading"`, which means they are created when `isLoading` is `false` and destroyed when it is `true`. `isLoading` is set to `true` inside the invidious and local API functions, before that it is `false` just long enough for the ft-player component to start doing it's thing, as at that point the data hasn't been fetched there aren't any formats available so the error pops up.

By setting the default value of `isLoading` to `true` we make sure that the ft-player and other components are only created once the data is available and `isLoading` is set to `false`.

## Screenshots <!-- If appropriate -->
![no-sources-available](https://user-images.githubusercontent.com/48293849/210178816-32bb7237-82d8-44c0-8140-bf78da47b3e5.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Play a video and check that the error doesn't show up anymore

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0