### PR TITLE
Improve the performance of the side nav

### DIFF
--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -29,8 +29,9 @@ export default defineComponent({
       return this.$store.getters.getActiveProfile
     },
     activeSubscriptions: function () {
-      const profile = JSON.parse(JSON.stringify(this.activeProfile))
-      return profile.subscriptions.sort((a, b) => {
+      const subscriptions = JSON.parse(JSON.stringify(this.activeProfile.subscriptions))
+
+      subscriptions.sort((a, b) => {
         const nameA = a.name.toLowerCase()
         const nameB = b.name.toLowerCase()
         if (nameA < nameB) {
@@ -40,13 +41,15 @@ export default defineComponent({
           return 1
         }
         return 0
-      }).map((channel) => {
-        if (this.backendPreference === 'invidious') {
-          channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstance)
-        }
-
-        return channel
       })
+
+      if (this.backendPreference === 'invidious') {
+        subscriptions.forEach((channel) => {
+          channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstance)
+        })
+      }
+
+      return subscriptions
     },
     hidePopularVideos: function () {
       return this.$store.getters.getHidePopularVideos


### PR DESCRIPTION
# Improve the performance of the side nav

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Performance

## Description
As Array.map creates a new array, it's best to only use it when you are creating an array with new objects, if you use it to only modify properties, then you end up with two arrays containing the exact same objects. For modifying existing objects, it's better to just use a for loop as it saves the extra array creation, unless you'll be sorting it afterwards and don't want to modify the order of the original one. We have this pattern in various places throught FreeTube but I thought I would start with fixing it in the side nav.

I also changed the cloning to only clone the subscriptions list, as we don't need the rest of the profile.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the active subscriptions list in the side nav updates when you change profiles.