### PR TITLE
Fix live videos as list items had no save to playlist button

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -45,7 +45,7 @@
         @click="handleExternalPlayer"
       />
       <ft-icon-button
-        v-if="!isLive"
+        v-if="!isUpcoming"
         :title="$t('Video.Save Video')"
         :icon="['fas', 'star']"
         class="favoritesIcon"


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fix live videos as list items had no save to playlist button

Such button is already present in watch page (for live videos)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After:
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/8bd4979d-b1b1-467f-a95b-4191bb4c41cf)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
