### PR TITLE
Fix vunerability in CSV import regex

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -216,13 +216,13 @@ export default defineComponent({
       this.setProgressBarPercentage(0)
       let count = 0
 
-      const splitCSVRegex = /(?:,|\n|^)("(?:(?:"")*[^"]*)*"|[^\n",]*|(?:\n|$))/g
+      const splitCSVRegex = /(?:,|\n|^)("(?:(?:"")|[^"])*"|[^\n",]*|(?:\n|$))/g
 
       const ytsubs = youtubeSubscriptions.slice(1).map(yt => {
         return [...yt.matchAll(splitCSVRegex)].map(s => {
           let newVal = s[1]
           if (newVal.startsWith('"')) {
-            newVal = newVal.substring(1, newVal.length - 2).replace('""', '"')
+            newVal = newVal.substring(1, newVal.length - 2).replaceAll('""', '"')
           }
           return newVal
         })


### PR DESCRIPTION
# Fix vunerability in CSV import regex

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/security/code-scanning/62

## Description
GitHub's code scanning has been warning us about a potential vunerability in the CSV regex, so I finally decided to look into it when it flagged it again in #3455. Specifically an exponential/catastrophic backtracking one. If you are interested https://www.regular-expressions.info/catastrophic.html is a good read (the suggested fixes with atomic groups unfortunately don't work for us, as JavaScript doesn't support atomic groups).

https://regex101.com/ was very helpful in testing this as you can switch between different regex engines to try stuff out but also input test data and check if it correctly handles it.

## Testing <!-- for code that is not small enough to be easily understandable -->
I created this CSV based on the description of the vunerability given to us by GitHub:
> This part of the regular expression may cause exponential backtracking on strings starting with '"' and containing many repetitions of '!'.

Importing this CSV before this PR freezes FreeTube, so you'll have to force kill it from the task manager, with this PR it will now spit out errors from YouTube and Invidious about not being able to find the channel, without breaking anything.

[exponential-backtracking.csv](https://github.com/FreeTubeApp/FreeTube/files/11334948/exponential-backtracking.csv)

To test that it still works with a normal subscription CSV you can export, clear your subscriptions and import your own or use the one in this issue: #2219

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 45d679b84bfa8a797c6c586f0177efc4c3f498da