### PR TITLE
Fix playlist thumbnail not getting proxied through Invidious

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -41,20 +41,31 @@ export default defineComponent({
       return this.$store.getters.getThumbnailPreference
     },
 
+    backendPreference: function () {
+      return this.$store.getters.getBackendPreference
+    },
+
     hideViews: function () {
       return this.$store.getters.getHideVideoViews
     },
 
     thumbnail: function () {
+      let baseUrl
+      if (this.backendPreference === 'invidious') {
+        baseUrl = this.currentInvidiousInstance
+      } else {
+        baseUrl = 'https://i.ytimg.com'
+      }
+
       switch (this.thumbnailPreference) {
         case 'start':
-          return `https://i.ytimg.com/vi/${this.firstVideoId}/mq1.jpg`
+          return `${baseUrl}/vi/${this.firstVideoId}/mq1.jpg`
         case 'middle':
-          return `https://i.ytimg.com/vi/${this.firstVideoId}/mq2.jpg`
+          return `${baseUrl}/vi/${this.firstVideoId}/mq2.jpg`
         case 'end':
-          return `https://i.ytimg.com/vi/${this.firstVideoId}/mq3.jpg`
+          return `${baseUrl}/vi/${this.firstVideoId}/mq3.jpg`
         default:
-          return `https://i.ytimg.com/vi/${this.firstVideoId}/mqdefault.jpg`
+          return `${baseUrl}/vi/${this.firstVideoId}/mqdefault.jpg`
       }
     }
   },


### PR DESCRIPTION
# Fix playlist thumbnail not getting proxied through Invidious

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Fix playlist thumbnail not getting proxied through Invidious on the playlist page. Copied the logic over from ft-list-video.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/bb4a0569-ba16-49f7-ab52-9af5d73452e5)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/54613bf5-7fed-4881-a6f7-a96c415be5bd)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Set the API to Invidious
2. Open a playlist e.g. https://www.youtube.com/playlist?list=PL8mG-RkN2uTwKxRN7Qd_qTNn6lqHkdN8g
3. Use the select element item in the devtools (CTRL+SHIFT+C) to select the playlist thumbnail
4. Check that the `src` attribute of the image starts with the Invidious instance you are using

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 15b8dffaf37781dec3c936aa591da354441e95f3