### PR TITLE
Fix handling of `channel.subscriber.text` being `undefined`

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -54,7 +54,7 @@ export default defineComponent({
 
       this.channelName = this.data.name
       this.id = this.data.id
-      if (this.hideChannelSubscriptions || this.data.subscribers === null) {
+      if (this.hideChannelSubscriptions || this.data.subscribers == null) {
         this.subscriberCount = null
       } else {
         this.subscriberCount = this.data.subscribers.replace(/ subscriber(s)?/, '')

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -370,7 +370,7 @@ function parseListItem(item) {
       let subscribers = null
       let videos = null
       let handle = null
-      if (channel.subscribers.text.startsWith('@')) {
+      if (channel.subscribers.text?.startsWith('@')) {
         handle = channel.subscribers.text
 
         if (channel.videos.text !== 'N/A') {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
`channel.subscriber.text` can be `undefined`, the code doesn't expect that

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before fix errors:
![Screenshot 2023-03-22 at 09 56 10](https://user-images.githubusercontent.com/1018543/226784809-6e36d470-5a99-4fc3-af35-b32ef87f3568.png)
![Screenshot 2023-03-22 at 09 57 57](https://user-images.githubusercontent.com/1018543/226784821-b6030f1a-3b55-4d49-a457-5a01bb191284.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Local API
- Search for `pikachu` and filter for channels
- Ensure no error in console

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
