### PR TITLE
Update subscription view to be able to load videos from video cache again

### DIFF
--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -110,12 +110,7 @@ export default defineComponent({
           }
         })
 
-        this.updateAllSubscriptionsList([])
-        this.updateProfileSubscriptions({
-          activeProfile: MAIN_PROFILE_ID,
-          videoList: [],
-          errorChannels: []
-        })
+        this.clearSubscriptionsCache()
       }
     },
 
@@ -129,8 +124,7 @@ export default defineComponent({
       'updateProfile',
       'removeProfile',
       'updateActiveProfile',
-      'updateAllSubscriptionsList',
-      'updateProfileSubscriptions'
+      'clearSubscriptionsCache',
     ])
   }
 })

--- a/src/renderer/store/modules/subscriptions.js
+++ b/src/renderer/store/modules/subscriptions.js
@@ -1,39 +1,71 @@
 import { MAIN_PROFILE_ID } from '../../../constants'
 
-const state = {
-  allSubscriptionsList: [],
-  profileSubscriptions: {
-    activeProfile: MAIN_PROFILE_ID,
+const defaultState = {
+  subscriptionsCacheForAllSubscriptionsProfile: {
     videoList: [],
-    errorChannels: []
-  }
+  },
+  subscriptionsCacheForActiveProfile: {
+    videoList: [],
+    profileID: '',
+    errorChannels: [],
+  },
+}
+
+function deepCopy(obj) {
+  return JSON.parse(JSON.stringify(obj))
+}
+
+const state = {
+  subscriptionsCacheForAllSubscriptionsProfile: deepCopy(defaultState.subscriptionsCacheForAllSubscriptionsProfile),
+  subscriptionsCacheForActiveProfile: deepCopy(defaultState.subscriptionsCacheForActiveProfile),
 }
 
 const getters = {
-  getAllSubscriptionsList: () => {
-    return state.allSubscriptionsList
+  getSubscriptionsCacheForAllSubscriptionsProfile: () => {
+    return state.subscriptionsCacheForAllSubscriptionsProfile
   },
-  getProfileSubscriptions: () => {
-    return state.profileSubscriptions
-  }
+  getSubscriptionsCacheForProfile: (state) => (profileId) => {
+    if (state.subscriptionsCacheForActiveProfile.profileID !== profileId) { return null }
+
+    return state.subscriptionsCacheForActiveProfile
+  },
 }
 
 const actions = {
-  updateAllSubscriptionsList ({ commit }, subscriptions) {
-    commit('setAllSubscriptionsList', subscriptions)
+  updateSubscriptionsCacheForActiveProfile: ({ commit }, payload) => {
+    if (payload.profileID === MAIN_PROFILE_ID) {
+      commit('updateSubscriptionsCacheForAllSubscriptionsProfile', {
+        videoList: payload.videoList,
+      })
+    } else {
+      // When cache for a non default profile (the one for all subscriptions) updated
+      // The cache for all subscriptions could be stale at that point
+      commit('clearSubscriptionsCacheForAllSubscriptionsProfile')
+    }
+
+    commit('updateSubscriptionsCacheForActiveProfile', payload)
   },
-  updateProfileSubscriptions ({ commit }, subscriptions) {
-    commit('setProfileSubscriptions', subscriptions)
-  }
+  clearSubscriptionsCache: ({ commit }) => {
+    commit('clearSubscriptionsCacheForAllSubscriptionsProfile')
+    commit('clearSubscriptionsCacheForActiveProfile')
+  },
 }
 
 const mutations = {
-  setAllSubscriptionsList (state, allSubscriptionsList) {
-    state.allSubscriptionsList = allSubscriptionsList
+  updateSubscriptionsCacheForAllSubscriptionsProfile (state, { videoList }) {
+    state.subscriptionsCacheForAllSubscriptionsProfile.videoList = videoList
   },
-  setProfileSubscriptions (state, profileSubscriptions) {
-    state.profileSubscriptions = profileSubscriptions
-  }
+  updateSubscriptionsCacheForActiveProfile (state, { profileID, videoList, errorChannels }) {
+    state.subscriptionsCacheForActiveProfile.profileID = profileID
+    state.subscriptionsCacheForActiveProfile.videoList = videoList
+    state.subscriptionsCacheForActiveProfile.errorChannels = errorChannels
+  },
+  clearSubscriptionsCacheForAllSubscriptionsProfile (state) {
+    state.subscriptionsCacheForAllSubscriptionsProfile = deepCopy(defaultState.subscriptionsCacheForAllSubscriptionsProfile)
+  },
+  clearSubscriptionsCacheForActiveProfile (state) {
+    state.subscriptionsCacheForActiveProfile = deepCopy(defaultState.subscriptionsCacheForActiveProfile)
+  },
 }
 
 export default {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -30,7 +30,7 @@ export default defineComponent({
       dataLimit: 100,
       videoList: [],
       errorChannels: [],
-      attemptedFetch: false
+      attemptedFetch: false,
     }
   },
   computed: {
@@ -65,13 +65,24 @@ export default defineComponent({
     activeProfile: function () {
       return this.$store.getters.getActiveProfile
     },
-
-    profileSubscriptions: function () {
-      return this.$store.getters.getProfileSubscriptions
+    activeProfileId: function () {
+      return this.activeProfile._id
     },
 
-    allSubscriptionsList: function () {
-      return this.$store.getters.getAllSubscriptionsList
+    subscriptionsCacheForAllSubscriptionsProfile: function () {
+      return this.$store.getters.getSubscriptionsCacheForAllSubscriptionsProfile
+    },
+    videoCacheForAllSubscriptionsProfilePresent: function () {
+      return this.subscriptionsCacheForAllSubscriptionsProfile.videoList.length > 0
+    },
+
+    subscriptionsCacheForActiveProfile: function () {
+      return this.$store.getters.getSubscriptionsCacheForProfile(this.activeProfile._id)
+    },
+    videoCacheForActiveProfilePresent: function () {
+      if (this.subscriptionsCacheForActiveProfile == null) { return false }
+
+      return this.subscriptionsCacheForActiveProfile.videoList.length > 0
     },
 
     historyCache: function () {
@@ -92,12 +103,13 @@ export default defineComponent({
 
     fetchSubscriptionsAutomatically: function() {
       return this.$store.getters.getFetchSubscriptionsAutomatically
-    }
+    },
   },
   watch: {
     activeProfile: async function (_) {
-      this.getProfileSubscriptions()
-    }
+      this.isLoading = true
+      this.loadVideosFromCacheSometimes()
+    },
   },
   mounted: async function () {
     document.addEventListener('keydown', this.keyboardShortcutHandler)
@@ -108,43 +120,70 @@ export default defineComponent({
       this.dataLimit = dataLimit
     }
 
-    if (this.profileSubscriptions.videoList.length !== 0) {
-      if (this.profileSubscriptions.activeProfile === this.activeProfile._id) {
-        const subscriptionList = JSON.parse(JSON.stringify(this.profileSubscriptions))
-        if (this.hideWatchedSubs) {
-          this.videoList = await Promise.all(subscriptionList.videoList.filter((video) => {
-            const historyIndex = this.historyCache.findIndex((x) => {
-              return x.videoId === video.videoId
-            })
-
-            return historyIndex === -1
-          }))
-        } else {
-          this.videoList = subscriptionList.videoList
-          this.errorChannels = subscriptionList.errorChannels
-        }
-      } else {
-        this.getProfileSubscriptions()
-      }
-
-      this.isLoading = false
-    } else if (this.fetchSubscriptionsAutomatically) {
-      setTimeout(async () => {
-        this.getSubscriptions()
-      }, 300)
-    } else {
-      this.isLoading = false
-    }
+    this.loadVideosFromCacheSometimes()
   },
   beforeDestroy: function () {
     document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
+    loadVideosFromCacheSometimes() {
+      // Called on view visible (initial view rendering, tab switching, etc.)
+      if (this.videoCacheForActiveProfilePresent) {
+        this.loadVideosFromCacheForActiveProfile()
+        return
+      }
+
+      if (this.videoCacheForAllSubscriptionsProfilePresent) {
+        this.loadVideosFromCacheForAllSubscriptionsProfile()
+        return
+      }
+
+      this.maybeLoadVideosForSubscriptionsFromRemote()
+    },
+
+    async loadVideosFromCacheForActiveProfile() {
+      const subscriptionList = JSON.parse(JSON.stringify(this.subscriptionsCacheForActiveProfile))
+      this.errorChannels = subscriptionList.errorChannels
+      if (this.hideWatchedSubs) {
+        this.videoList = await Promise.all(subscriptionList.videoList.filter((video) => {
+          const historyIndex = this.historyCache.findIndex((x) => {
+            return x.videoId === video.videoId
+          })
+
+          return historyIndex === -1
+        }))
+      } else {
+        this.videoList = subscriptionList.videoList
+      }
+      this.isLoading = false
+    },
+
+    async loadVideosFromCacheForAllSubscriptionsProfile() {
+      const cachedVideosFromAllSubscriptions = this.subscriptionsCacheForAllSubscriptionsProfile.videoList
+      // Load videos from cached videos for all subscriptions
+      this.videoList = await Promise.all(cachedVideosFromAllSubscriptions.filter((video) => {
+        const channelIndex = this.activeSubscriptionList.findIndex((subscribedChannel) => {
+          return subscribedChannel.id === video.authorId
+        })
+
+        if (this.hideWatchedSubs) {
+          const historyIndex = this.historyCache.findIndex((x) => {
+            return x.videoId === video.videoId
+          })
+
+          return channelIndex !== -1 && historyIndex === -1
+        } else {
+          return channelIndex !== -1
+        }
+      }))
+      this.isLoading = false
+    },
+
     goToChannel: function (id) {
       this.$router.push({ path: `/channel/${id}` })
     },
 
-    getSubscriptions: function () {
+    loadVideosForSubscriptionsFromRemote: function () {
       if (this.activeSubscriptionList.length === 0) {
         this.isLoading = false
         this.videoList = []
@@ -209,11 +248,6 @@ export default defineComponent({
               return item.durationText !== 'PREMIERE'
             })
           }
-          const profileSubscriptions = {
-            activeProfile: this.activeProfile._id,
-            videoList: videoList,
-            errorChannels: this.errorChannels
-          }
 
           this.videoList = await Promise.all(videoList.filter((video) => {
             if (this.hideWatchedSubs) {
@@ -226,43 +260,25 @@ export default defineComponent({
               return true
             }
           }))
-          this.updateProfileSubscriptions(profileSubscriptions)
+          this.updateSubscriptionsCacheForActiveProfile({
+            profileID: this.activeProfileId,
+            videoList: videoList,
+            errorChannels: this.errorChannels,
+          })
           this.isLoading = false
           this.updateShowProgressBar(false)
-
-          if (this.activeProfile === MAIN_PROFILE_ID) {
-            this.updateAllSubscriptionsList(profileSubscriptions.videoList)
-          }
         }
       })
     },
 
-    getProfileSubscriptions: async function () {
-      if (this.allSubscriptionsList.length !== 0) {
-        this.isLoading = true
-        this.videoList = await Promise.all(this.allSubscriptionsList.filter((video) => {
-          const channelIndex = this.activeSubscriptionList.findIndex((x) => {
-            return x.id === video.authorId
-          })
-
-          if (this.hideWatchedSubs) {
-            const historyIndex = this.historyCache.findIndex((x) => {
-              return x.videoId === video.videoId
-            })
-
-            return channelIndex !== -1 && historyIndex === -1
-          } else {
-            return channelIndex !== -1
-          }
-        }))
-        this.isLoading = false
-      } else if (this.fetchSubscriptionsAutomatically) {
-        this.getSubscriptions()
-      } else if (this.activeProfile._id === this.profileSubscriptions.activeProfile) {
-        this.videoList = this.profileSubscriptions.videoList
+    maybeLoadVideosForSubscriptionsFromRemote: async function () {
+      if (this.fetchSubscriptionsAutomatically) {
+        // `this.isLoading = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+        this.loadVideosForSubscriptionsFromRemote()
       } else {
         this.videoList = []
         this.attemptedFetch = false
+        this.isLoading = false
       }
     },
 
@@ -476,7 +492,7 @@ export default defineComponent({
         case 'r':
         case 'R':
           if (!this.isLoading) {
-            this.getSubscriptions()
+            this.loadVideosForSubscriptionsFromRemote()
           }
           break
       }
@@ -484,8 +500,7 @@ export default defineComponent({
 
     ...mapActions([
       'updateShowProgressBar',
-      'updateProfileSubscriptions',
-      'updateAllSubscriptionsList'
+      'updateSubscriptionsCacheForActiveProfile',
     ]),
 
     ...mapMutations([

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -68,7 +68,7 @@
       :title="$t('Subscriptions.Refresh Subscriptions')"
       :size="12"
       theme="primary"
-      @click="getSubscriptions"
+      @click="loadVideosForSubscriptionsFromRemote"
     />
   </div>
 </template>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
There is another caching strategy in #3668

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This is a change as base for adding live stream tab for subscription view
The original plan is to only refactor the code first but some existing code/feature seems disabled (intentionally or accidentally I am not sure)

### Load videos from video cache
When videos for all subscriptions loaded (main profile), there is some code (though disabled due to bug) to cache all loaded videos and use those when active profile changed

The flow in this PR is like:
- Loading videos from remote would put those **profile ID**, videos (and other stuff) in a local cache for active profile (now called `subscriptionsCacheForActiveProfile`)
  - Additionally if the active profile is default profile it would also store the videos (only) into another cache (now `subscriptionsCacheForAllSubscriptionsProfile`)
  - Else (non default profile), it will clear `subscriptionsCacheForAllSubscriptionsProfile`
- Switching to another profile would load videos from cache `subscriptionsCacheForActiveProfile` if profile ID matches
- Else if `subscriptionsCacheForAllSubscriptionsProfile` has videos cached it would load videos from it with filtering (video channel is in active profile)
- Else load videos automatically if preference set
- Else do nothing

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
For loading from `subscriptionsCacheForAllSubscriptionsProfile`

https://github.com/FreeTubeApp/FreeTube/assets/1018543/73ab35e1-e604-4334-b138-7527fc0114ae


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

Preparation: 
- Create 3+ profiles (other than default)
- 2 with overlapping (or not) channels (A, B), 1 with no channels (C)

**Before starting each test please reopen window/app/refresh to ensure local state is reset**

A. Auto fetching disabled
A1. Loading from `subscriptionsCacheForAllSubscriptionsProfile`
- Switch to default profile (if not already)
- Ensure no video loaded
- Load videos from remote (via button, KB shortcut whatever)
- Ensure videos loaded
- Switch to profile A
- Ensure **correct** videos loaded, no network request made for fetching videos
- Switch to profile B
- Ensure **correct** videos loaded, no network request made for fetching videos
- Switch to profile C
- Ensure **correct** (no) videos loaded, no network request made for fetching videos
- Switch to default profile
- Ensure **correct** (all) videos loaded, no network request made for fetching videos

A2. Auto clearing of `subscriptionsCacheForAllSubscriptionsProfile` & Loading from `subscriptionsCacheForActiveProfile`
- Switch to default profile (if not already)
- Load videos from remote
- Ensure videos loaded
- Switch to profile A
- Load videos from remote
- Switch to default profile
- Ensure **NO** videos loaded
- Switch to profile A
- Ensure **correct** videos loaded, no network request made for fetching videos
- Switch to profile B
- Ensure **NO** videos loaded

B. Auto fetching enabled
B1. Loading from `subscriptionsCacheForAllSubscriptionsProfile`
- Same as A1 except `Load videos from remote` is done automatically

B2. Auto clearing of `subscriptionsCacheForAllSubscriptionsProfile` & Loading from `subscriptionsCacheForActiveProfile`
- Switch to default profile (if not already)
- Ensure videos loaded
- Switch to profile A
- Load videos from remote (manually)
- Switch to profile B
- Ensure **correct** videos loaded, with network request made for fetching videos
- Switch to default profile
- Ensure **correct** videos loaded, with network request made for fetching videos

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
Refactoring code and typing test cases & testing might be more tiring than actual implementation
