### PR TITLE
Extract chapters from the description if they are missing

### DIFF
--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -122,7 +122,7 @@
       />
       <watch-video-chapters
         v-if="!hideChapters && !isLoading && videoChapters.length > 0"
-        :compact="backendPreference === 'invidious'"
+        :compact="!videoChapters[0].thumbnail"
         :chapters="videoChapters"
         :current-chapter-index="videoCurrentChapterIndex"
         class="watchVideo"


### PR DESCRIPTION
# Extract chapters from the description if they are missing

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
For some videos YouTube doesn't show any chapter markers on the player progress bar, as those are the ones that we currently extract with the local API that also means we don't show them in FreeTube. This pull request adds a fallback to extracting the chapters from the description if YouTube doesn't provide any, with the same mechanism that we have been using for the Invidious API.

## Testing <!-- for code that is not small enough to be easily understandable -->
https://youtu.be/zaeUG2k-PbI

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0