### PR TITLE
comment url & custom emoji on invidious API

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -119,7 +119,7 @@ export function youtubeImageUrlToInvidious(url, currentInstance = null) {
 }
 
 export function invidiousImageUrlToInvidious(url, currentInstance = null) {
-  return url.replace(/^.+(ggpht.+)/, currentInstance)
+  return url.replace(/(\/ggpht\/)/, `${currentInstance}/ggpht/`)
 }
 
 function parseInvidiousCommentData(response) {
@@ -128,7 +128,7 @@ function parseInvidiousCommentData(response) {
     comment.authorLink = comment.authorId
     comment.authorThumb = youtubeImageUrlToInvidious(comment.authorThumbnails[1].url)
     comment.likes = comment.likeCount
-    comment.text = autolinker.link(stripHTML(comment.content))
+    comment.text = autolinker.link(stripHTML(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstance())))
     comment.dataType = 'invidious'
     comment.isOwner = comment.authorIsChannelOwner
     comment.numReplies = comment.replies?.replyCount ?? 0

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -406,7 +406,7 @@ export function createWebURL(path) {
 
 // strip html tags but keep <br>, <b>, </b> <s>, </s>, <i>, </i>
 export function stripHTML(value) {
-  return value.replaceAll(/(<(?!br|\/?[bis]>)([^>]+)>)/gi, '')
+  return value.replaceAll(/(<(?!br|\/?[bis]|img>)([^>]+)>)/gi, '')
 }
 
 /**


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #3642

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This PR mainly fixes the issue of custom emojis not showing up when using the invidious API, but also slightly touches the upstream issue of improper YouTube links in channels. An [Invidious PR](https://github.com/iv-org/invidious/pull/3911) was just put up to fully mediate this issue though.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
**Comment before fix (note messed up channel URL and no custom emoji):**
![Screenshot from 2023-06-12 10-19-15](https://github.com/FreeTubeApp/FreeTube/assets/83597346/d8f98d31-18a0-4d3b-b7b8-c0044847ab11)

**Comment after FreeTube fix, but without upstream fixes (current state, note emoji fix):**
![Screenshot from 2023-06-12 10-20-18](https://github.com/FreeTubeApp/FreeTube/assets/83597346/ea54b3e5-86d5-41c8-a145-a6dd532c1a33)

**Comment with both FreeTube and upstream fix:**
![Screenshot from 2023-06-12 10-23-25](https://github.com/FreeTubeApp/FreeTube/assets/83597346/da3792c9-4c9e-4d99-be0b-40b1f448c25f)



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

This was tested by confirming the comment now looks as inspected utilizing both a remote invidious instance and a locally "fixed" instance of invidious which shows proper channel URL/linking.

## Desktop
<!-- Please complete the following information-->
- **FreeTube version:** [b50573f](https://github.com/FreeTubeApp/FreeTube/commit/b50573ffa486c636ae569cc0cb363fad58375347)