### PR TITLE
fix live chat error

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -212,7 +212,7 @@ export default defineComponent({
       const parsedComment = {
         message: autolinker.link(parseLocalTextRuns(comment.message.runs, 20)),
         author: {
-          name: comment.author.name.text,
+          name: comment.author.name,
           thumbnailUrl: comment.author.thumbnails.at(-1).url,
           isOwner: comment.author.id === this.channelId,
           isModerator: comment.author.is_moderator,
@@ -222,7 +222,7 @@ export default defineComponent({
 
       if (badge) {
         parsedComment.badge = {
-          url: badge.custom_thumbnail.at(-1).url,
+          url: badge.custom_thumbnail.at(-1)?.url,
           tooltip: badge.tooltip ?? ''
         }
       }


### PR DESCRIPTION
# fix live chat error

## Pull Request Type
- [x] Bugfix

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/3544


## Description
Fix error when url is missing from badge, fix name not shown when viewing live chat

## Testing 
- Go to Go to https://www.youtube.com/watch?v=36YnV9STBqc
- See no error

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0