### PR TITLE
Use smaller web version of linkedom

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -32,10 +32,6 @@ const config = {
     path: path.join(__dirname, '../dist'),
     filename: '[name].js',
   },
-  externals: {
-    // ignore linkedom's unnecessary broken canvas import, as youtubei.js only uses linkedom to generate DASH manifests
-    canvas: '{}'
-  },
   module: {
     rules: [
       {
@@ -132,6 +128,9 @@ const config = {
   resolve: {
     alias: {
       vue$: 'vue/dist/vue.common.js',
+
+      // use the web version of linkedom
+      linkedom$: 'linkedom/worker',
 
       // defaults to the prebundled browser version which causes webpack to error with:
       // "Critical dependency: require function is used in a way in which dependencies cannot be statically extracted"


### PR DESCRIPTION
# Use smaller web version of linkedom

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
YouTube.js has a dependency `linkedom` that it uses to generate the DASH manifests. `linkedom` is designed to work in node as well as web environments, turns out that it defaults to the node version, which is also the one that includes the optional `canvas` import that we ignore. This PR switches to the web version, which works the same for what YouTube.js uses it for, with the benefit of being smaller as it doesn't include any node specific code (bye canvas import). By switching we reduce the size of the `renderer.js` file by 0.12MB! 😃

linkedom is still the 3rd largest dependency in the bundled renderer.js file, with video.js (and it's dependencies) taking up the spot in first place and YouTube.js is a close second.

YouTube.js could probably be a bit smaller if we didn't have to use the commonjs build (thanks webpack) and also it's build targets Chrome 58, which was released almost 6 years ago! It has polyfills for any "modern" (well the developers of `@silvermine/videojs-quality-selector` probably think they are futuristic, but everyone else likely uses them daily) JavaScript features and syntax, yes also async/awaits.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/214360029-9339b8c2-af83-4e6e-8992-f3313b7190f5.png) ![after](https://user-images.githubusercontent.com/48293849/214360041-80cbd3bf-8893-4e3e-8f54-70860ddcbbc1.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Open a video and select the DASH formats, they should work without any difference to before.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0