### PR TITLE
Use a player event to trigger the DASH quality selector creation

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -445,15 +445,6 @@ export default defineComponent({
           })
         }
 
-        if (this.useDash) {
-          // this.dataSetup.plugins.httpSourceSelector = {
-          // default: 'auto'
-          // }
-
-          // this.player.httpSourceSelector()
-          this.createDashQualitySelector(this.player.qualityLevels())
-        }
-
         if (this.autoplayVideos) {
           // Calling play() won't happen right away, so a quick timeout will make it function properly.
           setTimeout(() => {
@@ -498,8 +489,10 @@ export default defineComponent({
           this.player.on('wheel', this.mouseScrollSkip)
         }
 
-        this.player.on('fullscreenchange', this.fullscreenOverlay)
-        this.player.on('fullscreenchange', this.toggleFullscreenClass)
+        this.player.on('fullscreenchange', () => {
+          this.fullscreenOverlay()
+          this.toggleFullscreenClass()
+        })
 
         this.player.on('ready', () => {
           this.$emit('ready')
@@ -511,6 +504,15 @@ export default defineComponent({
         })
 
         this.player.one('loadedmetadata', () => {
+          if (this.useDash) {
+            // this.dataSetup.plugins.httpSourceSelector = {
+            // default: 'auto'
+            // }
+
+            // this.player.httpSourceSelector()
+            this.createDashQualitySelector(this.player.qualityLevels())
+          }
+
           this.checkAspectRatio()
         })
 
@@ -1501,12 +1503,6 @@ export default defineComponent({
     },
 
     createDashQualitySelector: function (levels) {
-      if (levels.levels_.length === 0) {
-        setTimeout(() => {
-          this.createDashQualitySelector(this.player.qualityLevels())
-        }, 200)
-        return
-      }
       const adaptiveFormats = this.adaptiveFormats
       const activeAdaptiveFormats = this.activeAdaptiveFormats
       const setDashQualityLevel = this.setDashQualityLevel


### PR DESCRIPTION
# Use a player event to trigger the DASH quality selector creation

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
Yay one less setTimeout.

## Testing <!-- for code that is not small enough to be easily understandable -->
Change between formats and check that the DASH quality selector is created when the DASH formats are enabled.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0