### PR TITLE
Only use android formats when the video id in the response is correct

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -158,10 +158,16 @@ export async function getLocalVideoInfo(id, attemptBypass = false) {
       const androidInnertube = await createInnertube({ clientType: ClientType.ANDROID, generateSessionLocally: false })
       const androidInfo = await androidInnertube.getBasicInfo(id, 'ANDROID')
 
-      if (androidInfo.playability_status.status === 'OK') {
-        info.streaming_data = androidInfo.streaming_data
+      // Sometimes when YouTube detects a third party client or has applied an IP-ratelimit,
+      // they replace the response with a different video id
+      // https://github.com/TeamNewPipe/NewPipe/issues/8713
+      // https://github.com/TeamPiped/Piped/issues/2487
+      if (androidInfo.basic_info.id !== id) {
+        console.error(`Failed to fetch android formats. Wrong video ID in response: ${androidInfo.basic_info.id}, expected: ${id}`)
+      } else if (androidInfo.playability_status.status === 'OK') {
+        console.error('Failed to fetch android formats', JSON.stringify(androidInfo.playability_status))
       } else {
-        console.error('Failed to fetch android formats', JSON.parse(JSON.stringify(androidInfo.playability_status)))
+        info.streaming_data = androidInfo.streaming_data
       }
     } catch (error) {
       console.error('Failed to fetch android formats')


### PR DESCRIPTION
# Only use android formats when the video id in the response is correct

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Extra checks

## Related issue
Follow up to #3715

## Description
Sometimes when YouTube detects a third party client or has applied an IP-ratelimit, they replace the response with a different video id. Here are the issues about it in the NewPipe and Piped repositories:
https://github.com/TeamNewPipe/NewPipe/issues/8713
https://github.com/TeamPiped/Piped/issues/2487

This pull request adds a check to detect that, just in case it happens.

## Testing <!-- for code that is not small enough to be easily understandable -->
Doesn't change any behaviour at the moment, so feel free to test but you shouldn't notice anything different at the moment.