### PR TITLE
IV: Allow fetching more community posts

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -145,16 +145,21 @@ function parseInvidiousCommentData(response) {
   })
 }
 
-export async function invidiousGetCommunityPosts(channelId) {
+export async function invidiousGetCommunityPosts(channelId, continuation = null) {
   const payload = {
     resource: 'channels',
     id: channelId,
-    subResource: 'community'
+    subResource: 'community',
+    params: {}
+  }
+
+  if (continuation) {
+    payload.params.continuation = continuation
   }
 
   const response = await invidiousAPICall(payload)
   response.comments = response.comments.map(communityPost => parseInvidiousCommunityData(communityPost))
-  return response.comments
+  return { posts: response.comments, continuation: response.continuation ?? null }
 }
 
 function parseInvidiousCommunityData(data) {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1123,8 +1123,18 @@ export default defineComponent({
     },
 
     getCommunityPostsInvidious: function() {
-      invidiousGetCommunityPosts(this.id).then(posts => {
-        this.latestCommunityPosts = posts
+      let more = false
+      if (this.communityContinuationData) {
+        more = true
+      }
+
+      invidiousGetCommunityPosts(this.id, this.communityContinuationData).then(({ posts, continuation }) => {
+        if (more) {
+          this.latestCommunityPosts.push(...posts)
+        } else {
+          this.latestCommunityPosts = posts
+        }
+        this.communityContinuationData = continuation
       }).catch(async (err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -1267,8 +1277,7 @@ export default defineComponent({
               this.getCommunityPostsLocalMore()
               break
             case 'invidious':
-              // not supported by invidious yet...
-              // this.getCommunityPostsInvidiousMore()
+              this.getCommunityPostsInvidious()
               break
           }
           break


### PR DESCRIPTION
# IV: Allow fetching more community posts

## Pull Request Type
- [x] Feature Implementation

## Related issue
Relies on https://github.com/iv-org/invidious/pull/3761 (tested with an invidious docker instance)

## Description
This pull request makes it possible to fetch more community posts while using the Invidious API

## Testing 
- switch to invidious api (turn off fallback)
- Navigate to https://www.youtube.com/channel/UC-lHJZR3Gqxm24_Vd_AJ5Yw/community
- scroll down
- click Fetch more results
- See more posts

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
