### PR TITLE
Changed undefined to null

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -313,11 +313,11 @@ export default defineComponent({
       }
 
       // Get playlist ID from history ONLY if option enabled
-      if (!this.showVideoWithLastViewedPlaylist) { return }
-      if (!this.saveVideoHistoryWithLastViewedPlaylist) { return }
+      if (!this.showVideoWithLastViewedPlaylist) { return null }
+      if (!this.saveVideoHistoryWithLastViewedPlaylist) { return null }
       const historyIndex = this.historyIndex
       if (historyIndex === -1) {
-        return undefined
+        return null
       }
 
       return this.historyCache[historyIndex].lastViewedPlaylistId


### PR DESCRIPTION
# Fixing external player not opening on Subscriptions page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
none

## Description
There is no edge case for undefined in the function that opens external players in `/src/renderer/store/modules/utils.js:openInExternalPlayer()` so I found where the undefined came from and changed it into a null.
This is because if playlistId is set to undefined it will break as it expects null or string. Undefined makes it believe it is a playlist and ignores the videoId
This was not an issue in the recent version of FreeTube (0.18.0).

## Screenshots 
![Screenshot_20230207_162049](https://user-images.githubusercontent.com/35738771/217378778-3e24cf89-3ad6-4f0f-8565-a25bc8e49d88.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
After changes I tested:
Opening a video on subscriptions page. (worked)
Opening a video on watch page. (worked)
Openng a playlist on search page. (worked)

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux
- **OS Version:** 5.15.91-1-MANJARO (64-bit)
- **FreeTube version:** c349d6398598efa9a2e2ca4ba1782492d830f65d (Latest commit)

## Additional context
none
