### PR TITLE
Update export data default filename to use today's date in local timezone instead of UTC

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -9,11 +9,12 @@ import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculateColorLuminance, getRandomColor } from '../../helpers/colors'
 import {
   copyToClipboard,
+  getTodayDateStrLocalTimezone,
   readFileFromDialog,
   showOpenDialog,
   showSaveDialog,
   showToast,
-  writeFileFromDialog
+  writeFileFromDialog,
 } from '../../helpers/utils'
 import { invidiousAPICall } from '../../helpers/api/invidious'
 import { getLocalChannel } from '../../helpers/api/local'
@@ -509,8 +510,8 @@ export default defineComponent({
       const subscriptionsDb = this.profileList.map((profile) => {
         return JSON.stringify(profile)
       }).join('\n') + '\n'// a trailing line is expected
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'freetube-subscriptions-' + date + '.db'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'freetube-subscriptions-' + dateStr + '.db'
 
       const options = {
         defaultPath: exportFileName,
@@ -526,8 +527,8 @@ export default defineComponent({
     },
 
     exportYouTubeSubscriptions: async function () {
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'youtube-subscriptions-' + date + '.json'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'youtube-subscriptions-' + dateStr + '.json'
 
       const options = {
         defaultPath: exportFileName,
@@ -579,8 +580,8 @@ export default defineComponent({
     },
 
     exportOpmlYouTubeSubscriptions: async function () {
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'youtube-subscriptions-' + date + '.opml'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'youtube-subscriptions-' + dateStr + '.opml'
 
       const options = {
         defaultPath: exportFileName,
@@ -612,8 +613,8 @@ export default defineComponent({
     },
 
     exportCsvYouTubeSubscriptions: async function () {
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'youtube-subscriptions-' + date + '.csv'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'youtube-subscriptions-' + dateStr + '.csv'
 
       const options = {
         defaultPath: exportFileName,
@@ -639,8 +640,8 @@ export default defineComponent({
     },
 
     exportNewPipeSubscriptions: async function () {
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'newpipe-subscriptions-' + date + '.json'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'newpipe-subscriptions-' + dateStr + '.json'
 
       const options = {
         defaultPath: exportFileName,
@@ -744,8 +745,8 @@ export default defineComponent({
       const historyDb = this.historyCache.map((historyEntry) => {
         return JSON.stringify(historyEntry)
       }).join('\n') + '\n'
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'freetube-history-' + date + '.db'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'freetube-history-' + dateStr + '.db'
 
       const options = {
         defaultPath: exportFileName,
@@ -875,8 +876,8 @@ export default defineComponent({
     },
 
     exportPlaylists: async function () {
-      const date = new Date().toISOString().split('T')[0]
-      const exportFileName = 'freetube-playlists-' + date + '.db'
+      const dateStr = getTodayDateStrLocalTimezone()
+      const exportFileName = 'freetube-playlists-' + dateStr + '.db'
 
       const options = {
         defaultPath: exportFileName,

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -619,3 +619,14 @@ export function toDistractionFreeTitle(title, minUpperCase = 3) {
 export function formatNumber(number, options = undefined) {
   return Intl.NumberFormat([i18n.locale.replace('_', '-'), 'en'], options).format(number)
 }
+
+export function getTodayDateStrLocalTimezone() {
+  const timeNow = new Date()
+  // `Date#getTimezoneOffset` returns the difference, in minutes
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
+  const timeNowStr = new Date(timeNow.getTime() - (timeNow.getTimezoneOffset() * 60000)).toISOString()
+  // `Date#toISOString` returns string with `T` as date/time separator (ISO 8601 format)
+  // e.g. 2011-10-05T14:48:00.000Z
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+  return timeNowStr.split('T')[0]
+}


### PR DESCRIPTION
# Update export data default filename to use today's date in local timezone instead of UTC

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
FT uses UTC date as default filename for data export
This PR makes it uses local timezone instead
e.g. I export data before 2023-03-01 8:00am on UTC+8 timezone, default filename 2023-02-28 => 2023-03-01

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Timezone with plus diff:
- Update computer timezone to plus diff (up to +11 or +12?)
- Update time to before 11am
- Export data to ensure default filename set to today not yesterday

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 12.6.2
- **FreeTube version:** f56f6e7a201115f70fda829625d79fb9fbcdc34b

## Additional context
<!-- Add any other context about the pull request here. -->
