### PR TITLE
Trigger checkAspectRatio on loadedmetadata event

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -492,12 +492,15 @@ export default defineComponent({
 
         this.player.on('ready', () => {
           this.$emit('ready')
-          this.checkAspectRatio()
           this.createStatsModal()
           if (this.captionHybridList.length !== 0) {
             this.transformAndInsertCaptions()
           }
           this.toggleScreenshotButton()
+        })
+
+        this.player.one('loadedmetadata', () => {
+          this.checkAspectRatio()
         })
 
         this.player.on('ended', () => {
@@ -673,13 +676,6 @@ export default defineComponent({
     checkAspectRatio() {
       const videoWidth = this.player.videoWidth()
       const videoHeight = this.player.videoHeight()
-
-      if (videoWidth === 0 || videoHeight === 0) {
-        setTimeout(() => {
-          this.checkAspectRatio()
-        }, 200)
-        return
-      }
 
       if ((videoWidth - videoHeight) <= 240) {
         this.player.fluid(false)


### PR DESCRIPTION
# Trigger checkAspectRatio on loadedmetadata event

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor removing setTimeout

## Description
The previous implementation with setTimeout was buggy and would run endlessly if the audio formats were selected until you left the watch page.
By running the function for the `loadedmetadata` event instead of the `ready` event, the player already knows the dimensions of the video, so we don't need to check in a loop.

Should also fix the rare unreproducable bug that I sometimes experience where square videos take up the full width of the window, overflowing the bottom of the window.

## Screenshots <!-- If appropriate -->

![error](https://user-images.githubusercontent.com/48293849/216694413-190adf9f-7925-41cd-8c37-6d9eae452e09.png)

## Testing <!-- for code that is not small enough to be easily understandable -->

1. Open a short
2. Make sure the aspect ratio of the player is 16:9
<br>

1. Set the default formats to audio
2. Open a video
3. Navigate back to the previous page
4. Check that the error message doesn't show up

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0