### PR TITLE
Lazy load sidebar channel and chapters thumbnails

### DIFF
--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -95,7 +95,6 @@
 
 .channelThumbnail {
   border-radius: 50%;
-  width: 35px;
   vertical-align: middle;
 }
 

--- a/src/renderer/components/side-nav/side-nav.vue
+++ b/src/renderer/components/side-nav/side-nav.vue
@@ -214,6 +214,9 @@
           >
             <img
               class="channelThumbnail"
+              height="35"
+              width="35"
+              loading="lazy"
               :src="channel.thumbnail"
               :alt="isOpen ? '' : channel.name"
             >

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.vue
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.vue
@@ -50,6 +50,7 @@
           alt=""
           aria-hidden="true"
           class="chapterThumbnail"
+          loading="lazy"
           :src="chapter.thumbnail"
         >
         <div class="chapterTimestamp">


### PR DESCRIPTION
# Lazy load sidebar channel and chapters thumbnails

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Performance optimisation

## Description
Lazy loading the channel thumbnails not only avoids unnecessary network requests, but also speeds up the loading of the side bar, as the channels sections currently waits until it has downloaded every single thumbnail before it shows itself. Reducing the number of requests should also lower the chance of getting ratelimited by YouTube's thumbnail servers or Invidious' image proxy. Specify the height and width of the thumbnails allows the rendering engine to reserve the space, so when the image loads it doesn't cause a layout shift, which can be jarring for users and also force it to recalculate the position of other elements on the page. You probably won't see the images loading in while you are scrolling as Chromium tries to predict where you are going to scroll to and load them in time for the images to show up in the viewport (the visible area of the page)

Fetching less thumbnails at startup also stops them competing with the subscription requests for space on the network.

Also took the chance to make the chapter thumbnails lazy load, as the chapters section starts collapsed, so they only need to be loaded when you exand it.

## Testing <!-- for code that is not small enough to be easily understandable -->
Turn off automatic subscription loading
Make sure the hide active subscriptions setting is disabled
The number of image requests in the devtools should be a lot lower and increase when you scroll through the subscriptions list on the left side.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0