### PR TITLE
Update mastodon link in `About` view

### DIFF
--- a/src/renderer/views/About/About.js
+++ b/src/renderer/views/About/About.js
@@ -49,7 +49,7 @@ export default Vue.extend({
         {
           icon: ['fab', 'mastodon'],
           title: this.$t('About.Mastodon'),
-          content: '<a href="https://mastodon.technology/@FreeTube">@FreeTube@mastodon.technology</a>'
+          content: '<a href="https://fosstodon.org/@FreeTube">@FreeTube@fosstodon.org</a>'
         },
         {
           icon: ['fas', 'comment-dots'],


### PR DESCRIPTION
# Update mastodon link in `About` view

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
AFAIK, mastodon.technology is fully shut down at this point, and as a result, the mastodon link in the About view is now a broken link. This PR aims to address this by updating the link to point to `@FreeTube@fosstodon.org`.

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0