### PR TITLE
Utils: Don't provide `ytdl://` protocol links to external players

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -565,21 +565,14 @@ const actions = {
           showExternalPlayerUnsupportedActionToast(externalPlayer, 'looping playlists')
         }
       }
-      if (cmdArgs.supportsYtdlProtocol) {
-        args.push(`${cmdArgs.playlistUrl}ytdl://${payload.playlistId}`)
-      } else {
-        args.push(`${cmdArgs.playlistUrl}https://youtube.com/playlist?list=${payload.playlistId}`)
-      }
+
+      args.push(`${cmdArgs.playlistUrl}https://youtube.com/playlist?list=${payload.playlistId}`)
     } else {
       if (payload.playlistId != null && payload.playlistId !== '' && !ignoreWarnings) {
         showExternalPlayerUnsupportedActionToast(externalPlayer, 'opening playlists')
       }
       if (payload.videoId != null) {
-        if (cmdArgs.supportsYtdlProtocol) {
-          args.push(`${cmdArgs.videoUrl}ytdl://${payload.videoId}`)
-        } else {
-          args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
-        }
+        args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
       }
     }
 


### PR DESCRIPTION
## Pull Request Type
- Other

## Description
Providing these type of links is currently unnecessary and can turn into a hassle when the players are extended by scripts that are not expecting them and don't function as intended.

## Desktop
- **FreeTube version:** `development` (242c93e16311a631e57dfd9143dc418e9d2838c8)
