### PR TITLE
Hide the proxy settings in the web build

### DIFF
--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -8,8 +8,6 @@ import FtInput from '../ft-input/ft-input.vue'
 import FtLoader from '../ft-loader/ft-loader.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 
-// FIXME: Missing web logic branching
-
 import { ipcRenderer } from 'electron'
 import debounce from 'lodash.debounce'
 

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -17,8 +17,8 @@
       <hr>
       <data-settings />
       <hr>
-      <proxy-settings />
-      <hr>
+      <proxy-settings v-if="usingElectron" />
+      <hr v-if="usingElectron">
       <download-settings v-if="usingElectron" />
       <hr v-if="usingElectron">
       <parental-control-settings />


### PR DESCRIPTION
# Hide the proxy settings in the web build

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
The proxy configuration is setup in the Electron main process, as that doesn't exist in the web build we don't need to show the proxy settings.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0