### PR TITLE
Create Subscribe Button reusable component

### DIFF
--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
@@ -1,0 +1,123 @@
+import Vue from 'vue'
+import { mapActions } from 'vuex'
+
+import FtButton from '../../components/ft-button/ft-button.vue'
+
+import { MAIN_PROFILE_ID } from '../../../constants'
+import { showToast } from '../../helpers/utils'
+
+export default Vue.extend({
+  name: 'FtSubscribeButton',
+  components: {
+    'ft-button': FtButton
+  },
+  props: {
+    channelId: {
+      type: String,
+      required: true
+    },
+    channelName: {
+      type: String,
+      required: true
+    },
+    channelThumbnail: {
+      type: String,
+      required: true
+    },
+    subscriptionCountText: {
+      default: '',
+      type: String,
+      required: false
+    }
+  },
+  computed: {
+    profileList: function () {
+      return this.$store.getters.getProfileList
+    },
+
+    activeProfile: function () {
+      return this.$store.getters.getActiveProfile
+    },
+
+    subscriptionInfo: function () {
+      return this.activeProfile.subscriptions.find((channel) => {
+        return channel.id === this.channelId
+      }) ?? null
+    },
+
+    isSubscribed: function () {
+      return this.subscriptionInfo !== null
+    },
+
+    subscribedText: function () {
+      let subscribedValue = (this.isSubscribed ? this.$t('Channel.Unsubscribe') : this.$t('Channel.Subscribe')).toUpperCase()
+      if (this.subscriptionCountText !== '') {
+        subscribedValue += ' ' + this.subscriptionCountText
+      }
+      return subscribedValue
+    }
+
+  },
+  methods: {
+    handleSubscription: function () {
+      if (this.channelId === '') {
+        return
+      }
+
+      const currentProfile = JSON.parse(JSON.stringify(this.activeProfile))
+      const primaryProfile = JSON.parse(JSON.stringify(this.profileList[0]))
+
+      if (this.isSubscribed) {
+        currentProfile.subscriptions = currentProfile.subscriptions.filter((channel) => {
+          return channel.id !== this.channelId
+        })
+
+        this.updateProfile(currentProfile)
+        showToast(this.$t('Channel.Channel has been removed from your subscriptions'))
+
+        if (this.activeProfile._id === MAIN_PROFILE_ID) {
+          // Check if a subscription exists in a different profile.
+          // Remove from there as well.
+          let duplicateSubscriptions = 0
+
+          this.profileList.forEach((profile) => {
+            if (profile._id === MAIN_PROFILE_ID) {
+              return
+            }
+            duplicateSubscriptions += this.unsubscribe(profile, this.channelId)
+          })
+
+          if (duplicateSubscriptions > 0) {
+            const message = this.$t('Channel.Removed subscription from {count} other channel(s)', { count: duplicateSubscriptions })
+            showToast(message)
+          }
+        }
+      } else {
+        const subscription = {
+          id: this.channelId,
+          name: this.channelName,
+          thumbnail: this.channelThumbnail
+        }
+        currentProfile.subscriptions.push(subscription)
+
+        this.updateProfile(currentProfile)
+        showToast(this.$t('Channel.Added channel to your subscriptions'))
+
+        if (this.activeProfile._id !== MAIN_PROFILE_ID) {
+          const index = primaryProfile.subscriptions.findIndex((channel) => {
+            return channel.id === this.channelId
+          })
+
+          if (index === -1) {
+            primaryProfile.subscriptions.push(subscription)
+            this.updateProfile(primaryProfile)
+          }
+        }
+      }
+    },
+
+    ...mapActions([
+      'updateProfile'
+    ])
+  }
+})

--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.scss
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.scss
@@ -1,0 +1,6 @@
+.subscribeButton {
+  align-self: center;
+  height: 50%;
+  margin-bottom: 10px;
+  min-width: 150px;
+}

--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.vue
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.vue
@@ -1,0 +1,12 @@
+<template>
+  <ft-button
+    :label="subscribedText"
+    class="subscribeButton"
+    background-color="var(--primary-color)"
+    text-color="var(--text-with-main-color)"
+    @click="handleSubscription"
+  />
+</template>
+
+<script src="./ft-subscribe-button.js" />
+<style scoped src="./ft-subscribe-button.scss" lang="scss" />

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -4,7 +4,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtButton from '../ft-button/ft-button.vue'
 import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
 import FtShareButton from '../ft-share-button/ft-share-button.vue'
