### PR TITLE
Prevent loading forever in live chat in non-electron builds

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -85,6 +85,7 @@ export default defineComponent({
     if (!process.env.IS_ELECTRON) {
       this.hasError = true
       this.errorMessage = this.$t('Video["Live Chat is currently not supported in this build."]')
+      this.isLoading = false
     } else {
       switch (this.backendPreference) {
         case 'local':


### PR DESCRIPTION
# Prevent loading forever in live chat in non-electron builds

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
MarmadileManteater/FreeTubeCordova#151

## Description
In the created hook of the `watch-video-live-chat` component, the `isLoading` flag is never set to `false` when `process.env.IS_ELECTRON` is `false`. The result is that the component appears to be loading forever, and never displays the appropriate message: "Live Chat is currently not supported in this build" in non-electron builds.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/106682128/232941522-956f85df-acab-4b8a-a244-cf143c67a203.png)|![image](https://user-images.githubusercontent.com/106682128/232941416-a0d41f98-67cf-4f39-b10a-cc4f60125996.png)|
## Testing <!-- for code that is not small enough to be easily understandable -->
1. `yarn dev:web`
2. Navigate to a live video with a chat. EX: https://youtu.be/jfKfPfyJRdk
3. Ensure that the live chat displays the message "Live Chat is currently not supported in this build."

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
 - FreeTube version: 92d969ba3fdfbf5755537b4f99c75c4c66a4a64a
