### PR TITLE
Filter out WebM DASH formats

### DIFF
--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -113,6 +113,10 @@ export default defineComponent({
       return this.$store.getters.getDefaultQuality
     },
 
+    allowDashAv1Formats: function () {
+      return this.$store.getters.getAllowDashAv1Formats
+    },
+
     defaultTheatreMode: function () {
       return this.$store.getters.getDefaultTheatreMode
     },
@@ -276,6 +280,7 @@ export default defineComponent({
       'updateDefaultPlayback',
       'updateDefaultVideoFormat',
       'updateDefaultQuality',
+      'updateAllowDashAv1Formats',
       'updateVideoVolumeMouseScroll',
       'updateVideoPlaybackRateMouseScroll',
       'updateVideoSkipMouseScroll',

--- a/src/renderer/components/player-settings/player-settings.scss
+++ b/src/renderer/components/player-settings/player-settings.scss
@@ -1,3 +1,7 @@
+.av1Switch {
+  align-self: center;
+}
+
 .screenshotFolderContainer {
   align-items: center;
   column-gap: 1rem;

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -159,6 +159,14 @@
         :select-values="qualityValues"
         @change="updateDefaultQuality"
       />
+      <ft-toggle-switch
+        class="av1Switch"
+        :label="$t('Settings.Player Settings.Allow DASH AV1 formats')"
+        :compact="true"
+        :default-value="allowDashAv1Formats"
+        :tooltip="$t('Tooltips.Player Settings.Allow DASH AV1 formats')"
+        @change="updateAllowDashAv1Formats"
+      />
     </ft-flex-box>
     <br>
     <ft-flex-box>

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -495,3 +495,33 @@ export function parseLocalComment(comment, commentThread = undefined) {
     replies: []
   }
 }
+
+/**
+ * video.js only supports MP4 DASH not WebM DASH
+ * so we filter out the WebM DASH formats
+ * @param {Format[]} formats
+ * @param {boolean} allowAv1 Use the AV1 formats if they are available
+ */
+export function filterFormats(formats, allowAv1 = false) {
+  const audioFormats = []
+  const h264Formats = []
+  const av1Formats = []
+
+  for (const format of formats) {
+    const mimeType = format.mime_type
+
+    if (mimeType.startsWith('audio/mp4')) {
+      audioFormats.push(format)
+    } else if (allowAv1 && mimeType.startsWith('video/mp4; codecs="av01')) {
+      av1Formats.push(format)
+    } else if (mimeType.startsWith('video/mp4; codecs="avc')) {
+      h264Formats.push(format)
+    }
+  }
+
+  if (allowAv1 && av1Formats.length > 0) {
+    return [...audioFormats, ...av1Formats]
+  } else {
+    return [...audioFormats, ...h264Formats]
+  }
+}

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -507,7 +507,7 @@ export function filterFormats(formats, allowAv1 = false) {
   const h264Formats = []
   const av1Formats = []
 
-  for (const format of formats) {
+  formats.forEach(format => {
     const mimeType = format.mime_type
 
     if (mimeType.startsWith('audio/mp4')) {
@@ -517,7 +517,7 @@ export function filterFormats(formats, allowAv1 = false) {
     } else if (mimeType.startsWith('video/mp4; codecs="avc')) {
       h264Formats.push(format)
     }
-  }
+  })
 
   if (allowAv1 && av1Formats.length > 0) {
     return [...audioFormats, ...av1Formats]

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -278,7 +278,8 @@ const state = {
   screenshotFolderPath: '',
   screenshotFilenamePattern: '%Y%M%D-%H%N%S',
   fetchSubscriptionsAutomatically: true,
-  settingsPassword: ''
+  settingsPassword: '',
+  allowDashAv1Formats: false
 }
 
 const stateWithSideEffects = {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -279,7 +279,7 @@ const state = {
   screenshotFilenamePattern: '%Y%M%D-%H%N%S',
   fetchSubscriptionsAutomatically: true,
   settingsPassword: '',
-  allowDashAv1Formats: false
+  allowDashAv1Formats: false,
 }
 
 const stateWithSideEffects = {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -263,6 +263,7 @@ Settings:
       1440p: 1440p
       4k: 4k
       8k: 8k
+    Allow DASH AV1 formats: Allow DASH AV1 formats
     Screenshot:
       Enable: Enable Screenshot
       Format Label: Screenshot Format
@@ -778,6 +779,9 @@ Tooltips:
     Default Video Format: Set the formats used when a video plays. DASH formats can
       play higher qualities. Legacy formats are limited to a max of 720p but use less
       bandwidth. Audio formats are audio only streams.
+    Allow DASH AV1 formats: DASH AV1 formats may look better than DASH H.264 formats.
+      DASH AV1 formats require more power to playback! They are not available on all videos,
+      in those cases the player will use the DASH H.264 formats instead.
     Scroll Playback Rate Over Video Player: While the cursor is over the video, press and
       hold the Control key (Command Key on Mac) and scroll the mouse wheel forwards or backwards to control
       the playback rate. Press and hold the Control key (Command Key on Mac) and left click the mouse


### PR DESCRIPTION
# Filter out WebM DASH formats

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation

## Description
video.js only supports MP4 DASH, so when the player catches wind of the WebM DASH formats it breaks down. This pull request filters out the WebM DASH formats. It also adds a setting to choose between using the MP4 AV1 formats if they are available or always use the MP4 H.264 formats.

Only allowing the quality selector to see the MP4 H.264 formats, seems to make it work sometimes, unfortunately switching between qualities with AV1 formats is still broken.

AV1 formats retain more quality than H.264 formats, so they are definitely preferred, unfortunately they are also more demanding on your hardware, especially if you don't have dedicated hardware AV1 decoders.

This also fixes the duplicate qualities in the selector in almost all situations, HDR qualities still show two, they seem identical except the itag and almost double as high bitrate on one format compared to the other. My guess is that they might be different HDR implementations or maybe one is SDR and the other is HDR but they are both labelled as HDR.

LTT video about AV1: https://www.youtube.com/watch?v=WVjtK71qqXU
Tom Scott video about why YouTube's compression can't cope with snow and confetti (even though it's a 6 year old video it has AV1 formats, I wonder if YouTube used it for testing purposes): https://youtu.be/r6Rp-uo6HmI

## Testing <!-- for code that is not small enough to be easily understandable -->
Animals https://youtu.be/Ac07Qt84WDw
Confetti https://youtu.be/4JLLokZWDqE (this looks a lot better with AV1 compared to H264)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0