### PR TITLE
Bind `v-if` directive to function instead of function call

### DIFF
--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
@@ -54,7 +54,8 @@ export default defineComponent({
      *
      * @return {bool} false to hide the video, true to show it
      */
-    showResult: function (data) {
+    showResult: function () {
+      const { data } = this
       if (!data.type) {
         return false
       }

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="showResult(data)"
+    v-if="showResult"
     v-observe-visibility="firstScreen ? false : {
       callback: onVisibilityChanged,
       once: true,


### PR DESCRIPTION
# Bind `v-if` directive to function instead of function call

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Inside of the `ft-lazy-list-wrapper`, there is a `v-if` directive which is bound to a function call. This is problematic because it is never re-evaluated if it is bound this way. This can cause an issue with the web build where some videos (from specific channels) are hidden despite having their data completely present.
![image](https://user-images.githubusercontent.com/106682128/213218575-269eadee-b991-4950-b0e3-43bbac1766b7.png)


## Screenshots <!-- If appropriate -->
|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/106682128/213217274-827a1eb1-f78e-4bff-9d67-ffd35bd84e80.png)|![image](https://user-images.githubusercontent.com/106682128/213217480-501fc406-c403-4bba-9a23-1a1f073b20ee.png)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn dev:web`
2. Navigate to an affected channel (ex: https://youtube.com/channel/UC1BWMtZbNLVMSFgwSukjqCw)
3. Check if you see any videos

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0