-import { MAIN_PROFILE_ID } from '../../../constants'
+import FtSubscribeButton from '../ft-subscribe-button/ft-subscribe-button.vue'
 import { formatNumber, openExternalLink, showToast } from '../../helpers/utils'
 
 export default defineComponent({
@@ -13,7 +13,8 @@ export default defineComponent({
     'ft-card': FtCard,
     'ft-button': FtButton,
     'ft-icon-button': FtIconButton,
-    'ft-share-button': FtShareButton
+    'ft-share-button': FtShareButton,
+    'ft-subscribe-button': FtSubscribeButton
   },
   props: {
     id: {
@@ -236,26 +237,6 @@ export default defineComponent({
       return formatNumber(this.viewCount) + ` ${this.$t('Video.Views').toLowerCase()}`
     },
 
-    isSubscribed: function () {
-      const subIndex = this.activeProfile.subscriptions.findIndex((channel) => {
-        return channel.id === this.channelId
-      })
-
-      if (subIndex === -1) {
-        return false
-      } else {
-        return true
-      }
-    },
-
-    subscribedText: function () {
-      if (this.isSubscribed) {
-        return `${this.$t('Channel.Unsubscribe').toUpperCase()} ${this.subscriptionCountText}`
-      } else {
-        return `${this.$t('Channel.Subscribe').toUpperCase()} ${this.subscriptionCountText}`
-      }
-    },
-
     dateString() {
       const date = new Date(this.published)
       const localeDateString = new Intl.DateTimeFormat([this.currentLocale, 'en'], { dateStyle: 'medium' }).format(date)
@@ -330,76 +311,6 @@ export default defineComponent({
         this.removeFromPlaylist()
       } else {
         this.addToPlaylist()
-      }
-    },
-
-    handleSubscription: function () {
-      if (this.channelId === '') {
-        return
-      }
-
-      const currentProfile = JSON.parse(JSON.stringify(this.activeProfile))
-      const primaryProfile = JSON.parse(JSON.stringify(this.profileList[0]))
-
-      if (this.isSubscribed) {
-        currentProfile.subscriptions = currentProfile.subscriptions.filter((channel) => {
-          return channel.id !== this.channelId
-        })
-
-        this.updateProfile(currentProfile)
-        showToast(this.$t('Channel.Channel has been removed from your subscriptions'))
-
-        if (this.activeProfile._id === MAIN_PROFILE_ID) {
-          // Check if a subscription exists in a different profile.
-          // Remove from there as well.
-          let duplicateSubscriptions = 0
-
-          this.profileList.forEach((profile) => {
-            if (profile._id === MAIN_PROFILE_ID) {
-              return
-            }
-            const parsedProfile = JSON.parse(JSON.stringify(profile))
-            const index = parsedProfile.subscriptions.findIndex((channel) => {
-              return channel.id === this.channelId
-            })
-
-            if (index !== -1) {
-              duplicateSubscriptions++
-
-              parsedProfile.subscriptions = parsedProfile.subscriptions.filter((x) => {
-                return x.id !== this.channelId
-              })
-
-              this.updateProfile(parsedProfile)
-            }
-          })
-
-          if (duplicateSubscriptions > 0) {
-            const message = this.$t('Channel.Removed subscription from {count} other channel(s)', { count: duplicateSubscriptions })
-            showToast(message)
-          }
-        }
-      } else {
-        const subscription = {
-          id: this.channelId,
-          name: this.channelName,
-          thumbnail: this.channelThumbnail
-        }
-        currentProfile.subscriptions.push(subscription)
-
-        this.updateProfile(currentProfile)
-        showToast(this.$t('Channel.Added channel to your subscriptions'))
-
-        if (this.activeProfile._id !== MAIN_PROFILE_ID) {
-          const index = primaryProfile.subscriptions.findIndex((channel) => {
-            return channel.id === this.channelId
-          })
-
-          if (index === -1) {
-            primaryProfile.subscriptions.push(subscription)
-            this.updateProfile(primaryProfile)
-          }
-        }
       }
     },
 

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -30,13 +30,12 @@
             >
               {{ channelName }}
             </router-link>
-            <ft-button
+            <ft-subscribe-button
               v-if="!hideUnsubscribeButton"
-              :label="subscribedText"
-              class="subscribeButton"
-              background-color="var(--primary-color)"
-              text-color="var(--text-with-main-color)"
-              @click="handleSubscription"
+              :channel-id="channelId"
+              :channel-name="channelName"
+              :channel-thumbnail="channelThumbnail"
+              :subscription-count-text="subscriptionCountText"
             />
           </div>
         </div>

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -69,13 +69,6 @@
   justify-content: space-between;
 }
 
-.subscribeButton {
-  height: 50px;
-  min-width: 150px;
-  align-self: center;
-  margin-bottom: 10px;
-}
-
 .shareIcon {
   align-self: center;
 }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -10,9 +10,9 @@ import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
 import FtShareButton from '../../components/ft-share-button/ft-share-button.vue'
+import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe-button.vue'
 
 import autolinker from 'autolinker'
-import { MAIN_PROFILE_ID } from '../../../constants'
 import { copyToClipboard, extractNumberFromString, formatNumber, isNullOrEmpty, showToast } from '../../helpers/utils'
 import packageDetails from '../../../../package.json'
 import {
@@ -44,7 +44,8 @@ export default defineComponent({
     'ft-loader': FtLoader,
     'ft-element-list': FtElementList,
     'ft-age-restricted': FtAgeRestricted,
-    'ft-share-button': FtShareButton
+    'ft-share-button': FtShareButton,
+    'ft-subscribe-button': FtSubscribeButton
   },
   data: function () {
     return {
@@ -142,14 +143,6 @@ export default defineComponent({
 
     isSubscribed: function () {
       return this.subscriptionInfo !== null
-    },
-
-    subscribedText: function () {
-      if (this.isSubscribed) {
-        return this.$t('Channel.Unsubscribe').toUpperCase()
-      } else {
-        return this.$t('Channel.Subscribe').toUpperCase()
-      }
     },
 
     videoShortLiveSelectNames: function () {
@@ -1139,72 +1132,6 @@ export default defineComponent({
           this.getCommunityPostsLocal()
         }
       })
-    },
-
-    handleSubscription: function () {
-      const currentProfile = JSON.parse(JSON.stringify(this.activeProfile))
-      const primaryProfile = JSON.parse(JSON.stringify(this.profileList[0]))
-
-      if (this.isSubscribed) {
-        currentProfile.subscriptions = currentProfile.subscriptions.filter((channel) => {
-          return channel.id !== this.id
-        })
-
-        this.updateProfile(currentProfile)
-        showToast(this.$t('Channel.Channel has been removed from your subscriptions'))
-
-        if (this.activeProfile._id === MAIN_PROFILE_ID) {
-          // Check if a subscription exists in a different profile.
-          // Remove from there as well.
-          let duplicateSubscriptions = 0
-
-          this.profileList.forEach((profile) => {
-            if (profile._id === MAIN_PROFILE_ID) {
-              return
-            }
-            const parsedProfile = JSON.parse(JSON.stringify(profile))
-            const index = parsedProfile.subscriptions.findIndex((channel) => {
-              return channel.id === this.id
-            })
-
-            if (index !== -1) {
-              duplicateSubscriptions++
-
-              parsedProfile.subscriptions = parsedProfile.subscriptions.filter((x) => {
-                return x.id !== this.id
-              })
-
-              this.updateProfile(parsedProfile)
-            }
-          })
-
-          if (duplicateSubscriptions > 0) {
-            const message = this.$t('Channel.Removed subscription from {count} other channel(s)', { count: duplicateSubscriptions })
-            showToast(message)
-          }
-        }
-      } else {
-        const subscription = {
-          id: this.id,
-          name: this.channelName,
-          thumbnail: this.thumbnailUrl
-        }
-        currentProfile.subscriptions.push(subscription)
-
-        this.updateProfile(currentProfile)
-        showToast(this.$t('Channel.Added channel to your subscriptions'))
-
-        if (this.activeProfile._id !== MAIN_PROFILE_ID) {
-          const index = primaryProfile.subscriptions.findIndex((channel) => {
-            return channel.id === this.id
-          })
-
-          if (index === -1) {
-            primaryProfile.subscriptions.push(subscription)
-            this.updateProfile(primaryProfile)
-          }
-        }
-      }
     },
 
     setErrorMessage: function (errorMessage, responseHasNameAndThumbnail = false) {

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -67,13 +67,12 @@
               class="shareIcon"
             />
 
-            <ft-button
+            <ft-subscribe-button
               v-if="!hideUnsubscribeButton && (!errorMessage || isSubscribed)"
-              :label="subscribedText"
-              background-color="var(--primary-color)"
-              text-color="var(--text-with-main-color)"
-              class="subscribeButton"
-              @click="handleSubscription"
+              class="subscribeButtons"
+              :channel-id="id"
+              :channel-name="channelName"
+              :channel-thumbnail="thumbnailUrl"
             />
           </div>
         </div>

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.css
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.css
@@ -62,7 +62,7 @@
 }
 
 .unsubscribeContainer .btn {
-  padding: 5px 10px;
+  height: 80%;
 }
 
 @media only screen and (max-width: 680px) {

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -4,8 +4,7 @@ import FtButton from '../../components/ft-button/ft-button.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtInput from '../../components/ft-input/ft-input.vue'
-import FtPrompt from '../../components/ft-prompt/ft-prompt.vue'
-import { showToast } from '../../helpers/utils'
+import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe-button.vue'
 import { invidiousGetChannelInfo, youtubeImageUrlToInvidious, invidiousImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getLocalChannel } from '../../helpers/api/local'
 
@@ -16,7 +15,7 @@ export default defineComponent({
     'ft-card': FtCard,
     'ft-flex-box': FtFlexBox,
     'ft-input': FtInput,
-    'ft-prompt': FtPrompt
+    'ft-subscribe-button': FtSubscribeButton
   },
   data: function () {
     return {
@@ -121,45 +120,6 @@ export default defineComponent({
       })
     },
 
-    handleUnsubscribeButtonClick: function(channel) {
-      this.channelToUnsubscribe = channel
-      this.showUnsubscribePrompt = true
-    },
-
-    handleUnsubscribePromptClick: function(value) {
-      this.showUnsubscribePrompt = false
-      if (value !== 'yes') {
-        this.channelToUnsubscribe = null
-        return
-      }
-      this.unsubscribeChannel()
-    },
-
-    unsubscribeChannel: function () {
-      const currentProfile = JSON.parse(JSON.stringify(this.activeProfile))
-      let index = currentProfile.subscriptions.findIndex(channel => {
-        return channel.id === this.channelToUnsubscribe.id
-      })
-      currentProfile.subscriptions.splice(index, 1)
-
-      this.updateProfile(currentProfile)
-      showToast(this.$t('Channels.Unsubscribed', { channelName: this.channelToUnsubscribe.name }))
-
-      index = this.subscribedChannels.findIndex(channel => {
-        return channel.id === this.channelToUnsubscribe.id
-      })
-      this.subscribedChannels.splice(index, 1)
-
-      index = this.filteredChannels.findIndex(channel => {
-        return channel.id === this.channelToUnsubscribe.id
-      })
-      if (index !== -1) {
-        this.filteredChannels.splice(index, 1)
-      }
-
-      this.channelToUnsubscribe = null
-    },
-
     thumbnailURL: function(originalURL) {
       let newURL = originalURL
       const hostname = new URL(originalURL).hostname
@@ -207,8 +167,7 @@ export default defineComponent({
     },
 
     ...mapActions([
-      'updateProfile',
-      'updateSubscriptionDetails',
+      'updateSubscriptionDetails'
     ])
   }
 })

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -52,24 +52,18 @@
               v-if="!hideUnsubscribeButton"
               class="unsubscribeContainer"
             >
-              <ft-button
-                :label="$t('Channels.Unsubscribe')"
-                background-color="var(--search-bar-color)"
-                text-color="var(--secondary-text-color)"
-                @click="handleUnsubscribeButtonClick(channel)"
+              <ft-subscribe-button
+                class="btn"
+                :channel-id="channel.id"
+                :channel-name="channel.name"
+                :channel-thumbnail="channel.thumbnail"
+                :is-subscribed="true"
               />
             </div>
           </div>
         </ft-flex-box>
       </template>
     </ft-card>
-    <ft-prompt
-      v-if="showUnsubscribePrompt"
-      :label="$t('Channels.Unsubscribe Prompt', { channelName: channelToUnsubscribe.name })"
-      :option-names="unsubscribePromptNames"
-      :option-values="unsubscribePromptValues"
-      @click="handleUnsubscribePromptClick"
-    />
   </div>
 </template>
 


### PR DESCRIPTION
# Create Subscribe Button reusable component

## Pull Request Type
- [x] Other

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/1934#issuecomment-1468773708

## Description
Turns the subscribe button into a reusable component

## Screenshots 
<img width="141" alt="image" src="https://user-images.githubusercontent.com/78101139/234342431-2be262c3-bece-43af-a143-dae05ff03bd9.png">


## Testing 
- Go to a channel (subscribe + unsubscribe)
- Go to a video (subscribe + unsubscribe)
- Go to Subscribed Channels page (Unsubscribe from a channel)

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0