### PR TITLE
Adjust `side-nav-more-options` to account for anchor style

### DIFF
--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -6,6 +6,9 @@
   position: relative;
   padding: 5px;
   cursor: pointer;
+  color: white;
+  text-decoration: none;
+  display: block;
 }
 
 .navOption:hover {


### PR DESCRIPTION


# Adjust `side-nav-more-options` to account for difference in style between `router-link` and `div`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Somewhat recently, the `side-nav-more-options` icons were changed to be `router-link`s instead of `div`s, but the style difference between `router-link` and `div` still needs to be accounted for because `router-link`s carry with them all of the styles of anchors. Due to this, the text in the more options menu is the primary link color _(instead of white)_ and the background color is not visible on hover _(due to the display being inline)_. This PR aims to address this by adding some of the styles that `div`s have to the `.navOption` class in the `side-nav-more-options` component.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/106682128/213827863-677903eb-4ea5-4fcb-9a47-8b47b9048fb1.gif)|![after](https://user-images.githubusercontent.com/106682128/213827873-f64a33a7-6fda-473e-8cf9-6facf88f5985.gif)|


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Make sure the window is narrow enough that the `More` navbar item appears: _(width < 678px)_.
2. Click the `More` navbar item.
3. Ensure that the navbar options under `More` have white text and a background hover effect.

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0

