### PR TITLE
Correct argument on `invidiousGetPlaylistInfo`

### DIFF
--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -124,7 +124,7 @@ export default defineComponent({
     getPlaylistInvidious: function () {
       this.isLoading = true
 
-      invidiousGetPlaylistInfo({ playlistId: this.playlistId }).then((result) => {
+      invidiousGetPlaylistInfo(this.playlistId).then((result) => {
         this.infoData = {
           id: result.playlistId,
           title: result.title,


### PR DESCRIPTION
# Correct argument on `invidiousGetPlaylistInfo`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `invidiousGetPlaylistInfo` function expects a string (the playlist id); however, an object containing the playlist id is passed instead, and this causes an error. This PR aims to address this.

## Screenshots <!-- If appropriate -->
|Before|After|
|--|--|
|![before-playlists](https://user-images.githubusercontent.com/106682128/213198942-c32b0930-3e9c-4a8d-b49e-e45572d9df9e.png)|![after-playlists](https://user-images.githubusercontent.com/106682128/213198951-33cce533-d6af-4fd1-a57c-51a416ad3278.png)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Make sure your backend preference is set to `Invidious API`
2. Make sure `Fallback to Non-Preferred Backend on Failure` is turned off
3. Check a playlist page (ex: https://www.youtube.com/playlist?list=PL25E387C266BEFA18)

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0