### PR TITLE
Fix fetching more IV replies

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -268,7 +268,7 @@ export default defineComponent({
       const replyToken = this.commentData[index].replyToken
       invidiousGetCommentReplies({ id: this.id, replyToken: replyToken })
         .then(({ commentData, continuation }) => {
-          this.commentData[index].replies = commentData
+          this.commentData[index].replies = this.commentData[index].replies.concat(commentData)
           this.commentData[index].showReplies = true
           this.commentData[index].replyToken = continuation
           this.isLoading = false


### PR DESCRIPTION
# Fix fetching more IV replies

## Pull Request Type
- [x] Bugfix

## Description
Comment replies were getting overwritten when using the invidious api

## Testing 
- use invidious api
- go to a video
- load comments
- get replies of a comment
- get more replies

## Desktop
- **OS:** windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
