### PR TITLE
Ensure screen saver blocker removed when window closed

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -357,10 +357,7 @@ export default defineComponent({
       navigator.mediaSession.playbackState = 'none'
     }
 
-    if (process.env.IS_ELECTRON && this.powerSaveBlocker !== null) {
-      const { ipcRenderer } = require('electron')
-      ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER, this.powerSaveBlocker)
-    }
+    this.stopPowerSaveBlocker()
   },
   methods: {
     initializePlayer: async function () {
@@ -550,11 +547,7 @@ export default defineComponent({
             navigator.mediaSession.playbackState = 'none'
           }
 
-          if (process.env.IS_ELECTRON && this.powerSaveBlocker !== null) {
-            const { ipcRenderer } = require('electron')
-            ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER, this.powerSaveBlocker)
-            this.powerSaveBlocker = null
-          }
+          this.stopPowerSaveBlocker()
         })
 
         this.player.on('error', (error, message) => {
@@ -564,11 +557,7 @@ export default defineComponent({
             navigator.mediaSession.playbackState = 'none'
           }
 
-          if (process.env.IS_ELECTRON && this.powerSaveBlocker !== null) {
-            const { ipcRenderer } = require('electron')
-            ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER, this.powerSaveBlocker)
-            this.powerSaveBlocker = null
-          }
+          this.stopPowerSaveBlocker()
         })
 
         this.player.on('play', async () => {
@@ -588,11 +577,7 @@ export default defineComponent({
             navigator.mediaSession.playbackState = 'paused'
           }
 
-          if (process.env.IS_ELECTRON && this.powerSaveBlocker !== null) {
-            const { ipcRenderer } = require('electron')
-            ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER, this.powerSaveBlocker)
-            this.powerSaveBlocker = null
-          }
+          this.stopPowerSaveBlocker()
         })
 
         this.player.on(this.statsModalEventName, () => {
@@ -2029,6 +2014,14 @@ export default defineComponent({
             this.takeScreenshot()
             break
         }
+      }
+    },
+
+    stopPowerSaveBlocker: function() {
+      if (process.env.IS_ELECTRON && this.powerSaveBlocker !== null) {
+        const { ipcRenderer } = require('electron')
+        ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER, this.powerSaveBlocker)
+        this.powerSaveBlocker = null
       }
     },
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -42,6 +42,10 @@ const VHS_BANDWIDTH_VARIANCE = videojs.Vhs.BANDWIDTH_VARIANCE
 
 export default defineComponent({
   name: 'FtVideoPlayer',
+  beforeRouteLeave: function (_to, _from, next) {
+    window.removeEventListener('beforeunload', this.stopPowerSaveBlocker)
+    next()
+  },
   props: {
     format: {
       type: String,
@@ -339,6 +343,8 @@ export default defineComponent({
       navigator.mediaSession.setActionHandler('play', () => this.player.play())
       navigator.mediaSession.setActionHandler('pause', () => this.player.pause())
     }
+
+    window.addEventListener('beforeunload', this.stopPowerSaveBlocker)
   },
   beforeDestroy: function () {
     document.removeEventListener('keydown', this.keyboardShortcutHandler)


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Similar to #1217 
Might work for reload case in #3286 too

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
`beforeDestroy` doesn't work for window close
https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/389

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy! (Well or a video with at least 1 min is needed, definitely too big to be uploaded)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Change screen saver to minimum (1 min for MacOS I think)
- Use FT to play random video
- Close window
- Wait 1 min to ensure screen saver/sleep triggered

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
