### PR TITLE
Fix extracting chapters with handles from description

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -368,7 +368,7 @@ export default defineComponent({
               })
             }
           } else {
-            chapters = this.extractChaptersFromDescription(this.videoDescription)
+            chapters = this.extractChaptersFromDescription(result.basic_info.short_description)
           }
 
           if (chapters.length > 0) {


### PR DESCRIPTION
# Fix extracting chapters with handles from description

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
If YouTube doesn't provide chapters, we extract them from the description, for the local API we do it on the already parsed text runs, that means it can contain HTML. So if a creator uses channel handles in their chapters, we display the raw HTML for the links to the user (see first screenshot). This pull request instead extracts it from the text description, avoiding the problem.

Note: This doesn't affect the Invidious API as we already use the text description to extract the chapters.

## Screenshots <!-- If appropriate -->
![before](https://user-images.githubusercontent.com/48293849/233482339-d39dfb1b-3110-47b4-a27b-19a286411829.png)

![after](https://user-images.githubusercontent.com/48293849/233482362-5aa3484f-ca57-4c3b-9034-22d6dcce46af.png)

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/watch?v=t1v050SqcD8

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 3597499df133348628a921a0ef7d05a2ef676b5f