### PR TITLE
Move the channel about tab into it's own component

### DIFF
--- a/src/renderer/components/channel-about/channel-about.css
+++ b/src/renderer/components/channel-about/channel-about.css
@@ -1,0 +1,42 @@
+.about {
+  background-color: var(--card-bg-color);
+  margin-top: 0;
+  padding: 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.aboutInfo {
+  font-size: 17px;
+  white-space: pre-wrap;
+}
+
+.aboutTags {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 5px 15px;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+}
+
+.aboutTag {
+  display: flex;
+  list-style: none;
+}
+
+.aboutTagLink {
+  background-color: var(--secondary-card-bg-color);
+  border-radius: 7px;
+  color: inherit;
+  padding: 7px;
+  text-decoration: none;
+}
+
+.aboutDetails {
+  text-align: left;
+}
+
+.aboutDetails th {
+  padding-right: 10px;
+}

--- a/src/renderer/components/channel-about/channel-about.js
+++ b/src/renderer/components/channel-about/channel-about.js
@@ -1,0 +1,70 @@
+import { defineComponent } from 'vue'
+
+import FtChannelBubble from '../../components/ft-channel-bubble/ft-channel-bubble.vue'
+import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
+
+import { formatNumber } from '../../helpers/utils'
+
+export default defineComponent({
+  name: 'ChannelAbout',
+  components: {
+    'ft-channel-bubble': FtChannelBubble,
+    'ft-flex-box': FtFlexBox
+  },
+  props: {
+    description: {
+      type: String,
+      default: ''
+    },
+    joined: {
+      type: [Date, Number],
+      default: 0
+    },
+    views: {
+      type: Number,
+      default: null
+    },
+    location: {
+      type: String,
+      default: null
+    },
+    tags: {
+      type: Array,
+      default: () => ([])
+    },
+    relatedChannels: {
+      type: Array,
+      default: () => ([])
+    }
+  },
+  computed: {
+    hideFeaturedChannels: function () {
+      return this.$store.getters.getHideFeaturedChannels
+    },
+
+    hideSearchBar: function () {
+      return this.$store.getters.getHideSearchBar
+    },
+
+    searchSettings: function () {
+      return this.$store.getters.getSearchSettings
+    },
+
+    currentLocale: function () {
+      return this.$i18n.locale.replace('_', '-')
+    },
+
+    formattedJoined: function () {
+      return new Intl.DateTimeFormat([this.currentLocale, 'en'], { dateStyle: 'long' }).format(this.joined)
+    },
+
+    formattedViews: function () {
+      return formatNumber(this.views)
+    },
+  },
+  methods: {
+    goToChannel: function (id) {
+      this.$router.push({ path: `/channel/${id}` })
+    },
+  }
+})

--- a/src/renderer/components/channel-about/channel-about.vue
+++ b/src/renderer/components/channel-about/channel-about.vue
@@ -1,0 +1,104 @@
+<template>
+  <div
+    class="about"
+  >
+    <template
+      v-if="description"
+    >
+      <h2>{{ $t("Channel.About.Channel Description") }}</h2>
+      <div
+        class="aboutInfo"
+        v-html="description"
+      />
+    </template>
+    <template
+      v-if="joined || views !== null || location"
+    >
+      <h2>{{ $t('Channel.About.Details') }}</h2>
+      <table
+        class="aboutDetails"
+      >
+        <tr
+          v-if="joined"
+        >
+          <th
+            scope="row"
+          >
+            {{ $t('Channel.About.Joined') }}
+          </th>
+          <td>{{ formattedJoined }}</td>
+        </tr>
+        <tr
+          v-if="views !== null"
+        >
+          <th
+            scope="row"
+          >
+            {{ $t('Video.Views') }}
+          </th>
+          <td>{{ formattedViews }}</td>
+        </tr>
+        <tr
+          v-if="location"
+        >
+          <th
+            scope="row"
+          >
+            {{ $t('Channel.About.Location') }}
+          </th>
+          <td>{{ location }}</td>
+        </tr>
+      </table>
+    </template>
+    <template
+      v-if="tags.length > 0"
+    >
+      <h2>{{ $t('Channel.About.Tags.Tags') }}</h2>
+      <ul
+        class="aboutTags"
+      >
+        <li
+          v-for="tag in tags"
+          :key="tag"
+          class="aboutTag"
+        >
+          <router-link
+            v-if="!hideSearchBar"
+            class="aboutTagLink"
+            :title="$t('Channel.About.Tags.Search for', { tag })"
+            :to="{
+              path: `/search/${encodeURIComponent(tag)}`,
+              query: searchSettings
+            }"
+          >
+            {{ tag }}
+          </router-link>
+          <span
+            v-else
+            class="aboutTagLink"
+          >
+            {{ tag }}
+          </span>
+        </li>
+      </ul>
+    </template>
+    <template
+      v-if="!hideFeaturedChannels && relatedChannels.length > 0"
+    >
+      <h2>{{ $t("Channel.About.Featured Channels") }}</h2>
+      <ft-flex-box>
+        <ft-channel-bubble
+          v-for="(channel, index) in relatedChannels"
+          :key="index"
+          :channel-name="channel.name"
+          :channel-thumbnail="channel.thumbnailUrl"
+          role="link"
+          @click="goToChannel(channel.id)"
+        />
+      </ft-flex-box>
+    </template>
+  </div>
+</template>
+
+<script src="./channel-about.js" />
+<style scoped src="./channel-about.css" />

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -122,50 +122,6 @@
   box-sizing: border-box;
 }
 
