### PR TITLE
Implement the shorts tab on channel pages

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -264,6 +264,85 @@ export function parseLocalChannelVideos(videos, author) {
 }
 
 /**
+ * @param {import('youtubei.js').YTNodes.ReelItem[]} shorts
+ * @param {Misc.Author} author
+ */
+export function parseLocalChannelShorts(shorts, author) {
+  return shorts.map(short => {
+    // unfortunately the only place with the duration is the accesibility string
+    const duration = parseShortDuration(short.accessibility_label, short.id)
+
+    return {
+      type: 'video',
+      videoId: short.id,
+      title: short.title.text,
+      author: author.name,
+      authorId: author.id,
+      viewCount: parseLocalSubscriberCount(short.views.text),
+      lengthSeconds: isNaN(duration) ? '' : duration
+    }
+  })
+}
+
+/**
+ * Shorts can only be up to 60 seconds long, so we only need to handle seconds and minutes
+ * Of course this is YouTube, so are edge cases that don't match the docs, like example 3 taken from LTT
+ *
+ * https://support.google.com/youtube/answer/10059070?hl=en
+ *
+ * Example input strings:
+ * - These mice keep getting WEIRDER... - 59 seconds - play video
+ * - How Low Can Our Resolution Go? - 1 minute - play video
+ * - I just found out about Elon. #SHORTS - 1 minute, 1 second - play video
+ * @param {string} accessibilityLabel
+ * @param {string} videoId only used for error logging
+ */
+function parseShortDuration(accessibilityLabel, videoId) {
+  // we want to count from the end of the array,
+  // as it's possible that the title could contain a `-` too
+  const timeString = accessibilityLabel.split('-').at(-2)
+
+  if (typeof timeString === 'undefined') {
+    console.error(`Failed to parse local API short duration from accessibility label. video ID: ${videoId}, text: "${accessibilityLabel}"`)
+    return NaN
+  }
+
+  let duration = 0
+
+  const matches = timeString.matchAll(/(\d+) (second|minute)s?/g)
+
+  // matchAll returns an iterator, which doesn't have a length property
+  // so we need to check if it's empty this way instead
+  let validDuration = false
+
+  for (const match of matches) {
+    let number = parseInt(match[1])
+
+    if (isNaN(number) || match[2].length === 0) {
+      validDuration = false
+      break
+    }
+
+    validDuration = true
+
+    if (match[2] === 'minute') {
+      number *= 60
+    }
+
+    duration += number
+  }
+
+  if (!validDuration) {
+    console.error(`Failed to parse local API short duration from accessibility label. video ID: ${videoId}, text: "${accessibilityLabel}"`)
+    return NaN
+  }
+
+  return duration
+}
+
+global.parseShortDuration = parseShortDuration
+
+/**
  * @typedef {import('youtubei.js').YTNodes.Playlist} Playlist
  * @typedef {import('youtubei.js').YTNodes.GridPlaylist} GridPlaylist
  */

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -99,6 +99,19 @@
               {{ $t("Channel.Videos.Videos").toUpperCase() }}
             </div>
             <div
+              id="shortsTab"
+              class="tab"
+              :class="(currentTab==='shorts')?'selectedTab':''"
+              role="tab"
+              aria-selected="true"
+              aria-controls="shortPanel"
+              tabindex="0"
+              @click="changeTab('shorts')"
+              @keydown.left.right.enter.space="changeTab('shorts', $event)"
+            >
+              {{ $t("Channel.Shorts.Shorts").toUpperCase() }}
+            </div>
+            <div
               v-if="!hideLiveStreams"
               id="liveTab"
               class="tab"
@@ -190,6 +203,16 @@
         @change="videoSortBy = $event"
       />
       <ft-select
+        v-if="showShortSortBy"
+        v-show="currentTab === 'shorts' && latestShorts.length > 0"
+        class="sortSelect"
+        :value="videoShortLiveSelectValues[0]"
+        :select-names="videoShortLiveSelectNames"
+        :select-values="videoShortLiveSelectValues"
+        :placeholder="$t('Search Filters.Sort By.Sort By')"
+        @change="shortSortBy = $event"
+      />
+      <ft-select
         v-if="!hideLiveStreams && showLiveSortBy"
         v-show="currentTab === 'live' && latestLive.length > 0"
         class="sortSelect"
@@ -228,6 +251,20 @@
         >
           <p class="message">
             {{ $t("Channel.Videos.This channel does not currently have any videos") }}
+          </p>
+        </ft-flex-box>
+        <ft-element-list
+          v-if="currentTab === 'shorts'"
+          id="shortPanel"
+          :data="latestShorts"
+          role="tabpanel"
+          aria-labelledby="shortsTab"
+        />
+        <ft-flex-box
+          v-if="currentTab === 'shorts' && latestShorts.length === 0"
+        >
+          <p class="message">
+            {{ $t("Channel.Shorts.This channel does not currently have any shorts") }}
           </p>
         </ft-flex-box>
         <ft-element-list

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -534,6 +534,9 @@ Channel:
       Newest: Newest
       Oldest: Oldest
       Most Popular: Most Popular
+  Shorts:
+    Shorts: Shorts
+    This channel does not currently have any shorts: This channel does not currently have any shorts
   Live:
     Live: Live
     This channel does not currently have any live streams: This channel does not currently


### PR DESCRIPTION
# Implement the shorts tab on channel pages

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
https://github.com/LuanRT/YouTube.js/pull/401 (Adds support for the accessibility labels, so we can extract the duration of shorts)
https://github.com/iv-org/invidious/issues/3801 (Invidious bug report about the upcoming issue)

## Description
**draft until https://github.com/LuanRT/YouTube.js/pull/401 is merged and released**

This pull request implements the channel shorts tab for both the local and Invidious APIs. As the Invidious API currently has a bug that results in all shorts being labelled as upcoming, this pull request also includes a work around for that.

Sorting is currently broken and will always sort by newest on the Invidious API. Sorting the shorts tab is a todo in their code base: https://github.com/iv-org/invidious/blob/master/src/invidious/channels/videos.cr#L135

## Screenshots <!-- If appropriate -->
_too lazy, also it just looks like the videos and live tabs anyway_

## Testing <!-- for code that is not small enough to be easily understandable -->
Test the shorts tab on both the local and Invidious APIs, including loading more and sorting (sorting only works for the local API at the moment, see description above)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a4d45b5fa8a8a1726808c9eebe307643f8dde9c9