### PR TITLE
Fix locale files so yaml parsing won't cause errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,9 +22,18 @@ module.exports = {
     {
       files: ['*.json'],
       parser: 'jsonc-eslint-parser',
+      extends: ['plugin:jsonc/base'],
       rules: {
         'no-tabs': 'off',
         'comma-spacing': 'off'
+      }
+    },
+    {
+      files: ['*.yaml', '*.yml'],
+      parser: 'yaml-eslint-parser',
+      extends: ['plugin:yml/recommended'],
+      rules: {
+        'yml/no-irregular-whitespace': 'off'
       }
     }
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,22 @@
       "less",
       "postcss",
       "scss"
-  ]
+  ],
+  "eslint.packageManager": "yarn",
+  "eslint.probe": [
+      "javascript",
+      "vue",
+      "json",
+      "jsonc",
+      "yml",
+      "yaml"
+  ],
+  "eslint.validate": [
+    "javascript",
+    "vue",
+    "json",
+    "jsonc",
+    "yml",
+    "yaml"
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint-style:css": "stylelint \"**/*.css\"",
     "lint-style-fix:scss": "stylelint --fix \"**/*.scss\"",
     "lint-style-fix:css": "stylelint --fix \"**/*.css\"",
+    "lint-yml": "eslint --ext .yml,.yaml ./",
     "pack": "run-p pack:main pack:renderer",
     "pack:main": "webpack --mode=production --node-env=production --config _scripts/webpack.main.config.js",
     "pack:renderer": "webpack --mode=production --node-env=production --config _scripts/webpack.renderer.config.js",
@@ -93,13 +94,14 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-jsonc": "^2.7.0",
+    "eslint-plugin-jsonc": "^2.8.0",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-unicorn": "^47.0.0",
     "eslint-plugin-vue": "^9.11.1",
     "eslint-plugin-vuejs-accessibility": "^2.1.0",
+    "eslint-plugin-yml": "^1.7.0",
     "html-webpack-plugin": "^5.5.1",
     "js-yaml": "^4.1.0",
     "json-minimizer-webpack-plugin": "^4.0.0",
@@ -122,6 +124,7 @@
     "vue-loader": "^15.10.0",
     "webpack": "^5.82.0",
     "webpack-cli": "^5.1.0",
-    "webpack-dev-server": "^4.15.0"
+    "webpack-dev-server": "^4.15.0",
+    "yaml-eslint-parser": "^1.2.2"
   }
 }

--- a/static/locales/bs.yaml
+++ b/static/locales/bs.yaml
@@ -183,9 +183,6 @@ Video:
     Seconds: ''
     Weeks: ''
   Streamed on: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Views: ''

--- a/static/locales/eo.yaml
+++ b/static/locales/eo.yaml
@@ -147,9 +147,6 @@ Video:
     Dec: ''
     Days: ''
     Upcoming: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Views: ''

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -351,9 +351,6 @@ Video:
     video: ''
     Unsupported Actions:
       reversing playlists: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   View: ''

--- a/static/locales/fil.yaml
+++ b/static/locales/fil.yaml
@@ -132,9 +132,6 @@ Video:
     Nov: ''
     Day: ''
     Ago: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   View: ''

--- a/static/locales/gsw.yaml
+++ b/static/locales/gsw.yaml
@@ -143,9 +143,6 @@ Video:
       shuffling playlists: ''
   Stats:
     Bandwidth: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Videos: ''

--- a/static/locales/la.yaml
+++ b/static/locales/la.yaml
@@ -205,9 +205,6 @@ Video:
     Dec: ''
     Days: ''
     Upcoming: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Views: ''

--- a/static/locales/si.yaml
+++ b/static/locales/si.yaml
@@ -128,9 +128,6 @@ Video:
     Dec: ''
     Days: ''
     Upcoming: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Views: ''

--- a/static/locales/ti.yaml
+++ b/static/locales/ti.yaml
@@ -136,9 +136,6 @@ Video:
       shuffling playlists: ''
   Stats:
     Bandwidth: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Videos: ''

--- a/static/locales/tok.yaml
+++ b/static/locales/tok.yaml
@@ -141,9 +141,6 @@ Video:
       shuffling playlists: ''
   Stats:
     Bandwidth: ''
-Videos:
-  #& Sort By
-{}
 Playlist:
   #& About
   Videos: ''
@@ -166,4 +163,3 @@ Invidious API Error (Click to copy): ''
 Loop is now enabled: ''
 Default Invidious instance has been set to {instance}: ''
 Screenshot Error: ''
-

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -84,7 +84,7 @@ History:
   Search bar placeholder: "تاریخ میں تلاش کریں۔"
 Settings:
   # On Settings Page
