### PR TITLE
Fix last view playlist saving with multiple windows

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -58,8 +58,8 @@ class History {
     return db.history.update({ videoId }, { $set: { watchProgress } }, { upsert: true })
   }
 
-  static updateLastViewedPlaylist(videoId, playlistId) {
-    return db.history.update({ videoId }, { $set: { lastViewedPlaylistId: playlistId } }, { upsert: true })
+  static updateLastViewedPlaylist(videoId, lastViewedPlaylistId) {
+    return db.history.update({ videoId }, { $set: { lastViewedPlaylistId } }, { upsert: true })
   }
 
   static delete(videoId) {

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -42,12 +42,12 @@ class History {
     )
   }
 
-  static updateLastViewedPlaylist(videoId, playlistId) {
+  static updateLastViewedPlaylist(videoId, lastViewedPlaylistId) {
     return ipcRenderer.invoke(
       IpcChannels.DB_HISTORY,
       {
         action: DBActions.HISTORY.UPDATE_PLAYLIST,
-        data: { videoId, playlistId }
+        data: { videoId, lastViewedPlaylistId }
       }
     )
   }

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -33,8 +33,8 @@ class History {
     return baseHandlers.history.updateWatchProgress(videoId, watchProgress)
   }
 
-  static updateLastViewedPlaylist(videoId, playlistId) {
-    return baseHandlers.history.updateLastViewedPlaylist(videoId, playlistId)
+  static updateLastViewedPlaylist(videoId, lastViewedPlaylistId) {
+    return baseHandlers.history.updateLastViewedPlaylist(videoId, lastViewedPlaylistId)
   }
 
   static delete(videoId) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -790,7 +790,7 @@ function runApp() {
           return null
 
         case DBActions.HISTORY.UPDATE_PLAYLIST:
-          await baseHandlers.history.updateLastViewedPlaylist(data.videoId, data.playlistId)
+          await baseHandlers.history.updateLastViewedPlaylist(data.videoId, data.lastViewedPlaylistId)
           syncOtherWindows(
             IpcChannels.SYNC_HISTORY,
             event,

--- a/src/renderer/store/modules/history.js
+++ b/src/renderer/store/modules/history.js
@@ -56,10 +56,10 @@ const actions = {
     }
   },
 
-  async updateLastViewedPlaylist({ commit }, { videoId, playlistId }) {
+  async updateLastViewedPlaylist({ commit }, { videoId, lastViewedPlaylistId }) {
     try {
-      await DBHistoryHandlers.updateLastViewedPlaylist(videoId, playlistId)
-      commit('updateRecordLastViewedPlaylistIdInHistoryCache', { videoId, playlistId })
+      await DBHistoryHandlers.updateLastViewedPlaylist(videoId, lastViewedPlaylistId)
+      commit('updateRecordLastViewedPlaylistIdInHistoryCache', { videoId, lastViewedPlaylistId })
     } catch (errMessage) {
       console.error(errMessage)
     }
@@ -104,13 +104,13 @@ const mutations = {
     state.historyCache.splice(i, 1, targetRecord)
   },
 
-  updateRecordLastViewedPlaylistIdInHistoryCache(state, { videoId, playlistId }) {
+  updateRecordLastViewedPlaylistIdInHistoryCache(state, { videoId, lastViewedPlaylistId }) {
     const i = state.historyCache.findIndex((currentRecord) => {
       return currentRecord.videoId === videoId
     })
 
     const targetRecord = Object.assign({}, state.historyCache[i])
-    targetRecord.lastViewedPlaylistId = playlistId
+    targetRecord.lastViewedPlaylistId = lastViewedPlaylistId
     state.historyCache.splice(i, 1, targetRecord)
   },
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -239,7 +239,6 @@ export default defineComponent({
     this.useTheatreMode = this.defaultTheatreMode
 
     this.checkIfPlaylist()
-    this.handlePlaylistPersisting()
     this.checkIfTimestamp()
 
     if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
@@ -946,7 +945,7 @@ export default defineComponent({
     handlePlaylistPersisting: function () {
       // Only save playlist ID if enabled, and it's not special video types
       if (!(this.rememberHistory && this.saveVideoHistoryWithLastViewedPlaylist)) { return }
-      if (this.isUpcoming || this.isLoading || this.isLive) { return }
+      if (this.isUpcoming || this.isLive) { return }
 
       const payload = {
         videoId: this.videoId,
@@ -987,6 +986,10 @@ export default defineComponent({
         } else {
           this.addToHistory(0)
         }
+
+        // Must be called AFTER history entry inserted
+        // Otherwise the value is not saved for first time watched videos
+        this.handlePlaylistPersisting()
       }
     },
 
@@ -1160,7 +1163,6 @@ export default defineComponent({
       this.videoChapters = []
 
       this.handleWatchProgress()
-      this.handlePlaylistPersisting()
 
       if (!this.isUpcoming && !this.isLoading) {
         const player = this.$refs.videoPlayer.player

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -951,7 +951,7 @@ export default defineComponent({
       const payload = {
         videoId: this.videoId,
         // Whether there is a playlist ID or not, save it
-        playlistId: this.$route.query?.playlistId,
+        lastViewedPlaylistId: this.$route.query?.playlistId,
       }
       this.updateLastViewedPlaylist(payload)
     },


### PR DESCRIPTION
# Fix last view playlist saving with multiple windows

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Fixes issue in feature introduced by #3006

## Description
I found that sometimes my written feature #3006 is not working
This should fix it

## Screenshots <!-- If appropriate -->
![image](https://user-images.githubusercontent.com/1018543/215430485-838d930d-ffd7-4c5e-be91-d7176311500f.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Ensure history does not contain the video to be tested
- Open a new window (2+ in total, referred as A & B)
- In A, watch the video with playlist and **stay** in watch view
- In B, visit history view and click on new entry
- Ensure in B you still see playlist when video being played

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** b02b3e93226e06ae3d694403c112108e5f3a9b4b

## Additional context
This bug is caused by calling the saving before history entry for the video is added, but it still works sometimes since there is another call when route changed
Thus first time watched videos without leaving the watch view will be saved without the last viewed playlist
