### PR TITLE
Fix code for getting event.key lowercase value

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1823,7 +1823,7 @@ export default Vue.extend({
       }
 
       // allow copying text
-      if ((event.ctrlKey || event.metaKey) && event.key.lowercase() === 'c') {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'c') {
         return
       }
 


### PR DESCRIPTION
# Fix code for getting event.key lowercase value

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Introduced in #3027 (My PR)

## Description
#3027 calls `lowercase()` but should be `toLowerCase()`

## Screenshots <!-- If appropriate -->
N/A after fix

## Testing <!-- for code that is not small enough to be easily understandable -->
- `yarn dev`
- View a video
- No error should appear on console

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** ae50ec72056d2ba56d9ea4188acf7a0fa5cf87f5

## Additional context
<!-- Add any other context about the pull request here. -->