-  Settings:
+  Settings: ''
   The app needs to restart for changes to take effect. Restart and apply change?: 'دی
     تبدیلیاں اثر انداز ہونے کے لیے ایپ کو دوبارہ شروع کرنے کی ضرورت ہے۔ دوبارہ شروع
     کریں اور تبدیلی کا اطلاق کریں؟'
@@ -244,4 +244,3 @@ Downloading has completed: '"{videoTitle}" نے ڈاؤن لوڈ مکمل کر ل
 Starting download: '"{videoTitle}" کا ڈاؤن لوڈ شروع ہو رہا ہے'
 Downloading failed: '"{videoTitle}" کو ڈاؤن لوڈ کرنے میں ایک مسئلہ تھا'
 Screenshot Error: 'اسکرین شاٹ ناکام ہو گیا۔ {error}'
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,10 +3542,10 @@ eslint-plugin-import@^2.27.5:
     semver "^6.3.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-jsonc@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.7.0.tgz#ffce6c670f76aeb74765ac2f0fd97071d791d188"
-  integrity sha512-DZgC71h/hZ9t5k/OGAKOMdJCleg2neZLL7No+YYi2ZMroCN4X5huZdrLf1USbrc6UTHwYujd1EDwXHg1qJ6CYw==
+eslint-plugin-jsonc@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.8.0.tgz#040483bdcbc70a71af7fce72a0de8da45b71e27d"
+  integrity sha512-K4VsnztnNwpm+V49CcCu5laq8VjclJpuhfI9LFkOrOyK+BKdQHMzkWo43B4X4rYaVrChm4U9kw/tTU5RHh5Wtg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     jsonc-eslint-parser "^2.0.4"
@@ -3620,6 +3620,16 @@ eslint-plugin-vuejs-accessibility@^2.1.0:
     aria-query ">=5.0.0"
     emoji-regex "^10.0.0"
     vue-eslint-parser "^9.0.1"
+
+eslint-plugin-yml@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-yml/-/eslint-plugin-yml-1.7.0.tgz#cda4ba4b706baeff5316ebc1cc2242e2b97f859a"
+  integrity sha512-qq61FQJk+qIgWl0R06bec7UQQEIBrUH22jS+MroTbFUKu+3/iVlGRpZd8mjpOAm/+H/WEDFwy4x/+kKgVGbsWw==
+  dependencies:
+    debug "^4.3.2"
+    lodash "^4.17.21"
+    natural-compare "^1.4.0"
+    yaml-eslint-parser "^1.2.1"
 
 eslint-scope@5.1.1:
   version "5.1.1"
@@ -8408,10 +8418,24 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-eslint-parser@^1.2.1, yaml-eslint-parser@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yaml-eslint-parser/-/yaml-eslint-parser-1.2.2.tgz#1a9673ebe254328cfc2fa99f297f6d8c9364ccd8"
+  integrity sha512-pEwzfsKbTrB8G3xc/sN7aw1v6A6c/pKxLAkjclnAyo5g5qOh6eL9WGu0o3cSDQZKrTNk4KL4lQSwZW+nBkANEg==
+  dependencies:
+    eslint-visitor-keys "^3.0.0"
+    lodash "^4.17.21"
+    yaml "^2.0.0"
+
 yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^20.2.3:
   version "20.2.9"


### PR DESCRIPTION
# Try to fix Weblate issue

## Pull Request Type
- [x] Bugfix
- [x] Other- fixed json linting and added basic yaml linting

## Related issue
https://github.com/FreeTubeApp/FreeTube/issues/3522

## Description
Fix locale yaml files so weblate can parse them + add linting for yaml/yml and fix json linting

## Testing 
`yarn run dev` with this patch

```diff

diff --git a/_scripts/ProcessLocalesPlugin.js b/_scripts/ProcessLocalesPlugin.js
index 58bf5acc..5ac86b24 100644
--- a/_scripts/ProcessLocalesPlugin.js
+++ b/_scripts/ProcessLocalesPlugin.js
@@ -1,4 +1,4 @@
-const { existsSync, readFileSync } = require('fs')
+const { existsSync, readFileSync, readdirSync } = require('fs')
 const { brotliCompress, constants } = require('zlib')
 const { promisify } = require('util')
 const { load: loadYaml } = require('js-yaml')
@@ -72,7 +72,10 @@ class ProcessLocalesPlugin {
   loadLocales() {
     this.locales = []
 
-    const activeLocales = JSON.parse(readFileSync(`${this.inputDir}/activeLocales.json`))
+    const activeLocales = readdirSync(this.inputDir)
+      .filter(e => e.endsWith('.yaml'))
+      .map(e => e.replace('.yaml', ''))
+    // const activeLocales = JSON.parse(readFileSync(`${this.inputDir}/activeLocales.json`))
 
     for (const locale of activeLocales) {
       const contents = readFileSync(`${this.inputDir}/${locale}.yaml`, 'utf-8')

```

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0
