### PR TITLE
Fix joined date erroring on channels without a joined date

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -599,7 +599,7 @@ export default defineComponent({
         const views = extractNumberFromString(about.views.text)
         this.views = isNaN(views) ? null : views
 
-        this.joined = new Date(about.joined.text.replace('Joined').trim())
+        this.joined = about.joined.text !== 'N/A' ? new Date(about.joined.text.replace('Joined').trim()) : 0
 
         this.location = about.country.text !== 'N/A' ? about.country.text : null
       } catch (err) {
@@ -756,7 +756,7 @@ export default defineComponent({
         this.updateSubscriptionDetails({ channelThumbnailUrl: thumbnail, channelName: channelName, channelId: channelId })
         this.description = autolinker.link(response.description)
         this.views = response.totalViews
-        this.joined = new Date(response.joined * 1000)
+        this.joined = response.joined > 0 ? new Date(response.joined * 1000) : 0
         this.relatedChannels = response.relatedChannels.map((channel) => {
           const thumbnailUrl = channel.authorThumbnails.at(-1).url
           return {


### PR DESCRIPTION
# Fix joined date erroring on channels without a joined date

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Channels like https://youtube.com/@YouTube don't have a joined date on their about page, for the local API this was causing an error and for the Invidious API it was showing 1 January 1970. This pull request ensures that we don't try to show it in the UI if it's not available.

## Screenshots <!-- If appropriate -->
![error](https://user-images.githubusercontent.com/48293849/225758201-7c1eb4f0-6572-4a3f-8074-b9076f4cf139.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit the about tab on the https://youtube.com/@YouTube channel with both APIs and check that no error shows up and that that no Joined date is shown.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0