### PR TITLE
Update video list display & watch page to not use stored watch progress when progress saving disabled

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -499,7 +499,10 @@ export default defineComponent({
 
       if (historyIndex !== -1) {
         this.watched = true
-        this.watchProgress = this.historyCache[historyIndex].watchProgress
+        if (this.saveWatchedProgress) {
+          // For UX consistency, no progress reading if writing disabled
+          this.watchProgress = this.historyCache[historyIndex].watchProgress
+        }
 
         if (this.historyCache[historyIndex].published !== '') {
           const videoPublished = this.historyCache[historyIndex].published

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -944,7 +944,8 @@ export default defineComponent({
           } else {
             this.$refs.videoPlayer.player.currentTime(this.timestamp)
           }
-        } else if (historyIndex !== -1) {
+        } else if (this.saveWatchedProgress && historyIndex !== -1) {
+          // For UX consistency, no progress reading if writing disabled
           const watchProgress = this.historyCache[historyIndex].watchProgress
 
           if (watchProgress < (this.videoLengthSeconds - 10)) {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I had `Save Watched Progress` enabled and played many videos
Disabled afterward and found it annoying to sometimes having videos starting on saved play progress instead of from the beginning
This PR ensures every video starts from the beginning when `Save Watched Progress` disabled, and updated progress display to not show any saved play progress in list view

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Before: 
![image](https://user-images.githubusercontent.com/1018543/233284872-bbefc607-c205-4a94-aac3-d68713463bcf.png)

After:
![image](https://user-images.githubusercontent.com/1018543/233284819-cfd1adc0-7163-4e0d-8566-28ad7689b35f.png)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Enable `Save Watched Progress`
- Play any video, jump to any time in the middle
- Go back to history view, ensure progress is shown
- Play it again, ensure play progress is restored (start from where you left)
- Disable `Save Watched Progress`
- Go back to history view, ensure progress is NOT shown
- Play it again, ensure play progress is NOT restored

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
