### PR TITLE
Skip the exists check for the databases, as stat does it anyway

### DIFF
--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -6,12 +6,13 @@ if (process.env.IS_ELECTRON_MAIN) {
   const { app } = require('electron')
   const { join } = require('path')
   // this code only runs in the electron main process, so hopefully using sync fs code here should be fine 😬
-  const { existsSync, statSync, realpathSync } = require('fs')
+  const { statSync, realpathSync } = require('fs')
   const userDataPath = app.getPath('userData') // This is based on the user's OS
   dbPath = (dbName) => {
     let path = join(userDataPath, `${dbName}.db`)
 
-    if (existsSync(path) && statSync(path).isSymbolicLink) {
+    // returns undefined if the path doesn't exist
+    if (statSync(path, { throwIfNoEntry: false })?.isSymbolicLink) {
       path = realpathSync(path)
     }
 


### PR DESCRIPTION
# Skip the exists check for the databases, as stat does it anyway

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Performance improvement

## Description
Instead of querying the file system for the existence of the file and then a second time to get the stats, we can do it once instead. As 99% of the time when you use FreeTube the database files will exist, they'll only be missing the first time you ever start FreeTube or if you delete them, so doing an extra existence check only slows it down for 99% of the times that code is run.

As statSync can be told to return undefined if the file doesn't exist, we don't even need a try-catch handler.

Found out about that option in https://marvinh.dev/blog/speeding-up-javascript-ecosystem-part-2/

## Testing <!-- for code that is not small enough to be easily understandable -->
***1.**
Start FreeTube normally

**2.**
Backup your files, then delete the originals and start FreeTube

**3.**
symlink your files to the FreeTube folder and start FreeTube

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0