### PR TITLE
Ensure FT stay "running in background" on MacOS after all window closed

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -975,7 +975,7 @@ function runApp() {
 
   // ************************************************* //
 
-  app.once('window-all-closed', () => {
+  app.on('window-all-closed', () => {
     // Clear cache and storage if it's the last window
     session.defaultSession.clearCache()
     session.defaultSession.clearStorageData({
@@ -991,11 +991,15 @@ function runApp() {
       ]
     })
 
+    // For MacOS the app would still "run in background"
+    // and create new window on event `activate`
     if (process.platform !== 'darwin') {
       app.quit()
     }
   })
 
+  // MacOS event
+  // https://www.electronjs.org/docs/latest/api/app#event-activate-macos
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow()


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Fixes #2934

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I think FT already stay "running in background" on MacOS after closing all windows, but only once (due to calling `once` instead of `on` in main app code)
This PR simply changes `once` to `on` for `window-all-closed` event

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
