### PR TITLE
Use android formats when available, web for everything else

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "vue-router": "^3.6.5",
     "vue-tiny-slider": "^0.1.39",
     "vuex": "^3.6.2",
-    "youtubei.js": "^5.1.0"
+    "youtubei.js": "^5.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8585,10 +8585,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-youtubei.js@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-5.1.0.tgz#a71474f23fbf8679c1f517f3f8a33064e898683e"
-  integrity sha512-Rbe71rqqSVGj2kBv7FeIDbod+AEcd84F/7inSLWjt6jv8tmTGLjXr8cjlqzY5WhpNKMJuSUVKLFgCb3V0SHTUA==
+youtubei.js@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-5.2.0.tgz#97e66de34072c40e04e7cf5172c0cf3a1eeccbf7"
+  integrity sha512-UXbkHnLp+YUSbA6ye58knH11RRx52BWpO/k6wSKQTm6eC/MSUBQO4KdYrO1INptlbOWWn7DjW5LwLMZ6e4qdMw==
   dependencies:
     jintr "^1.0.0"
     linkedom "^0.14.12"


### PR DESCRIPTION
# Use android formats when available, web for everything else

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation

## Related issue
may help with #3457 until youtube breaks stuff again

## Description
This pull request makes FreeTube use the android formats when available (will work for the moment but YouTube loves to break the android client, not just with throttling but returning 403s and other unpleasant things), so if anything is wrong with the android formats, it uses the web ones. So that we still have all the same video metadata as before, only the formats are used from the android client, everything else is taken from the web client.

Known issue:
The android client has ultra low formats in addition to the normal ones, so when you select the audio formats, our current labelling is only designed for 4 formats (low, medium, high, best) instead of the android client's 7, so we need to add new labels for the ultra low ones, so that the top 4 actually get the correct labels instead of bitrates.

can be fixed in a separate pull request

## Testing <!-- for code that is not small enough to be easily understandable -->
Try various videos with the local API **without proxing through Invidious**, seeking should also be a lot quicker.