### PR TITLE
Add 50fps and live support to frame by frame keyboard shortcuts

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -158,6 +158,7 @@ export async function getFormatsFromHLSManifest(manifestUrl) {
 
   const formats = []
   let currentHeight = 0
+  let currentFPS = 0
 
   for (const line of lines) {
     if (line.startsWith('#')) {
@@ -165,14 +166,17 @@ export async function getFormatsFromHLSManifest(manifestUrl) {
         continue
       }
 
-      const height = line
-        .split(',')
-        .find(part => part.startsWith('RESOLUTION'))
+      const parts = line.split(',')
+      const height = parts.find(part => part.startsWith('RESOLUTION'))
         .split('x')[1]
+      const fps = parts.find(part => part.startsWith('FRAME-RATE'))
+        .split('=')[1]
       currentHeight = parseInt(height)
+      currentFPS = parseInt(fps)
     } else {
       formats.push({
         height: currentHeight,
+        fps: currentFPS,
         url: line.trim()
       })
     }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -408,6 +408,7 @@ export default defineComponent({
               .map((format) => {
                 return {
                   url: format.url,
+                  fps: format.fps,
                   type: 'application/x-mpegURL',
                   label: 'Dash',
                   qualityLabel: `${format.height}p`


### PR DESCRIPTION
# Add 50fps and live support to frame by frame keyboard shortcuts

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
This pull request refactors the frame by frame code to support videos that have framerates other than 60 or 30 and adds support for live streams too. Additionally I was able to get rid of the part where it read the DASH manifest from the disk, so it should now work properly in the web (and cordova if someone has a keyboard hooked up to their phone) builds too.

Live streams seem to be broken for Invidious at the moment, so I wasn't able to test if my changes work for that (the HLS manifests provided by Invidious return 429 errors for all live streams and instances I tried).

## Testing <!-- for code that is not small enough to be easily understandable -->

**Unfortunately live streams don't seem to be working with Invidious at the moment and always return 429 errors for the HLS manifests, so that test can't be done with the Invidious API enabled, all others can.**

50/25fps https://youtu.be/U4DVfOmcwuk
60/30fps https://youtu.be/HJDMo__4JAg
30fps https://youtu.be/g7oNuP83VXs
live 30fps (144p is 15fps) https://youtu.be/jfKfPfyJRdk

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** bc039cd1aa0ea7578a49ff57051a1049d903907e