### PR TITLE
Fix searching (2nd time onward) in channel view broken

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -676,12 +676,13 @@ export default Vue.extend({
         }
       }
 
+      // `currentTabNode` can be `null` on 2nd+ search
       const currentTabNode = document.querySelector('.tabs > .tab[aria-selected="true"]')
       // `newTabNode` can be `null` when `tab` === "search"
       const newTabNode = document.getElementById(`${tab}Tab`)
-      document.querySelector('.tabs > .tab[tabindex="0"]').setAttribute('tabindex', '-1')
+      document.querySelector('.tabs > .tab[tabindex="0"]')?.setAttribute('tabindex', '-1')
       newTabNode?.setAttribute('tabindex', '0')
-      currentTabNode.setAttribute('aria-selected', 'false')
+      currentTabNode?.setAttribute('aria-selected', 'false')
       newTabNode?.setAttribute('aria-selected', 'true')
       this.currentTab = tab
       newTabNode?.focus({ focusVisible: true })


### PR DESCRIPTION
# Fix searching (2nd time onward) in channel view broken

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
#3062 only fixes 1st search

## Description
Since there is no search tab
Code being run when already in channel search result view would cause code error (missing node)
This PR fixes that issue

## Screenshots <!-- If appropriate -->
Test yourself~

## Testing <!-- for code that is not small enough to be easily understandable -->
- View random channel
- Search something via search input box
- Search something else via search input box (2nd search)
- Should see results (not getting result via Invidious API should be a separate issue)

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** 8db8ca2992711285309d83d3df30b9953ae2ebb9

## Additional context
<!-- Add any other context about the pull request here. -->
