### PR TITLE
Fix search bar keyboard shortcuts after hide search bar is disabled

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -285,6 +285,10 @@ export default defineComponent({
       this.$refs.input.focus()
     },
 
+    blur() {
+      this.$refs.input.focus()
+    },
+
     ...mapActions([
       'getYoutubeUrlInfo'
     ])

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -42,10 +42,6 @@ export default defineComponent({
       return this.$store.getters.getEnableSearchSuggestions
     },
 
-    searchInput: function () {
-      return this.$refs.searchInput.$refs.input
-    },
-
     searchSettings: function () {
       return this.$store.getters.getSearchSettings
     },
@@ -114,7 +110,7 @@ export default defineComponent({
         this.$refs.searchContainer.blur()
         this.showSearchContainer = false
       } else {
-        this.searchInput.blur()
+        this.$refs.searchInput.blur()
       }
 
       clearLocalSearchSuggestionsSession()
@@ -209,7 +205,7 @@ export default defineComponent({
 
     focusSearch: function () {
       if (!this.hideSearchBar) {
-        this.searchInput.focus()
+        this.$refs.searchInput.focus()
       }
     },
 


### PR DESCRIPTION
# Fix search bar keyboard shortcuts after hide search bar is disabled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3500

## Description
Refs aren't reactive, so they can't be used in computed properties, as they won't trigger any updates when they change.

Relevant snippet from the Vue docs (highlighting my own):
> `$refs` are only populated after the component has been rendered, and **they are not reactive**. It is only meant as an escape hatch for direct child manipulation - **you should avoid accessing `$refs` from within templates or computed properties**.

https://v2.vuejs.org/v2/guide/components-edge-cases.html#Accessing-Child-Component-Instances-amp-Child-Elements

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Use shortcut Alt + D or Command/Ctrl + L to focus search bar to check if it works
2. Navigate to Parental Control Settings and enable Hide search bar
3. Test shortcuts to verify they are disabled
4. Disable Hide search bar
5. Try to use shortcuts again