### PR TITLE
Migrate live chat to YouTube.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@fortawesome/free-brands-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/vue-fontawesome": "^2.0.9",
-    "@freetube/youtube-chat": "^1.1.2",
     "@freetube/yt-comment-scraper": "^6.2.0",
     "@silvermine/videojs-quality-selector": "^1.2.5",
     "autolinker": "^4.0.0",
@@ -77,7 +76,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^2.8.0",
+    "youtubei.js": "^2.9.0",
     "yt-channel-info": "^3.2.1"
   },
   "devDependencies": {

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
@@ -1,6 +1,5 @@
 <template>
   <ft-card
-    v-if="!hideLiveChat"
     class="relative"
   >
     <ft-loader
@@ -52,7 +51,7 @@
           :aria-label="$t('Video.Show Super Chat Comment')"
           :style="{ backgroundColor: 'var(--primary-color)' }"
           class="superChat"
-          :class="comment.superchat.colorClass"
+          :class="comment.superChat.colorClass"
           role="button"
           tabindex="0"
           @click="showSuperChatComment(comment)"
@@ -60,7 +59,7 @@
           @keydown.enter.prevent="showSuperChatComment(comment)"
         >
           <img
-            :src="comment.author.thumbnail.url"
+            :src="comment.author.thumbnailUrl"
             class="channelThumbnail"
             alt=""
           >
@@ -70,7 +69,7 @@
             <span
               class="donationAmount"
             >
-              {{ comment.superchat.amount }}
+              {{ comment.superChat.amount }}
             </span>
           </p>
         </div>
@@ -78,7 +77,7 @@
       <div
         v-if="showSuperChat"
         class="openedSuperChat"
-        :class="superChat.superchat.colorClass"
+        :class="superChat.superChat.colorClass"
         role="button"
         tabindex="0"
         @click="showSuperChat = false"
@@ -93,7 +92,7 @@
             class="upperSuperChatMessage"
           >
             <img
-              :src="superChat.author.thumbnail.url"
+              :src="superChat.author.thumbnailUrl"
               class="channelThumbnail"
               alt=""
             >
@@ -105,13 +104,12 @@
             <p
               class="donationAmount"
             >
-              {{ superChat.superchat.amount }}
+              {{ superChat.superChat.amount }}
             </p>
           </div>
           <p
-            v-if="superChat.message.length > 0"
             class="chatMessage"
-            v-html="superChat.messageHtml"
+            v-html="superChat.message"
           />
         </div>
       </div>
@@ -125,17 +123,16 @@
           v-for="(comment, index) in comments"
           :key="index"
           class="comment"
-          :class="{ superChatMessage: typeof (comment.superchat) !== 'undefined' }"
+          :class="comment.superChat ? `superChatMessage ${comment.superChat.colorClass}` : ''"
         >
-          <div
-            v-if="typeof (comment.superchat) !== 'undefined'"
-            :class="comment.superchat.colorClass"
+          <template
+            v-if="comment.superChat"
           >
             <div
               class="upperSuperChatMessage"
             >
               <img
-                :src="comment.author.thumbnail.url"
+                :src="comment.author.thumbnailUrl"
                 class="channelThumbnail"
                 alt=""
               >
@@ -147,20 +144,20 @@
               <p
                 class="donationAmount"
               >
-                {{ comment.superchat.amount }}
+                {{ comment.superChat.amount }}
               </p>
             </div>
             <p
-              v-if="comment.message.length > 0"
+              v-if="comment.message"
               class="chatMessage"
-              v-html="comment.messageHtml"
+              v-html="comment.message"
             />
-          </div>
+          </template>
           <template
             v-else
           >
             <img
-              :src="comment.author.thumbnail.url"
+              :src="comment.author.thumbnailUrl"
               class="channelThumbnail"
               alt=""
             >
@@ -170,28 +167,27 @@
               <span
                 class="channelName"
                 :class="{
-                  member: typeof (comment.author.badge) !== 'undefined' || comment.membership,
-                  moderator: comment.isOwner,
-                  owner: comment.author.name === channelName
+                  member: comment.author.isMember,
+                  moderator: comment.author.isModerator,
+                  owner: comment.author.isOwner
                 }"
               >
                 {{ comment.author.name }}
               </span>
               <span
-                v-if="typeof (comment.author.badge) !== 'undefined'"
+                v-if="comment.author.badge"
                 class="badge"
               >
                 <img
-                  :src="comment.author.badge.thumbnail.url"
+                  :src="comment.author.badge.url"
                   alt=""
