### PR TITLE
Fix the flash when more data loaded in History & UserPlaylists view

### DIFF
--- a/src/renderer/views/History/History.js
+++ b/src/renderer/views/History/History.js
@@ -45,9 +45,6 @@ export default defineComponent({
       this.searchDataLimit = 100
       this.filterHistoryAsync()
     },
-    activeData() {
-      this.refreshPage()
-    },
     fullData() {
       this.activeData = this.fullData
       this.filterHistory()
@@ -111,16 +108,6 @@ export default defineComponent({
         }
         this.activeData = filteredQuery.length < this.searchDataLimit ? filteredQuery : filteredQuery.slice(0, this.searchDataLimit)
       }
-    },
-    refreshPage: function() {
-      const scrollPos = window.scrollY || window.scrollTop || document.getElementsByTagName('html')[0].scrollTop
-      this.isLoading = true
-      nextTick(() => {
-        this.isLoading = false
-        nextTick(() => {
-          window.scrollTo(0, scrollPos)
-        })
-      })
     },
   }
 })

--- a/src/renderer/views/UserPlaylists/UserPlaylists.js
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.js
@@ -48,9 +48,6 @@ export default defineComponent({
       this.searchDataLimit = 100
       this.filterPlaylistAsync()
     },
-    activeData() {
-      this.refreshPage()
-    },
     fullData() {
       this.activeData = this.fullData
       this.filterPlaylist()
@@ -63,13 +60,13 @@ export default defineComponent({
       this.dataLimit = limit
     }
 
+    this.activeData = this.fullData
+
     if (this.activeData.length < this.favoritesPlaylist.videos.length) {
       this.showLoadMoreButton = true
     } else {
       this.showLoadMoreButton = false
     }
-
-    this.activeData = this.fullData
 
     this.filterPlaylistDebounce = debounce(this.filterPlaylist, 500)
   },
@@ -115,15 +112,5 @@ export default defineComponent({
         this.activeData = filteredQuery.length < this.searchDataLimit ? filteredQuery : filteredQuery.slice(0, this.searchDataLimit)
       }
     },
-    refreshPage: function() {
-      const scrollPos = window.scrollY || window.scrollTop || document.getElementsByTagName('html')[0].scrollTop
-      this.isLoading = true
-      nextTick(() => {
-        this.isLoading = false
-        nextTick(() => {
-          window.scrollTo(0, scrollPos)
-        })
-      })
-    }
   }
 })


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Only possible due to #3342

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
There is a workaround which forces re-render of all list entries (videos) when loading another page
It becomes unnecessary after #3342 merged
This PR removes that workaround which now causes unnecessary re-render

This PR also fixes the issue if UserPlaylists view not having load more button visible on load when there are too many entries

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
A: History view re-render removal
- Go history view
- Press load more (if not enough entries (> 100) add more yourself)
- Ensure no re-render

B+C: UserPlaylists view re-render removal + Load more button visible on load
- Go UserPlaylists view
- Ensure load more button visible (if not enough entries (> 100) add more yourself)
- Press load more
- Ensure no re-render

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
