### PR TITLE
# Remove `Remove All Subscriptions` button if hide unsubscribe button is enabled

### DIFF
--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -53,7 +53,11 @@ export default defineComponent({
         this.$t('Yes'),
         this.$t('No')
       ]
-    }
+    },
+
+    hideUnsubscribeButton: function() {
+      return this.$store.getters.getHideUnsubscribeButton
+    },
   },
   methods: {
     handleSearchCache: function (option) {

--- a/src/renderer/components/privacy-settings/privacy-settings.vue
+++ b/src/renderer/components/privacy-settings/privacy-settings.vue
@@ -54,6 +54,7 @@
         @click="showRemoveHistoryPrompt = true"
       />
       <ft-button
+        v-if="!hideUnsubscribeButton"
         :label="$t('Settings.Privacy Settings.Remove All Subscriptions / Profiles')"
         text-color="var(--text-with-main-color)"
         background-color="var(--primary-color)"
@@ -75,7 +76,7 @@
       @click="handleRemoveHistory"
     />
     <ft-prompt
-      v-if="showRemoveSubscriptionsPrompt"
+      v-if="showRemoveSubscriptionsPrompt && !hideUnsubscribeButton"
       :label="removeSubscriptionsPromptMessage"
       :option-names="promptNames"
       :option-values="promptValues"


### PR DESCRIPTION
# Remove `Remove All Subscriptions` button if hide unsubscribe button is enabled

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #3503

## Description

Added a v-if statement to the `Remove All Subscriptions` button and the associated prompt. Now if `hideUnsubscribeButton` is `true` it will be removed from the DOM.

### Changed components:
- privacy-settings.vue

## Screenshots 

### Before

![before](https://github.com/FreeTubeApp/FreeTube/assets/63408969/73fe39b7-d503-44a3-a0d5-3d49ab707136)

### After

![after](https://github.com/FreeTubeApp/FreeTube/assets/63408969/e650525b-7fed-49d4-92e3-6d775831c972)

## Desktop
- **OS:** Windows 11
- **OS Version:** 22H2
- **FreeTube version:** Release 0.18.0 Beta
