### PR TITLE
Use the new retrieve_player option in YouTube.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^2.6.0",
+    "youtubei.js": "^2.7.0",
     "yt-channel-info": "^3.2.1",
     "yt-dash-manifest-generator": "1.1.0",
     "ytdl-core": "https://github.com/absidue/node-ytdl-core#fix-likes-extraction",

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,4 +1,4 @@
-import { Innertube, Session } from 'youtubei.js'
+import { Innertube } from 'youtubei.js'
 import { join } from 'path'
 
 import { PlayerCache } from './PlayerCache'
@@ -18,31 +18,19 @@ import { extractNumberFromString, getUserDataPath } from '../utils'
  * @returns the Innertube instance
  */
 async function createInnertube(options = { withPlayer: false, location: undefined }) {
+  let cache
   if (options.withPlayer) {
     const userData = await getUserDataPath()
-
-    return await Innertube.create({
-      // use browser fetch
-      location: options.location,
-      fetch: (input, init) => fetch(input, init),
-      cache: new PlayerCache(join(userData, 'player_cache'))
-    })
-  } else {
-    // from https://github.com/LuanRT/YouTube.js/pull/240
-    const sessionData = await Session.getSessionData(undefined, options.location)
-
-    const session = new Session(
-      sessionData.context,
-      sessionData.api_key,
-      sessionData.api_version,
-      sessionData.account_index,
-      undefined, // player
-      undefined, // cookies
-      (input, init) => fetch(input, init) // use browser fetch
-    )
-
-    return new Innertube(session)
+    cache = new PlayerCache(join(userData, 'player_cache'))
   }
+
+  return await Innertube.create({
+    retrieve_player: !!options.withPlayer,
+    location: options.location,
+    // use browser fetch
+    fetch: (input, init) => fetch(input, init),
+    cache
+  })
 }
 
 let searchSuggestionsSession = null

--- a/yarn.lock
+++ b/yarn.lock
@@ -8685,10 +8685,10 @@ yauzl@^2.10.0:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
 
-youtubei.js@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.6.0.tgz#7ba11f0d81b2e8d76a0993524b98ca7554d1090a"
-  integrity sha512-QnpOdcCqikI5qVTmMY7Orx/CglNVfsP+OGUgavodX20MtSRYUqjR/s/HYo1vWAol1hZT+PThEnIUrX/6U9IueA==
+youtubei.js@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.7.0.tgz#2b980f3e97c9b05097d3b387ff4f6a8d42a61e0d"
+  integrity sha512-npMhgWSru/tPdHvUUqgc0UZv9J7nn/o2V9cfcMS2WvnjhHW9vc9wR54QxyNxURC3uFKkk5WBouu+QjMn+bMtwg==
   dependencies:
     "@protobuf-ts/runtime" "^2.7.0"
     jintr "^0.3.1"


### PR DESCRIPTION
# Use the new retrieve_player option in YouTube.js

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
closes #3021 

## Description
In YouTube.js's latest release the `retrieve_player` option was added, allowing us to simplify the code on our end. This isn't mentioned in the release notes, however it was added in this PR and is mentioned there https://github.com/LuanRT/YouTube.js/pull/269.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that no extra requests show up in the network tab in the devtools while fetching search suggestions, trending or playlists.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0
