### PR TITLE
Properly show live and upcoming videos in playlists and up next

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -311,7 +311,10 @@ export function parseLocalPlaylistVideo(video) {
     title: video.title.text,
     author: video.author.name,
     authorId: video.author.id,
-    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds
+    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
+    liveNow: video.is_live,
+    isUpcoming: video.is_upcoming,
+    premiereDate: video.upcoming
   }
 }
 
@@ -400,10 +403,10 @@ export function parseLocalWatchNextVideo(video) {
     author: video.author.name,
     authorId: video.author.id,
     viewCount: extractNumberFromString(video.view_count.text),
-    // CompactVideo doesn't have is_live, is_upcoming or is_premiere,
-    // so we have to make do with this for the moment, to stop toLocalePublicationString erroring
     publishedText: video.published.text === 'N/A' ? null : video.published.text,
-    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds
+    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
+    liveNow: video.is_live,
+    isUpcoming: video.is_premiere
   }
 }
 


### PR DESCRIPTION
# Properly show live and upcoming videos in playlists and up next

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
YouTube.js didn't have these fields back when I migrated the watch and playlist pages over, so now that they are here we might as well use them.

## Screenshots <!-- If appropriate -->
![before-upcoming](https://user-images.githubusercontent.com/48293849/222806115-a1d52989-e58b-4466-a073-391992f05189.png)
![after-upcoming](https://user-images.githubusercontent.com/48293849/222806132-372d7a22-87c8-4aff-bf73-dd7e1d1671a9.png)

![before-live](https://user-images.githubusercontent.com/48293849/222806145-5e5fafbc-f50b-48a4-9854-dd8ded6acdb7.png)
![after-live](https://user-images.githubusercontent.com/48293849/222806153-646411cf-605d-4b2c-bf44-45276006b56c.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Upcoming Live Streams playlist
https://www.youtube.com/playlist?list=PLU12uITxBEPHHlOIWGAIezbshH82rGpKp

Live playlist
https://www.youtube.com/playlist?list=PLU12uITxBEPHOJO1FU8qll6gQmKcXp5S7

Potential live streams in the Up Next section
https://www.youtube.com/watch?v=rUxyKA_-grg

couldn't find a video with upcoming videos in the Up Next section

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0