### PR TITLE
Clean up some code that was leftover from before the YouTube.js migration

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -38,7 +38,7 @@ export default defineComponent({
     }
   },
   mounted: function () {
-    if (this.data.dataSource === 'local' || typeof (this.data.avatars) !== 'undefined') {
+    if (this.data.dataSource === 'local') {
       this.parseLocalData()
     } else {
       this.parseInvidiousData()
@@ -46,14 +46,14 @@ export default defineComponent({
   },
   methods: {
     parseLocalData: function () {
-      this.thumbnail = this.data.thumbnail ?? this.data.bestAvatar.url
+      this.thumbnail = this.data.thumbnail
 
       if (!this.thumbnail.includes('https:')) {
         this.thumbnail = `https:${this.thumbnail}`
       }
 
       this.channelName = this.data.name
-      this.id = this.data.channelID
+      this.id = this.data.id
       if (this.hideChannelSubscriptions || this.data.subscribers === null) {
         this.subscriberCount = null
       } else {

--- a/src/renderer/components/ft-list-playlist/ft-list-playlist.js
+++ b/src/renderer/components/ft-list-playlist/ft-list-playlist.js
@@ -19,8 +19,8 @@ export default defineComponent({
   },
   data: function () {
     return {
-      playlistLink: '',
-      channelLink: '',
+      playlistId: '',
+      channelId: '',
       title: 'Pop Music Playlist - Timeless Pop Songs (Updated Weekly 2020)',
       thumbnail: 'https://i.ytimg.com/vi/JGwWNGJdvx8/mqdefault.jpg',
       channelName: '#RedMusic: Just Hits',
@@ -37,20 +37,6 @@ export default defineComponent({
       return this.$store.getters.getListType
     },
 
-    playlistId: function () {
-      return this.playlistLink.replace('https://www.youtube.com/playlist?list=', '')
-    },
-
-    channelId: function () {
-      if (this.channelLink === null) {
-        return null
-      }
-
-      let id = this.channelLink.replace('https://www.youtube.com/user/', '')
-      id = id.replace('https://www.youtube.com/channel/', '')
-      return id
-    },
-
     externalPlayer: function () {
       return this.$store.getters.getExternalPlayer
     },
@@ -60,10 +46,7 @@ export default defineComponent({
     }
   },
   mounted: function () {
-    // temporary until we've migrated the whole local API to youtubei.js
     if (this.data.dataSource === 'local') {
-      this.parseLocalDataNew()
-    } else if (typeof (this.data.owner) === 'object') {
       this.parseLocalData()
     } else {
       this.parseInvidiousData()
@@ -87,8 +70,8 @@ export default defineComponent({
       this.title = this.data.title
       this.thumbnail = this.data.playlistThumbnail.replace('https://i.ytimg.com', this.currentInvidiousInstance).replace('hqdefault', 'mqdefault')
       this.channelName = this.data.author
-      this.channelLink = this.data.authorUrl
-      this.playlistLink = this.data.playlistId
+      this.channelId = this.data.authorId
+      this.playlistId = this.data.playlistId
       this.videoCount = this.data.videoCount
 
       if (this.data.proxyThumbnail === false) {
@@ -98,21 +81,10 @@ export default defineComponent({
 
     parseLocalData: function () {
       this.title = this.data.title
-      this.thumbnail = this.data.firstVideo.bestThumbnail.url
-      this.channelName = this.data.owner.name
-      this.channelLink = this.data.owner.url
-      this.playlistLink = this.data.url
-      this.videoCount = this.data.length
-    },
-
-    // TODO: after the local API is fully switched to YouTube.js
-    // cleanup the old local API stuff
-    parseLocalDataNew: function () {
-      this.title = this.data.title
       this.thumbnail = this.data.thumbnail
       this.channelName = this.data.channelName
-      this.channelLink = this.data.channelId
-      this.playlistLink = this.data.playlistId
+      this.channelId = this.data.channelId
+      this.playlistId = this.data.playlistId
       this.videoCount = this.data.videoCount
     },
 

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -372,7 +372,7 @@ function parseListItem(item) {
         dataSource: 'local',
         thumbnail: channel.author.best_thumbnail?.url,
         name: channel.author.name,
-        channelID: channel.author.id,
+        id: channel.author.id,
         subscribers,
         videos,
         handle,


### PR DESCRIPTION
# Clean up some code that was leftover from before the YouTube.js migration

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Cleanup

## Description
Now that the local API is fully migrated to YouTube.js we can clean up this code that was leftover from the before times. This doesn't change any functionality.

(I'll submit a separate pull request to remove the now unneeded polyfills for the web build)

## Testing <!-- for code that is not small enough to be easily understandable -->
With the local API
Search for "Linus Tech Tips" with the type search filter set to channels
Search for "Linus Tech Tips Factory Tours" with the type search filter set to playlists

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0