### PR TITLE
Fix Ctrl/Cmd + C unable to copy text when viewing video

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1822,6 +1822,11 @@ export default Vue.extend({
         return
       }
 
+      // allow copying text
+      if ((event.ctrlKey || event.metaKey) && event.key.lowercase() === 'c') {
+        return
+      }
+
       if (this.player !== null) {
         switch (event.key) {
           case ' ':


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
#986

## Description
Fix Ctrl/Cmd + C unable to copy text when viewing video

## Screenshots <!-- If appropriate -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
- View random video (better with caption like https://youtu.be/CjVZHohRnXE to test caption feature)
- Select some text (like video title)
- Press `c` should toggle caption
- Press `Ctrl`/`Cmd` + `c` should copy text (and **not** toggle caption)

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** 

## Additional context
<!-- Add any other context about the pull request here. -->
