### PR TITLE
Escape HTML in local API text runs to prevent XSS

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -9,6 +9,7 @@ import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculateColorLuminance, getRandomColor } from '../../helpers/colors'
 import {
   copyToClipboard,
+  escapeHTML,
   getTodayDateStrLocalTimezone,
   readFileFromDialog,
   showOpenDialog,
@@ -587,12 +588,7 @@ export default defineComponent({
       let opmlData = '<opml version="1.1"><body><outline text="YouTube Subscriptions" title="YouTube Subscriptions">'
 
       this.profileList[0].subscriptions.forEach((channel) => {
-        const escapedName = channel.name
-          .replaceAll('&', '&amp;')
-          .replaceAll('<', '&lt;')
-          .replaceAll('>', '&gt;')
-          .replaceAll('"', '&quot;')
-          .replaceAll('\'', '&apos;')
+        const escapedName = escapeHTML(channel.name)
 
         const channelOpmlString = `<outline text="${escapedName}" title="${escapedName}" type="rss" xmlUrl="https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}"/>`
         opmlData += channelOpmlString

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { PlayerCache } from './PlayerCache'
 import {
   CHANNEL_HANDLE_REGEX,
+  escapeHTML,
   extractNumberFromString,
   getUserDataPath,
   toLocalePublicationString
@@ -551,8 +552,12 @@ export function parseLocalTextRuns(runs, emojiSize = 16, options = { looseChanne
   const parsedRuns = []
 
   for (const run of runs) {
+    // may contain HTML, so we need to escape it, as we don't render unwanted HTML
+    // example: https://youtu.be/Hh_se2Zqsdk (see pinned comment)
+    const text = escapeHTML(run.text)
+
     if (run instanceof Misc.EmojiRun) {
-      const { emoji, text } = run
+      const { emoji } = run
 
       // empty array if video creator removes a channel emoji so we ignore.
       // eg: pinned comment here https://youtu.be/v3wm83zoSSY
@@ -577,7 +582,7 @@ export function parseLocalTextRuns(runs, emojiSize = 16, options = { looseChanne
         parsedRuns.push(`<img src="${emoji.image[0].url}" alt="${altText}" width="${emojiSize}" height="${emojiSize}" loading="lazy" style="vertical-align: middle">`)
       }
     } else {
-      const { text, bold, italics, strikethrough, endpoint } = run
+      const { bold, italics, strikethrough, endpoint } = run
 
       if (endpoint) {
         switch (endpoint.metadata.page_type) {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -646,3 +646,16 @@ export function getTodayDateStrLocalTimezone() {
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
   return timeNowStr.split('T')[0]
 }
+
+/**
+ * Escapes HTML tags to avoid XSS
+ * @param {string} untrusted
+ * @returns {string}
+ */
+export function escapeHTML(untrusted) {
+  return untrusted.replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\'', '&apos;')
+}


### PR DESCRIPTION
# Escape HTML in local API text runs to prevent XSS

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
discussed on Matrix

## Description
Currently the local API doesn't escape HTML in text runs, which allows people to inject arbitrary HTML into FreeTube, the biggest attack vector are the comments, as any user can make them.

This pull request fixes this by escaping HTML tags in the text, before doing any further handling on it.

Why can't we just use Vue's safe text handling instead of v-html?
As text runs can contain formatting as well as links, we need to add HTML tags to the text and have them be rendered, so we don't want Vue escaping the safe HTML tags that we have added to the text.

## Screenshots <!-- If appropriate -->
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/2d7f898c-883e-494d-9cdf-e672a80c8dcb)
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/c8470374-1fd1-44c6-bf32-2c6aba0c1142)

## Testing <!-- for code that is not small enough to be easily understandable -->
pinned comment on https://youtu.be/Hh_se2Zqsdk