### PR TITLE
Prevent `channelInstance` from being `null` in community tab fallback

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -396,160 +396,161 @@ export default defineComponent({
       this.$router.push({ path: `/channel/${id}` })
     },
 
+    getChannelInstanceLocal: async function (expectedId) {
+      const channel = await getLocalChannel(this.id)
+
+      let channelName
+      let channelThumbnailUrl
+
+      if (channel.alert) {
+        this.setErrorMessage(channel.alert)
+        return
+      } else if (channel.memo.has('ChannelAgeGate')) {
+        /** @type {import('youtubei.js/dist/src/parser/classes/ChannelAgeGate').default} */
+        const ageGate = channel.memo.get('ChannelAgeGate')[0]
+
+        channelName = ageGate.channel_title
+        channelThumbnailUrl = ageGate.avatar[0].url
+
+        this.channelName = channelName
+        this.thumbnailUrl = channelThumbnailUrl
+
+        document.title = `${channelName} - ${packageDetails.productName}`
+
+        this.updateSubscriptionDetails({ channelThumbnailUrl, channelName, channelId: this.id })
+
+        this.setErrorMessage(this.$t('Channel["This channel is age resticted and currently cannot be viewed in FreeTube."]'), true)
+        return
+      }
+
+      this.errorMessage = ''
+      if (expectedId !== this.id) {
+        return
+      }
+
+      let channelId
+      let subscriberText = null
+      let tags = []
+
+      switch (channel.header.type) {
+        case 'C4TabbedHeader': {
+          // example: Linus Tech Tips
+          // https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw
+
+          /**
+           * @type {import('youtubei.js/dist/src/parser/classes/C4TabbedHeader').default}
+           */
+          const header = channel.header
+
+          channelId = header.author.id
+          channelName = header.author.name
+          channelThumbnailUrl = header.author.best_thumbnail.url
+          subscriberText = header.subscribers?.text
+          break
+        }
+        case 'CarouselHeader': {
+          // examples: Music and YouTube Gaming
+          // https://www.youtube.com/channel/UC-9-kyTW8ZkZNDHQJ6FgpwQ
+          // https://www.youtube.com/channel/UCOpNcN46UbXVtpKMrmU4Abg
+
+          /**
+           * @type {import('youtubei.js/dist/src/parser/classes/CarouselHeader').default}
+           */
+          const header = channel.header
+
+          /**
+           * @type {import('youtubei.js/dist/src/parser/classes/TopicChannelDetails').default}
+           */
+          const topicChannelDetails = header.contents.find(node => node.type === 'TopicChannelDetails')
+          channelName = topicChannelDetails.title.text
+          subscriberText = topicChannelDetails.subtitle.text
+          channelThumbnailUrl = topicChannelDetails.avatar[0].url
+
+          if (channel.metadata.external_id) {
+            channelId = channel.metadata.external_id
+          } else {
+            channelId = topicChannelDetails.subscribe_button.channel_id
+          }
+          break
+        }
+        case 'InteractiveTabbedHeader': {
+          // example: Minecraft - Topic
+          // https://www.youtube.com/channel/UCQvWX73GQygcwXOTSf_VDVg
+
+          /**
+           * @type {import('youtubei.js/dist/src/parser/classes/InteractiveTabbedHeader').default}
+           */
+          const header = channel.header
+          channelName = header.title.text
+          channelId = this.id
+          channelThumbnailUrl = header.box_art.at(-1).url
+
+          const badges = header.badges.map(badge => badge.label).filter(tag => tag)
+          tags.push(...badges)
+          break
+        }
+      }
+
+      this.channelName = channelName
+      this.thumbnailUrl = channelThumbnailUrl
+      this.isFamilyFriendly = !!channel.metadata.is_family_safe
+
+      if (channel.metadata.tags) {
+        tags.push(...channel.metadata.tags)
+      }
+
+      // deduplicate tags
+      // a Set can only ever contain unique elements,
+      // so this is an easy way to get rid of duplicates
+      if (tags.length > 0) {
+        tags = Array.from(new Set(tags))
+      }
+      this.tags = tags
+
+      document.title = `${channelName} - ${packageDetails.productName}`
+
+      if (!this.hideChannelSubscriptions && subscriberText) {
+        const subCount = parseLocalSubscriberCount(subscriberText)
+
+        if (isNaN(subCount)) {
+          this.subCount = null
+        } else {
+          this.subCount = subCount
+        }
+      } else {
+        this.subCount = null
+      }
+
+      this.updateSubscriptionDetails({ channelThumbnailUrl, channelName, channelId })
+
+      if (channel.header.banner?.length > 0) {
+        this.bannerUrl = channel.header.banner[0].url
+      } else {
+        this.bannerUrl = null
+      }
+
+      this.relatedChannels = channel.channels.map(({ author }) => {
+        let thumbnailUrl = author.best_thumbnail.url
+
+        if (thumbnailUrl.startsWith('//')) {
+          thumbnailUrl = `https:${thumbnailUrl}`
+        }
+
+        return {
+          name: author.name,
+          id: author.id,
+          thumbnailUrl
+        }
+      })
+      return channel
+    },
+
     getChannelLocal: async function () {
       this.apiUsed = 'local'
       this.isLoading = true
       const expectedId = this.id
-
       try {
-        const channel = await getLocalChannel(this.id)
-
-        let channelName
-        let channelThumbnailUrl
-
-        if (channel.alert) {
-          this.setErrorMessage(channel.alert)
-          return
-        } else if (channel.memo.has('ChannelAgeGate')) {
-          /** @type {import('youtubei.js/dist/src/parser/classes/ChannelAgeGate').default} */
-          const ageGate = channel.memo.get('ChannelAgeGate')[0]
-
-          channelName = ageGate.channel_title
-          channelThumbnailUrl = ageGate.avatar[0].url
-
-          this.channelName = channelName
-          this.thumbnailUrl = channelThumbnailUrl
-
-          document.title = `${channelName} - ${packageDetails.productName}`
-
-          this.updateSubscriptionDetails({ channelThumbnailUrl, channelName, channelId: this.id })
-
-          this.setErrorMessage(this.$t('Channel["This channel is age resticted and currently cannot be viewed in FreeTube."]'), true)
-          return
-        }
-
-        this.errorMessage = ''
-        if (expectedId !== this.id) {
-          return
-        }
-
-        let channelId
-        let subscriberText = null
-        let tags = []
-
-        switch (channel.header.type) {
-          case 'C4TabbedHeader': {
-            // example: Linus Tech Tips
-            // https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw
-
-            /**
-             * @type {import('youtubei.js/dist/src/parser/classes/C4TabbedHeader').default}
-             */
-            const header = channel.header
-
-            channelId = header.author.id
-            channelName = header.author.name
-            channelThumbnailUrl = header.author.best_thumbnail.url
-            subscriberText = header.subscribers?.text
-            break
-          }
-          case 'CarouselHeader': {
-            // examples: Music and YouTube Gaming
-            // https://www.youtube.com/channel/UC-9-kyTW8ZkZNDHQJ6FgpwQ
-            // https://www.youtube.com/channel/UCOpNcN46UbXVtpKMrmU4Abg
-
-            /**
-             * @type {import('youtubei.js/dist/src/parser/classes/CarouselHeader').default}
-             */
-            const header = channel.header
-
-            /**
-             * @type {import('youtubei.js/dist/src/parser/classes/TopicChannelDetails').default}
-             */
-            const topicChannelDetails = header.contents.find(node => node.type === 'TopicChannelDetails')
-            channelName = topicChannelDetails.title.text
-            subscriberText = topicChannelDetails.subtitle.text
-            channelThumbnailUrl = topicChannelDetails.avatar[0].url
-
-            if (channel.metadata.external_id) {
-              channelId = channel.metadata.external_id
-            } else {
-              channelId = topicChannelDetails.subscribe_button.channel_id
-            }
-            break
-          }
-          case 'InteractiveTabbedHeader': {
-            // example: Minecraft - Topic
-            // https://www.youtube.com/channel/UCQvWX73GQygcwXOTSf_VDVg
-
-            /**
-             * @type {import('youtubei.js/dist/src/parser/classes/InteractiveTabbedHeader').default}
-             */
-            const header = channel.header
-            channelName = header.title.text
-            channelId = this.id
-            channelThumbnailUrl = header.box_art.at(-1).url
-
-            const badges = header.badges.map(badge => badge.label).filter(tag => tag)
-            tags.push(...badges)
-            break
-          }
-        }
-
-        this.channelName = channelName
-        this.thumbnailUrl = channelThumbnailUrl
-        this.isFamilyFriendly = !!channel.metadata.is_family_safe
-
-        if (channel.metadata.tags) {
-          tags.push(...channel.metadata.tags)
-        }
-
-        // deduplicate tags
-        // a Set can only ever contain unique elements,
-        // so this is an easy way to get rid of duplicates
-        if (tags.length > 0) {
-          tags = Array.from(new Set(tags))
-        }
-        this.tags = tags
-
-        document.title = `${channelName} - ${packageDetails.productName}`
-
-        if (!this.hideChannelSubscriptions && subscriberText) {
-          const subCount = parseLocalSubscriberCount(subscriberText)
-
-          if (isNaN(subCount)) {
-            this.subCount = null
-          } else {
-            this.subCount = subCount
-          }
-        } else {
-          this.subCount = null
-        }
-
-        this.updateSubscriptionDetails({ channelThumbnailUrl, channelName, channelId })
-
-        if (channel.header.banner?.length > 0) {
-          this.bannerUrl = channel.header.banner[0].url
-        } else {
-          this.bannerUrl = null
-        }
-
-        this.relatedChannels = channel.channels.map(({ author }) => {
-          let thumbnailUrl = author.best_thumbnail.url
-
-          if (thumbnailUrl.startsWith('//')) {
-            thumbnailUrl = `https:${thumbnailUrl}`
-          }
-
-          return {
-            name: author.name,
-            id: author.id,
-            thumbnailUrl
-          }
-        })
-
-        this.channelInstance = channel
-
+        const channel = await this.getChannelInstanceLocal(expectedId)
         if (channel.has_about) {
           this.getChannelAboutLocal()
         } else {
@@ -1117,7 +1118,7 @@ export default defineComponent({
     getCommunityPostsInvidious: function() {
       invidiousGetCommunityPosts(this.id).then(posts => {
         this.latestCommunityPosts = posts
-      }).catch((err) => {
+      }).catch(async (err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
         showToast(`${errorMessage}: ${err}`, 10000, () => {
@@ -1125,6 +1126,8 @@ export default defineComponent({
         })
         if (process.env.IS_ELECTRON && this.backendPreference === 'invidious' && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
+          // set local channel instance before calling community posts local
+          this.channelInstance = await this.getChannelInstanceLocal(this.id)
           this.getCommunityPostsLocal()
         }
       })


### PR DESCRIPTION
# Prevent `channelInstance` from being `null` in community tab fallback
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `getCommunityPostsLocal` uses `channelInstance`, but when it is called after the Invidious API fails inside of the `getCommunityPostsInvidious` method, the `channelInstance` is still `null`. This PR aims to address this by pulling the logic for getting a local API `channelInstance` out of the `getChannelLocal` method and into a new method called `getChannelInstanceLocal` (which is now called within `getChannelLocal`). Then, `getChannelInstanceLocal` can be called before the `getCommunityPostsLocal` inside of the `getCommunityPostsInvidious` fallback.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
_before_
![channel-instance-is-null-before](https://user-images.githubusercontent.com/106682128/226906646-7f4c977c-4309-4f4d-9453-56f0aaeb31c7.PNG)
_after_
![channel-instance-is-not-null-after](https://user-images.githubusercontent.com/106682128/226906653-a7250c67-6a02-4484-bcee-be63953b500d.PNG)


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Make sure the backend preference is set to `Invidious API`
2. Make sure `Fallback to non-preferred backend` is enabled
3. Navigate to a channel where the community posts fail to load in the Invidious API (EX: https://www.youtube.com/channel/UC2bso7dShHmrlH9EzGyH-CQ)
4. Make sure the community posts load without any Local API errors

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 0.18.0
## Additional Info
There may be better ways to accomplish this, but I felt like separating the logic for getting the local API channel instance from the `getChannelLocal` method made sense. The code still essentially functions the same for the Local API, but the structure should allow for the `channelInstance` to be set within fallbacks as well as the `getChannelLocal` method. It might make more sense to call `getChannelInstanceLocal` within `getCommunityPostsLocal` if `channelInstance` is `null`.