### PR TITLE
Improve performance of list elements and icon buttons

### DIFF
--- a/src/renderer/components/ft-community-post/ft-community-post.js
+++ b/src/renderer/components/ft-community-post/ft-community-post.js
@@ -64,7 +64,7 @@ export default defineComponent({
       return this.$store.getters.getListType
     }
   },
-  mounted: function () {
+  created: function () {
     this.parseVideoData()
   },
   methods: {

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -74,8 +74,10 @@ export default defineComponent({
       window.addEventListener('resize', this.handleResize)
     }
   },
-  destroyed: function () {
-    window.removeEventListener('resize', this.handleResize)
+  beforeDestroy: function () {
+    if (this.dropdownModalOnMobile) {
+      window.removeEventListener('resize', this.handleResize)
+    }
   },
   methods: {
     sanitizeForHtmlId,

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -19,76 +19,78 @@
       @keydown.enter.prevent="handleIconClick"
       @keydown.space.prevent="handleIconClick"
     />
-    <ft-prompt
-      v-if="useModal"
-      v-show="dropdownShown"
-      :autosize="true"
-      :label="sanitizeForHtmlId(`iconButtonPrompt-${title}`)"
-      @click="dropdownShown = false"
+    <template
+      v-if="dropdownShown"
     >
-      <slot>
-        <ul
-          v-if="dropdownOptions.length > 0"
-          class="list"
-          role="listbox"
-          :aria-expanded="dropdownShown"
-        >
-          <li
-            v-for="(option, index) in dropdownOptions"
-            :id="sanitizeForHtmlId(title + '-' + index)"
-            :key="index"
-            role="option"
-            aria-selected="false"
-            tabindex="-1"
-            :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
-            @click="handleDropdownClick({url: option.value, index: index}, $event)"
-            @keydown.enter="handleDropdownClick({url: option.value, index: index}, $event)"
-            @keydown.space="handleDropdownClick({url: option.value, index: index}, $event)"
+      <ft-prompt
+        v-if="useModal"
+        :autosize="true"
+        :label="sanitizeForHtmlId(`iconButtonPrompt-${title}`)"
+        @click="dropdownShown = false"
+      >
+        <slot>
+          <ul
+            v-if="dropdownOptions.length > 0"
+            class="list"
+            role="listbox"
+            :aria-expanded="dropdownShown"
           >
-            {{ option.type === 'divider' ? '' : option.label }}
-          </li>
-        </ul>
-      </slot>
-    </ft-prompt>
-    <div
-      v-else
-      v-show="dropdownShown"
-      ref="dropdown"
-      tabindex="-1"
-      class="iconDropdown"
-      :class="{
-        left: dropdownPositionX === 'left',
-        right: dropdownPositionX === 'right',
-        center: dropdownPositionX === 'center',
-        bottom: dropdownPositionY === 'bottom',
-        top: dropdownPositionY === 'top'
-      }"
-      @focusout="handleDropdownFocusOut"
-    >
-      <slot>
-        <ul
-          v-if="dropdownOptions.length > 0"
-          class="list"
-          role="listbox"
-          :aria-expanded="dropdownShown"
-        >
-          <li
-            v-for="(option, index) in dropdownOptions"
-            :id="sanitizeForHtmlId(title + '-' + index)"
-            :key="index"
-            role="option"
-            aria-selected="false"
-            tabindex="-1"
-            :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
-            @click="handleDropdownClick({url: option.value, index: index}, $event)"
-            @keydown.enter="handleDropdownClick({url: option.value, index: index}, $event)"
-            @keydown.space="handleDropdownClick({url: option.value, index: index}, $event)"
+            <li
+              v-for="(option, index) in dropdownOptions"
+              :id="sanitizeForHtmlId(title + '-' + index)"
+              :key="index"
+              role="option"
+              aria-selected="false"
+              tabindex="-1"
+              :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
+              @click="handleDropdownClick({url: option.value, index: index})"
+              @keydown.enter="handleDropdownClick({url: option.value, index: index})"
+              @keydown.space="handleDropdownClick({url: option.value, index: index})"
+            >
+              {{ option.type === 'divider' ? '' : option.label }}
+            </li>
+          </ul>
+        </slot>
+      </ft-prompt>
+      <div
+        v-else
+        ref="dropdown"
+        tabindex="-1"
+        class="iconDropdown"
+        :class="{
+          left: dropdownPositionX === 'left',
+          right: dropdownPositionX === 'right',
+          center: dropdownPositionX === 'center',
+          bottom: dropdownPositionY === 'bottom',
+          top: dropdownPositionY === 'top'
+        }"
+        @focusout="handleDropdownFocusOut"
+      >
+        <slot>
+          <ul
+            v-if="dropdownOptions.length > 0"
+            class="list"
+            role="listbox"
+            :aria-expanded="dropdownShown"
           >
-            {{ option.type === 'divider' ? '' : option.label }}
-          </li>
-        </ul>
-      </slot>
-    </div>
+            <li
+              v-for="(option, index) in dropdownOptions"
+              :id="sanitizeForHtmlId(title + '-' + index)"
+              :key="index"
+              role="option"
+              aria-selected="false"
+              tabindex="-1"
+              :class="option.type === 'divider' ? 'listItemDivider' : 'listItem'"
+              @click="handleDropdownClick({url: option.value, index: index}, $event)"
+              @keydown.enter="handleDropdownClick({url: option.value, index: index}, $event)"
+              @keydown.space="handleDropdownClick({url: option.value, index: index}, $event)"
+            >
+              {{ option.type === 'divider' ? '' : option.label }}
+            </li>
+          </ul>
+        </slot>
+      </div>
+    </template>
   </div>
 </template>
 

--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -37,7 +37,7 @@ export default defineComponent({
       return this.$store.getters.getHideChannelSubscriptions
     }
   },
-  mounted: function () {
+  created: function () {
     if (this.data.dataSource === 'local') {
       this.parseLocalData()
     } else {

--- a/src/renderer/components/ft-list-playlist/ft-list-playlist.js
+++ b/src/renderer/components/ft-list-playlist/ft-list-playlist.js
@@ -45,7 +45,7 @@ export default defineComponent({
       return this.$store.getters.getDefaultPlayback
     }
   },
-  mounted: function () {
+  created: function () {
     if (this.data.dataSource === 'local') {
       this.parseLocalData()
     } else {

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -99,7 +99,7 @@ export default defineComponent({
     inHistory: function () {
       // When in the history page, showing relative dates isn't very useful.
       // We want to show the exact date instead
-      return this.$router.currentRoute.name === 'history'
+      return this.$route.name === 'history'
     },
 
     invidiousUrl: function () {
@@ -152,15 +152,14 @@ export default defineComponent({
     },
 
     dropdownOptions: function () {
-      const options = []
-      options.push(
+      const options = [
         {
           label: this.watched
             ? this.$t('Video.Remove From History')
             : this.$t('Video.Mark As Watched'),
           value: 'history'
         }
-      )
+      ]
       if (!this.hideSharingActions) {
         options.push(
           {
@@ -295,9 +294,9 @@ export default defineComponent({
 
     displayTitle: function () {
       if (this.showDistractionFreeTitles) {
-        return toDistractionFreeTitle(this.data.title)
+        return toDistractionFreeTitle(this.title)
       } else {
-        return this.data.title
+        return this.title
       }
     },
 
@@ -327,7 +326,7 @@ export default defineComponent({
       return this.$i18n.locale.replace('_', '-')
     },
   },
-  mounted: function () {
+  created: function () {
     this.parseVideoData()
     this.checkIfWatched()
   },


### PR DESCRIPTION
# Improve performance of list elements and icon buttons

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Performance improvement

## Description
_Sorry in advance for the wall of text 🫂_

This pull request improves the initial creation performance of list elements (`ft-list-video`, `ft-list-channel`, `ft-list-playlist`) and `ft-icon-button`. Take a look at the screenshots below to see the before and after times for the list items and icon buttons, please keep in mind that the number will differ depending on your machine and what else it is currently doing, however on any machine the after numbers should be smaller than the before ones.

The biggest changes in this pull request are the following two things:

### 1. Move the data parsing in the list elements from the `mounted` hook to the `created` hook

The mounted hook is called after the component has been created, rendered and the initial DOM changes have been made.
The created hook on the other hand is called after the component instance has been created, the props are available and reactivity has been setup, before any rendering is done.

As we are currently parsing the data in the mounted hook, that means Vue first creates creates "empty" DOM elements and then later after it detects the changes to the data made by the parsing, it triggers an update, rerenders the element and changes the elements in the DOM to contain the data.

Moving the parsing to the created hook means that when Vue goes to render the component for the first time, all of the data needed for rendering is already available, so it can render it with the data and doesn't need the update (updates will still happen if the data changes, e.g. video is favourited or watched). This also means that the ft-icon-buttons don't need to get updated either.

### 2. Create the ft-icon-button dropdowns when they are needed

How often do you actually use the 3 dots dropdown on ft-list-videos? Probably not very often and when you do, you probably only do it on a few of them in the list and don't touch most of them.

Currently the ft-icon-button dropdowns are always generated and then hidden and shown with CSS (using `v-show` to toggle `display: none`). By switching to v-if, we only create them when the ft-icon-button is activated (by mouse or keyboard), which speeds up the intial load and also saves work creating dropdowns that might never be used. At the moment even for icon buttons without a dropdown and empty dropdown div is created.

## Screenshots <!-- If appropriate -->
<details><summary><b>ft-list-video</b></summary>

![list-video-before](https://user-images.githubusercontent.com/48293849/227721878-f70a5302-22ac-47af-a1f4-253208b53de5.png)
![list-video-after](https://user-images.githubusercontent.com/48293849/227721880-b4221d88-8a25-4b7a-8a7a-f8497a0c3f85.png)

</details>

<details><summary><b>ft-list-video</b></summary>

![icon-button-before](https://user-images.githubusercontent.com/48293849/227724180-1b3167d9-1a14-4afb-adfa-dba0d955d8e6.png)
![icon-button-after](https://user-images.githubusercontent.com/48293849/227724183-67dd4b0f-2859-4e4e-99b7-97363b06ad21.png)

</details>

## Testing <!-- for code that is not small enough to be easily understandable -->

To get the most repeatable results, these tests were performed on an fresh FreeTube setup by deleting the database files in the development data folder `%appdata%/Electron` before testing. That way we avoid any extra random delays that come into play when you have favourites and history (the delays will vary depending on how many history and saved items you have, as well as where the videos are in those lists, if they are in there at all).
Additionally I made sure to use a small enough window size `1186x761px`, just big enough to fit 6 videos inside the visible area of the screen (while the devtools are open, resizing a window will make the dimensions show up in the top right for a short moment), to avoid lazy loaded items making the results unpredictable (the first 16 items are always loaded, if you scroll down or have a large window size, other items get lazy loaded in later).

The first step is to make the vue devtools show up, you can do this by going to `node_modules\vue-devtools\lib\index.js` and changing line 5 (that dependency hasn't received an update in ages and Electron now requires an absolute path to the extension):

```diff
- const extPath = path.join(__dirname, '..', 'vender')
+ const extPath = path.resolve(path.join(__dirname, '..', 'vender'))
```
yarn will undo those changes the next time you use `yarn install`, `yarn add`, `yarn remove` and friends, commands like `yarn dev` don't make any changes to the dependencies, so they won't cause yarn to reset the vue-devtools package.

Now to the actual testing:

1. Start FreeTube with `yarn dev` (I recommend closing FreeTube between test runs, so that you get the "worst case" scenario, without giving V8 a chance to do JIT optimisations, which will result in faster numbers which will skew your results)
2. Click on the trending tab (we want to preload the trending cache)
3. Click back to the subscriptions tab
4. Start the Vue performance test/measuring
4.1. In the devtools go to the `Vue` tab
4.2. Inside that click on the `Performance` tab (has a bar graph icon, if you hover over the icon it says `Switch to Performance`)
4.3. Switch to `Component render`
4.4. Click `Start`
5. Click on the trending tab
6. Wait until it's loaded and the component list in the devtools has stopped changing
7. Click `Stop` on the performance test

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 3a997fa569bb7337a456a85459989f76b25223c1