### PR TITLE
Better solution for hiding the PIP button for the audio formats

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -364,6 +364,12 @@ export default defineComponent({
           await this.determineDefaultQualityLegacy()
         }
 
+        if (this.format === 'audio') {
+          const controlBarItems = this.dataSetup.controlBar.children
+          const index = controlBarItems.indexOf('pictureInPictureToggle')
+          controlBarItems.splice(index, 1)
+        }
+
         this.player = videojs(this.$refs.video, {
           html5: {
             preloadTextTracks: false,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -98,7 +98,6 @@ export default defineComponent({
       timestamp: null,
       playNextTimeout: null,
       playNextCountDownIntervalId: null,
-      pictureInPictureButtonInverval: null,
       infoAreaSticky: true
     }
   },
@@ -212,25 +211,6 @@ export default defineComponent({
           }
           break
       }
-    },
-    activeFormat: function (format) {
-      clearInterval(this.pictureInPictureButtonInverval)
-
-      // only hide/show the button once the player is available
-      this.pictureInPictureButtonInverval = setInterval(() => {
-        if (!this.hidePlayer) {
-          const pipButton = document.querySelector('.vjs-picture-in-picture-control')
-          if (pipButton === null) {
-            return
-          }
-          if (format === 'audio') {
-            pipButton.classList.add('vjs-hidden')
-          } else {
-            pipButton.classList.remove('vjs-hidden')
-          }
-          clearInterval(this.pictureInPictureButtonInverval)
-        }
-      }, 100)
     }
   },
   mounted: function () {


### PR DESCRIPTION
# Better solution for hiding the PIP button for the audio formats

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Improve existing feature

## Related issue

originally implemented in #2227

## Description
Since the original pull request I've learnt a lot more about FreeTube's code and have found out that the ft-player component is destroyed and recreated when the formats are changed, so I've now changed the implementation so video.js doesn't even add the PIP button to the player if the audio formats are selected.

This gets rid of a setInterval call which was based on a randomly selected timeout, yay :)

## Testing <!-- for code that is not small enough to be easily understandable -->
Watch a video and change the formats.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0