### PR TITLE
Fix text wrapping for community posts

### DIFF
--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -66,6 +66,11 @@
   }
 }
 
+.postText {
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
 .bottomSection {
   color: var(--tertiary-text-color);
   display: block;

--- a/src/renderer/components/ft-community-post/ft-community-post.vue
+++ b/src/renderer/components/ft-community-post/ft-community-post.vue
@@ -25,7 +25,10 @@
         {{ publishedText }}
       </p>
     </div>
-    <p v-html="postText" />
+    <p
+      class="postText"
+      v-html="postText"
+    />
     <tiny-slider
       v-if="type === 'multiImage' && postContent.content.length > 0"
       v-bind="tinySliderOptions"
@@ -114,5 +117,5 @@
 </template>
 
 <script src="./ft-community-post.js" />
-<style src="./ft-community-post.scss" lang="scss" />
+<style scoped src="./ft-community-post.scss" lang="scss" />
 <style src="./slider-style.css" lang="css" />


### PR DESCRIPTION
# Fix text wrapping for community posts

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3443

## Description
Fixes long links not being wrapped for community posts and also that line breaks were getting stripped.

## Screenshots <!-- If appropriate -->
<details><summary>TheHatedOne</summary>

![before-1](https://github.com/FreeTubeApp/FreeTube/assets/48293849/9e6e3010-6364-4283-99a4-f19d940c7fb2)
![after-1](https://github.com/FreeTubeApp/FreeTube/assets/48293849/1fa56e5f-19e3-442d-8110-815570d333bf)

</details>

<details><summary>MrBeast</summary>

![before-2](https://github.com/FreeTubeApp/FreeTube/assets/48293849/a5498e5c-27d1-481d-bdf9-8172f45ff6fd)
![after-2](https://github.com/FreeTubeApp/FreeTube/assets/48293849/0786ddbe-6ff5-4b3e-ac99-d3b549dfec51)

</details>

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Check that the link gets wrapped instead of overflowing for https://www.youtube.com/@TheHatedOne/community
2. Check that the line breaks are preserved for https://www.youtube.com/@MrBeast/community

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a4d45b5fa8a8a1726808c9eebe307643f8dde9c9