### PR TITLE
Fix trending video list not updated without a workaround

### DIFF
--- a/src/renderer/components/ft-element-list/ft-element-list.vue
+++ b/src/renderer/components/ft-element-list/ft-element-list.vue
@@ -4,7 +4,7 @@
   >
     <ft-list-lazy-wrapper
       v-for="(result, index) in data"
-      :key="index"
+      :key="result.type === 'video' ? `${result.videoId}-${index}` : index"
       appearance="result"
       :data="result"
       :first-screen="index < 16"

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -122,14 +122,7 @@ export default defineComponent({
       // the ft-element-list component has a bug where it doesn't change despite the data changing
       // so we need to use this hack to make vue completely get rid of it and rerender it
       // we should find a better way to do it to avoid the trending page flashing
-      this.isLoading = true
-      setTimeout(() => {
-        this.shownResults = this.trendingCache[this.currentTab]
-        this.isLoading = false
-        setTimeout(() => {
-          this.$refs[this.currentTab].focus()
-        })
-      })
+      this.shownResults = this.trendingCache[this.currentTab]
     },
     getTrendingInfoInvidious: function () {
       this.isLoading = true


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Similar "incorrect key messed up render update" issue occurred in #3289

## Description
Workaround is used to force render update when data (list of video entries) is changed
This PR makes it uses correct key to ensure render update is done without workaround
Since trending page only has videos (I assume) only video type is handled now, another PR will be created to handle all "result types"

## Screenshots <!-- If appropriate -->
Lazy!

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Test with both Local/Invidious API plz
- Go Trending Page
- Switching to all tabs to warm up result cache
- Switching to all tabs randomly/sequentially to ensure rendered video list updated 

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
