### PR TITLE
Fix keyboard shortcut to toggle the captions

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1319,13 +1319,16 @@ export default defineComponent({
     },
 
     toggleCaptions: function () {
-      const tracks = this.player.textTracks().tracks_
+      // skip videojs-http-streaming's segment-metadata track
+      // https://github.com/videojs/http-streaming#segment-metadata
+      const trackIndex = this.useDash ? 1 : 0
 
-      if (tracks.length > 1) {
-        if (tracks[1].mode === 'showing') {
-          tracks[1].mode = 'disabled'
+      const tracks = this.player.textTracks()
+      if (tracks.length > trackIndex) {
+        if (tracks[trackIndex].mode === 'showing') {
+          tracks[trackIndex].mode = 'disabled'
         } else {
-          tracks[1].mode = 'showing'
+          tracks[trackIndex].mode = 'showing'
         }
       }
     },


### PR DESCRIPTION
# Fix keyboard shortcut to toggle the captions

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3570

## Description
Currently the keyboard shortcut to toggle the captions, only works for the DASH formats, this pull request makes it work for the audio and legacy formats too.

## Testing <!-- for code that is not small enough to be easily understandable -->
**subtitles don't work on some Invidious instances, due to YouTube ratelimiting them, so best to test this with the local API**

1. Open https://youtu.be/mBIdAMcvRhY
2. Toggle the captions with the `c` key
3. Change formats
4. (repeat 2 and 3 until you've tried all formats)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 15b8dffaf37781dec3c936aa591da354441e95f3