### PR TITLE
Hide the channel sort by dropdown when the tab isn't sortable

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -71,6 +71,9 @@ export default defineComponent({
       videoSortBy: 'newest',
       liveSortBy: 'newest',
       playlistSortBy: 'newest',
+      showVideoSortBy: true,
+      showLiveSortBy: true,
+      showPlaylistSortBy: true,
       lastSearchQuery: '',
       relatedChannels: [],
       latestVideos: [],
@@ -260,6 +263,9 @@ export default defineComponent({
       this.searchContinuationData = null
       this.communityContinuationData = null
       this.showSearchBar = true
+      this.showVideoSortBy = true
+      this.showLiveSortBy = true
+      this.showPlaylistSortBy = true
 
       if (this.hideLiveStreams && currentTab === 'live') {
         currentTab = 'videos'
@@ -628,7 +634,9 @@ export default defineComponent({
         const channel = this.channelInstance
         let videosTab = await channel.getVideos()
 
-        if (this.videoSortBy !== 'newest') {
+        this.showVideoSortBy = videosTab.filters.length > 1
+
+        if (this.showVideoSortBy && this.videoSortBy !== 'newest') {
           const index = this.videoShortLiveSelectValues.indexOf(this.videoSortBy)
           videosTab = await videosTab.applyFilter(videosTab.filters[index])
         }
@@ -684,7 +692,9 @@ export default defineComponent({
         const channel = this.channelInstance
         let liveTab = await channel.getLiveStreams()
 
-        if (this.liveSortBy !== 'newest') {
+        this.showLiveSortBy = liveTab.filters.length > 1
+
+        if (this.showLiveSortBy && this.liveSortBy !== 'newest') {
           const index = this.videoShortLiveSelectValues.indexOf(this.liveSortBy)
           liveTab = await liveTab.applyFilter(liveTab.filters[index])
         }
@@ -918,7 +928,9 @@ export default defineComponent({
           playlistsTab = await playlistsTab.applyContentTypeFilter(createdPlaylistsFilter)
         }
 
-        if (this.playlistSortBy !== 'newest' && playlistsTab.sort_filters.length > 0) {
+        this.showPlaylistSortBy = playlistsTab.sort_filters.length > 1
+
+        if (this.showPlaylistSortBy && this.playlistSortBy !== 'newest') {
           const index = this.playlistSelectValues.indexOf(this.playlistSortBy)
           playlistsTab = await playlistsTab.applySort(playlistsTab.sort_filters[index])
         }

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -277,6 +277,7 @@
         </ft-flex-box>
       </div>
       <ft-select
+        v-if="showVideoSortBy"
         v-show="currentTab === 'videos' && latestVideos.length > 0"
         class="sortSelect"
         :value="videoShortLiveSelectValues[0]"
@@ -286,7 +287,7 @@
         @change="videoSortBy = $event"
       />
       <ft-select
-        v-if="!hideLiveStreams"
+        v-if="!hideLiveStreams && showLiveSortBy"
         v-show="currentTab === 'live' && latestLive.length > 0"
         class="sortSelect"
         :value="videoShortLiveSelectValues[0]"
@@ -296,6 +297,7 @@
         @change="liveSortBy = $event"
       />
       <ft-select
+        v-if="showPlaylistSortBy"
         v-show="currentTab === 'playlists' && latestPlaylists.length > 0"
         class="sortSelect"
         :value="playlistSelectValues[0]"


### PR DESCRIPTION
# Hide the channel sort by dropdown when the tab isn't sortable

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3251

## Description
YouTube doesn't allow sorting tabs with only a few videos in them, so if we try and do it on the local API we get greeted by an error. This pull request hides the sort by dropdowns when they aren't available on YouTube.

## Screenshots <!-- If appropriate -->
![videos](https://user-images.githubusercontent.com/48293849/226115257-4ad41e40-f32a-497a-8bba-8717415b2b50.png)

![live](https://user-images.githubusercontent.com/48293849/226115260-d19a1fee-8877-46b9-b0d8-08d4580bc51c.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit these channels with the local API and make sure that the sort by dropdown is hidden if the tab only has a few videos
https://www.youtube.com/@onetv4548
https://www.youtube.com/@ShortCircuit/streams

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** cbf398e1a0fed7e650c653162de9ccba763496c4