-.aboutTab {
-  background-color: var(--card-bg-color);
-  position: relative;
-  margin-top: 0px;
-  padding: 10px;
-  z-index: 1;
-}
-
-.aboutInfo {
-  font-family: 'Roboto', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-  font-size: 17px;
-  white-space: pre-wrap;
-}
-
-.aboutTags {
-  display: flex;
-  flex-flow: row wrap;
-  gap: 5px 15px;
-  justify-content: center;
-  margin: 0;
-  padding: 0;
-}
-
-.aboutTag {
-  display: flex;
-  list-style: none;
-}
-
-.aboutTagLink {
-  background-color: var(--secondary-card-bg-color);
-  border-radius: 7px;
-  color: inherit;
-  padding: 7px;
-  text-decoration: none;
-}
-
-.aboutDetails {
-  text-align: left;
-}
-
-.aboutDetails th {
-  padding-right: 10px;
-}
-
 .channelSearch {
   margin-top: 10px;
   max-width: 250px;

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -4,12 +4,12 @@ import FtCard from '../../components/ft-card/ft-card.vue'
 import FtInput from '../../components/ft-input/ft-input.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
-import FtChannelBubble from '../../components/ft-channel-bubble/ft-channel-bubble.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
 import FtShareButton from '../../components/ft-share-button/ft-share-button.vue'
 import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe-button.vue'
+import ChannelAbout from '../../components/channel-about/channel-about.vue'
 
 import autolinker from 'autolinker'
 import { copyToClipboard, extractNumberFromString, formatNumber, isNullOrEmpty, showToast } from '../../helpers/utils'
@@ -38,12 +38,12 @@ export default defineComponent({
     'ft-input': FtInput,
     'ft-select': FtSelect,
     'ft-flex-box': FtFlexBox,
-    'ft-channel-bubble': FtChannelBubble,
     'ft-loader': FtLoader,
     'ft-element-list': FtElementList,
     'ft-age-restricted': FtAgeRestricted,
     'ft-share-button': FtShareButton,
-    'ft-subscribe-button': FtSubscribeButton
+    'ft-subscribe-button': FtSubscribeButton,
+    'channel-about': ChannelAbout
   },
   data: function () {
     return {
@@ -117,10 +117,6 @@ export default defineComponent({
       return this.$store.getters.getCurrentInvidiousInstance
     },
 
-    currentLocale: function () {
-      return this.$i18n.locale.replace('_', '-')
-    },
-
     activeProfile: function () {
       return this.$store.getters.getActiveProfile
     },
@@ -156,14 +152,6 @@ export default defineComponent({
       return formatNumber(this.subCount)
     },
 
-    formattedViews: function () {
-      return formatNumber(this.views)
-    },
-
-    formattedJoined: function () {
-      return new Intl.DateTimeFormat([this.currentLocale, 'en'], { dateStyle: 'long' }).format(this.joined)
-    },
-
     showFetchMoreButton: function () {
       switch (this.currentTab) {
         case 'videos':
@@ -184,24 +172,12 @@ export default defineComponent({
       return this.$store.getters.getHideChannelSubscriptions
     },
 
-    searchSettings: function () {
-      return this.$store.getters.getSearchSettings
-    },
-
-    hideSearchBar: function () {
-      return this.$store.getters.getHideSearchBar
-    },
-
     hideSharingActions: function () {
       return this.$store.getters.getHideSharingActions
     },
 
     hideLiveStreams: function () {
       return this.$store.getters.getHideLiveStreams
-    },
-
-    hideFeaturedChannels: function() {
-      return this.$store.getters.getHideFeaturedChannels
     },
 
     hideChannelPlaylists: function() {
@@ -411,10 +387,6 @@ export default defineComponent({
       } else {
         this.$router.replace({ path: `/channel/${id}` })
       }
-    },
-
-    goToChannel: function (id) {
-      this.$router.push({ path: `/channel/${id}` })
     },
 
     getChannelLocal: async function () {

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -169,113 +169,16 @@
       v-if="!isLoading && !errorMessage && (isFamilyFriendly || !showFamilyFriendlyOnly)"
       class="card"
     >
-      <div
+      <channel-about
         v-if="currentTab === 'about'"
         id="aboutPanel"
-        class="aboutTab"
-      >
-        <h2
-          v-if="description"
-        >
-          {{ $t("Channel.About.Channel Description") }}
-        </h2>
-        <div
-          v-if="description"
-          class="aboutInfo"
-          v-html="description"
-        />
-        <h2
-          v-if="joined || views !== null || location"
-        >
-          {{ $t('Channel.About.Details') }}
-        </h2>
-        <table
-          v-if="joined || views !== null || location"
-          class="aboutDetails"
-        >
-          <tr
-            v-if="joined"
-          >
-            <th
-              scope="row"
-            >
-              {{ $t('Channel.About.Joined') }}
-            </th>
-            <td>{{ formattedJoined }}</td>
-          </tr>
-          <tr
-            v-if="views !== null"
-          >
-            <th
-              scope="row"
-            >
-              {{ $t('Video.Views') }}
-            </th>
-            <td>{{ formattedViews }}</td>
-          </tr>
-          <tr
-            v-if="location"
-          >
-            <th
-              scope="row"
-            >
-              {{ $t('Channel.About.Location') }}
-            </th>
-            <td>{{ location }}</td>
-          </tr>
-        </table>
-        <h2
-          v-if="tags.length > 0"
-        >
-          {{ $t('Channel.About.Tags.Tags') }}
-        </h2>
-        <ul
-          v-if="tags.length > 0"
-          class="aboutTags"
-        >
-          <li
-            v-for="tag in tags"
-            :key="tag"
-            class="aboutTag"
-          >
-            <router-link
-              v-if="!hideSearchBar"
-              class="aboutTagLink"
-              :title="$t('Channel.About.Tags.Search for', { tag })"
-              :to="{
-                path: `/search/${encodeURIComponent(tag)}`,
-                query: searchSettings
-              }"
-            >
-              {{ tag }}
-            </router-link>
-            <span
-              v-else
-              class="aboutTagLink"
-            >
-              {{ tag }}
-            </span>
-          </li>
-        </ul>
-        <h2
-          v-if="relatedChannels.length > 0 && !hideFeaturedChannels"
-        >
-          {{ $t("Channel.About.Featured Channels") }}
-        </h2>
-        <ft-flex-box
-          v-if="relatedChannels.length > 0 && !hideFeaturedChannels"
-        >
-          <ft-channel-bubble
-            v-for="(channel, index) in relatedChannels"
-            :key="index"
-            :channel-name="channel.name"
-            :channel-id="channel.id"
-            :channel-thumbnail="channel.thumbnailUrl"
-            role="link"
-            @click="goToChannel(channel.id)"
-          />
-        </ft-flex-box>
-      </div>
+        :description="description"
+        :joined="joined"
+        :views="views"
+        :location="location"
+        :tags="tags"
+        :related-channels="relatedChannels"
+      />
       <ft-select
         v-if="showVideoSortBy"
         v-show="currentTab === 'videos' && latestVideos.length > 0"


### PR DESCRIPTION
# Move the channel about tab into it's own component

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Refactor

## Related issue
https://github.com/FreeTubeApp/FreeTube/projects/10#card-88390939

## Description
This pull request creates a new component for the channel about tab, making it possible to reduce the complexity of the channel page component a bit. This doesn't add lazy loading or anything fancy like that yet.

P.S. Yes, I am aware that I picked the easiest part to split out into a separate component, I wanted something easy to start with 🙈

## Testing <!-- for code that is not small enough to be easily understandable -->
Please test the about tab on various channels. Here are some suggestions:
* https://youtube.com/@YouTube
* https://youtube.com/@LinusTechTips
* https://www.youtube.com/channel/UCQvWX73GQygcwXOTSf_VDVg

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a9fa327c9bafd8ba9952d6080a84a71ecd215a12