### PR TITLE
IV: Fix sorting upcoming subscriptions

### DIFF
--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -357,7 +357,13 @@ export default defineComponent({
 
         invidiousAPICall(subscriptionsPayload).then(async (result) => {
           resolve(await Promise.all(result.videos.map((video) => {
-            video.publishedDate = new Date(video.published * 1000)
+            if (video.liveNow) {
+              video.publishedDate = new Date().getTime()
+            } else if (video.isUpcoming) {
+              video.publishedDate = new Date(video.premiereTimestamp * 1000)
+            } else {
+              video.publishedDate = new Date(video.published * 1000)
+            }
             return video
           })))
         }).catch((err) => {


### PR DESCRIPTION
# Fix sorting upcoming subscriptions

## Pull Request Type
- [x] Bugfix

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/3357

## Description
`video.published` is set to current date/time for upcoming invidious videos so this PR uses `video.PremiereTimestamp` for sorting instead

## Testing 
- Subscribe to multiple channels with upcoming videos
- Switch to IV api
- Turn off RSS
- Go to subscriptions
- profit?

Example channel to subscribe to:
https://www.youtube.com/channel/UCUKPG1-r4WFyxpyhIuCs86Q

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
