### PR TITLE
Add support for symlinked database files

### DIFF
--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -5,8 +5,18 @@ let dbPath = null
 if (process.env.IS_ELECTRON_MAIN) {
   const { app } = require('electron')
   const { join } = require('path')
+  // this code only runs in the electron main process, so hopefully using sync fs code here should be fine 😬
+  const { existsSync, statSync, realpathSync } = require('fs')
   const userDataPath = app.getPath('userData') // This is based on the user's OS
-  dbPath = (dbName) => join(userDataPath, `${dbName}.db`)
+  dbPath = (dbName) => {
+    let path = join(userDataPath, `${dbName}.db`)
+
+    if (existsSync(path) && statSync(path).isSymbolicLink) {
+      path = realpathSync(path)
+    }
+
+    return path
+  }
 } else {
   dbPath = (dbName) => `${dbName}.db`
 }


### PR DESCRIPTION
# Add support for symlinked database files

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
closes #3114 

## Description
Linux users have asked many a time for the ability to symlink their database files from the location they wish to store them in, to the location that FreeTube expects them to be in. Historically we took the stance that it would need to be supported in `nedb`, the database dependency that we use, however I decided to throw this together and according to the Linux users, this seems to work, so I'm opening this pull request for it.

## Testing <!-- for code that is not small enough to be easily understandable -->
https://docs.freetubeapp.io/usage/data-location/
**Backup your database files!!!**

1. Close FreeTube
2. Move your database files to another location on the disk
3. Create symlinks at the original location pointing to the new location
4. Open FreeTube and check that your settings, profiles, history, playlists are still there

Now to check that the old behaviour still works
5. Close FreeTube
6. Move your database files back to their proper location
7. Open FreeTube and check that your settings, profiles, history, playlists are still there

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0