### PR TITLE
Remove unnecessary dislike icon on community posts

### DIFF
--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -90,10 +90,6 @@
     margin-left: 5px;
     margin-right: 6px;
   }
-
-  .dislikeCount {
-    margin-right: 10px;
-  }
 }
 
 .playlistWrapper {

--- a/src/renderer/components/ft-community-post/ft-community-post.vue
+++ b/src/renderer/components/ft-community-post/ft-community-post.vue
@@ -104,11 +104,6 @@
         class="thumbs-up-icon"
         :icon="['fas', 'thumbs-up']"
       /> {{ voteCount }}</span>
-      <span class="dislikeCount"><font-awesome-icon
-        class="thumbs-down-icon"
-        :icon="['fas', 'thumbs-down']"
-        flip="horizontal"
-      /></span>
       <span class="commentCount">
         <font-awesome-icon
           class="comment-count-icon"


### PR DESCRIPTION
# Remove unnecessary dislike icon on community posts

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3521

## Description
As we don't have the dislike count for community posts, we don't need to display the dislike icon (YouTube shows it so you can dislike a post but as we don't support logging in we don't need it)

## Screenshots <!-- If appropriate -->

![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/02618fc2-ab34-4371-8255-c376872792bc)
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/a872a282-572c-48e6-8e21-7517643ddcd1)

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/@LinusTechTips/community

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** c93c1d065da230fdac040952ea73a49f0607d3da