### PR TITLE
Add Live tab to channel pages

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -315,7 +315,7 @@ const actions = {
     let urlType = 'unknown'
 
     const channelPattern =
-      /^\/(?:(?:channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(?<tab>join|featured|videos|playlists|about|community|channels))?\/?$/
+      /^\/(?:(?:channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(?<tab>join|featured|videos|live|playlists|about|community|channels))?\/?$/
 
     const typePatterns = new Map([
       ['playlist', /^(\/playlist\/?|\/embed(\/?videoseries)?)$/],
@@ -421,6 +421,9 @@ const actions = {
 
         let subPath = null
         switch (match.groups.tab) {
+          case 'live':
+            subPath = 'live'
+            break
           case 'playlists':
             subPath = 'playlists'
             break

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -101,6 +101,20 @@
               {{ $t("Channel.Videos.Videos").toUpperCase() }}
             </div>
             <div
+              v-if="!hideLiveStreams"
+              id="liveTab"
+              class="tab"
+              :class="(currentTab==='live')?'selectedTab':''"
+              role="tab"
+              aria-selected="true"
+              aria-controls="livePanel"
+              tabindex="0"
+              @click="changeTab('live')"
+              @keydown.left.right.enter.space="changeTab('live', $event)"
+            >
+              {{ $t("Channel.Live.Live").toUpperCase() }}
+            </div>
+            <div
               id="playlistsTab"
               class="tab"
               role="tab"
@@ -265,11 +279,21 @@
       <ft-select
         v-show="currentTab === 'videos' && latestVideos.length > 0"
         class="sortSelect"
-        :value="videoSelectValues[0]"
-        :select-names="videoSelectNames"
-        :select-values="videoSelectValues"
+        :value="videoShortLiveSelectValues[0]"
+        :select-names="videoShortLiveSelectNames"
+        :select-values="videoShortLiveSelectValues"
         :placeholder="$t('Search Filters.Sort By.Sort By')"
         @change="videoSortBy = $event"
+      />
+      <ft-select
+        v-if="!hideLiveStreams"
+        v-show="currentTab === 'live' && latestLive.length > 0"
+        class="sortSelect"
+        :value="videoShortLiveSelectValues[0]"
+        :select-names="videoShortLiveSelectNames"
+        :select-values="videoShortLiveSelectValues"
+        :placeholder="$t('Search Filters.Sort By.Sort By')"
+        @change="liveSortBy = $event"
       />
       <ft-select
         v-show="currentTab === 'playlists' && latestPlaylists.length > 0"
@@ -299,6 +323,21 @@
         >
           <p class="message">
             {{ $t("Channel.Videos.This channel does not currently have any videos") }}
+          </p>
+        </ft-flex-box>
+        <ft-element-list
+          v-if="!hideLiveStreams"
+          v-show="currentTab === 'live'"
+          id="livePanel"
+          :data="latestLive"
+          role="tabpanel"
+          aria-labelledby="liveTab"
+        />
+        <ft-flex-box
+          v-if="!hideLiveStreams && currentTab === 'live' && latestLive.length === 0"
+        >
+          <p class="message">
+            {{ $t("Channel.Live.This channel does not currently have any live streams") }}
           </p>
         </ft-flex-box>
         <ft-element-list

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -528,6 +528,10 @@ Channel:
       Newest: Newest
       Oldest: Oldest
       Most Popular: Most Popular
+  Live:
+    Live: Live
+    This channel does not currently have any live streams: This channel does not currently
+      have any live streams
   Playlists:
     Playlists: Playlists
     This channel does not currently have any playlists: This channel does not currently


### PR DESCRIPTION
# Add Live tab to channel pages

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
Partially addresses #2852

## Description
This pull request adds the live tab to the channel pages, the tab will be hidden and inaccessible when the hide live streams distraction free setting is enabled.

## Screenshots <!-- If appropriate -->
![live-tab](https://user-images.githubusercontent.com/48293849/223517615-6a73353e-3811-4ce5-b736-68f423e1fa20.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Make sure the hide live streams distraction free setting is disabled

Channel with live tab: https://youtube.com/@LinusTechTips
Channel without live tab: https://youtube.com/@TheyreJustMovies
Direct link to live tab: https://youtube.com/@LinusTechTips/live

Enable the hide live streams distraction free setting
Check that the live tab is hidden
Check that the videos tab is selected when you try to use a direct link to the live tab: https://youtube.com/@LinusTechTips/live

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0