### PR TITLE
Fix searching in channel view broken

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -682,13 +682,14 @@ export default Vue.extend({
       }
 
       const currentTabNode = document.querySelector('.tabs > .tab[aria-selected="true"]')
+      // `newTabNode` can be `null` when `tab` === "search"
       const newTabNode = document.getElementById(`${tab}Tab`)
       document.querySelector('.tabs > .tab[tabindex="0"]').setAttribute('tabindex', '-1')
-      newTabNode.setAttribute('tabindex', '0')
+      newTabNode?.setAttribute('tabindex', '0')
       currentTabNode.setAttribute('aria-selected', 'false')
-      newTabNode.setAttribute('aria-selected', 'true')
+      newTabNode?.setAttribute('aria-selected', 'true')
       this.currentTab = tab
-      newTabNode.focus({ focusVisible: true })
+      newTabNode?.focus({ focusVisible: true })
     },
 
     newSearch: function (query) {


### PR DESCRIPTION
# Fix searching in channel view broken

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Bug might be introduced by https://github.com/FreeTubeApp/FreeTube/pull/2984

## Description
Searching in channel currently completely broken due to code error

## Screenshots <!-- If appropriate -->
Expected to see search results
![image](https://user-images.githubusercontent.com/1018543/212458570-c056c29a-f17c-469d-87f9-ed436b2b5b6b.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
- View random channel
- Search via search input box
- Should see results (not getting result via Invidious API should be a separate issue)

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** ae50ec72056d2ba56d9ea4188acf7a0fa5cf87f5

## Additional context
<!-- Add any other context about the pull request here. -->
