### PR TITLE
Fix thumbnail URL for protocol-relative URLs

### DIFF
--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -162,16 +162,20 @@ export default defineComponent({
 
     thumbnailURL: function(originalURL) {
       let newURL = originalURL
-      const hostname = new URL(originalURL).hostname
+      // Sometimes relative protocol URLs are passed in
+      if (originalURL.startsWith('//')) {
+        newURL = `https:${originalURL}`
+      }
+      const hostname = new URL(newURL).hostname
       if (hostname === 'yt3.ggpht.com' || hostname === 'yt3.googleusercontent.com') {
         if (this.backendPreference === 'invidious') { // YT to IV
-          newURL = youtubeImageUrlToInvidious(originalURL, this.currentInvidiousInstance)
+          newURL = youtubeImageUrlToInvidious(newURL, this.currentInvidiousInstance)
         }
       } else {
         if (this.backendPreference === 'local') { // IV to YT
-          newURL = originalURL.replace(this.re.ivToYt, `${this.ytBaseURL}/$1`)
+          newURL = newURL.replace(this.re.ivToYt, `${this.ytBaseURL}/$1`)
         } else { // IV to IV
-          newURL = invidiousImageUrlToInvidious(originalURL, this.currentInvidiousInstance)
+          newURL = invidiousImageUrlToInvidious(newURL, this.currentInvidiousInstance)
         }
       }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Sometimes the original thumbnail URLs are protocol-relative URLs, FT raises error since `URL` complains about this kind of URLs
This PR fixes it

## Screenshots <!-- If appropriate -->
![Screenshot 2023-04-20 at 09 10 52](https://user-images.githubusercontent.com/1018543/233236396-733c8230-07de-4515-ae22-57473ae3c1f3.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Subscribe to https://www.youtube.com/channel/UC4R8DWoMoI7CAwX8_LjQHig
- Visit Channels View
- Ensure no error in console, list of channels displayed

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
