### PR TITLE
Dont label draft pull requests

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -9,6 +9,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
     - uses: actions/labeler@v4
       with:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   triage:


### PR DESCRIPTION
# Dont label draft pull requests

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Other - Automation

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Before the workflow was always triggered when a draft pr was opened. The workflow added 'Waiting for review' label and maybe the dependencies label. Now labels will only be added until the pull requests is ready. 

Please let me know if u want something changed about this because this also prevents the dependencies label to get added on a draft. Reason for pointing this out is before this change if the author of a draft pr deceides to close the pr u could still search it based on label and now u cant.

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Tested in https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/pull/19