### PR TITLE
Add hide community, playlist and featured channels setting

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -62,6 +62,15 @@ export default defineComponent({
     hideChapters: function () {
       return this.$store.getters.getHideChapters
     },
+    hideFeaturedChannels: function() {
+      return this.$store.getters.getHideFeaturedChannels
+    },
+    hideChannelPlaylists: function() {
+      return this.$store.getters.getHideChannelPlaylists
+    },
+    hideChannelCommunity: function() {
+      return this.$store.getters.getHideChannelCommunity
+    },
     showDistractionFreeTitles: function () {
       return this.$store.getters.getShowDistractionFreeTitles
     },
@@ -101,7 +110,10 @@ export default defineComponent({
       'updateHideSharingActions',
       'updateHideChapters',
       'updateChannelsHidden',
-      'updateShowDistractionFreeTitles'
+      'updateShowDistractionFreeTitles',
+      'updateHideFeaturedChannels',
+      'updateHideChannelPlaylists',
+      'updateHideChannelCommunity'
     ])
   }
 })

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -52,6 +52,18 @@
           :default-value="hideChapters"
           @change="updateHideChapters"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Featured Channels')"
+          :compact="true"
+          :default-value="hideFeaturedChannels"
+          @change="updateHideFeaturedChannels"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Channel Playlists')"
+          :compact="true"
+          :default-value="hideChannelPlaylists"
+          @change="updateHideChannelPlaylists"
+        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch
@@ -107,6 +119,12 @@
           :compact="true"
           :default-value="showDistractionFreeTitles"
           @change="updateShowDistractionFreeTitles"
