### PR TITLE
Fix handling user channels without subscribers

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -392,7 +392,7 @@ export default defineComponent({
             channelId = header.author.id
             channelName = header.author.name
             channelThumbnailUrl = header.author.best_thumbnail.url
-            subscriberText = header.subscribers.text
+            subscriberText = header.subscribers?.text
             break
           }
           case 'CarouselHeader': {


### PR DESCRIPTION
# Fix handling user channels without subscribers

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Some user channels don't have a subscriber text which currently causes the local API to error

## Screenshots <!-- If appropriate -->
![error](https://user-images.githubusercontent.com/48293849/222523456-e982f740-de76-41a0-a073-f91bd15aa36a.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/@onetv4548

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0