### PR TITLE
Fix search view not loading result starting 2nd page via local API

### DIFF
--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -162,7 +162,7 @@ export default Vue.extend({
 
     getNextpageLocal: async function (payload) {
       try {
-        const { results, continuationData } = getLocalSearchContinuation(payload.options.nextPageRef)
+        const { results, continuationData } = await getLocalSearchContinuation(payload.options.nextPageRef)
 
         if (results.length === 0) {
           return


### PR DESCRIPTION
# Fix search view not loading result starting 2nd page via local API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Caused by https://github.com/FreeTubeApp/FreeTube/pull/3028


## Description
Missing `await` when calling `async` function

## Screenshots <!-- If appropriate -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
- Switch to local API, maybe disable fallback too
- Search whatever
- Press "fetch more results"
- Should load more results

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 12.6.2
- **FreeTube version:** 8db8ca2992711285309d83d3df30b9953ae2ebb9

## Additional context
<!-- Add any other context about the pull request here. -->
