### PR TITLE
Fix spacing in the load comment replies text

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -150,7 +150,7 @@
             <span v-if="comment.numReplies === 1">{{ $t("Comments.Reply").toLowerCase() }}</span>
             <span v-else>{{ $t("Comments.Replies").toLowerCase() }}</span>
             <span v-if="comment.hasOwnerReplied && !comment.showReplies"> {{ $t("Comments.From {channelName}", { channelName }) }}</span>
-            <span v-if="comment.numReplies > 1 && comment.hasOwnerReplied && !comment.showReplies">{{ $t("Comments.And others") }}</span>
+            <span v-if="comment.numReplies > 1 && comment.hasOwnerReplied && !comment.showReplies"> {{ $t("Comments.And others") }}</span>
           </span>
         </p>
         <div


### PR DESCRIPTION
# Fix spacing in the load comment replies text

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3164

## Description
Whoops missing a space 🙈.

## Screenshots <!-- If appropriate -->
Before:
![before](https://user-images.githubusercontent.com/48293849/217377220-9785ee9a-be2b-4beb-8faf-6e972634cfe7.png)

After:
![after](https://user-images.githubusercontent.com/48293849/217377241-484b59ec-d030-432d-88e2-950856e3df58.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Go to https://youtu.be/NXVeSJ1WAt0
2. Scroll down until u see the comment from Aaron Thomas/@dathomas77

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0