+        />
+        <ft-toggle-switch
+            :label="$t('Settings.Distraction Free Settings.Hide Channel Community')"
+            :compact="true"
+            :default-value="hideChannelCommunity"
+            @change="updateHideChannelCommunity"
         />
       </div>
     </div>

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -192,9 +192,13 @@ const state = {
   expandSideBar: false,
   forceLocalBackendForLegacy: false,
   hideActiveSubscriptions: false,
+  hideChannelCommunity: false,
+  hideChannelPlaylists: false,
+
   hideChannelSubscriptions: false,
   hideCommentLikes: false,
   hideComments: false,
+  hideFeaturedChannels: false,
   channelsHidden: '[]',
   hideVideoDescription: false,
   hideLiveChat: false,

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -213,6 +213,18 @@ export default defineComponent({
       return this.$store.getters.getHideLiveStreams
     },
 
+    hideFeaturedChannels: function() {
+      return this.$store.getters.getHideFeaturedChannels
+    },
+
+    hideChannelPlaylists: function() {
+      return this.$store.getters.getHideChannelPlaylists
+    },
+
+    hideChannelCommunity: function() {
+      return this.$store.getters.getHideChannelCommunity
+    },
+
     tabInfoValues: function () {
       const values = [
         'videos',
@@ -225,6 +237,16 @@ export default defineComponent({
       // remove tabs from the array based on user settings
       if (this.hideLiveStreams) {
         const index = values.indexOf('live')
+        values.splice(index, 1)
+      }
+
+      if (this.hideChannelPlaylists) {
+        const index = values.indexOf('playlists')
+        values.splice(index, 1)
+      }
+
+      if (this.hideChannelCommunity) {
+        const index = values.indexOf('community')
         values.splice(index, 1)
       }
 
@@ -265,6 +287,14 @@ export default defineComponent({
       this.showPlaylistSortBy = true
 
       if (this.hideLiveStreams && currentTab === 'live') {
+        currentTab = 'videos'
+      }
+
+      if (this.hideChannelPlaylists && currentTab === 'playlists') {
+        currentTab = 'videos'
+      }
+
+      if (this.hideChannelCommunity && currentTab === 'community') {
         currentTab = 'videos'
       }
 
@@ -345,6 +375,14 @@ export default defineComponent({
     let currentTab = this.$route.params.currentTab ?? 'videos'
 
     if (this.hideLiveStreams && currentTab === 'live') {
+      currentTab = 'videos'
+    }
+
+    if (this.hideChannelPlaylists && currentTab === 'playlists') {
+      currentTab = 'videos'
+    }
+
+    if (this.hideChannelCommunity && currentTab === 'community') {
       currentTab = 'videos'
     }
 
@@ -568,11 +606,11 @@ export default defineComponent({
           this.getChannelLiveLocal()
         }
 
-        if (channel.has_playlists) {
+        if (!this.hideChannelPlaylists && channel.has_playlists) {
           this.getChannelPlaylistsLocal()
         }
 
-        if (channel.has_community) {
+        if (!this.hideChannelCommunity && channel.has_community) {
           this.getCommunityPostsLocal()
         }
 
@@ -798,11 +836,11 @@ export default defineComponent({
           this.channelInvidiousLive()
         }
 
-        if (response.tabs.includes('playlists')) {
+        if (!this.hideChannelPlaylists && response.tabs.includes('playlists')) {
           this.getPlaylistsInvidious()
         }
 
-        if (response.tabs.includes('community')) {
+        if (!this.hideChannelCommunity && response.tabs.includes('community')) {
           this.getCommunityPostsInvidious()
         }
 

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -115,6 +115,7 @@
               {{ $t("Channel.Live.Live").toUpperCase() }}
             </div>
             <div
+              v-if="!hideChannelPlaylists"
               id="playlistsTab"
               class="tab"
               role="tab"
@@ -128,6 +129,7 @@
               {{ $t("Channel.Playlists.Playlists").toUpperCase() }}
             </div>
             <div
+              v-if="!hideChannelCommunity"
               id="communityTab"
               class="tab"
               role="tab"
@@ -258,12 +260,12 @@
           </li>
         </ul>
         <h2
-          v-if="relatedChannels.length > 0"
+          v-if="relatedChannels.length > 0 && !hideFeaturedChannels"
         >
           {{ $t("Channel.About.Featured Channels") }}
         </h2>
         <ft-flex-box
-          v-if="relatedChannels.length > 0"
+          v-if="relatedChannels.length > 0 && !hideFeaturedChannels"
         >
           <ft-channel-bubble
             v-for="(channel, index) in relatedChannels"
@@ -297,7 +299,7 @@
         @change="liveSortBy = $event"
       />
       <ft-select
-        v-if="showPlaylistSortBy"
+        v-if="!hideChannelPlaylists && showPlaylistSortBy"
         v-show="currentTab === 'playlists' && latestPlaylists.length > 0"
         class="sortSelect"
         :value="playlistSelectValues[0]"
@@ -343,21 +345,21 @@
           </p>
         </ft-flex-box>
         <ft-element-list
-          v-show="currentTab === 'playlists'"
+          v-if="!hideChannelPlaylists && currentTab === 'playlists'"
           id="playlistPanel"
           :data="latestPlaylists"
           role="tabpanel"
           aria-labelledby="playlistsTab"
         />
         <ft-flex-box
-          v-if="currentTab === 'playlists' && latestPlaylists.length === 0"
+          v-if="!hideChannelPlaylists && currentTab === 'playlists' && latestPlaylists.length === 0"
         >
           <p class="message">
             {{ $t("Channel.Playlists.This channel does not currently have any playlists") }}
           </p>
         </ft-flex-box>
         <ft-element-list
-          v-show="currentTab === 'community'"
+          v-if="!hideChannelCommunity && currentTab === 'community'"
           id="communityPanel"
           :data="latestCommunityPosts"
           role="tabpanel"
@@ -365,7 +367,7 @@
           display="list"
         />
         <ft-flex-box
-          v-if="currentTab === 'community' && latestCommunityPosts.length === 0"
+          v-if="!hideChannelCommunity && currentTab === 'community' && latestCommunityPosts.length === 0"
         >
           <p class="message">
             {{ $t("Channel.Community.This channel currently does not have any posts") }}

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -336,6 +336,10 @@ Settings:
     Hide Chapters: Hide Chapters
     Hide Channels: Hide Videos From Channels
     Hide Channels Placeholder: Channel Name or ID
+    Hide Featured Channels: Hide Featured Channels
+    Hide Channel Playlists: Hide Channel Playlists
+    Hide Channel Community: Hide Channel Community
+    Hide Channel Shorts: Hide Channel Shorts
   Data Settings:
     Data Settings: Data Settings
     Select Import Type: Select Import Type


### PR DESCRIPTION
# Title


## Pull Request Type
- [ ] Feature Implementation

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/3202

## Description
Adds settings to:
- hide community posts
- hide featured channels (the channel list under the about section)
- hide channel playlists (the playlist tab on channels)
- 
## Screenshots
With settings enabled:
![image](https://user-images.githubusercontent.com/78101139/235836561-b2bdb088-e0ce-4a47-9ae2-019866523f9a.png)

![image](https://user-images.githubusercontent.com/78101139/235836602-72173a7f-e595-4a1d-9cb8-1dd090bf868e.png)

Without new settings enabled:
![image](https://user-images.githubusercontent.com/78101139/235836660-9d4552a8-ce77-4d4a-8a69-9b85e79d0fd5.png)

![image](https://user-images.githubusercontent.com/78101139/235836681-b5c3f8be-b326-4631-bcea-f3cb20c8e9bc.png)

## Testing 
- go to mr beast's about page 
- see channels
- go to settings
- enable hide featured channels
- go to mr beast's about page
- dont see channels

- go to mr beast's page
- see playlist tab
- go to settings
- enable hide channel playlists
- go to mr beast's channel
- don't see playlist tab

- go to mr beast's page
- see community tab
- go to settings
- enable hide channel community 
- go to mr beast's channel
- don't see community tab

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 18
