### PR TITLE
Remove label if pr converts to draft

### DIFF
--- a/.github/workflows/remove-outdated-labels.yml
+++ b/.github/workflows/remove-outdated-labels.yml
@@ -1,9 +1,9 @@
 name: Remove outdated labels
 on:
-  # https://github.community/t/github-actions-are-severely-limited-on-prs/18179/15
   pull_request_target:
     types:
       - closed
+      - converted_to_draft
 jobs:
   remove-merged-pr-labels:
     name: Remove merged pull request labels
@@ -23,7 +23,7 @@ jobs:
 
   remove-closed-pr-labels:
     name: Remove closed pull request labels
-    if: github.event_name == 'pull_request_target' && (! github.event.pull_request.merged)
+    if: github.event_name == 'pull_request_target' && (! github.event.pull_request.merged) && (github.event.action != 'converted_to_draft')
     runs-on: ubuntu-latest
     steps:
       - uses: mondeja/remove-labels-gh-action@v1.1.1
@@ -36,3 +36,14 @@ jobs:
             PR: merge conflicts / rebase needed
             PR/Issue: dependent
             PR: stale
+
+  remove-draft-pr-labels:
+    name: Remove labels from draft pull requests
+    if: github.event_name == 'pull_request_target' && github.event.action == 'converted_to_draft'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v1.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            PR: waiting for review


### PR DESCRIPTION
# Remove label if pr converts to draft

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Other - Chore automation

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When user deceides pr isnt ready for review they can convert their pr to draft. In the past the waiting for review label would just stay there. Now it will be removed when a pr is converted to draft.

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
tested in https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/pull/26
other jobs were skipped https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/actions/runs/4175000215
