### PR TITLE
Decipher format URLs with the local API

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -115,14 +115,42 @@ export async function getLocalSearchContinuation(continuationData) {
 }
 
 export async function getLocalVideoInfo(id, attemptBypass = false) {
+  let info
+  let player
+
   if (attemptBypass) {
     const innertube = await createInnertube({ withPlayer: true, clientType: ClientType.TV_EMBEDDED })
+    player = innertube.actions.session.player
+
     // the second request that getInfo makes 404s with the bypass, so we use getBasicInfo instead
     // that's fine as we have most of the information from the original getInfo request
-    return await innertube.getBasicInfo(id, 'TV_EMBEDDED')
+    info = await innertube.getBasicInfo(id, 'TV_EMBEDDED')
   } else {
     const innertube = await createInnertube({ withPlayer: true })
-    return await innertube.getInfo(id)
+    player = innertube.actions.session.player
+
+    info = await innertube.getInfo(id)
+  }
+
+  if (info.streaming_data) {
+    decipherFormats(info.streaming_data.adaptive_formats, player)
+    decipherFormats(info.streaming_data.formats, player)
+  }
+
+  return info
+}
+
+/**
+ * @param {import('youtubei.js/dist/src/parser/classes/misc/Format').default[]} formats
+ * @param {import('youtubei.js/dist/index').Player} player
+ */
+function decipherFormats(formats, player) {
+  for (const format of formats) {
+    format.url = format.decipher(player)
+
+    // set these to undefined so that toDash doesn't try to decipher them again, throwing an error
+    format.cipher = undefined
+    format.signature_cipher = undefined
   }
 }
 


### PR DESCRIPTION
# Decipher format URLs with the local API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
So it turns out YouTube.js doesn't automatically decipher the format URLs, not sure how I didn't realise this earlier 🙈.

Anyway this should fix the audio and legacy formats not working sometimes (DASH worked, as YouTube.js's toDash function deciphers them while generating the DASH manifest).

## Testing <!-- for code that is not small enough to be easily understandable -->
Try a few videos and switch between audio, DASH and legacy formats, to make sure that they all work.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0