### PR TITLE
Use secondary colour theme for all share buttons

### DIFF
--- a/src/renderer/components/ft-share-button/ft-share-button.vue
+++ b/src/renderer/components/ft-share-button/ft-share-button.vue
@@ -2,7 +2,7 @@
   <ft-icon-button
     ref="iconButton"
     :title="$t(`Share.Share ${shareTargetType}`)"
-    :theme="isVideo?'secondary':'base-no-default'"
+    theme="secondary"
     :icon="['fas', 'share-alt']"
     :dropdown-modal-on-mobile="true"
     dropdown-position-x="left"


### PR DESCRIPTION
# Use secondary colour theme for all share buttons

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
closes #3162

## Description
This pull request makes the share button consistently themed throughout FreeTube.

## Screenshots <!-- If appropriate -->
Playlist:
![playlist-before](https://user-images.githubusercontent.com/48293849/217375730-fd182442-bac4-470a-b8a0-089935b915cd.png) ![playlist-after](https://user-images.githubusercontent.com/48293849/217375743-42554b7a-2c7c-41f1-ab4a-3831e532dfb8.png)

Channel:
![channel-before](https://user-images.githubusercontent.com/48293849/217375800-abfde52d-08cb-46ae-a267-7390512e09c8.png) ![channel-after](https://user-images.githubusercontent.com/48293849/217375805-a7ce8c45-f91c-4b13-a114-c92f3acdce6f.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Video: https://youtu.be/mWEE2RJj3YI
Channel: https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw
Playlist: https://www.youtube.com/playlist?list=PL8mG-RkN2uTzE4GpbGQ8J0p_p91D9oWQT

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0