### PR TITLE
Fix `history.db` imports

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -690,7 +690,7 @@ export default defineComponent({
 
       response.filePaths.forEach(filePath => {
         if (filePath.endsWith('.db')) {
-          this.importFreeTubeSubscriptions(textDecode.split('\n'))
+          this.importFreeTubeHistory(textDecode.split('\n'))
         } else if (filePath.endsWith('.json')) {
           this.importYouTubeHistory(JSON.parse(textDecode))
         }


### PR DESCRIPTION
# Fix `history.db` imports

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
In the `importHistory` method of the `data-settings` component, the `importFreeTubeSubscriptions` function is erroneously called instead of `importFreeTubeHistory`. The result is an error: `TypeError: textDecode.split is not a function`.

## Screenshots <!-- If appropriate -->
<!-- Please add 
before and after screenshots if there is a visible change. -->
|before|after|
|---|---|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/034665e6-7fb5-41be-b2cf-68d0fa3a30f7)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/4acf01aa-2689-4ad1-9a94-a9530a6e46fd)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Import a `history.db` under `Data Settings`
2. Ensure no console errors occur and that the history imports

## Desktop
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 7d8a4c8cd7f31d6e94fde92e8bebc9dedd5c990c

## Additional context
<!-- Add any other context about the pull request here. -->
