### PR TITLE
Show member icon when using invidious api

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -101,6 +101,10 @@ export async function invidiousGetCommentReplies({ id, replyToken }) {
 }
 
 export function youtubeImageUrlToInvidious(url, currentInstance = null) {
+  if (url == null) {
+    return null
+  }
+
   if (currentInstance === null) {
     currentInstance = getCurrentInstance()
   }
@@ -130,6 +134,8 @@ function parseInvidiousCommentData(response) {
     comment.numReplies = comment.replies?.replyCount ?? 0
     comment.replyToken = comment.replies?.continuation ?? ''
     comment.isHearted = comment.creatorHeart !== undefined
+    comment.isMember = comment.isSponsor
+    comment.memberIconUrl = youtubeImageUrlToInvidious(comment.sponsorIconUrl)
     comment.replies = []
     comment.time = toLocalePublicationString({
       publishText: comment.publishedText


### PR DESCRIPTION
# Show member icon when using invidious api

## Pull Request Type
- [x] Feature Implementation

## Description
Invidious can now support showing member icons  https://github.com/iv-org/invidious/pull/3636

## Screenshots
![image](https://user-images.githubusercontent.com/78101139/224596205-754cbfbb-908b-4958-92fc-63e2062f4d54.png)

## Testing 
1) Switch to Invidious API
2) Go to https://youtu.be/v3wm83zoSSY
3) Click View comments
4) See pinned comment has crown next to it (memberIcon)
5) Other comments dont have this icon

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
