### PR TITLE
Support YouTube's new layout for shorts only playlists

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -58,8 +58,8 @@ export default defineComponent({
     return {
       id: '',
       title: '',
-      channelName: '',
-      channelId: '',
+      channelName: null,
+      channelId: null,
       viewCount: 0,
       parsedViewCount: '',
       uploadedTime: '',
@@ -190,30 +190,34 @@ export default defineComponent({
           {
             label: this.$t('Video.Open in Invidious'),
             value: 'openInvidious'
-          },
-          {
-            type: 'divider'
-          },
-          {
-            label: this.$t('Video.Copy YouTube Channel Link'),
-            value: 'copyYoutubeChannel'
-          },
-          {
-            label: this.$t('Video.Copy Invidious Channel Link'),
-            value: 'copyInvidiousChannel'
-          },
-          {
-            type: 'divider'
-          },
-          {
-            label: this.$t('Video.Open Channel in YouTube'),
-            value: 'openYoutubeChannel'
-          },
-          {
-            label: this.$t('Video.Open Channel in Invidious'),
-            value: 'openInvidiousChannel'
           }
         )
+        if (this.channelId !== null) {
+          options.push(
+            {
+              type: 'divider'
+            },
+            {
+              label: this.$t('Video.Copy YouTube Channel Link'),
+              value: 'copyYoutubeChannel'
+            },
+            {
+              label: this.$t('Video.Copy Invidious Channel Link'),
+              value: 'copyInvidiousChannel'
+            },
+            {
+              type: 'divider'
+            },
+            {
+              label: this.$t('Video.Open Channel in YouTube'),
+              value: 'openYoutubeChannel'
+            },
+            {
+              label: this.$t('Video.Open Channel in Invidious'),
+              value: 'openInvidiousChannel'
+            }
+          )
+        }
       }
 
       return options
@@ -402,8 +406,8 @@ export default defineComponent({
       this.title = this.data.title
       // this.thumbnail = this.data.videoThumbnails[4].url
 
-      this.channelName = this.data.author
-      this.channelId = this.data.authorId
+      this.channelName = this.data.author ?? null
+      this.channelId = this.data.authorId ?? null
       this.duration = formatDurationAsTimestamp(this.data.lengthSeconds)
       this.description = this.data.description
       this.isLive = this.data.liveNow || this.data.lengthSeconds === 'undefined'

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -78,13 +78,14 @@
       </router-link>
       <div class="infoLine">
         <router-link
+          v-if="channelId !== null"
           class="channelName"
           :to="`/channel/${channelId}`"
         >
           <span>{{ channelName }}</span>
         </router-link>
         <template v-if="!isLive && !isUpcoming && !isPremium && !hideViews">
-          <span class="viewCount"> • {{ parsedViewCount }} </span>
+          <span class="viewCount"><template v-if="channelId !== null"> •</template> {{ parsedViewCount }} </span>
           <span v-if="viewCount === 1">{{ $t("Video.View").toLowerCase() }}</span>
           <span v-else>{{ $t("Video.Views").toLowerCase() }}</span>
         </template>

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -406,18 +406,37 @@ function handleSearchResponse(response) {
 }
 
 /**
- * @param {import('youtubei.js').YTNodes.PlaylistVideo} video
+ * @param {import('youtubei.js').YTNodes.PlaylistVideo|import('youtubei.js').YTNodes.ReelItem} video
  */
 export function parseLocalPlaylistVideo(video) {
-  return {
-    videoId: video.id,
-    title: video.title.text,
-    author: video.author.name,
-    authorId: video.author.id,
-    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
-    liveNow: video.is_live,
-    isUpcoming: video.is_upcoming,
-    premiereDate: video.upcoming
+  if (video.type === 'ReelItem') {
+    /** @type {import('youtubei.js').YTNodes.ReelItem} */
+    const short = video
+
+    // unfortunately the only place with the duration is the accesibility string
+    const duration = parseShortDuration(video.accessibility_label, short.id)
+
+    return {
+      type: 'video',
+      videoId: short.id,
+      title: short.title.text,
+      viewCount: parseLocalSubscriberCount(short.views.text),
+      lengthSeconds: isNaN(duration) ? '' : duration
+    }
+  } else {
+    /** @type {import('youtubei.js').YTNodes.PlaylistVideo} */
+    const video_ = video
+
+    return {
+      videoId: video_.id,
+      title: video_.title.text,
+      author: video_.author.name,
+      authorId: video_.author.id,
+      lengthSeconds: isNaN(video_.duration.seconds) ? '' : video_.duration.seconds,
+      liveNow: video_.is_live,
+      isUpcoming: video_.is_upcoming,
+      premiereDate: video_.upcoming
+    }
   }
 }
 


### PR DESCRIPTION
# Support YouTube's new layout for shorts only playlists

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation

## Related issue
https://github.com/yt-dlp/yt-dlp/pull/7425

## Description
YouTube is now using a new layout for playlists that only contain shorts, it's the same one which is used for the shorts tab on channel pages and therefore has the same missing information: published date, channel (id and name). On channel pages we can use the name and id of the current channel, however as playlists can contain videos from multiple channels we can't do that.

Unfortunately it looks like YouTube hasn't implemented continuations for the new layout yet, so you will only see 100 videos, even if the playlist has more. Hopefully when they do add them, it'll just start working, otherwise we can do a follow up pull request to support those then.

As the channel information is missing, this pull request also hides the copy channel link options in the 3 dots menu.

This only makes changes to the local API, any changes for the Invidious API will need to be done on the Invidious side.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/9cf74327-9294-4a23-a487-539a685a8407)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/a6b4d3a4-dc4e-45e3-a748-cb8f72f2d1a6)

## Testing <!-- for code that is not small enough to be easily understandable -->
Linus Tech Tips autogenerated channel shorts playlist (95 videos): https://youtube.com/playlist?list=UUSHXuqSBlHAE6Xw-yeJA0Tunw
Gibi ASMR autogenerated channel shorts playlist (135 videos, only 100 will show up): https://youtube.com/playlist?list=UUSHE6acMV3m35znLcf0JGNn7Q