### PR TITLE
Workaround YouTube bug causing the community tab to be empty

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1038,11 +1038,25 @@ export default defineComponent({
          * @type {import('youtubei.js/dist/src/parser/youtube/Channel').default}
          */
         const channel = this.channelInstance
-        const communityTab = await channel.getCommunity()
+
+        /**
+         * @type {import('youtubei.js/dist/src/parser/youtube/Channel').default|import('youtubei.js/dist/src/parser/youtube/Channel').ChannelListContinuation}
+         */
+        let communityTab = await channel.getCommunity()
         if (expectedId !== this.id) {
           return
         }
-        this.latestCommunityPosts = communityTab.posts.map(parseLocalCommunityPost)
+
+        // work around YouTube bug where it will return a bunch of responses with only continuations in them
+        // e.g. https://www.youtube.com/@TheLinuxEXP/community
+
+        let posts = communityTab.posts
+        while (posts.length === 0 && communityTab.has_continuation) {
+          communityTab = await communityTab.getContinuation()
+          posts = communityTab.posts
+        }
+
+        this.latestCommunityPosts = posts.map(parseLocalCommunityPost)
         this.communityContinuationData = communityTab.has_continuation ? communityTab : null
       } catch (err) {
         console.error(err)
@@ -1064,8 +1078,17 @@ export default defineComponent({
         /**
          * @type {import('youtubei.js/dist/src/parser/youtube/Channel').ChannelListContinuation}
          */
-        const continuation = await this.communityContinuationData.getContinuation()
-        this.latestCommunityPosts = this.latestCommunityPosts.concat(continuation.posts.map(parseLocalCommunityPost))
+        let continuation = await this.communityContinuationData.getContinuation()
+
+        // work around YouTube bug where it will return a bunch of responses with only continuations in them
+        // e.g. https://www.youtube.com/@TheLinuxEXP/community
+        let posts = continuation.posts
+        while (posts.length === 0 && continuation.has_continuation) {
+          continuation = await continuation.getContinuation()
+          posts = continuation.posts
+        }
+
+        this.latestCommunityPosts = this.latestCommunityPosts.concat(posts.map(parseLocalCommunityPost))
         this.communityContinuationData = continuation.has_continuation ? continuation : null
       } catch (err) {
         console.error(err)


### PR DESCRIPTION
# Workaround YouTube bug causing the community tab to be empty

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3306

## Description
For some channels YouTube will return responses for the community tab that only contain continuations, currently that means you have to click the load more button a couple of times before any posts show up. This pull request detects the only continuation responses and will automatically follow the continuations until it finds one with contents and then shows that.

While we can't know for sure what exactly is happening on YouTube's side to make this occur, my guess is that it might have something to do with them filtering out posts that are only visible to channel members/sponsors.
So what I think it probably happening, is that YouTube is getting a page/chunk of posts from their database, then filtering out the member only posts and the returning the filtered page/chunk as is. So if all recent posts have been member only, that would explain the empty continuations.

"Why doesn't this issue appear on the YouTube website?"
Well it actually does but due to YouTube's autoloading behaviour relying on the continutation being in the viewport, it actually ends up autoloading more until it reaches a continuation that has contents. So similar to what this pull request does, except that this pull request does it intentionally.

## Testing <!-- for code that is not small enough to be easily understandable -->
https://youtube.com/@TheLinuxEXP/community

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 3332a40005d30bb50eb3a868ebd8337f599cedef