### PR TITLE
Fix comment reply author link style

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -168,18 +168,15 @@
               >
             </router-link>
             <p class="commentAuthorWrapper">
-              <span
+              <router-link
                 class="commentAuthor"
                 :class="{
                   commentOwner: reply.isOwner
                 }"
+                :to="`/channel/${reply.authorLink}`"
               >
-                <router-link
-                  :to="`/channel/${reply.authorLink}`"
-                >
-                  {{ reply.author }}
-                </router-link>
-              </span>
+                {{ reply.author }}
+              </router-link>
               <img
                 v-if="reply.isMember"
                 :src="reply.memberIconUrl"


### PR DESCRIPTION
# Fix comment reply author link style

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
Style broken since class name applied on wrapper `span` instead of the link itself

## Screenshots <!-- If appropriate -->
After fix
![image](https://user-images.githubusercontent.com/1018543/212620373-516001e2-fb58-486f-a67d-48088035383b.png)

Before fix
![image](https://user-images.githubusercontent.com/1018543/212620446-203fd1fb-4bfe-4668-a940-313a86c97d32.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
- View a video with comment and reply (e.g. https://youtu.be/FPF7Z7TLdsk)
- Open reply
- Reply author names' style should be same as comment author (and also still work as links)

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 12.6.2
- **FreeTube version:** 8db8ca2992711285309d83d3df30b9953ae2ebb9

## Additional context
<!-- Add any other context about the pull request here. -->
