### PR TITLE
Use a computed property instead of a prop to specify the chapters layout

### DIFF
--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.js
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.js
@@ -7,10 +7,6 @@ export default defineComponent({
     'ft-card': FtCard
   },
   props: {
-    compact: {
-      type: Boolean,
-      default: false
-    },
     chapters: {
       type: Array,
       required: true
@@ -29,6 +25,10 @@ export default defineComponent({
   computed: {
     currentTitle: function () {
       return this.chapters[this.currentIndex].title
+    },
+
+    compact: function () {
+      return !this.chapters[0].thumbnail
     }
   },
   watch: {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -122,7 +122,6 @@
       />
       <watch-video-chapters
         v-if="!hideChapters && !isLoading && videoChapters.length > 0"
-        :compact="!videoChapters[0].thumbnail"
         :chapters="videoChapters"
         :current-chapter-index="videoCurrentChapterIndex"
         class="watchVideo"


### PR DESCRIPTION
# Use a computed property instead of a prop to specify the chapters layout

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
As this the layout of the chapters is decided based on data that is also passed into the component, we can move that decision inside the component instead of it being made in the parent component and passed down.

## Testing <!-- for code that is not small enough to be easily understandable -->
Open a video with chapters on the local and the Invidious API and check that it is compact on the Invidious API and has thumbnails on the local API.

Only compact with Invidious: https://youtu.be/uJvCVw1yONQ
Compact on both APIs: https://youtu.be/zaeUG2k-PbI (see #3167)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0