-                  :title="comment.author.badge.thumbnail.alt"
+                  :title="comment.author.badge.tooltip"
                   class="badgeImage"
                 >
               </span>
               <span
-                v-if="comment.message.length > 0"
                 class="chatMessage"
-                v-html="comment.messageHtml"
+                v-html="comment.message"
               />
             </p>
           </template>

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -59,6 +59,7 @@ export default Vue.extend({
       hidePlayer: false,
       isFamilyFriendly: false,
       isLive: false,
+      liveChat: null,
       isLiveContent: false,
       isUpcoming: false,
       upcomingTimestamp: null,
@@ -304,7 +305,7 @@ export default Vue.extend({
           channelId: this.channelId
         })
 
-        this.videoPublished = new Date(result.primary_info.published.text.replace('-', '/')).getTime()
+        this.videoPublished = new Date(result.page[0].microformat.publish_date.replace('-', '/')).getTime()
 
         if (result.secondary_info?.description.runs) {
           try {
@@ -409,6 +410,12 @@ export default Vue.extend({
         }
 
         this.videoChapters = chapters
+
+        if (!this.hideLiveChat && this.isLive && this.isLiveContent && result.livechat) {
+          this.liveChat = result.getLiveChat()
+        } else {
+          this.liveChat = null
+        }
 
         // the bypassed result is missing some of the info that we extract in the code above
         // so we only overwrite the result here

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -153,9 +153,10 @@
       class="sidebarArea"
     >
       <watch-video-live-chat
-        v-if="!isLoading && isLive"
+        v-if="!isLoading && !hideLiveChat && isLive"
+        :live-chat="liveChat"
         :video-id="videoId"
-        :channel-name="channelName"
+        :channel-id="channelId"
         class="watchVideoSideBar watchVideoPlaylist"
         :class="{ theatrePlaylist: useTheatreMode }"
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,14 +1058,6 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.9.tgz#7df35818135be54fd87568f16ec7b998a3d0cce8"
   integrity sha512-tUmO92PFHbLOplitjHNBVGMJm6S57vp16tBXJVPKSI/6CfjrgLycqKxEpC6f7qsOqUdoXs5nIv4HLUfrOMHzuw==
 
-"@freetube/youtube-chat@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@freetube/youtube-chat/-/youtube-chat-1.1.2.tgz#29e8e1fc94a278e2da38c1241fb611a744a3a0a6"
-  integrity sha512-VT/00nshjwf5WC7cZ9EV5lGMo83DDyC0XYnoNwmSk34sWCco8h8/EXKnCDTG82clZrS2mJHYlYRfXN/6FWd6ig==
-  dependencies:
-    axios "^0.21.1"
-    tslib "^1.11.1"
-
 "@freetube/yt-comment-scraper@^6.2.0":
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/@freetube/yt-comment-scraper/-/yt-comment-scraper-6.2.0.tgz#ed11d65111d03076ff842eb9c3eb25413f8632ab"
@@ -2077,13 +2069,6 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
 
 axios@^0.27.2:
   version "0.27.2"
@@ -4361,7 +4346,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0:
+follow-redirects@^1.0.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
@@ -8414,11 +8399,6 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.11.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
 tslib@^2.0.3, tslib@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -9174,10 +9154,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-youtubei.js@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.8.0.tgz#f0170f390791cde733facf615f3cf0e2470c31de"
-  integrity sha512-UEH3wP1Wmrmnh2wJohhg+rAq94bF2EqGnlnph2z91kZ+I1tQzlZD09Zc7QNqCYV0t2G4Cl2Lu+DqXrdhf1/SoQ==
+youtubei.js@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-2.9.0.tgz#17426dfb0555169cddede509d50d3db62c102270"
+  integrity sha512-paxfeQGwxGw0oPeKdC96jNalS0OnYQ5xdJY27k3J+vamzVcwX6Ky+idALW6Ej9aUC7FISbchBsEVg0Wa7wgGyA==
   dependencies:
     "@protobuf-ts/runtime" "^2.7.0"
     jintr "^0.3.1"


### PR DESCRIPTION
# Migrate live chat to YouTube.js

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor/Migration

## Description
This pull request migrates the live chat over to YouTube.js, allowing us to remove the `@freetube/youtube-chat` dependency. I also upgraded YouTube.js to 2.9.0 as that includes some live chat improvements, that this pull request uses.

## Testing <!-- for code that is not small enough to be easily understandable -->
live streams from: https://www.youtube.com/@live, like https://youtu.be/jfKfPfyJRdk

Local API: live chat should work
Invidious with backend fallback: live chat should work
Invidious without backend fallback: live chat should show an enable button and only show up after clicking it

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0