### PR TITLE
Clear community posts array when switching channels

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -250,6 +250,7 @@ export default defineComponent({
       this.latestLive = []
       this.liveSortBy = 'newest'
       this.latestPlaylists = []
+      this.latestCommunityPosts = []
       this.searchResults = []
       this.shownElementList = []
       this.apiUsed = ''


### PR DESCRIPTION
# Clear community posts array when switching channels

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3304

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

## Screenshots <!-- If appropriate -->
![wrong-posts](https://user-images.githubusercontent.com/48293849/225764191-e3b43b60-3bd9-4ed6-852e-64d3acaa59e4.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Visit the LinusTechTips channel https://youtube.com/@LinusTechTips
2. Click on the community tab
3. Click on the about tab and then in featured channels click on TechLinked
4. Click on the community tab
5. Check that the posts are from the TechLinked channel and not from the LinusTechTips channel

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0