### PR TITLE
Fix cursor moving while navigating search suggestions

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -230,6 +230,7 @@ export default defineComponent({
       this.searchState.showOptions = true
       const isArrow = event.key === 'ArrowDown' || event.key === 'ArrowUp'
       if (isArrow) {
+        event.preventDefault()
         if (event.key === 'ArrowDown') {
           this.searchState.selectedOption = (this.searchState.selectedOption + 1) % this.visibleDataList.length
         } else if (event.key === 'ArrowUp') {


### PR DESCRIPTION
# Fix cursor moving while navigating search suggestions

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3561

## Description
Currently navigating through the search suggestions in the search bar moves the cursor around in the search bar. As you may want to keep typing, the cursor moving around unnecessarily is undesired.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Enter some text into the search bar
2. Use the up and down arrow keys to navigate through the search suggestions
3. Check that the cursor is still where you left it

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 5445800ff361ca3423b62fbefb6c6e2845fda199