### PR TITLE
Small community post fixes

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -159,7 +159,9 @@ export async function invidiousGetCommunityPosts(channelId) {
 
 function parseInvidiousCommunityData(data) {
   return {
-    postText: data.contentHtml,
+    // use #/ to support channel YT links.
+    // ex post: https://www.youtube.com/post/UgkxMpGt1SVlHwA1afwqDr2DZLn-hmJJQqKo
+    postText: data.contentHtml.replaceAll('href="/', 'href="#/'),
     postId: data.commentId,
     authorThumbnails: data.authorThumbnails.map(thumbnail => {
       thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
@@ -179,6 +181,15 @@ function parseInvidiousCommunityAttachments(data) {
     return null
   }
 
+  // I've only seen this appear when a video was made private.
+  // This is not currently supported on local api.
+  if (data.error) {
+    return {
+      type: 'error',
+      message: data.error
+    }
+  }
+
   if (data.type === 'image') {
     return {
       type: data.type,
@@ -190,7 +201,7 @@ function parseInvidiousCommunityAttachments(data) {
   }
 
   if (data.type === 'video') {
-    data.videoThumbnails = data.videoThumbnails.map(thumbnail => {
+    data.videoThumbnails = data.videoThumbnails?.map(thumbnail => {
       thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
       return thumbnail
     })

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -685,7 +685,7 @@ export function parseLocalCommunityPost(post) {
   }
 
   return {
-    postText: post.content.text === 'N/A' ? '' : post.content.text,
+    postText: post.content.text === 'N/A' ? '' : Autolinker.link(parseLocalTextRuns(post.content.runs, 16)),
     postId: post.id,
     authorThumbnails: post.author.thumbnails,
     publishedText: post.published.text,

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -679,7 +679,7 @@ export function parseLocalSubscriberCount(text) {
  * @param {import('youtubei.js/dist/src/parser/classes/BackstagePost').default} post
  */
 export function parseLocalCommunityPost(post) {
-  let replyCount = post.action_buttons.reply_button?.text ?? null
+  let replyCount = post.action_buttons?.reply_button?.text ?? null
   if (replyCount !== null) {
     replyCount = parseLocalSubscriberCount(post?.action_buttons.reply_button.text)
   }


### PR DESCRIPTION
# Small community post fixes

## Pull Request Type
- [x] Bugfix

## Related issue
closes #3387

## Description
- render text runs (links, mentions, bold, strikethrough, emojis etc.)   - local (https://www.youtube.com/channel/UCX6OQ3DkcsbYNE6H8uQQuVA/community 2nd post)
- fix broken mention links - invidious ( https://www.youtube.com/channel/UCX6OQ3DkcsbYNE6H8uQQuVA/community 2nd post)
- fix error when a video attachment is privated - invidious (https://www.youtube.com/channel/UCxMMA6NjRPaVH52iGRe7VpA 1st post)
- fix error when action button is missing - local (https://www.youtube.com/channel/UCF3D1D3RL6z8QJzgc6dtQRg)

## Testing 
Try above links 

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0