### PR TITLE
Make the View Comments and Load More Comments buttons larger

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -1,11 +1,26 @@
+.card {
+  padding: 0 16px;
+}
+
+.getCommentsTitle,
+.commentsTitle,
+.getMoreComments {
+  margin: 0;
+}
+
 .getCommentsTitle {
-  height: 10px;
-  margin-top: 5px;
-  margin-bottom: 0px;
+  padding-bottom: 8px;
+  padding-top: 8px;
   text-align: center;
   text-decoration: underline;
   cursor: pointer;
   color: var(--title-color);
+}
+
+.commentsTitle,
+.getMoreComments {
+  padding-bottom: 1em;
+  padding-top: 1em;
 }
 
 .center {
@@ -19,6 +34,10 @@
 .comment {
   padding: 15px;
   position: relative;
+}
+
+.comment:last-child {
+  padding-bottom: 0;
 }
 
 .hideComments {
@@ -147,9 +166,6 @@
 }
 
 .getMoreComments {
-  height: 10px;
-  margin-top: 5px;
-  margin-bottom: 10px;
   text-align: center;
   text-decoration: underline;
   cursor: pointer;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -1,5 +1,7 @@
 <template>
-  <ft-card>
+  <ft-card
+    class="card"
+  >
     <h4
       v-if="commentData.length === 0 && !isLoading"
       class="getCommentsTitle"
@@ -33,6 +35,7 @@
     />
     <h3
       v-if="commentData.length > 0 && !isLoading && showComments"
+      class="commentsTitle"
     >
       {{ $t("Comments.Comments") }}
       <span


### PR DESCRIPTION
# Make the View Comments and Load More Comments buttons larger

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the clickable area to trigger the "Click to View Comments" and "Load More Comments" is very small. This pull request increases the clickable area without any noticable visual changes, the larger target area, should make it easier to use on touch displays.

## Screenshots <!-- If appropriate -->
Legend:
Blue: the space that the element itself takes up (clickable)
Orange: margin around to the element (not clickable)
Green: padding around the element (clickable)

Before:
![view-comments-before](https://user-images.githubusercontent.com/48293849/215329722-c3cbe797-8c5c-4906-b511-6a849c38b321.png)
![load-more-before](https://user-images.githubusercontent.com/48293849/215329741-08c32afe-8b13-44d4-939a-b90a18fd4758.png)

After:
![view-comments-after](https://user-images.githubusercontent.com/48293849/215329755-cbc6d99a-a470-49a1-9bb4-924fdbae1daa.png)
![load-more-after](https://user-images.githubusercontent.com/48293849/215329758-4a2e2d07-b3de-4b3c-a4f6-992263578a7a.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
View and load more comments

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0