### PR TITLE
Add DeArrow support for ft-list-video titles

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -74,7 +74,7 @@
           query: playlistIdFinal ? {playlistId: playlistIdFinal} : {}
         }"
       >
-        {{ displayTitle }}
+        {{ title }}
       </router-link>
       <div class="infoLine">
         <router-link

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.js
@@ -38,11 +38,19 @@ export default defineComponent({
     },
     sponsorBlockShowSkippedToast: function () {
       return this.$store.getters.getSponsorBlockShowSkippedToast
+    },
+
+    deArrowTitles: function () {
+      return this.$store.getters.getDeArrowTitles
     }
   },
   methods: {
     handleUpdateSponsorBlock: function (value) {
       this.updateUseSponsorBlock(value)
+    },
+
+    handleUpdateDeArrowTitles: function (value) {
+      this.updateDeArrowTitles(value)
     },
 
     handleUpdateSponsorBlockUrl: function (value) {
@@ -58,7 +66,8 @@ export default defineComponent({
     ...mapActions([
       'updateUseSponsorBlock',
       'updateSponsorBlockUrl',
-      'updateSponsorBlockShowSkippedToast'
+      'updateSponsorBlockShowSkippedToast',
+      'updateDeArrowTitles'
     ])
   }
 })

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -19,6 +19,13 @@
           @change="handleUpdateSponsorBlockShowSkippedToast"
         />
       </ft-flex-box>
+      <ft-flex-box class="settingsFlexStart500px">
+        <ft-toggle-switch
+          :label="$t('Settings.SponsorBlock Settings.DeArrowTitles')"
+          :default-value="deArrowTitles"
+          @change="handleUpdateDeArrowTitles"
+        />
+      </ft-flex-box>
       <ft-flex-box>
         <ft-input
           :placeholder="$t('Settings.SponsorBlock Settings[\'SponsorBlock API Url (Default is https://sponsor.ajay.app)\']')"

--- a/src/renderer/helpers/sponsorblock.js
+++ b/src/renderer/helpers/sponsorblock.js
@@ -1,16 +1,17 @@
 import store from '../store/index'
-
-export async function sponsorBlockSkipSegments(videoId, categories) {
+async function getVideoHash(videoId) {
   const videoIdBuffer = new TextEncoder().encode(videoId)
 
   const hashBuffer = await crypto.subtle.digest('SHA-256', videoIdBuffer)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
 
-  const videoIdHashPrefix = hashArray
+  return hashArray
     .map(byte => byte.toString(16).padStart(2, '0'))
     .slice(0, 4)
     .join('')
-
+}
+export async function sponsorBlockSkipSegments(videoId, categories) {
+  const videoIdHashPrefix = await getVideoHash(videoId)
   const requestUrl = `${store.getters.getSponsorBlockUrl}/api/skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
 
   try {
@@ -27,6 +28,26 @@ export async function sponsorBlockSkipSegments(videoId, categories) {
       .flatMap((result) => result.segments)
   } catch (error) {
     console.error('failed to fetch SponsorBlock segments', requestUrl, error)
+    throw error
+  }
+}
+
+export async function deArrow(videoId) {
+  const videoIdHashPrefix = (await getVideoHash(videoId)).substring(0, 4)
+  const requestUrl = `${store.getters.getSponsorBlockUrl}/api/branding/${videoIdHashPrefix}`
+
+  try {
+    const response = await fetch(requestUrl)
+
+    // 404 means that there are no segments registered for the video
+    if (response.status === 404) {
+      return []
+    }
+
+    const json = await response.json()
+    return json[videoId] ?? undefined
+  } catch (error) {
+    console.error('failed to fetch DeArrow data', requestUrl, error)
     throw error
   }
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -286,6 +286,7 @@ const state = {
   settingsPassword: '',
   allowDashAv1Formats: false,
   commentAutoLoadEnabled: false,
+  deArrowTitles: false,
 }
 
 const stateWithSideEffects = {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -27,6 +27,7 @@ const state = {
     movies: null
   },
   cachedPlaylist: null,
+  deArrowCache: [],
   showProgressBar: false,
   progressBarPercentage: 0,
   regionNames: [],
@@ -55,6 +56,10 @@ const getters = {
 
   getSessionSearchHistory () {
     return state.sessionSearchHistory
+  },
+
+  getDeArrowCache () {
+    return state.deArrowCache
   },
 
   getPopularCache () {
@@ -469,6 +474,10 @@ const actions = {
     commit('setSessionSearchHistory', [])
   },
 
+  clearDeArrowCache ({ commit }) {
+    commit('setDeArrowCache', [])
+  },
+
   async getExternalPlayerCmdArgumentsData ({ commit }, payload) {
     const fileName = 'external-player-map.json'
     let fileData
@@ -612,6 +621,20 @@ const mutations = {
 
   setSessionSearchHistory (state, history) {
     state.sessionSearchHistory = history
+  },
+
+  setDeArrowCache (state, cache) {
+    state.deArrowCache = cache
+  },
+
+  addVideoToDeArrowCache (state, payload) {
+    const sameVideo = state.deArrowCache.findIndex((video) => {
+      return video.videoId === payload.videoId
+    })
+
+    if (sameVideo !== -1) {
+      state.deArrowCache[sameVideo.videoId] = payload
+    }
   },
 
   addToSessionSearchHistory (state, payload) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -410,6 +410,7 @@ Settings:
     Enable SponsorBlock: Enable SponsorBlock
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API Url (Default is https://sponsor.ajay.app)
     Notify when sponsor segment is skipped: Notify when sponsor segment is skipped
+    DeArrowTitles: DeArrow Titles
     Skip Options:
       Skip Option: Skip Option
       Auto Skip: Auto Skip


### PR DESCRIPTION
# Add DeArrow support for ft-list-video titles

## Pull Request Type
- [x] Feature Implementation

## Description
DeArrow is offered through the SponsorBlock api to remove clickbaity titles and thumbnails. This PR adds support for the titles as the thumbnails are more complicated and require communicating with another server

## Testing 
- Go to Mr Beast's channel (without DeArrow)
- Notice the title of the videos
- Turn on DeArrow
- Go to Mr Beast's channel
- Notice different titles for some channels

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.18.0