### PR TITLE
Setting loudness to default volume in new videos

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -89,6 +89,7 @@ export default defineComponent({
       id: '',
       powerSaveBlocker: null,
       volume: 1,
+      muted: false,
       player: null,
       useDash: false,
       useHls: false,
@@ -315,9 +316,16 @@ export default defineComponent({
   },
   mounted: function () {
     const volume = sessionStorage.getItem('volume')
+    const muted = sessionStorage.getItem('muted')
 
     if (volume !== null) {
       this.volume = volume
+    }
+
+    if (muted !== null) {
+      // as sessionStorage stores string values which are truthy by default so we must check with 'true'
+      // otherwise 'false' will be returned as true as well
+      this.muted = (muted === 'true')
     }
 
     this.dataSetup.playbackRates = this.playbackRates
@@ -400,6 +408,7 @@ export default defineComponent({
         })
 
         this.player.volume(this.volume)
+        this.player.muted(this.muted)
         this.player.playbackRate(this.defaultPlayback)
         this.player.textTrackSettings.setValues(this.defaultCaptionSettings)
         // Remove big play button
@@ -712,10 +721,12 @@ export default defineComponent({
     },
 
     updateVolume: function (_event) {
-      // 0 means muted
       // https://docs.videojs.com/html5#volume
-      const volume = this.player.muted() ? 0 : this.player.volume()
+      const volume = this.player.volume()
+      const muted = this.player.muted()
+
       sessionStorage.setItem('volume', volume)
+      sessionStorage.setItem('muted', muted)
     },
 
     mouseScrollVolume: function (event) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -349,6 +349,7 @@ const stateWithSideEffects = {
     defaultValue: 1,
     sideEffectsHandler: (_, value) => {
       sessionStorage.setItem('volume', value)
+      value === 0 ? sessionStorage.setItem('muted', true) : sessionStorage.setItem('muted', false)
     }
   },
 


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
https://github.com/FreeTubeApp/FreeTube/issues/3125
Partially fixes #3125

## Description
When user mutes a video and opens new video, it will open with volume set to default volume set by user in settings. However, if video was not muted, and new video is opened, then volume will remain at it's original value.

## Screenshots <!-- If appropriate -->
n/a

## Testing <!-- for code that is not small enough to be easily understandable -->
Code is self-explanatory and it didn't affect anything else.

## Desktop
<!-- Please complete the following information-->
- **OS: Windows**
- **OS Version: Windows 11 22H2**
- **FreeTube version: development build**

## Additional context
<!-- Add any other context about the pull request here. -->
Instead of starting the new video muted, and settings it to default volume on unmuting, I made volume be set directly to default volume for new videos if previous video was muted by user.  If someone can point me in the right direction, I can attempt to fix this issue as suggested in #3125 but I was unable to find the function responsible for settings the value back to 100% on unmuting, hence tried to partially fix the issue. 