### PR TITLE
Support storyboards on very short shorts

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -89,13 +89,18 @@ export function toLocalePublicationString ({ publishText, isLive = false, isUpco
   return i18n.t('Video.Publicationtemplate', { number: strings[0], unit })
 }
 
-export function buildVTTFileLocally(storyboard) {
+export function buildVTTFileLocally(storyboard, videoLengthSeconds) {
   let vttString = 'WEBVTT\n\n'
   // how many images are in one image
   const numberOfSubImagesPerImage = storyboard.columns * storyboard.rows
   // the number of storyboard images
   const numberOfImages = Math.ceil(storyboard.thumbnail_count / numberOfSubImagesPerImage)
-  const intervalInSeconds = storyboard.interval / 1000
+  let intervalInSeconds
+  if (storyboard.interval > 0) {
+    intervalInSeconds = storyboard.interval / 1000
+  } else {
+    intervalInSeconds = videoLengthSeconds / (numberOfImages * numberOfSubImagesPerImage)
+  }
   let startHours = 0
   let startMinutes = 0
   let startSeconds = 0
@@ -110,11 +115,11 @@ export function buildVTTFileLocally(storyboard) {
       // add the timestamp information
       const paddedStartHours = startHours.toString().padStart(2, '0')
       const paddedStartMinutes = startMinutes.toString().padStart(2, '0')
-      const paddedStartSeconds = startSeconds.toString().padStart(2, '0')
+      const paddedStartSeconds = startSeconds.toFixed(3).padStart(6, '0')
       const paddedEndHours = endHours.toString().padStart(2, '0')
       const paddedEndMinutes = endMinutes.toString().padStart(2, '0')
-      const paddedEndSeconds = endSeconds.toString().padStart(2, '0')
-      vttString += `${paddedStartHours}:${paddedStartMinutes}:${paddedStartSeconds}.000 --> ${paddedEndHours}:${paddedEndMinutes}:${paddedEndSeconds}.000\n`
+      const paddedEndSeconds = endSeconds.toFixed(3).padStart(6, '0')
+      vttString += `${paddedStartHours}:${paddedStartMinutes}:${paddedStartSeconds} --> ${paddedEndHours}:${paddedEndMinutes}:${paddedEndSeconds}\n`
       // add the current image url as well as the x, y, width, height information
       vttString += `${currentUrl}#xywh=${xCoord},${yCoord},${storyboard.thumbnail_width},${storyboard.thumbnail_height}\n\n`
       // update the variables

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -643,7 +643,7 @@ export default defineComponent({
           }
 
           if (result.storyboards?.type === 'PlayerStoryboardSpec') {
-            await this.createLocalStoryboardUrls(result.storyboards.boards[2])
+            await this.createLocalStoryboardUrls(result.storyboards.boards.at(-1))
           }
         }
 
@@ -1290,7 +1290,7 @@ export default defineComponent({
     },
 
     createLocalStoryboardUrls: async function (storyboardInfo) {
-      const results = buildVTTFileLocally(storyboardInfo)
+      const results = buildVTTFileLocally(storyboardInfo, this.videoLengthSeconds)
       const userData = await getUserDataPath()
       let fileLocation
       let uriSchema


### PR DESCRIPTION
# Support storyboards on very short shorts

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Issue noticed in #3093 

## Description
For long videos, YouTube returns storyboards with an image for every 10 seconds, as you are unlikely to notice it as the progress bar can only be so wide, so making them more granular would be pointless. However for very short videos like the one in the test case below, which is only 13 seconds long, it's definitely worth having more granular thumbnails, so YouTube returns them in a sub one seconds intervals (for that video 0.14s), so that means that the interval value in the storyboards, which is an integer is 0. The current code relies on that interval always being larger than 0.

This pull request adds support for those 0 interval storyboards by dividing the length of the video by the number of thumbnails on the storyboards. Unfortunately YouTube also only returns very low quality thumbnails for those videos, so we can either leave them being tiny like they are now, or stretch them to be larger like YouTube does, which looks bad too.

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/shorts/Jj9PmISOzCQ

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0