### PR TITLE
Use a single import for the brand icons

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -55,10 +55,12 @@ import {
   faTimesCircle,
   faUsers
 } from '@fortawesome/free-solid-svg-icons'
-import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub'
-import { faBitcoin } from '@fortawesome/free-brands-svg-icons/faBitcoin'
-import { faMonero } from '@fortawesome/free-brands-svg-icons/faMonero'
-import { faMastodon } from '@fortawesome/free-brands-svg-icons/faMastodon'
+import {
+  faBitcoin,
+  faGithub,
+  faMastodon,
+  faMonero
+} from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 Vue.config.devtools = process.env.NODE_ENV === 'development'


### PR DESCRIPTION
# Use a single import for the brand icons

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
As the brand icons are currently imported with 4 different imports, webpack treats them as 4 different imports, effectively acting as if they were imports 4 different modules. Switching to a single import, makes webpack treat it as a single module, allowing webpack's ModuleConcatenationPlugin to do it's magic and inline the icon code.

This results in a -242 byte reduction of the renderer.js file.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/213578217-44eccc13-7331-4f45-aa80-23735f7b0a44.png) ![after](https://user-images.githubusercontent.com/48293849/213578228-b8659726-e1ad-4dd7-81b2-da44d4f6654c.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the brand icons show up on the about page

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0