### PR TITLE
Fix alt + arrow keyboard shortcut when a channel tab is focused

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1230,6 +1230,10 @@ export default defineComponent({
 
     changeTab: function (tab, event) {
       if (event instanceof KeyboardEvent) {
+        if (event.altKey) {
+          return
+        }
+
         // use arrowkeys to navigate
         event.preventDefault()
         if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {


### PR DESCRIPTION
# Fix alt + arrow keyboard shortcut when a channel tab is focused

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3307

## Description
Currently the channel tabs swallow all arrow key events, even when combined with alt or option to make up the history navigation shortcuts.

## Testing <!-- for code that is not small enough to be easily understandable -->
Click on a tab on the channels page, then try navigating with the alt/option+left arrow or alt/option+ right arrow

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 3332a40005d30bb50eb3a868ebd8337f599cedef