### PR TITLE
Don't react when selecting the current trending tab

### DIFF
--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -57,6 +57,10 @@ export default Vue.extend({
   },
   methods: {
     changeTab: function (tab) {
+      if (tab === this.currentTab) {
+        return
+      }
+
       this.currentTab = tab
       if (this.trendingCache[this.currentTab] && this.trendingCache[this.currentTab].length > 0) {
         this.getTrendingInfoCache()


### PR DESCRIPTION
# Don't react when selecting the current trending tab

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes  #3069

## Description
Currently if you select the already selected trending tab it fetches the info from the trending cache again, this PR stops it from doing that as it's not necessary.

## Testing <!-- for code that is not small enough to be easily understandable -->
Try selecting the already selected trending tab, nothing should happen

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0