### PR TITLE
Remove empty translation strings at build time

### DIFF
--- a/_scripts/ProcessLocalesPlugin.js
+++ b/_scripts/ProcessLocalesPlugin.js
@@ -44,6 +44,8 @@ class ProcessLocalesPlugin {
                 delete data['Locale Name']
               }
 
+              this.removeEmptyValues(data)
+
               let filename = `${this.outputDir}/${locale}.json`
               let output = JSON.stringify(data)
 
@@ -91,6 +93,25 @@ class ProcessLocalesPlugin {
         [constants.BROTLI_PARAM_SIZE_HINT]: buffer.byteLength
       }
     })
+  }
+
+  /**
+   * vue-i18n doesn't fallback if the translation is an empty string
+   * so we want to get rid of them and also remove the empty objects that can get left behind
+   * if we've removed all the keys and values in them
+   * @param {object|string} data
+   */
+  removeEmptyValues(data) {
+    for (const key of Object.keys(data)) {
+      const value = data[key]
+      if (typeof value === 'object') {
+        this.removeEmptyValues(value)
+      }
+
+      if (!value || (typeof value === 'object' && Object.keys(value).length === 0)) {
+        delete data[key]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# Remove empty translation strings at build time

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3359

## Description
vue-i18n doesn't fallback to en-US if a translation contains an empty string, it does correctly fallback if the translation does exist at all.
Some language files have a lot of empty strings, unfortunately weblate seems to have added those empty strings, so if we remove them in the files, it's possible that weblate will just add them back. Instead I decided to remove them at build time, that way even if weblate adds more empty strings in the future, we won't be affected by it.

## Testing <!-- for code that is not small enough to be easily understandable -->
Set the FreeTube language to español (Argentina)/`es_AR`, instead of loads of things being unlabelled, they should have the en-US strings.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 94f21f293d8f1a23c48a31b0bf242ef7b029e833