### PR TITLE
Fix live premieres being treated as non-live videos

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -264,7 +264,7 @@ export default defineComponent({
     },
 
     publishedString() {
-      if (this.isLiveContent && this.isLive) {
+      if (this.isLive) {
         return this.$t('Video.Started streaming on')
       } else if (this.isLiveContent && !this.isLive) {
         return this.$t('Video.Streamed on')

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -383,7 +383,7 @@ export default defineComponent({
 
         this.videoChapters = chapters
 
-        if (!this.hideLiveChat && this.isLive && this.isLiveContent && result.livechat) {
+        if (!this.hideLiveChat && this.isLive && result.livechat) {
           this.liveChat = result.getLiveChat()
         } else {
           this.liveChat = null
@@ -396,7 +396,7 @@ export default defineComponent({
           result = bypassedResult
         }
 
-        if ((this.isLive && this.isLiveContent) && !this.isUpcoming) {
+        if (this.isLive && !this.isUpcoming) {
           try {
             const formats = await getFormatsFromHLSManifest(result.streaming_data.hls_manifest_url)
 


### PR DESCRIPTION
# Fix live premieres being treated as non-live videos

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes  #3310

## Description
Currently we detect live videos on the watch page by checking isLive and isLiveContent, that is fine for normal live streams but for currently live premiere videos, the isLiveContent property is set to false. That caused live premiere videos to be treated as normal videos, causing errors.
I've now switched the check to just isLive. isLiveContent is still useful for detecting live stream replays, which we use to show a "streamed on x" text instead of "published on x" text.

Another way to look at it, is that anything with isLive and isLiveContent set to true, is being streamed from somewhere to YouTube and then to you, anything with isLive set to true but isLiveContent set to false, is already entirely on YouTube's servers so it's only getting streamed from YouTube to you.

## Testing <!-- for code that is not small enough to be easily understandable -->
Find a stream on https://www.youtube.com/@live (click on the live header to see all of them that are currently live) that is live but is marked as premiere (scrolling down to load more and CTRL+F is your friend), you may have to use the 3 dots menu in the top right of the website to change location if there aren't any listed for your current location.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** de65e504c9fc47bc7211a7124b838800cabb06c3