### PR TITLE
Fix video throttling because of range header

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -18,6 +18,16 @@ import { calculateColorLuminance, colors } from '../../helpers/colors'
 import { pathExists } from '../../helpers/filesystem'
 import { getPicturesPath, showSaveDialog, showToast } from '../../helpers/utils'
 
+// YouTube now throttles if you use the `Range` header for the DASH formats, instead of the range query parameter
+// videojs-http-streaming calls this hook everytime it makes a request,
+// so we can use it to convert the Range header into the range query parameter for the streaming URLs
+videojs.Vhs.xhr.beforeRequest = (options) => {
+  if (options.headers?.Range && new URL(options.uri).hostname.endsWith('.googlevideo.com')) {
+    options.uri += `&range=${options.headers.Range.replace('bytes=', '')}`
+    delete options.headers.Range
+  }
+}
+
 export default defineComponent({
   name: 'FtVideoPlayer',
   props: {


### PR DESCRIPTION
# Fix video throttling because of range header

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/yt-dlp/yt-dlp/issues/6369

## Description
YouTube now throttles the DASH formats if you use the [HTTP Range header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range), the Range header is the standardised way of telling a server you only want part of a file. For a while YouTube has been using a `range` query parameter instead of the standard header, however now they seem to mandate it for the DASH formats, if you don't want your streams to be throttled.

## Testing <!-- for code that is not small enough to be easily understandable -->
It looks like they haven't rolled the throttling out for everyone on every video yet.
So you can try multiple videos and also make sure that no new errors show up because of this change.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0