### PR TITLE
Fix focus related race conditions

### DIFF
--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -94,8 +94,8 @@ export default defineComponent({
           // wait until the dropdown is visible
           // then focus it so we can hide it automatically when it loses focus
           setTimeout(() => {
-            this.$refs.dropdown.focus()
-          }, 0)
+            this.$refs.dropdown?.focus()
+          })
         }
       } else {
         this.$emit('click')

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -42,7 +42,7 @@ export default defineComponent({
         // wait until the profile list is visible
         // then focus it so we can hide it automatically when it loses focus
         setTimeout(() => {
-          this.$refs.profileList.$el.focus()
+          this.$refs.profileList?.$el?.focus()
         })
       }
     },

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -103,7 +103,7 @@ export default defineComponent({
 
         this.$store.commit('setTrendingCache', { value: results, page: this.currentTab })
         setTimeout(() => {
-          this.$refs[this.currentTab].focus()
+          this.$refs[this.currentTab]?.focus()
         })
       } catch (err) {
         console.error(err)
@@ -149,7 +149,7 @@ export default defineComponent({
         this.isLoading = false
         this.$store.commit('setTrendingCache', { value: returnData, page: this.currentTab })
         setTimeout(() => {
-          this.$refs[this.currentTab].focus()
+          this.$refs[this.currentTab]?.focus()
         })
       }).catch((err) => {
         console.error(err)


### PR DESCRIPTION
# Fix focus related race conditions

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3444

## Description
Fixes errors caused by focus being called on elements that Vue hasn't created yet. `setTimeout()` with no delay, just makes code run asynchronously, regardless of whether Vue has had time to create the elements or not. When you hold the <kbd>R</kbd> key on the trending tab, you trigger the refresh before Vue has had time to modify any HTML, so the element that we want to focus is never created. You might think that using Vue's `nextTick()` function would be more appropriate, however as that delays until after the next DOM update, it would mean that in this case the code would be triggered multiple times (however many times the refresh finished while you were holding the <kbd>R</kbd> key), when you finally let go of the <kbd>R</kbd>.

While I was at it, I decided to make the same change in other places that we call focus with a delay, which should hopefully fix similar errors caused by spamming/abusing FreeTube in those areas (looking at you @efb4f5ff-1298-471a-8973-3d47447115dc with your auto clicker 🙄).

## Testing <!-- for code that is not small enough to be easily understandable -->
On the trending page, hold the <kbd>R</kbd> key and check that no errors appear in the console.