### PR TITLE
Add QT Url support for freetube protocol

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1026,7 +1026,15 @@ function runApp() {
   }
 
   function baseUrl(arg) {
-    return arg.replace('freetube://', '')
+    let newArg = arg.replace('freetube://', '')
+    // add support for authority free url
+      .replace('freetube:', '')
+
+    // fix for QT Url
+    if (newArg.startsWith('https') && !newArg.charAt(5) !== ':') {
+      newArg = 'https:' + newArg.substring(5)
+    }
+    return newArg
   }
 
   function getLinkUrl(argv) {


### PR DESCRIPTION
# Add QT Url support for FreeTube protocol

## Pull Request Type
- [x] Bugfix

## Related issue
https://github.com/libredirect/libredirect/issues/212
https://github.com/FreeTubeApp/FreeTube/issues/373#issuecomment-1116352210

## Description
The way QT parses the url, it removes the : after https as it recognizes "freetube://" as the protocol.
This PR makes it so that "freetube:" can be used as the protocol instead and will readd the missing colon after the 'https'

## Testing 
None, I don't use QT (I use Windows)

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
