### PR TITLE
Better idle mouse hiding implementation

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.css
+++ b/src/renderer/components/ft-video-player/ft-video-player.css
@@ -6,6 +6,10 @@
   width:100%;
 }
 
+.ftVideoPlayer.vjs-user-inactive {
+  cursor: none;
+}
+
 :deep(.sponsorBlockMarker), :deep(.chapterMarker) {
   position: absolute;
   opacity: 0.6;

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -28,7 +28,6 @@ export default defineComponent({
     if (this.player !== null && !this.player.isInPictureInPicture()) {
       this.player.dispose()
       this.player = null
-      clearTimeout(this.mouseTimeout)
     } else if (this.player.isInPictureInPicture()) {
       this.player.play()
     }
@@ -102,8 +101,6 @@ export default defineComponent({
       maxFramerate: 0,
       activeSourceList: [],
       activeAdaptiveFormats: [],
-      mouseTimeout: null,
-      touchTimeout: null,
       playerStats: null,
       statsModal: null,
       showStatsModal: false,
@@ -341,7 +338,6 @@ export default defineComponent({
       if (!this.player.isInPictureInPicture()) {
         this.player.dispose()
         this.player = null
-        clearTimeout(this.mouseTimeout)
       }
     }
 
@@ -467,9 +463,6 @@ export default defineComponent({
 
         document.removeEventListener('keydown', this.keyboardShortcutHandler)
         document.addEventListener('keydown', this.keyboardShortcutHandler)
-
-        this.player.on('mousemove', this.hideMouseTimeout)
-        this.player.on('mouseleave', this.removeMouseTimeout)
 
         this.player.on('volumechange', this.updateVolume)
         if (this.videoVolumeMouseScroll) {
@@ -1691,22 +1684,6 @@ export default defineComponent({
         this.player.exitFullscreen()
       } else {
         this.player.requestFullscreen()
-      }
-    },
-
-    hideMouseTimeout: function () {
-      if (typeof this.$refs.video !== 'undefined') {
-        this.$refs.video.style.cursor = 'default'
-        clearTimeout(this.mouseTimeout)
-        this.mouseTimeout = setTimeout(() => {
-          this.$refs.video.style.cursor = 'none'
-        }, 2650)
-      }
-    },
-
-    removeMouseTimeout: function () {
-      if (this.mouseTimeout !== null) {
-        clearTimeout(this.mouseTimeout)
       }
     },
 


### PR DESCRIPTION
# Better idle mouse hiding implementation

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #699

## Description
When the mouse is over the player we want to hide it after a certain amount of time so that it isn't distracting for the user when watching the video. The current implementation is based on mouse movements, so it won't hide the mouse in situations where the mouse didn't start out over the player but is over the player later, like when you full screen the video or move the window around with keyboard shortcuts.

This new approach relies on video.js's own idle detection, which not only fires off two events `useractive` and `userinactive` but also helpfully adds respective CSS classes to the player. We can therefore take advantage of the `vjs-user-inactive` class to hide the cursor with CSS. This also means we don't need to essentially recreate video.js's idle detection inside the FreeTube code.

Also did I mention that this gets rid of a timeout 😊.

## Testing <!-- for code that is not small enough to be easily understandable -->
(shamelessly copied the reproduction steps from the issue 🙈)

1. Watch a video in fullscreen
2. While the video still keeps playing click on 'Exit fullscreen icon'
3. Click on 'fullscreen button' and don't move the mouse after.
4. Mediabar dissapears but the mouse pointer not, but Mouse pointer does dissapear when it registers a movement.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0