### PR TITLE
Fix positioning of the live chat scroll to bottom button

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -207,6 +207,7 @@
   cursor: pointer;
   border-radius: 200px 200px 200px 200px;
   -webkit-border-radius: 200px 200px 200px 200px;
+  text-align: center;
   transition: background 0.2s ease-out;
 }
 
@@ -220,6 +221,5 @@
   color: var(--text-with-accent-color);
   font-size: 22px;
   position: relative;
-  left: 0.5rem;
   top: 0.45rem;
 }


### PR DESCRIPTION
# Fix positioning of the live chat scroll to bottom button

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3159

## Description
The arrow in the scroll to bottom button in the live chat is not horizontally centered.

## Screenshots <!-- If appropriate -->
before:
![before](https://user-images.githubusercontent.com/48293849/217373953-8aea2fb6-e4ed-4e84-bf19-aa62c27fe471.png)

after:
![after](https://user-images.githubusercontent.com/48293849/217373967-dcfcf01d-9337-4b0b-8558-1302fabf3219.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
pick a live video from https://youtube.com/@live (e.g. https://youtu.be/jfKfPfyJRdk), scroll up a bit in the live chat so that the scroll to bottom button shows up

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0