### PR TITLE
Parse shorts links in text runs

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -525,6 +525,7 @@ export function parseLocalTextRuns(runs, emojiSize = 16, options = { looseChanne
             break
           }
           case 'WEB_PAGE_TYPE_PLAYLIST':
+          case 'WEB_PAGE_TYPE_SHORTS':
             parsedRuns.push(`https://www.youtube.com${endpoint.metadata.url}`)
             break
           case 'WEB_PAGE_TYPE_BROWSE':


### PR DESCRIPTION
# Parse shorts links in text runs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Bugfix

## Related issue
closes #3497

## Description
When parsing text runs for the local API we weren't handling shorts links, so it was falling back to parsing it as an external link, which failed, as the link didn't have a domain and caused the error to show up.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open https://youtu.be/oqrONAqFtCQ with the local API
2. Check that the error no longer shows up

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** e32417b9cbc5b6c2a65af8a59757ee0c7bdcf7f0