### PR TITLE
Improve community tab responsiveness

### DIFF
--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -9,6 +9,10 @@
   }
 }
 
+.ft-list-post {
+  box-sizing: border-box;
+}
+
 .circle {
   background-color: transparent;
   border-radius: 50%;

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -4,6 +4,9 @@
 .outside {
   margin: auto;
   width: 40%;
+  @media screen and (max-width: 768px) {
+    width: 100%;
+  }
 }
 
 .circle {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -7,6 +7,7 @@
 
 .channelDetails {
   padding: 0;
+  max-width: 92vw;
 }
 
 .channelBannerContainer {
@@ -239,5 +240,12 @@
   .channelSearch {
     width: 100%;
     max-width: none;
+  }
+
+  .tabs {
+    overflow-x: scroll;
+  }
+  #communityPanel {
+    margin-top: 1rem;
   }
 }


### PR DESCRIPTION
# Improve community tab responsiveness

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The community tab has a lot of margin on each side of the posts which makes the window overflow when the width is narrow. The tab headings also overflow the page in the horizontal direction. This PR aims to address this by making the community posts take up the full width of the main content area and setting the `overflow-x` of the tab headings to `scroll`.

## Screenshots <!-- If appropriate -->
|before|after|
|------|------|
|![community-tab-before](https://user-images.githubusercontent.com/106682128/226890187-2af6b39a-a7df-422c-ab47-8f17a46ae805.png)|![community-tab-after](https://user-images.githubusercontent.com/106682128/226890194-b8d49d9b-b0ba-4898-b8ef-41d1ed8fa773.png)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Navigate to a channel which has community posts
2. Click on the community tab
3. Check to see if the page overflows when shrinking the window width to below `768px`

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0

## Additional context
This is a change that I had made in my FreeTubeCordova fork about 2 weeks ago, and so, I cherry picked this change and made this PR because I feel it would also be helpful upstream. It might not be perfect. Honestly, the breakpoints could be different if that made more sense. I just picked `768` because I felt that would make the view look good on most mobile devices.
