### PR TITLE
Fix reading instances from the Invidious fallback file

### DIFF
--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -45,7 +45,7 @@ const actions = {
       const filePath = `${fileLocation}${fileName}`
       if (!process.env.IS_ELECTRON || await pathExists(filePath)) {
         console.warn('reading static file for invidious instances')
-        const fileData = process.env.IS_ELECTRON ? JSON.parse(await fs.readFile(filePath)) : await (await fetch(createWebURL(filePath))).text()
+        const fileData = process.env.IS_ELECTRON ? await fs.readFile(filePath, 'utf8') : await (await fetch(createWebURL(filePath))).text()
         instances = JSON.parse(fileData).filter(e => {
           return process.env.IS_ELECTRON || e.cors
         }).map(e => {


### PR DESCRIPTION
# Fix reading instances from the Invidious fallback file

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
The current implementation was trying to JSON.parse an object, as the JSON had already been parsed, this was causing it to convert that object to a string `[object Object]` which of course failed to parse as JSON.

## Screenshots <!-- If appropriate -->
![error](https://github.com/FreeTubeApp/FreeTube/assets/48293849/c1674f51-48f9-45d7-81aa-aca15e60e65d)

## Testing <!-- for code that is not small enough to be easily understandable -->
Open FreeTube, without the fix FreeTube won't finish starting even if you don't have Invidious selected as the default API (we really need to change that behaviour at some point). Alternatively if the invidious instances API is back up when you test this, turn your internet off and then launch FreeTube.