### PR TITLE
Reset sort by when changing channels

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -247,9 +247,11 @@ export default defineComponent({
       this.searchPage = 2
       this.relatedChannels = []
       this.latestVideos = []
+      this.videoSortBy = 'newest'
       this.latestLive = []
       this.liveSortBy = 'newest'
       this.latestPlaylists = []
+      this.playlistSortBy = 'newest'
       this.searchResults = []
       this.shownElementList = []
       this.apiUsed = ''

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -278,6 +278,7 @@
       </div>
       <ft-select
         v-show="currentTab === 'videos' && latestVideos.length > 0"
+        key="videoSortBy"
         class="sortSelect"
         :value="videoShortLiveSelectValues[0]"
         :select-names="videoShortLiveSelectNames"
@@ -288,6 +289,7 @@
       <ft-select
         v-if="!hideLiveStreams"
         v-show="currentTab === 'live' && latestLive.length > 0"
+        key="liveSortBy"
         class="sortSelect"
         :value="videoShortLiveSelectValues[0]"
         :select-names="videoShortLiveSelectNames"
@@ -297,6 +299,7 @@
       />
       <ft-select
         v-show="currentTab === 'playlists' && latestPlaylists.length > 0"
+        key="playlistSortBy"
         class="sortSelect"
         :value="playlistSelectValues[0]"
         :select-names="playlistSelectNames"


### PR DESCRIPTION
# Reset sort by when changing channels

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3287 

## Description
When you change channels the sort by values currently don't get reset, this pull request fixes it (I've already pushed a fix for the live sort by to the live tab PR). That means that while the drop down shows it correctly sorted by newest, the actual API requests use the value from the previous channel page, which is fixed now.

## Testing <!-- for code that is not small enough to be easily understandable -->
Set the sort by values on the videos and playlists tabs to something other than newest, change to a different channel, make sure the videos and playlists are sorted by newest.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0