### PR TITLE
Update watch page chapter component to scroll to current chapter on expand

### DIFF
--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.js
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.js
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import FtCard from '../ft-card/ft-card.vue'
 
 export default defineComponent({
@@ -23,8 +23,12 @@ export default defineComponent({
     }
   },
   computed: {
+    currentChapter: function () {
+      return this.chapters[this.currentIndex]
+    },
+
     currentTitle: function () {
-      return this.chapters[this.currentIndex].title
+      return this.currentChapter.title
     },
 
     compact: function () {
@@ -67,6 +71,24 @@ export default defineComponent({
       }
 
       chapterElements[newIndex].focus()
-    }
+    },
+
+    toggleShowChapters() {
+      this.showChapters = !this.showChapters
+
+      if (this.showChapters) { this.scrollToCurrentChapter() }
+    },
+
+    scrollToCurrentChapter() {
+      const container = this.$refs.chaptersWrapper
+      const currentChaptersItem = (this.$refs.currentChaptersItem || [])[0]
+      // Must wait until rendering done after value change
+      nextTick(() => {
+        if (container != null && currentChaptersItem != null) {
+          // Watch view can be ready sooner than this component
+          container.scrollTop = currentChaptersItem.offsetTop - container.offsetTop
+        }
+      })
+    },
   }
 })

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.vue
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.vue
@@ -8,9 +8,9 @@
         : $t('Chapters.Chapters list hidden, current chapter: {chapterName}', null, { chapterName: currentTitle })
       "
       :aria-pressed="showChapters"
-      @click="showChapters = !showChapters"
-      @keydown.space.stop.prevent="showChapters = !showChapters"
-      @keydown.enter.stop.prevent="showChapters = !showChapters"
+      @click="toggleShowChapters"
+      @keydown.space.stop.prevent="toggleShowChapters"
+      @keydown.enter.stop.prevent="toggleShowChapters"
     >
       {{ $t("Chapters.Chapters") }}
 
@@ -36,6 +36,7 @@
       <div
         v-for="(chapter, index) in chapters"
         :key="index"
+        :ref="index === currentIndex ? 'currentChaptersItem' : null"
         class="chapter"
         role="button"
         tabindex="0"


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Similar to https://github.com/FreeTubeApp/FreeTube/pull/3399

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Very annoying to have to scroll & find current chapter after watching video for several chapters and then expand the chapter panel
This PR makes expanding also scroll to current chapter in the chapter panel

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before:
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/0549a94d-eb6f-4fe6-99b8-a87491d97ca6)
After:
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/897e1822-4b26-4e7f-b1e4-f33218a886f8)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Find a video with chapters, the more the better, e.g. https://youtu.be/IL2P1IB-2nc
- Update progress to some chapters later
- Expand chapter panel
- Ensure current chapter in sight

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
