### PR TITLE
Fix workflow warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     - run: yarn run ci
     - run: yarn run lint
     - name: Get Version Number
-      uses: nyaayaya/package-version@v1
+      uses: jozsefsallai/node-package-version@v1.0.4
       with:
         path: 'package.json'
         follow-symlinks: false
@@ -84,7 +84,7 @@ jobs:
         # script: if ${{ env.IS_DEV }} then echo "::set-output name=VERSION_NUMBER::${{ env.VERSION_NUMBER_NIGHTLY }}" else echo "::set-output name=VERSION_NUMBER::${{ env.VERSION_NUMBER }}" fi
 
     - name: Update package.json version
-      uses: jossef/action-set-json-field@v2
+      uses: jossef/action-set-json-field@v2.1
       with:
         file: package.json
         field: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
     - run: yarn run lint
 
     - name: Get Version Number
-      uses: nyaayaya/package-version@v1
+      uses: jozsefsallai/node-package-version@v1.0.4
       with:
         path: 'package.json'
         follow-symlinks: false


### PR DESCRIPTION
# Fix workflow warnings

## Pull Request Type
- [x] Workflows
- [x] Dependencies

## Related issue
Build action displayed warning about two actions that used npm 12 

## Description
- update actions to version that uses npm v16

## Testing
Ran build workflow on my fork and it worked (only a macos warning still appears)

## Desktop
- **OS:** windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0