### PR TITLE
Fix video comment external link parsing for local API

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -527,7 +527,7 @@ export function parseLocalTextRuns(runs, emojiSize = 16, options = { looseChanne
             break
           case 'WEB_PAGE_TYPE_UNKNOWN':
           default: {
-            const url = new URL(endpoint.payload.url)
+            const url = new URL(endpoint.payload?.content?.confirmDialogRenderer?.confirmButton?.buttonRenderer?.command?.urlEndpoint?.url || endpoint.payload.url)
             if (url.hostname === 'www.youtube.com' && url.pathname === '/redirect' && url.searchParams.has('q')) {
               // remove utm tracking parameters
               const realURL = new URL(url.searchParams.get('q'))


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
There is an error when parsing a "run" (part of a comment) from local API 
> `endpoint.payload.url` is `undefined`

This PR fixes it

## Screenshots <!-- If appropriate -->
Comment to be parsed
![image](https://user-images.githubusercontent.com/1018543/232938686-05147ab2-be86-4d05-b4ae-7570fca3aaf8.png)

Actual `run` object from Youtubei.js
![image](https://user-images.githubusercontent.com/1018543/232938494-ecf6dc42-553a-4a01-a787-1e9284e51cad.png)
![image](https://user-images.githubusercontent.com/1018543/232938506-1d1b2682-35e0-46b7-845e-49f550beac12.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- View https://www.youtube.com/watch?v=eBZ2vA9D2RA&list=PLzFTGYa_evXiOHCB_cb1Sqsk-LIARmLgd
- View comment, change sort to latest (should load the comment in screenshot)
- Ensure no error in console


## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
