### PR TITLE
Update views to ignore keyboard events caused by user holding keys

### DIFF
--- a/src/renderer/views/Popular/Popular.js
+++ b/src/renderer/views/Popular/Popular.js
@@ -62,11 +62,18 @@ export default defineComponent({
       this.$store.commit('setPopularCache', this.shownResults)
     },
 
-    // This function should always be at the bottom of this file
+    /**
+     * This function `keyboardShortcutHandler` should always be at the bottom of this file
+     * @param {KeyboardEvent} event the keyboard event
+     */
     keyboardShortcutHandler: function (event) {
       if (event.ctrlKey || document.activeElement.classList.contains('ft-input')) {
         return
       }
+      // Avoid handling events due to user holding a key (not released)
+      // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat
+      if (event.repeat) { return }
+
       switch (event.key) {
         case 'r':
         case 'R':

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -467,11 +467,18 @@ export default defineComponent({
       sessionStorage.setItem('subscriptionLimit', this.dataLimit)
     },
 
-    // This function should always be at the bottom of this file
+    /**
+     * This function `keyboardShortcutHandler` should always be at the bottom of this file
+     * @param {KeyboardEvent} event the keyboard event
+     */
     keyboardShortcutHandler: function (event) {
       if (event.ctrlKey || document.activeElement.classList.contains('ft-input')) {
         return
       }
+      // Avoid handling events due to user holding a key (not released)
+      // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat
+      if (event.repeat) { return }
+
       switch (event.key) {
         case 'r':
         case 'R':

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -167,11 +167,18 @@ export default defineComponent({
       })
     },
 
-    // This function should always be at the bottom of this file
+    /**
+     * This function `keyboardShortcutHandler` should always be at the bottom of this file
+     * @param {KeyboardEvent} event the keyboard event
+     */
     keyboardShortcutHandler: function (event) {
       if (event.ctrlKey || document.activeElement.classList.contains('ft-input')) {
         return
       }
+      // Avoid handling events due to user holding a key (not released)
+      // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat
+      if (event.repeat) { return }
+
       switch (event.key) {
         case 'r':
         case 'R':


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Discover when looking at #3700

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Subscription, Trending & Popular view can reloading by pressing `r`
But if `r` key is hold down it will keep reloading
I think FT should prevent user from getting rate limited accidentally as much as possible

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Go to Subscription, Trending & Popular view
- Hold `r`
- It should only reload info once


## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
