### PR TITLE
Fix lists occasionally having the wrong layout

### DIFF
--- a/src/renderer/components/ft-element-list/ft-element-list.js
+++ b/src/renderer/components/ft-element-list/ft-element-list.js
@@ -23,19 +23,13 @@ export default defineComponent({
       default: false
     }
   },
-  data: function () {
-    return {
-      displayValue: this.display
-    }
-  },
   computed: {
     listType: function () {
       return this.$store.getters.getListType
-    }
-  },
-  mounted: function () {
-    if (this.display === '') {
-      this.displayValue = this.listType
+    },
+
+    displayValue: function () {
+      return this.display === '' ? this.listType : this.display
     }
   }
 })


### PR DESCRIPTION
# Fix lists occasionally having the wrong layout

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3322
closes #3320

## Description
The channel page has a race condition, that can occur when you rapidly switch tabs, resulting in the contents of that tab being displayed in the wrong layout. Deciding the layout in a computed property instead of the mounted lifecycle hook fixes the issue.

Switching to a computed property also has the advantage that it reacts to changes to the layout setting and will now update live if the setting is changed from another window.

## Testing <!-- for code that is not small enough to be easily understandable -->
### 1st test case
Quickly switch between various channel tabs, they should all have the correct layout. As this is a race condition, you might not notice the bug.

### 2nd test case
1. Have two FreeTube windows open, one with a channel page open and the second one with a the settings page open.
2. In the window with the settings open change between the grid and list layout types, check that the lists of videos and playlists in the second window get updated immediately (the layout of the community tab is broken when list is selected, this will be fixed in a separate pull request).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0