### PR TITLE
Import store modules with ES6 imports instead of dynamically

### DIFF
--- a/src/renderer/store/modules/index.js
+++ b/src/renderer/store/modules/index.js
@@ -1,14 +1,22 @@
 /**
  * The file enables `@/store/index.js` to import all vuex modules
- * in a one-shot manner. There should not be any reason to edit this file.
+ * in a one-shot manner.
  */
 
-const files = require.context('.', false, /\.js$/)
-const modules = {}
+import history from './history'
+import invidious from './invidious'
+import playlists from './playlists'
+import profiles from './profiles'
+import settings from './settings'
+import subscriptions from './subscriptions'
+import utils from './utils'
 
-files.keys().forEach(key => {
-  if (key === './index.js') return
-  modules[key.replaceAll(/(\.\/|\.js)/g, '')] = files(key).default
-})
-
-export default modules
+export default {
+  history,
+  invidious,
+  playlists,
+  profiles,
+  settings,
+  subscriptions,
+  utils
+}


### PR DESCRIPTION
# Import store modules with ES6 imports instead of dynamically

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This changes the way that the store modules are imported. While there was nothing wrong with the previous approach, doing it dynamically also meant that it was done dynamically at runtime too (the for loop and the replaceAll stuck around in the output JavaScript files). ES6 imports are static and therefore statically analysable, allowing webpack to produce a smaller and more efficient output.

The main goal of this change is to reduce the output size and as it doesn't worsen the development experience, I think it's an alright change. This will probably also result in a very minor performance increase, not that anyone will notice it.

renderer.js: -7375 bytes
web.js: -8017 bytes

_Yes, I edited that file that said it shouldn't need to be edited._

## Screenshots <!-- If appropriate -->
renderer:
![renderer_before](https://user-images.githubusercontent.com/48293849/212469766-2b6caf15-08a7-4ada-a8a1-28fb405fbdce.png) ![renderer_after](https://user-images.githubusercontent.com/48293849/212469769-85943d66-c878-48cf-9571-da5b95ee8ac2.png)

web:
![web_before](https://user-images.githubusercontent.com/48293849/212469780-30a309a0-b87d-46af-861a-22bcffbd5aa4.png) ![web_after](https://user-images.githubusercontent.com/48293849/212469783-bb98ca30-b450-4c3b-9d54-3b2b761e3352.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that all your settings get loaded correctly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0