### PR TITLE
Fixed incorrect invidious comment linking

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -406,7 +406,7 @@ export function createWebURL(path) {
 
 // strip html tags but keep <br>, <b>, </b> <s>, </s>, <i>, </i>
 export function stripHTML(value) {
-  return value.replaceAll(/(<(?!br|\/?[bis]|img>)([^>]+)>)/gi, '')
+  return value.replaceAll(/(<(?!br|\/?[abis]|img>)([^>]+)>)/gi, '')
 }
 
 /**


### PR DESCRIPTION
# Fixed incorrect invidious comment linking

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #3669 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
A small PR to fix the linking within comments. Previously, the stripping of anchor tags was confusing the auto-linker due to indivious' truncation of the url (adding the "..."). This new change keeps the anchor tags in place, and feeds them to the auto-linker.

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

This was tested to confirm previous bugged comments were functional, mainly using https://youtu.be/4OjoZZVyHgc

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora
- **OS Version:** 37
- **FreeTube version:** [87a389c](https://github.com/FreeTubeApp/FreeTube/commit/87a389cce0219dcc86467743622cbb472bc674b5)
