### PR TITLE
Set the Vue compiler whitespace option to condense

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -46,6 +46,11 @@ const config = {
       {
         test: /\.vue$/,
         loader: 'vue-loader',
+        options: {
+          compilerOptions: {
+            whitespace: 'condense',
+          }
+        }
       },
       {
         test: /\.scss$/,

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -42,7 +42,12 @@ const config = {
       },
       {
         test: /\.vue$/,
-        loader: 'vue-loader'
+        loader: 'vue-loader',
+        options: {
+          compilerOptions: {
+            whitespace: 'condense',
+          }
+        }
       },
       {
         test: /\.scss$/,

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -95,22 +95,22 @@
           <span>{{ channelName }}</span>
         </router-link>
         <template v-if="!isLive && !isUpcoming && !isPremium && !hideViews">
-          <span class="viewCount">• {{ parsedViewCount }}</span>
+          <span class="viewCount"> • {{ parsedViewCount }} </span>
           <span v-if="viewCount === 1">{{ $t("Video.View").toLowerCase() }}</span>
           <span v-else>{{ $t("Video.Views").toLowerCase() }}</span>
         </template>
         <span
           v-if="uploadedTime !== '' && !isLive && !inHistory"
           class="uploadedTime"
-        >• {{ uploadedTime }}</span>
+        > • {{ uploadedTime }}</span>
         <span
           v-if="inHistory"
           class="uploadedTime"
-        >• {{ publishedText }}</span>
+        > • {{ publishedText }}</span>
         <span
           v-if="isLive && !hideViews"
           class="viewCount"
-        >• {{ parsedViewCount }} {{ $t("Video.Watching").toLowerCase() }}</span>
+        > • {{ parsedViewCount }} {{ $t("Video.Watching").toLowerCase() }}</span>
       </div>
       <p
         v-if="listType !== 'grid' && appearance === 'result'"


### PR DESCRIPTION
# Set the Vue compiler whitespace option to condense

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
In Vue 3 the whitespace option defaults to `condense`. This is a small step towards migrating to Vue 3 that we can already do now. I fixed the only spot I noticed that was broken by that option (the spacing in the ft-list-video component), I'm opening this as a draft, so we can test the rest of FreeTube with this option, to check if we need to make any other changes.

## Testing <!-- for code that is not small enough to be easily understandable -->
The goal is for FreeTube to be visually the same before and after changing the value of that option, so please let me know if you notice any missing whitespace after this change.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0