### PR TITLE
Prevent throwing when when poll choices do not have images (Invidious API)

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -221,7 +221,7 @@ function parseInvidiousCommunityAttachments(data) {
       content: data.choices.map(choice => {
         return {
           text: choice.text,
-          image: choice.image.map(thumbnail => {
+          image: choice.image?.map(thumbnail => {
             thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
             return thumbnail
           })


### PR DESCRIPTION
# Prevent throwing when poll choices do not have images (Invidious API)

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
When using the Invidious API, if a community poll choice does not have any images attached to it, a `map` will be called on an undefined value and that causes the community tab to fail to load. This PR aims to address this by using optional chaining to prevent the `.map` call from throwing.

## Screenshots <!-- If appropriate -->
_before_
![community-polls-without-images-fail-to-load-with-invidious](https://user-images.githubusercontent.com/106682128/226898046-dbdab824-37e3-4a5e-8cef-1b101a3d675f.gif)
_after_
![community-polls-loading-without-images-in-invidious](https://user-images.githubusercontent.com/106682128/226898086-63ed9fd5-e02a-4848-9b7e-9cd76682dfe2.gif)



## Testing <!-- for code that is not small enough to be easily understandable -->
1. Make sure your backend preference is set to `Invidious API`
2. Make sure `Fallback to non-preferred backend on failure` is turned off
3. Navigate to a channel with community polls that do not contain images within their choices: (EX: https://www.youtube.com/channel/UC2bso7dShHmrlH9EzGyH-CQ)
4. Ensure no errors occur and that the community tab loads properly

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0
