### PR TITLE
Use webpack externals to exclude dependencies

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -32,6 +32,10 @@ const config = {
     path: path.join(__dirname, '../dist'),
     filename: '[name].js',
   },
+  externals: {
+    // ignore linkedom's unnecessary broken canvas import, as youtubei.js only uses linkedom to generate DASH manifests
+    canvas: '{}'
+  },
   module: {
     rules: [
       {
@@ -122,10 +126,6 @@ const config = {
     new MiniCssExtractPlugin({
       filename: isDevMode ? '[name].css' : '[name].[contenthash].css',
       chunkFilename: isDevMode ? '[id].css' : '[id].[contenthash].css',
-    }),
-    // ignore linkedom's unnecessary broken canvas import, as youtubei.js only uses linkedom to generate DASH manifests
-    new webpack.IgnorePlugin({
-      resourceRegExp: /^canvas$/
     })
   ],
   resolve: {

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -22,9 +22,17 @@ const config = {
     path: path.join(__dirname, '../dist/web'),
     filename: '[name].js',
   },
-  externals: {
-    electron: '{}'
-  },
+  externals: [
+    {
+      electron: '{}'
+    },
+    ({ request }, callback) => {
+      if (request.startsWith('youtubei.js')) {
+        return callback(null, '{}')
+      }
+      callback()
+    }
+  ],
   module: {
     rules: [
       {
@@ -122,10 +130,6 @@ const config = {
     new MiniCssExtractPlugin({
       filename: isDevMode ? '[name].css' : '[name].[contenthash].css',
       chunkFilename: isDevMode ? '[id].css' : '[id].[contenthash].css',
-    }),
-    // ignore all youtubei.js imports, even the ones with paths in them
-    new webpack.IgnorePlugin({
-      resourceRegExp: /^youtubei\.js/
     })
   ],
   resolve: {


### PR DESCRIPTION
# Use webpack externals to exclude dependencies

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Build improvement

## Description
Using the IgnorePlugin makes some import errors show up in the web and renderer output, switching to externals stops webpack from sticking those errors into the bundled javascript file, which also has the advantage of making them slightly smaller.

## Screenshots <!-- If appropriate -->
Import errors:
![web-ignore-errors](https://user-images.githubusercontent.com/48293849/211149824-ae1656f2-385f-4c2d-bb07-5e6d6e3fc130.png)

Web:
![web-before](https://user-images.githubusercontent.com/48293849/211149833-ade49478-6948-4e14-a547-03c97c2fcb68.png) ![web-after](https://user-images.githubusercontent.com/48293849/211149834-b9e6069a-b48d-41ca-8265-6a0c082ced78.png)

Renderer:
![renderer-before](https://user-images.githubusercontent.com/48293849/211149849-5943136f-7555-4cd1-8c9a-3167a7e43444.png) ![renderer-after](https://user-images.githubusercontent.com/48293849/211149852-52b319b0-c3a8-4f1e-a93f-be27042364ee.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn dev`
`yarn dev:web`

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0