### PR TITLE
Fix the trending page refresh

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -626,6 +626,15 @@ const mutations = {
     state.trendingCache[page] = value
   },
 
+  clearTrendingCache(state) {
+    state.trendingCache = {
+      default: null,
+      music: null,
+      gaming: null,
+      movies: null
+    }
+  },
+
   setCachedPlaylist(state, value) {
     state.cachedPlaylist = value
   },

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -81,7 +81,12 @@ export default defineComponent({
       }
     },
 
-    getTrendingInfo: function () {
+    getTrendingInfo: function (refresh = false) {
+      if (refresh) {
+        this.trendingInstance = null
+        this.$store.commit('clearTrendingCache')
+      }
+
       if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
         this.getTrendingInfoInvidious()
       } else {
@@ -184,7 +189,7 @@ export default defineComponent({
         case 'r':
         case 'R':
           if (!this.isLoading) {
-            this.getTrendingInfo()
+            this.getTrendingInfo(true)
           }
           break
       }

--- a/src/renderer/views/Trending/Trending.vue
+++ b/src/renderer/views/Trending/Trending.vue
@@ -87,7 +87,7 @@
       class="floatingTopButton"
       :size="12"
       theme="primary"
-      @click="getTrendingInfo"
+      @click="getTrendingInfo(true)"
     />
   </div>
 </template>


### PR DESCRIPTION
# Fix the trending page refresh

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3343

## Description
Currently when you refresh the trending page, the cache doesn't get cleared, so it only refreshes the current tab and in the case of the local API it doesn't refresh it at all.
This pull request clears the cache when the user refreshes the trending tab, allowing it to work as expected.

## Testing <!-- for code that is not small enough to be easily understandable -->
Refresh the trending page, on various tabs and check that the cache is cleared for all tabs.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 86962f280298305d88848f02863161be24e86883