### PR TITLE
Only load the necessary configs in the dev-runner

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -9,15 +9,22 @@ const kill = require('tree-kill')
 const path = require('path')
 const { spawn } = require('child_process')
 
-const mainConfig = require('./webpack.main.config')
-const rendererConfig = require('./webpack.renderer.config')
-const webConfig = require('./webpack.web.config')
-
 let electronProcess = null
 let manualRestart = null
 
 const remoteDebugging = process.argv.indexOf('--remote-debug') !== -1
 const web = process.argv.indexOf('--web') !== -1
+
+let mainConfig
+let rendererConfig
+let webConfig
+
+if (!web) {
+  mainConfig = require('./webpack.main.config')
+  rendererConfig = require('./webpack.renderer.config')
+} else {
+  webConfig = require('./webpack.web.config')
+}
 
 if (remoteDebugging) {
   // disable dvtools open in electron


### PR DESCRIPTION
# Only load the necessary configs in the dev-runner

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - development improvement

## Description
Currently we load all 3 webpack configs everytime the dev-runner is started. As loading the locales can take anywhere from 50ms to 100ms, we don't really want to be doing it twice, especially as one of the configs is going to be completely ignored for electron and two of them for the web runner.

TL;DR small performance improvement to the initial startup of the dev-runner

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn dev` and `yarn dev:web`

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0