### PR TITLE
Fix typo causing the subtitle sorting to error

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1333,7 +1333,7 @@ export default defineComponent({
         captionTracks.unshift({
           url: url.toString(),
           label,
-          languageCode: locale
+          language_code: locale
         })
       }
     },


### PR DESCRIPTION
# Fix typo causing the subtitle sorting to error

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3095
closes #3071

## Description
Fix the subtitles button not showing up as the sorting was erroring, as the `language_code` property didn't exist.

## Testing <!-- for code that is not small enough to be easily understandable -->
Set FreeTube to a language other than english
Check that the subtitles button shows up on the videos provided in the issue:
https://youtu.be/TwJcSD7WsB0
https://youtu.be/3WvRrm2at3w

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0