### PR TITLE
Fix DASH default quality and quality selection

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -226,3 +226,33 @@ function parseInvidiousCommunityAttachments(data) {
 
   console.error('New Invidious Community Post Type: ' + data.type)
 }
+
+/**
+ * video.js only supports MP4 DASH not WebM DASH
+ * so we filter out the WebM DASH formats
+ * @param {any[]} formats
+ * @param {boolean} allowAv1 Use the AV1 formats if they are available
+ */
+export function filterInvidiousFormats(formats, allowAv1 = false) {
+  const audioFormats = []
+  const h264Formats = []
+  const av1Formats = []
+
+  formats.forEach(format => {
+    const mimeType = format.type
+
+    if (mimeType.startsWith('audio/mp4')) {
+      audioFormats.push(format)
+    } else if (allowAv1 && mimeType.startsWith('video/mp4; codecs="av01')) {
+      av1Formats.push(format)
+    } else if (mimeType.startsWith('video/mp4; codecs="avc')) {
+      h264Formats.push(format)
+    }
+  })
+
+  if (allowAv1 && av1Formats.length > 0) {
+    return [...audioFormats, ...av1Formats]
+  } else {
+    return [...audioFormats, ...h264Formats]
+  }
+}

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -562,6 +562,7 @@ export function mapLocalFormat(format) {
     bitrate: format.bitrate,
     mimeType: format.mime_type,
     height: format.height,
+    width: format.width,
     url: format.url
   }
 }
@@ -606,7 +607,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
  * @param {Format[]} formats
  * @param {boolean} allowAv1 Use the AV1 formats if they are available
  */
-export function filterFormats(formats, allowAv1 = false) {
+export function filterLocalFormats(formats, allowAv1 = false) {
   const audioFormats = []
   const h264Formats = []
   const av1Formats = []


### PR DESCRIPTION
# Fix DASH default quality and quality selection

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
potentially addresses #595 (it fixes the original issue but someone left comments requesting automatically switching to legacy when certain qualities aren't available in DASH, which this pull request most certainly doesn't do)
potentially addresses #1533 (the quality dropping part)

## Description
Fixes the default DASH quality selection and the DASH quality selector so that it should now be possible to switch between qualities in the quality selector when DASH is enabled. Fixing the default quality selection also fixes the slow loading times.

This also fixes the quality selector showing 1080p, even if you selected a different default quality.

Why wasn't the default quality selection working for DASH?
Well as it turns out even if you disable qualities videojs-http-streaming, it ignores your preferences if it thinks that it doesn't have enough bandwidth to play them (it's wrong but we can override it's decision as we know better). On my machine with the default quality set to 1080p it first requested 720p, then 144p and finally it switched up to 1080p, so the slow loading was caused by videojs-http-streaming wasting time doing pointless stuff.
The solution is to disable them as soon as possible and then also override videojs-http-streaming's default bandwidth with the one of the format, that way videojs-http-streaming will always select the correct quality at the start, as we've told it that it has enough bandwidth to play it.

As for why the quality selector works now, no idea it just started working while I was making all of these changes, so I'll take the win.

Loading and quality switching still isn't as fast as it is on YouTube but that's something for another day, if it's even possible to do with video.js.

## Testing <!-- for code that is not small enough to be easily understandable -->
Try various default qualites and switch between the qualities in the DASH quality selector (reminder for PikachuEXE as you asked last time: that's the quality selector that is shown when the DASH formats are selected).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0