### PR TITLE
Fix video fetch when using invidious API and sorting by popular.

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -210,7 +210,7 @@ export default defineComponent({
           break
         case 'invidious':
           this.latestVideosPage = 1
-          this.channelInvidiousNextPage()
+          this.channelInvidiousVideos()
           break
         default:
           this.getChannelVideosLocal()
@@ -226,7 +226,7 @@ export default defineComponent({
           this.getPlaylistsLocal()
           break
         case 'invidious':
-          this.channelInvidiousNextPage()
+          this.getPlaylistsInvidious()
           break
         default:
           this.getPlaylistsLocal()
@@ -416,23 +416,23 @@ export default defineComponent({
       })
     },
 
-    channelInvidiousNextPage: function () {
+    channelInvidiousVideos: function (fetchMore) {
       const payload = {
         resource: 'channels/videos',
         id: this.id,
         params: {
           sort_by: this.videoSortBy,
-          page: this.latestVideosPage
         }
       }
+      if (fetchMore) payload.params.continuation = this.videoContinuationString
 
       invidiousAPICall(payload).then((response) => {
-        this.latestVideos = this.latestVideos.concat(response)
-        this.latestVideosPage++
+        this.latestVideos = this.latestVideos.concat(response.videos)
+        this.videoContinuationString = response.continuation
         this.isElementListLoading = false
       }).catch((err) => {
         console.error(err)
-        const errorMessage = this.$t('Local API Error (Click to copy)')
+        const errorMessage = this.$t('Invidious API Error (Click to copy)')
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
@@ -629,7 +629,7 @@ export default defineComponent({
               this.channelLocalNextPage()
               break
             case 'invidious':
-              this.channelInvidiousNextPage()
+              this.channelInvidiousVideos(true)
               break
           }
           break


### PR DESCRIPTION


# Fix video fetch when using invidious API and sorting by popular.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11 
- **OS Version:** 22H2 (WSL2 + Ubuntu22.04)
- **FreeTube version:** 0.18.0

## Additional context
<!-- Add any other context about the pull request here. -->
