### PR TITLE
[Local API] Update subscription view to show live videos

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -247,6 +247,36 @@ export async function getLocalChannelVideos(id) {
   }
 }
 
+export async function getLocalChannelLiveStreams(id) {
+  const innertube = await createInnertube()
+
+  try {
+    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
+      browse_id: id,
+      params: 'EgdzdHJlYW1z8gYECgJ6AA%3D%3D'
+      // protobuf for the live tab (this is the one that YouTube uses,
+      // it has some empty fields in the protobuf but it doesn't work if you remove them)
+    }))
+
+    const liveStreamsTab = new YT.Channel(null, response)
+
+    // if the channel doesn't have a live tab, YouTube returns the home tab instead
+    // so we need to check that we got the right tab
+    if (liveStreamsTab.current_tab?.endpoint.metadata.url?.endsWith('/streams')) {
+      return parseLocalChannelVideos(liveStreamsTab.videos, liveStreamsTab.header.author)
+    } else {
+      return []
+    }
+  } catch (error) {
+    console.error(error)
+    if (error instanceof Utils.ChannelError) {
+      return null
+    } else {
+      throw error
+    }
+  }
+}
+
 /**
  * @param {import('youtubei.js').YTNodes.Video[]} videos
  * @param {Misc.Author} author

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -11,7 +11,10 @@ import FtChannelBubble from '../../components/ft-channel-bubble/ft-channel-bubbl
 import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculatePublishedDate, copyToClipboard, showToast } from '../../helpers/utils'
 import { invidiousAPICall } from '../../helpers/api/invidious'
-import { getLocalChannelVideos } from '../../helpers/api/local'
+import {
+  getLocalChannelLiveStreams,
+  getLocalChannelVideos,
+} from '../../helpers/api/local'
 
 export default defineComponent({
   name: 'Subscriptions',
@@ -268,12 +271,15 @@ export default defineComponent({
 
     getChannelVideosLocalScraper: async function (channel, failedAttempts = 0) {
       try {
-        const videos = await getLocalChannelVideos(channel.id)
+        const videos = []
+        const normalVideos = await getLocalChannelVideos(channel.id)
+        const liveStreams = await getLocalChannelLiveStreams(channel.id)
 
-        if (videos === null) {
+        if (normalVideos == null || liveStreams == null) {
           this.errorChannels.push(channel)
           return []
         }
+        videos.push(...normalVideos, ...liveStreams)
 
         videos.map(video => {
           if (video.liveNow) {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -155,7 +155,7 @@ export default defineComponent({
       }
 
       let useRss = this.useRssFeeds
-      if (this.activeSubscriptionList.length >= 125 && !useRss) {
+      if (this.activeSubscriptionList.length >= 62 && !useRss) {
         showToast(
           this.$t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
           10000

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -273,7 +273,7 @@ export default defineComponent({
       try {
         const videos = []
         const normalVideos = await getLocalChannelVideos(channel.id)
-        const liveStreams = await getLocalChannelLiveStreams(channel.id)
+        const liveStreams = this.hideLiveStreams ? [] : await getLocalChannelLiveStreams(channel.id)
 
         if (normalVideos == null || liveStreams == null) {
           this.errorChannels.push(channel)


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/issues/2852 related but this PR only changes Local API

## Description
This PR makes FT to also request live tab (unless hide live stream enabled) for each channel
This means the number of requests **doubles**
So this should be considered during review

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
With Linus Tech Tips in a profile only
https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/b4199c35-6472-4816-aef3-9b2cb47b99ac)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
A. With live stream (`hide live stream` off = show)
- Disable `hide live stream`
- Create a profile (optional but easier to spot issues)
- Subscribe a channel with live streams (e.g. https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw)
- Refresh subscriptions, confirm both normal videos & live streams in view
- Check network tab to ensure there are only 2 new requests (to `browse`)
 
B. With live stream (`hide live stream` on = hide)
- Enable `hide live stream`
- Create a profile (optional but easier to spot issues)
- Subscribe a channel with live streams (e.g. https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw)
- Refresh subscriptions, confirm only normal videos in view
- Check network tab to ensure there is only 1 new request (to `browse`)

C. Without live stream (`hide live stream` off = show)
- Disable `hide live stream`
- Create a profile (optional but easier to spot issues)
- Subscribe a channel without live streams (e.g. https://www.youtube.com/channel/UCz7eke4JGlbtc11_6mmA7ew)
- Refresh subscriptions, confirm normal videos in view
- Check network tab to ensure there is only 1 new request (to `browse`)

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
Scheduled Live Streams not tested
