### PR TITLE
Reset current chapter index when changing videos

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -195,6 +195,7 @@ export default defineComponent({
       this.videoStoryboardSrc = ''
       this.captionHybridList = []
       this.downloadLinks = []
+      this.videoCurrentChapterIndex = 0
 
       this.checkIfPlaylist()
       this.checkIfTimestamp()


### PR DESCRIPTION
# Reset current chapter index when changing videos

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3386

## Description
Currently the property on the watch page tracking the current chapter doesn't get reset when you switch to a new video. That can cause issues in some cases like in the issue linked above, causing the chapters component to break and spam the console with errors. This could probably also be fixed some other way by adjusting the chapters logic but resetting the property is a much easier fix.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open this playlist: https://youtube.com/playlist?list=PLieFcZgde9z-SDwkG-US6oRknDGNK0U7l
2. Click on the fifth video: "Have you ever dropped your phone into a lake?"
3. Seek to just before the end (or you can watch the whole video if you really want to)
4. Wait for it to start playing the next video
5. No error spam in the console

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 28b587ebeff06db81e2c4d81dbc5aba9e1f71462