### PR TITLE
Fix channel handle URLs with tabs

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -315,7 +315,7 @@ const actions = {
     let urlType = 'unknown'
 
     const channelPattern =
-      /^\/(?:(?:channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(join|featured|videos|playlists|about|community|channels))?\/?$/
+      /^\/(?:(?:channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(?<tab>join|featured|videos|playlists|about|community|channels))?\/?$/
 
     const typePatterns = new Map([
       ['playlist', /^(\/playlist\/?|\/embed(\/?videoseries)?)$/],
@@ -420,7 +420,7 @@ const actions = {
         }
 
         let subPath = null
-        switch (url.pathname.split('/').filter(i => i)[2]) {
+        switch (match.groups.tab) {
           case 'playlists':
             subPath = 'playlists'
             break


### PR DESCRIPTION
# Fix channel handle URLs with tabs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
found in https://github.com/FreeTubeApp/FreeTube/pull/1568#pullrequestreview-1320792874

## Description
The current code doesn't read the tab from the channel URL if the URL has a handle in it.

e.g. https://www.youtube.com/@mkbhd/playlists

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/@mkbhd/about
https://www.youtube.com/@mkbhd/playlists

check that these still work:
https://www.youtube.com/@mkbhd
https://www.youtube.com/@mkbhd/videos

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0