### PR TITLE
Update subscription view to render video as watched ASAP

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -327,6 +327,11 @@ export default defineComponent({
       return this.$i18n.locale.replace('_', '-')
     },
   },
+  watch: {
+    historyIndex() {
+      this.checkIfWatched()
+    },
+  },
   mounted: function () {
     this.parseVideoData()
     this.checkIfWatched()


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Before this change a view change (back & forth) is needed if video is watched in another window

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Subscribe some any channel
- Refresh subscription view
- Open an **unwatched** video in **new window** (middle click)
- Wait for video to play a little bit (to ensure it's marked as watched)
- Go back to last window with subscription view, ensure that video is marked as watched

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
I keep having trouble remembering which video is watched or not while I watch most videos in new windows
