### PR TITLE
Use smaller Vue esm runtime build

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -132,7 +132,7 @@ const config = {
   ],
   resolve: {
     alias: {
-      vue$: 'vue/dist/vue.common.js',
+      vue$: 'vue/dist/vue.runtime.esm.js',
 
       'youtubei.js$': 'youtubei.js/web',
     },

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -133,7 +133,7 @@ const config = {
   ],
   resolve: {
     alias: {
-      vue$: 'vue/dist/vue.esm.js'
+      vue$: 'vue/dist/vue.runtime.esm.js'
     },
     fallback: {
       buffer: require.resolve('buffer/'),

--- a/src/renderer/components/ft-community-post/ft-community-post.js
+++ b/src/renderer/components/ft-community-post/ft-community-post.js
@@ -1,18 +1,16 @@
-import Vue from 'vue'
+import { defineComponent } from 'vue'
 import FtListVideo from '../ft-list-video/ft-list-video.vue'
 import FtListPlaylist from '../ft-list-playlist/ft-list-playlist.vue'
 
 import autolinker from 'autolinker'
 import VueTinySlider from 'vue-tiny-slider'
 
-import {
-  toLocalePublicationString
-} from '../../helpers/utils'
+import { toLocalePublicationString } from '../../helpers/utils'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 
 import 'tiny-slider/dist/tiny-slider.css'
 
-export default Vue.extend({
+export default defineComponent({
   name: 'FtCommunityPost',
   components: {
     'ft-list-playlist': FtListPlaylist,


### PR DESCRIPTION
# Use smaller Vue esm runtime build

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Build optimisation

## Description
As we use vue-loader our {component}.vue templates get compiled at build time, which means we don't need to compile them at runtime. Currently we are using a the full Vue build, which contains both the runtime and compiler, switching to the runtime only build allows us to shave off a chunk of our bundle (0.04MB for the Electron build and 0.03MB for the web build).

https://v2.vuejs.org/v2/guide/installation.html#Runtime-Compiler-vs-Runtime-only

## Screenshots <!-- If appropriate -->
renderer:
![renderer-before](https://user-images.githubusercontent.com/48293849/223189390-e4d90841-0c18-4cfe-8c6a-52ab7b36500c.png) ![renderer-after](https://user-images.githubusercontent.com/48293849/223189402-4529ba32-ff8c-44b6-8c49-1b8e91f5275b.png)

web:
![web-before](https://user-images.githubusercontent.com/48293849/223189434-2537975a-51e7-4ea4-9c41-d05154f7226b.png) ![web-after](https://user-images.githubusercontent.com/48293849/223189447-cdb02499-7b2d-4731-8f71-6de1f2936415.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Test various functionality to check that it still works.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0