### PR TITLE
Cleanup some duplicate channel tab URL handling code

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -245,7 +245,6 @@ export default defineComponent({
       }
 
       this.id = this.$route.params.id
-      let currentTab = this.$route.params.currentTab ?? 'videos'
       this.searchPage = 2
       this.relatedChannels = []
       this.latestVideos = []
@@ -273,20 +272,10 @@ export default defineComponent({
       this.showLiveSortBy = true
       this.showPlaylistSortBy = true
 
-      if (this.hideChannelShorts && currentTab === 'shorts') {
-        currentTab = 'videos'
-      }
+      let currentTab = this.$route.params.currentTab ?? 'videos'
 
-      if (this.hideLiveStreams && currentTab === 'live') {
-        currentTab = 'videos'
-      }
-
-      if (this.hideChannelPlaylists && currentTab === 'playlists') {
-        currentTab = 'videos'
-      }
-
-      if (this.hideChannelCommunity && currentTab === 'community') {
-        currentTab = 'videos'
+      if (!this.tabInfoValues.includes(currentTab)) {
+        currentTab = this.tabInfoValues[0]
       }
 
       this.currentTab = currentTab
@@ -380,20 +369,8 @@ export default defineComponent({
 
     let currentTab = this.$route.params.currentTab ?? 'videos'
 
-    if (this.hideChannelShorts && currentTab === 'shorts') {
-      currentTab = 'videos'
-    }
-
-    if (this.hideLiveStreams && currentTab === 'live') {
-      currentTab = 'videos'
-    }
-
-    if (this.hideChannelPlaylists && currentTab === 'playlists') {
-      currentTab = 'videos'
-    }
-
-    if (this.hideChannelCommunity && currentTab === 'community') {
-      currentTab = 'videos'
+    if (!this.tabInfoValues.includes(currentTab)) {
+      currentTab = this.tabInfoValues[0]
     }
 
     this.currentTab = currentTab


### PR DESCRIPTION
# Cleanup some duplicate channel tab URL handling code

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Refactor

## Related issue
Noticed while working on #3689

## Description
As we already removed hidden tabs from the tabInfoValues array, we can check if the tab in the link is in that array, instead of duplicating the same checks to other places in the code.

tabInfoValues:
https://github.com/FreeTubeApp/FreeTube/blob/b0eb157ef8c969606fe995d64fff8ac234fcc4a0/src/renderer/views/Channel/Channel.js#L203-L235

## Testing <!-- for code that is not small enough to be easily understandable -->
Try various channel links with tabs in them, to make sure they work correctly when tabs are hidden.