### PR TITLE
Hide Most Popular menu entry if the selected backend is not Invidious and backend fallback is disabled

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -35,6 +35,8 @@ class Settings {
     return {
       hideTrendingVideos: db.settings.findOne({ _id: 'hideTrendingVideos' }),
       hidePopularVideos: db.settings.findOne({ _id: 'hidePopularVideos' }),
+      backendFallback: db.settings.findOne({ _id: 'backendFallback' }),
+      backendPreference: db.settings.findOne({ _id: 'backendPreference' }),
       hidePlaylists: db.settings.findOne({ _id: 'hidePlaylists' }),
     }
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -745,6 +745,8 @@ function runApp() {
             // Update app menu on related setting update
             case 'hideTrendingVideos':
             case 'hidePopularVideos':
+            case 'backendFallback':
+            case 'backendPreference':
             case 'hidePlaylists':
               await setMenu()
               break
@@ -1081,6 +1083,8 @@ function runApp() {
     const sidenavSettings = baseHandlers.settings._findSidenavSettings()
     const hideTrendingVideos = (await sidenavSettings.hideTrendingVideos)?.value
     const hidePopularVideos = (await sidenavSettings.hidePopularVideos)?.value
+    const backendFallback = (await sidenavSettings.backendFallback)?.value
+    const backendPreference = (await sidenavSettings.backendPreference)?.value
     const hidePlaylists = (await sidenavSettings.hidePlaylists)?.value
 
     const template = [
@@ -1215,7 +1219,7 @@ function runApp() {
             },
             type: 'normal'
           },
-          !hidePopularVideos && {
+          (!hidePopularVideos && (backendFallback || backendPreference === 'invidious')) && {
             label: 'Most Popular',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/popular', browserWindow)


### PR DESCRIPTION
# Hide Most Popular menu entry if the selected backend is not Invidious and backend fallback is disabled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3325 

## Description
Currently the `Most Popular` menu entry is only hidden if the `Hide popular videos` distraction free setting is enabled, that behaviour differs from the navigation bar, which also hides it if the local API is selected in combination with backend fallback being disabled.

## Testing <!-- for code that is not small enough to be easily understandable -->
Change the backend and backend fallback settings. Ensure that the `Most Popular` entry in the `Navigate` menu is hidden when the local API is selected in combination with backend fallback being disabled and that it's visible otherwise.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0