### PR TITLE
Generate local API sessions locally

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -35,7 +35,8 @@ async function createInnertube(options = { withPlayer: false, location: undefine
 
     // use browser fetch
     fetch: (input, init) => fetch(input, init),
-    cache
+    cache,
+    generate_session_locally: true
   })
 }
 


### PR DESCRIPTION
# Generate local API sessions locally

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This PR enables the new `generate_session_locally` in YouTube.js, this generates the session locally instead of pinging a YouTube endpoint to get it. In my testing this took the session creation time from about 100ms to less than 10ms.

## Testing <!-- for code that is not small enough to be easily understandable -->
Try various features with the local API enabled

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0