### PR TITLE
Add support for the short published dates

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -9,35 +9,35 @@ import router from '../router/index'
 // https://support.google.com/youtube/answer/11585688#change_handle
 export const CHANNEL_HANDLE_REGEX = /^@[\w.-]{3,30}$/
 
+const PUBLISHED_TEXT_REGEX = /(\d+)\s?([a-z]+)/i
+/**
+ * @param {string} publishedText
+ */
 export function calculatePublishedDate(publishedText) {
   const date = new Date()
   if (publishedText === 'Live') {
     return publishedText
   }
 
-  const textSplit = publishedText.split(' ')
+  const match = publishedText.match(PUBLISHED_TEXT_REGEX)
 
-  if (textSplit[0].toLowerCase() === 'streamed') {
-    textSplit.shift()
-  }
-
-  const timeFrame = textSplit[1]
-  const timeAmount = parseInt(textSplit[0])
+  const timeFrame = match[2]
+  const timeAmount = parseInt(match[1])
   let timeSpan = null
 
-  if (timeFrame.indexOf('second') > -1) {
+  if (timeFrame.startsWith('second') || timeFrame === 's') {
     timeSpan = timeAmount * 1000
-  } else if (timeFrame.indexOf('minute') > -1) {
+  } else if (timeFrame.startsWith('minute') || timeFrame === 'm') {
     timeSpan = timeAmount * 60000
-  } else if (timeFrame.indexOf('hour') > -1) {
+  } else if (timeFrame.startsWith('hour') || timeFrame === 'h') {
     timeSpan = timeAmount * 3600000
-  } else if (timeFrame.indexOf('day') > -1) {
+  } else if (timeFrame.startsWith('day') || timeFrame === 'd') {
     timeSpan = timeAmount * 86400000
-  } else if (timeFrame.indexOf('week') > -1) {
+  } else if (timeFrame.startsWith('week') || timeFrame === 'w') {
     timeSpan = timeAmount * 604800000
-  } else if (timeFrame.indexOf('month') > -1) {
+  } else if (timeFrame.startsWith('month') || timeFrame === 'mo') {
     timeSpan = timeAmount * 2592000000
-  } else if (timeFrame.indexOf('year') > -1) {
+  } else if (timeFrame.startsWith('year') || timeFrame === 'y') {
     timeSpan = timeAmount * 31556952000
   }
 
@@ -53,33 +53,36 @@ export function toLocalePublicationString ({ publishText, isLive = false, isUpco
   } else if (isRSS) {
     return publishText
   }
-  const strings = publishText.split(' ')
-  // filters out the streamed x hours ago and removes the streamed in order to keep the rest of the code working
-  if (strings[0].toLowerCase() === 'streamed') {
-    strings.shift()
-  }
-  const singular = (strings[0] === '1')
+
+  const match = publishText.match(PUBLISHED_TEXT_REGEX)
+  const singular = (match[1] === '1')
   let translationKey = ''
-  switch (strings[1].substring(0, 2)) {
+  switch (match[2].substring(0, 2)) {
     case 'se':
+    case 's':
       translationKey = 'Video.Published.Second'
       break
     case 'mi':
+    case 'm':
       translationKey = 'Video.Published.Minute'
       break
     case 'ho':
+    case 'h':
       translationKey = 'Video.Published.Hour'
       break
     case 'da':
+    case 'd':
       translationKey = 'Video.Published.Day'
       break
     case 'we':
+    case 'w':
       translationKey = 'Video.Published.Week'
       break
     case 'mo':
       translationKey = 'Video.Published.Month'
       break
     case 'ye':
+    case 'y':
       translationKey = 'Video.Published.Year'
       break
     default:
@@ -90,7 +93,7 @@ export function toLocalePublicationString ({ publishText, isLive = false, isUpco
   }
 
   const unit = i18n.t(translationKey)
-  return i18n.t('Video.Publicationtemplate', { number: strings[0], unit })
+  return i18n.t('Video.Publicationtemplate', { number: match[1], unit })
 }
 
 export function buildVTTFileLocally(storyboard, videoLengthSeconds) {


### PR DESCRIPTION
# Add support for the short published dates

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3587 

## Description
Looks like YouTube is experimenting with a shortened date format for the published dates, this pull request adds support for them.

## Testing <!-- for code that is not small enough to be easily understandable -->
To consistently get the short date formats, add this line to the `createInnertube` function in `src/renderer/helpers/api/local.js`.
```diff
src/renderer/helpers/api/local.js
@@ -41,6 +41,7 @@ async function createInnertube(options = { withPlayer: false, location: undefine
   }

   return await Innertube.create({
+    visitor_data: 'CgtQZ0JEVEdaUU54NCi927%2BjBg%3D%3D',
     retrieve_player: !!options.withPlayer,
     location: options.location,
     enable_safety_mode: !!options.safetyMode,
```

Then refresh your subscriptions and look at channels to make sure the dates are displayed correctly in FreeTube and that the subscription videos are sorted correctly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a11533ac8aed9551550a859f2220170cf3780e0b