### PR TITLE
Add an IS_ELECTRON_MAIN define instead of runtime detection

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const webpack = require('webpack')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const JsonMinimizerPlugin = require('json-minimizer-webpack-plugin')
 
@@ -33,7 +34,11 @@ const config = {
     __dirname: isDevMode,
     __filename: isDevMode
   },
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.IS_ELECTRON_MAIN': true
+    })
+  ],
   output: {
     filename: '[name].js',
     libraryTarget: 'commonjs2',

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -112,6 +112,7 @@ const config = {
     processLocalesPlugin,
     new webpack.DefinePlugin({
       'process.env.IS_ELECTRON': true,
+      'process.env.IS_ELECTRON_MAIN': false,
       'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames)
     }),
     new HtmlWebpackPlugin({

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -114,7 +114,8 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.IS_ELECTRON': false
+      'process.env.IS_ELECTRON': false,
+      'process.env.IS_ELECTRON_MAIN': false
     }),
     new webpack.ProvidePlugin({
       process: 'process/browser',

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -2,8 +2,7 @@ import Datastore from 'nedb-promises'
 
 let dbPath = null
 
-const isElectronMain = !!process?.versions?.electron
-if (isElectronMain) {
+if (process.env.IS_ELECTRON_MAIN) {
   const { app } = require('electron')
   const { join } = require('path')
   const userDataPath = app.getPath('userData') // This is based on the user's OS


### PR DESCRIPTION
# Add an IS_ELECTRON_MAIN define instead of runtime detection

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
Instead of detecting whether we are in the main process with a runtime check, we can do it at build time, allowing the other part of the if-else to be optimised out.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the database still gets loaded, so just open FreeTube and see if your settings are loaded.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0