### PR TITLE
Show message when the live chat is unavailable

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -88,8 +88,12 @@ export default defineComponent({
     } else {
       switch (this.backendPreference) {
         case 'local':
-          this.liveChatInstance = this.liveChat
-          this.startLiveChatLocal()
+          if (this.liveChat) {
+            this.liveChatInstance = this.liveChat
+            this.startLiveChatLocal()
+          } else {
+            this.showLiveChatUnavailable()
+          }
           break
         case 'invidious':
           if (this.backendFallback) {
@@ -114,9 +118,21 @@ export default defineComponent({
 
     getLiveChatLocal: async function () {
       const videoInfo = await getLocalVideoInfo(this.videoId)
-      this.liveChatInstance = videoInfo.getLiveChat()
 
-      this.startLiveChatLocal()
+      if (videoInfo.livechat) {
+        this.liveChatInstance = videoInfo.getLiveChat()
+
+        this.startLiveChatLocal()
+      } else {
+        this.showLiveChatUnavailable()
+      }
+    },
+
+    showLiveChatUnavailable: function () {
+      this.hasError = true
+      this.errorMessage = this.$t('Video["Live Chat is unavailable for this stream. It may have been disabled by the uploader."]')
+      this.isLoading = false
+      this.showEnableChat = false
     },
 
     startLiveChatLocal: function () {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -601,6 +601,7 @@ Video:
   'Live Chat is currently not supported with the Invidious API.  A direct connection to YouTube is required.': Live
     Chat is currently not supported with the Invidious API.  A direct connection to
     YouTube is required.
+  'Live Chat is unavailable for this stream. It may have been disabled by the uploader.': 'Live Chat is unavailable for this stream. It may have been disabled by the uploader.'
   Show Super Chat Comment: Show Super Chat Comment
   Scroll to Bottom: Scroll to Bottom
   Download Video: Download Video


### PR DESCRIPTION
# Show message when the live chat is unavailable

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3309

## Description
Currently if an uploader has disabled the live chat for a live stream or if it is unavailable for some other reason, FreeTube spits out an error. This pull request detects if the live chat is missing and shows a message to the user instead of spitting out an error.

## Screenshots <!-- If appropriate -->
![live-chat-unavailable](https://user-images.githubusercontent.com/48293849/226199845-c2a07c76-5247-481f-afed-1a3dfeca8ca5.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
Find a live stream on https://youtube.com/live that has the live chat disabled. (I'm not going to link specific ones, as the ones I found while reproducing the issue, will have probably ended by the time you test this pull request).

Please test with the local API, the Invidious API with backend fallback enabled and the Invidious API with backend fallback disabled, as they all function slightly differently.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0