### PR TITLE
Add more electron guards

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -5,7 +5,9 @@
     <meta charset="utf-8" />
     <meta name="viewport"
           content="width=device-width, initial-scale=1.0" />
+    <% if (!process.env.IS_ELECTRON) { %>
     <link rel="manifest" href="static/manifest.json" />
+    <% } %>
     <title></title>
     <% if (htmlWebpackPlugin.options.nodeModules) { %>
     <script>
@@ -18,13 +20,14 @@
 
   <body>
     <div id="app"></div>
+    <% if (!process.env.IS_ELECTRON) { %>
     <script>
     // This is the service worker with the Advanced caching
 
     // Add this below content to your HTML page, or add the js file to your page at the very top to register service worker
 
     // Check compatibility for the browser we're running this in
-    if ("serviceWorker" in navigator && !<%= process.env.IS_ELECTRON %>) {
+    if ("serviceWorker" in navigator) {
       if (navigator.serviceWorker.controller) {
         console.log("[PWA Builder] active service worker found, no need to register");
       } else {
@@ -39,6 +42,7 @@
       }
     }
     </script>
+    <% } %>
     <!-- webpack builds are automatically injected -->
   </body>
 

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1027,7 +1027,7 @@ export default Vue.extend({
             copyToClipboard(err.responseJSON.error)
           })
 
-          if (this.backendFallback && this.backendPreference === 'invidious') {
+          if (process.env.IS_ELECTRON && this.backendFallback && this.backendPreference === 'invidious') {
             showToast(this.$t('Falling back to the local API'))
             resolve(this.getChannelInfoLocal(channelId))
           } else {

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -261,7 +261,7 @@ export default Vue.extend({
         this.searchSuggestionsDataList = results.suggestions
       }).catch((err) => {
         console.error(err)
-        if (this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendFallback) {
           console.error(
             'Error gettings search suggestions.  Falling back to Local API'
           )

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -299,7 +299,7 @@ export default Vue.extend({
         showToast(`${errorMessage}: ${xhr.responseText}`, 10000, () => {
           copyToClipboard(xhr.responseText)
         })
-        if (this.backendFallback && this.backendPreference === 'invidious') {
+        if (process.env.IS_ELECTRON && this.backendFallback && this.backendPreference === 'invidious') {
           showToast(this.$t('Falling back to local API'))
           this.getCommentDataLocal()
         } else {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -334,7 +334,7 @@ export default Vue.extend({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getPlaylistInformationLocal()
         } else {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -495,7 +495,7 @@ export default Vue.extend({
         showToast(`${errorMessage}: ${err.responseJSON.error}`, 10000, () => {
           copyToClipboard(err.responseJSON.error)
         })
-        if (this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getPlaylistsLocal()
         } else {
@@ -532,7 +532,7 @@ export default Vue.extend({
         showToast(`${errorMessage}: ${err.responseJSON.error}`, 10000, () => {
           copyToClipboard(err.responseJSON.error)
         })
-        if (this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getPlaylistsLocal()
         } else {
@@ -727,7 +727,7 @@ export default Vue.extend({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.searchChannelLocal()
         } else {

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -157,7 +157,7 @@ export default Vue.extend({
         this.isLoading = false
       }).catch((err) => {
         console.error(err)
-        if (this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           console.warn('Error getting data with Invidious, falling back to local backend')
           this.getPlaylistLocal()
         } else {

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -268,7 +268,7 @@ export default Vue.extend({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.performSearchLocal(payload)
         } else {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -375,7 +375,7 @@ export default Vue.extend({
               resolve(this.getChannelVideosInvidiousRSS(channel, failedAttempts + 1))
               break
             case 1:
-              if (this.backendFallback) {
+              if (process.env.IS_ELECTRON && this.backendFallback) {
                 showToast(this.$t('Falling back to the local API'))
                 resolve(this.getChannelVideosLocalScraper(channel, failedAttempts + 1))
               } else {
@@ -414,7 +414,7 @@ export default Vue.extend({
           case 0:
             return this.getChannelVideosInvidiousScraper(channel, failedAttempts + 1)
           case 1:
-            if (this.backendFallback) {
+            if (process.env.IS_ELECTRON && this.backendFallback) {
               showToast(this.$t('Falling back to the local API'))
               return this.getChannelVideosLocalRSS(channel, failedAttempts + 1)
             } else {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -850,7 +850,7 @@ export default Vue.extend({
             copyToClipboard(err.responseText)
           })
           console.error(err)
-          if (this.backendPreference === 'invidious' && this.backendFallback) {
+          if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
             showToast(this.$t('Falling back to Local API'))
             this.getVideoInformationLocal()
           } else {
@@ -1201,7 +1201,7 @@ export default Vue.extend({
         }
       }
 
-      if (this.removeVideoMetaFiles) {
+      if (process.env.IS_ELECTRON && this.removeVideoMetaFiles) {
         if (process.env.NODE_ENV === 'development') {
           const dashFileLocation = `static/dashFiles/${videoId}.xml`
           const vttFileLocation = `static/storyboards/${videoId}.vtt`


### PR DESCRIPTION
# Add more electron guards

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
Wrapping code in is electron checks, allows terser to optimise out code in the web build. Unfortunately due to the nature of components in vue 2 requiring methods to be passed to Vue.extend, terser doesn't actually optimise out the local API methods in the web build, they just sit there unused. Nonetheless allowing it to optimise out at least some of the code, reduces the size of the output, in this case by 1857 bytes.

I also took the opportunity to add electron checks to the index.ejs file, which gets turned into the index.html file, allowing web only code to be optimised out in the electron build.

## Screenshots <!-- If appropriate -->
before:
![before](https://user-images.githubusercontent.com/48293849/210650091-cf45140a-c367-47c5-9f4e-50ac235b7876.png)

after:
![after](https://user-images.githubusercontent.com/48293849/210650125-6670eacc-81ba-44a6-a58b-8ce7c682f95f.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn pack:web` and `yarn dev:web`
Everything should still work the same as before.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0