### PR TITLE
Fix locale files so yaml parsing won't cause errors (Part 2)

### DIFF
--- a/static/locales/as.yaml
+++ b/static/locales/as.yaml
@@ -48,9 +48,6 @@ Video:
   Published:
     Jun: ''
     Months: ''
-Videos:
-  #& Sort By
-{}
 Change Format:
   Use Dash Formats: ''
 Comments:

--- a/static/locales/hi.yaml
+++ b/static/locales/hi.yaml
@@ -204,9 +204,6 @@ Video:
   Published:
     Sep: ''
     Year: ''
-Videos:
-  #& Sort By
-{}
 Change Format:
   Change Media Formats: ''
 Share:

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -194,8 +194,5 @@ Channel:
   Playlists: {}
 Video:
   'Live Chat is currently not supported with the Invidious API. A direct connection to YouTube is required.': ''
-Videos:
-  #& Sort By
-{}
 Comments:
   Replies: ''

--- a/static/locales/or.yaml
+++ b/static/locales/or.yaml
@@ -138,9 +138,6 @@ Video:
   External Player: {}
   Stats:
     Resolution: ''
-Videos:
-  #& Sort By
-{}
 Toggle Theatre Mode: ''
 Share:
   YouTube URL copied to clipboard: ''

--- a/static/locales/sat.yaml
+++ b/static/locales/sat.yaml
@@ -61,9 +61,6 @@ Video:
   Published:
     Oct: ''
     Years: ''
-Videos:
-  #& Sort By
-{}
 Change Format:
   Use Dash Formats: ''
 Share:


### PR DESCRIPTION
# Fix locale files so yaml parsing won't cause errors (Part 2)

## Pull Request Type
- [x] Bugfix

## Related issue
#3522 

## Description
Fix locale yaml files so weblate can parse them

## Testing 
See #3527 

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0

