### PR TITLE
Fix premieres on the subscription page

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -463,7 +463,7 @@ export default defineComponent({
         // Using `Math.ceil` so that -1.x days ago displayed as 1 day ago
         // Notice that the value is turned to negative to be displayed as "ago"
         this.uploadedTime = new Intl.RelativeTimeFormat(this.currentLocale).format(Math.ceil(-timeDiffFromNow), timeUnit)
-      } else if (typeof (this.data.publishedText) !== 'undefined' && this.data.publishedText !== null && !this.isLive) {
+      } else if (this.publishedText && !this.isLive) {
         // produces a string according to the template in the locales string
         this.uploadedTime = toLocalePublicationString({
           publishText: this.publishedText,

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -282,6 +282,8 @@ export default defineComponent({
         videos.map(video => {
           if (video.liveNow) {
             video.publishedDate = new Date().getTime()
+          } else if (video.isUpcoming) {
+            video.publishedDate = video.premiereDate
           } else {
             video.publishedDate = calculatePublishedDate(video.publishedText)
           }


### PR DESCRIPTION
# Fix premieres on the subscription page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently if you are subscribed to a channel that has a premiere video, when you refresch your subscriptions on the local API without RSS, you will see that it says it was uploaded x hours ago and an error in the console.

This pull request fixes it.

## Screenshots <!-- If appropriate -->
![error](https://user-images.githubusercontent.com/48293849/222518538-d046c37e-9b9e-4352-b9e4-b7b641aebd4b.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Subscribe to https://www.youtube.com/channel/UCBmEi75U56KU6ZphFbXiF3g and refresh your subscriptions with the local API **without** using RSS, although I suspect that by the time you get round to testing it, this premiere will already be published.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0