### PR TITLE
Add subsections to the distraction free settings

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.css
+++ b/src/renderer/components/distraction-settings/distraction-settings.css
@@ -1,3 +1,7 @@
+.groupTitle {
+  text-align: center;
+}
+
 @media only screen and (max-width: 800px) {
   br.hide-on-mobile {
     display: none;

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -2,82 +2,13 @@
   <ft-settings-section
     :title="$t('Settings.Distraction Free Settings.Distraction Free Settings')"
   >
+    <h4
+      class="groupTitle"
+    >
+      {{ $t('Settings.Distraction Free Settings.Sections.Side Bar') }}
+    </h4>
     <div class="switchColumnGrid">
       <div class="switchColumn">
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Video Views')"
-          :compact="true"
-          :default-value="hideVideoViews"
-          @change="updateHideVideoViews"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Video Likes And Dislikes')"
-          :compact="true"
-          :default-value="hideVideoLikesAndDislikes"
-          @change="updateHideVideoLikesAndDislikes"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Channel Subscribers')"
-          :compact="true"
-          :default-value="hideChannelSubscriptions"
-          @change="updateHideChannelSubscriptions"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Comment Likes')"
-          :compact="true"
-          :default-value="hideCommentLikes"
-          @change="updateHideCommentLikes"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Active Subscriptions')"
-          :compact="true"
-          :default-value="hideActiveSubscriptions"
-          @change="updateHideActiveSubscriptions"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Video Description')"
-          :compact="true"
-          :default-value="hideVideoDescription"
-          @change="updateHideVideoDescription"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Sharing Actions')"
-          :compact="true"
-          :default-value="hideSharingActions"
-          @change="updateHideSharingActions"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Chapters')"
-          :compact="true"
-          :default-value="hideChapters"
-          @change="updateHideChapters"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Featured Channels')"
-          :compact="true"
-          :default-value="hideFeaturedChannels"
-          @change="updateHideFeaturedChannels"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Channel Playlists')"
-          :compact="true"
-          :default-value="hideChannelPlaylists"
-          @change="updateHideChannelPlaylists"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Channel Shorts')"
-          :compact="true"
-          :default-value="hideChannelShorts"
-          @change="updateHideChannelShorts"
-        />
-      </div>
-      <div class="switchColumn">
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Recommended Videos')"
-          :compact="true"
-          :default-value="hideRecommendedVideos"
-          @change="handleHideRecommendedVideos"
-        />
         <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Hide Trending Videos')"
           :compact="true"
@@ -90,6 +21,8 @@
           :default-value="hidePopularVideos"
           @change="updateHidePopularVideos"
         />
+      </div>
+      <div class="switchColumn">
         <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Hide Playlists')"
           :compact="true"
@@ -97,11 +30,128 @@
           @change="updateHidePlaylists"
         />
         <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Active Subscriptions')"
+          :compact="true"
+          :default-value="hideActiveSubscriptions"
+          @change="updateHideActiveSubscriptions"
+        />
+      </div>
+    </div>
+    <h4
+      class="groupTitle"
+    >
+      {{ $t('Settings.Distraction Free Settings.Sections.Channel Pages') }}
+    </h4>
+    <div class="switchColumnGrid">
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Channel Shorts')"
+          :compact="true"
+          :default-value="hideChannelShorts"
+          @change="updateHideChannelShorts"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Channel Playlists')"
+          :compact="true"
+          :default-value="hideChannelPlaylists"
+          @change="updateHideChannelPlaylists"
+        />
+      </div>
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Channel Community')"
+          :compact="true"
+          :default-value="hideChannelCommunity"
+          @change="updateHideChannelCommunity"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Featured Channels')"
+          :compact="true"
+          :default-value="hideFeaturedChannels"
+          @change="updateHideFeaturedChannels"
+        />
+      </div>
+    </div>
+    <h4
+      class="groupTitle"
+    >
+      {{ $t('Settings.Distraction Free Settings.Sections.Watch Pages') }}
+    </h4>
+    <div class="switchColumnGrid">
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Video Likes And Dislikes')"
+          :compact="true"
+          :default-value="hideVideoLikesAndDislikes"
+          @change="updateHideVideoLikesAndDislikes"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Chapters')"
+          :compact="true"
+          :default-value="hideChapters"
+          @change="updateHideChapters"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Video Description')"
+          :compact="true"
+          :default-value="hideVideoDescription"
+          @change="updateHideVideoDescription"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Comment Likes')"
+          :compact="true"
+          :default-value="hideCommentLikes"
+          @change="updateHideCommentLikes"
+        />
+      </div>
+      <div class="switchColumn">
+        <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Hide Live Chat')"
           :compact="true"
           :default-value="hideLiveChat"
           @change="updateHideLiveChat"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Recommended Videos')"
+          :compact="true"
+          :default-value="hideRecommendedVideos"
+          @change="handleHideRecommendedVideos"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Comments')"
+          :compact="true"
+          :default-value="hideComments"
+          @change="updateHideComments"
+        />
+      </div>
+    </div>
+    <h4
+      class="groupTitle"
+    >
+      {{ $t('Settings.Distraction Free Settings.Sections.General') }}
+    </h4>
+    <div class="switchColumnGrid">
+      <div class="switchColumn">
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Video Views')"
+          :compact="true"
+          :default-value="hideVideoViews"
+          @change="updateHideVideoViews"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Channel Subscribers')"
+          :compact="true"
+          :default-value="hideChannelSubscriptions"
+          @change="updateHideChannelSubscriptions"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Sharing Actions')"
+          :compact="true"
+          :default-value="hideSharingActions"
+          @change="updateHideSharingActions"
+        />
+      </div>
+      <div class="switchColumn">
         <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Hide Live Streams')"
           :compact="true"
@@ -115,22 +165,10 @@
           @change="updateHideUpcomingPremieres"
         />
         <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Comments')"
-          :compact="true"
-          :default-value="hideComments"
-          @change="updateHideComments"
-        />
-        <ft-toggle-switch
           :label="$t('Settings.Distraction Free Settings.Display Titles Without Excessive Capitalisation')"
           :compact="true"
           :default-value="showDistractionFreeTitles"
           @change="updateShowDistractionFreeTitles"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Channel Community')"
-          :compact="true"
-          :default-value="hideChannelCommunity"
-          @change="updateHideChannelCommunity"
         />
       </div>
     </div>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -317,6 +317,11 @@ Settings:
     Fetch Automatically: Fetch Feed Automatically
   Distraction Free Settings:
     Distraction Free Settings: Distraction Free Settings
+    Sections:
+      Side Bar: Side Bar
+      Channel Pages: Channel Pages
+      Watch Pages: Watch Pages
+      General: General
     Hide Video Views: Hide Video Views
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers


### PR DESCRIPTION
# Add subsections to the distraction free settings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
We have a lot of distraction free settings, which makes it hard to find the ones you need but also makes it confusing because some are similarly named but apply to different parts of the app. To solve that, I decided to split them up into subsections with the following headings:
- Side Bar
- Channel Pages
- Watch Pages
- General

Settings in the general subsection apply to multiple places in FreeTube, e.g. "Hide Video Views" applies to video lists and on the watch page.

Please let me know what you think of the headings and whether you want me to reword them.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/a6991a01-3662-4424-8683-bc0f8affb223)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/bf1b3134-93f1-464f-9ffa-327721db4e0b)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 8dbad618f9549ee075fe70572c07e7a7a978ced6