### PR TITLE
Various changes to allow us to blend in more

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -287,10 +287,12 @@ function runApp() {
 
     // make InnerTube requests work with the fetch function
     // InnerTube rejects requests if the referer isn't YouTube or empty
-    const innertubeRequestFilter = { urls: ['https://www.youtube.com/youtubei/*'] }
+    const innertubeAndMediaRequestFilter = { urls: ['https://www.youtube.com/youtubei/*', 'https://*.googlevideo.com/videoplayback?*'] }
 
-    session.defaultSession.webRequest.onBeforeSendHeaders(innertubeRequestFilter, ({ requestHeaders }, callback) => {
-      requestHeaders.referer = 'https://www.youtube.com'
+    session.defaultSession.webRequest.onBeforeSendHeaders(innertubeAndMediaRequestFilter, ({ requestHeaders, url }, callback) => {
+      requestHeaders.Referer = 'https://www.youtube.com/'
+      requestHeaders.Origin = 'https://www.youtube.com'
+
       // eslint-disable-next-line n/no-callback-literal
       callback({ requestHeaders })
     })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -293,6 +293,10 @@ function runApp() {
       requestHeaders.Referer = 'https://www.youtube.com/'
       requestHeaders.Origin = 'https://www.youtube.com'
 
+      if (url.startsWith('https://www.youtube.com/youtubei/')) {
+        requestHeaders['Sec-Fetch-Site'] = 'same-origin'
+      }
+
       // eslint-disable-next-line n/no-callback-literal
       callback({ requestHeaders })
     })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -11,6 +11,8 @@ import baseHandlers from '../datastores/handlers/base'
 import { extractExpiryTimestamp, ImageCache } from './ImageCache'
 import { existsSync } from 'fs'
 
+import packageDetails from '../../package.json'
+
 if (process.argv.includes('--version')) {
   app.exit()
 } else {
@@ -262,6 +264,12 @@ function runApp() {
         proxyRules: `${proxyProtocol}://${proxyHostname}:${proxyPort}`
       })
     }
+
+    const fixedUserAgent = session.defaultSession.getUserAgent()
+      .split(' ')
+      .filter(part => !part.includes('Electron') && !part.includes(packageDetails.productName))
+      .join(' ')
+    session.defaultSession.setUserAgent(fixedUserAgent)
 
     // Set CONSENT cookie on reasonable domains
     const consentCookieDomains = [

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -295,6 +295,9 @@ function runApp() {
 
       if (url.startsWith('https://www.youtube.com/youtubei/')) {
         requestHeaders['Sec-Fetch-Site'] = 'same-origin'
+      } else {
+        // YouTube doesn't send the Content-Type header for the media requests, so we shouldn't either
+        delete requestHeaders['Content-Type']
       }
 
       // eslint-disable-next-line n/no-callback-literal

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -32,9 +32,10 @@ const TRACKING_PARAM_NAMES = [
  * @param {string|undefined} options.location the geolocation to pass to YouTube get different content
  * @param {boolean} options.safetyMode whether to hide mature content
  * @param {string} options.clientType use an alterate client
+ * @param {boolean} options.generateSessionLocally generate the session locally or let YouTube generate it (local is faster, remote is more accurate)
  * @returns the Innertube instance
  */
-async function createInnertube(options = { withPlayer: false, location: undefined, safetyMode: false, clientType: undefined }) {
+async function createInnertube(options = { withPlayer: false, location: undefined, safetyMode: false, clientType: undefined, generateSessionLocally: true }) {
   let cache
   if (options.withPlayer) {
     const userData = await getUserDataPath()
@@ -50,7 +51,7 @@ async function createInnertube(options = { withPlayer: false, location: undefine
     // use browser fetch
     fetch: (input, init) => fetch(input, init),
     cache,
-    generate_session_locally: true
+    generate_session_locally: !!options.generateSessionLocally
   })
 }
 
@@ -140,14 +141,14 @@ export async function getLocalVideoInfo(id, attemptBypass = false) {
   let player
 
   if (attemptBypass) {
-    const innertube = await createInnertube({ withPlayer: true, clientType: ClientType.TV_EMBEDDED })
+    const innertube = await createInnertube({ withPlayer: true, clientType: ClientType.TV_EMBEDDED, generateSessionLocally: false })
     player = innertube.actions.session.player
 
     // the second request that getInfo makes 404s with the bypass, so we use getBasicInfo instead
     // that's fine as we have most of the information from the original getInfo request
     info = await innertube.getBasicInfo(id, 'TV_EMBEDDED')
   } else {
-    const innertube = await createInnertube({ withPlayer: true })
+    const innertube = await createInnertube({ withPlayer: true, generateSessionLocally: false })
     player = innertube.actions.session.player
 
     info = await innertube.getInfo(id)


### PR DESCRIPTION
# Various changes to allow us to blend in more

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
This pull requests makes various changes to allow us to blend in more with YouTube's requests, like removing `Electron/<version>` and `FreeTube/<version>` from the user agent, setting the referer and origin headers for requests to the Innertube and the googlevideo domains.
I also decided to switch to letting YouTube generate the session for the watch page Innertube requests as those are the most sensitive ones.

This pull request doesn't fix the throttling issue, #3715 addresses that.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that everything still works/is as broken as it was before.