### PR TITLE
Fix the invalid syntax that weblate introduced to the language files

### DIFF
--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -289,10 +289,6 @@ Video:
     Video ID: ''
     Volume: ''
     Mimetype: ''
-#& Videos
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   View Full Playlist: ''

--- a/static/locales/bn.yaml
+++ b/static/locales/bn.yaml
@@ -186,10 +186,6 @@ Video:
     Months: ''
     Upcoming: ''
   Publicationtemplate: ''
-#& Videos
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Videos: ''

--- a/static/locales/es_AR.yaml
+++ b/static/locales/es_AR.yaml
@@ -327,9 +327,6 @@ Video:
   translated from English: traducido del inglés
   Stats:
     Mimetype: Tipo de medio
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Videos: ''

--- a/static/locales/gsw.yaml
+++ b/static/locales/gsw.yaml
@@ -118,7 +118,6 @@ Settings:
         Empty File Name: ''
   External Player Settings:
     Custom External Player Executable: ''
-    Players: {}
   Privacy Settings:
     Remember History: ''
     Are you sure you want to clear out your search cache?: ''

--- a/static/locales/ka.yaml
+++ b/static/locales/ka.yaml
@@ -343,10 +343,6 @@ Video:
     Video ID: ''
     Volume: ''
     Mimetype: ''
-#& Videos
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   View Full Playlist: ''

--- a/static/locales/km.yaml
+++ b/static/locales/km.yaml
@@ -170,10 +170,6 @@ Video:
     Video ID: ''
     Volume: ''
     Mimetype: ''
-#& Videos
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   View Full Playlist: ''

--- a/static/locales/ne.yaml
+++ b/static/locales/ne.yaml
@@ -222,9 +222,6 @@ Video:
     Unsupported Actions:
       setting a playback rate: ''
       shuffling playlists: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Playlist: ''

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -444,9 +444,6 @@ Video:
     Month: ''
     Ago: ''
   Started streaming on: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   View Full Playlist: ''

--- a/static/locales/ti.yaml
+++ b/static/locales/ti.yaml
@@ -104,7 +104,6 @@ Settings:
   External Player Settings:
     External Player Settings: ''
     Custom External Player Arguments: ''
-    Players: {}
   Privacy Settings:
     Save Watched Progress: ''
     Are you sure you want to clear out your search cache?: ''
@@ -260,7 +259,6 @@ Hashtags have not yet been implemented, try again later: ''
 Shuffle is now enabled: ''
 Playing Next Video Interval: ''
 'The playlist has ended.  Enable loop to continue playing': ''
-Age Restricted: {}
 External link opening has been disabled in the general settings: ''
 Screenshot Success: ''
 Ok: ''

--- a/static/locales/tig.yaml
+++ b/static/locales/tig.yaml
@@ -89,7 +89,6 @@ Settings:
         Forbidden Characters: ''
   External Player Settings:
     Ignore Unsupported Action Warnings: ''
-    Players: {}
   Privacy Settings:
     Privacy Settings: ''
     Automatically Remove Video Meta Files: ''
@@ -202,9 +201,6 @@ Video:
     Video statistics are not available for legacy videos: ''
     Bitrate: ''
     Dropped / Total Frames: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Playlist: ''

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -224,9 +224,6 @@ Video:
       shuffling playlists: ''
   Stats:
     Bandwidth: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Videos: ''


### PR DESCRIPTION
# Fix the invalid syntax that weblate introduced to the language files

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
When we enabled the remove empty strings plugin in weblate it decided to instead only remove some of the empty strings and also add invalid yaml syntax to our translation files, this pull request fixes those syntax errors.

This fixes the CI builds as well as local ones with `yarn dev` or `yarn build`.

https://github.com/FreeTubeApp/FreeTube/actions/runs/4601470434/jobs/8129360140#step:11:14

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn dev` it shouldn't produce any errors