### PR TITLE
Fix shift enter on top nav search input does not open search in a new window

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -223,7 +223,7 @@ export default defineComponent({
           event.preventDefault()
           this.inputData = this.visibleDataList[this.searchState.selectedOption]
         }
-        this.handleClick()
+        this.handleClick(event)
         // Early return
         return
       }


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Feature implemented in #2427 
Broken by #2943

## Description
Feature broken due to missing event when calling `handleClick`

## Screenshots <!-- If appropriate -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
- Enter text into top nav search input
- Shift enter
- Confirm search opened in new window

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** 0145a0425f7a482ce000a506dbf8497c48dcc383

## Additional context
Shift click still works without this fix
