### PR TITLE
IV: add support for hashtag pages

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -290,3 +290,15 @@ export function filterInvidiousFormats(formats, allowAv1 = false) {
   // }
   return [...audioFormats, ...h264Formats]
 }
+
+export async function getHashtagInvidious(hashtag, page) {
+  const payload = {
+    resource: 'hashtag',
+    id: hashtag,
+    params: {
+      page
+    }
+  }
+  const response = await invidiousAPICall(payload)
+  return response.results
+}

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -11,25 +11,16 @@
           class="elementList"
         >
           <ft-element-list
-            v-if="backendFallback || backendPreference === 'local' && videos.length > 0"
+            v-if="videos.length > 0"
             :data="videos"
           />
           <ft-flex-box
-            v-else-if="backendFallback || backendPreference === 'local' && videos.length === 0"
+            v-else-if="videos.length === 0"
           >
             <p
               class="message"
             >
               {{ $t("Hashtag.This hashtag does not currently have any videos") }}
-            </p>
-          </ft-flex-box>
-          <ft-flex-box
-            v-else
-          >
-            <p
-              class="message"
-            >
-              {{ $t("Hashtag.You can only view hashtag pages through the Local API") }}
             </p>
           </ft-flex-box>
         </div>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -879,7 +879,6 @@ Hashtag:
   Hashtag: Hashtag
   This hashtag does not currently have any videos: This hashtag does not currently
       have any videos
-  You can only view hashtag pages through the Local API: You can only view hashtag pages through the Local API
 Yes: Yes
 No: No
 Ok: Ok


### PR DESCRIPTION
# IV: add support for hashtag pages

## Pull Request Type
- [x] Feature Implementation

## Related issue
Follow up to https://github.com/FreeTubeApp/FreeTube/pull/3483
Relies on https://github.com/iv-org/invidious/pull/3692

## Description
This PR adds hashtag page support when using the invidious api

## Testing 
- use invidious as primary api (no fallback)
- switch to an invidious instance that has support or the hashtag api in it
- go to a hashtag page
- load more videos

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0