### PR TITLE
Update some views to opt out of "Hide Videos From Channels"

### DIFF
--- a/src/renderer/components/ft-element-list/ft-element-list.js
+++ b/src/renderer/components/ft-element-list/ft-element-list.js
@@ -21,7 +21,11 @@ export default defineComponent({
     showVideoWithLastViewedPlaylist: {
       type: Boolean,
       default: false
-    }
+    },
+    useChannelsHiddenPreference: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
     listType: function () {

--- a/src/renderer/components/ft-element-list/ft-element-list.vue
+++ b/src/renderer/components/ft-element-list/ft-element-list.vue
@@ -10,6 +10,7 @@
       :first-screen="index < 16"
       :layout="displayValue"
       :show-video-with-last-viewed-playlist="showVideoWithLastViewedPlaylist"
+      :use-channels-hidden-preference="useChannelsHiddenPreference"
     />
   </ft-auto-grid>
 </template>

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
@@ -33,6 +33,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    useChannelsHiddenPreference: {
+      type: Boolean,
+      default: true,
+    },
   },
   data: function () {
     return {
@@ -44,6 +48,9 @@ export default defineComponent({
       return this.$store.getters.getHideLiveStreams
     },
     channelsHidden: function() {
+      // Some component users like channel view will have this disabled
+      if (!this.useChannelsHiddenPreference) { return [] }
+
       return JSON.parse(this.$store.getters.getChannelsHidden)
     },
     hideUpcomingPremieres: function () {

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -244,6 +244,7 @@
           v-show="currentTab === 'videos'"
           id="videoPanel"
           :data="latestVideos"
+          :use-channels-hidden-preference="false"
           role="tabpanel"
           aria-labelledby="videosTab"
         />
@@ -258,6 +259,7 @@
           v-if="!hideChannelShorts && currentTab === 'shorts'"
           id="shortPanel"
           :data="latestShorts"
+          :use-channels-hidden-preference="false"
           role="tabpanel"
           aria-labelledby="shortsTab"
         />
@@ -273,6 +275,7 @@
           v-show="currentTab === 'live'"
           id="livePanel"
           :data="latestLive"
+          :use-channels-hidden-preference="false"
           role="tabpanel"
           aria-labelledby="liveTab"
         />
@@ -287,6 +290,7 @@
           v-if="!hideChannelPlaylists && currentTab === 'playlists'"
           id="playlistPanel"
           :data="latestPlaylists"
+          :use-channels-hidden-preference="false"
           role="tabpanel"
           aria-labelledby="playlistsTab"
         />
@@ -301,6 +305,7 @@
           v-if="!hideChannelCommunity && currentTab === 'community'"
           id="communityPanel"
           :data="latestCommunityPosts"
+          :use-channels-hidden-preference="false"
           role="tabpanel"
           aria-labelledby="communityTab"
           display="list"
@@ -315,6 +320,7 @@
         <ft-element-list
           v-show="currentTab === 'search'"
           :data="searchResults"
+          :use-channels-hidden-preference="false"
         />
         <ft-flex-box
           v-if="currentTab === 'search' && searchResults.length === 0"

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -36,6 +36,7 @@
         v-if="activeData.length > 0 && !isLoading"
         :data="activeData"
         :show-video-with-last-viewed-playlist="true"
+        :use-channels-hidden-preference="false"
       />
       <ft-flex-box
         v-if="showLoadMoreButton"

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -50,6 +50,7 @@
       <ft-element-list
         v-else
         :data="activeVideoList"
+        :use-channels-hidden-preference="false"
       />
       <ft-flex-box>
         <ft-button

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -42,6 +42,7 @@
       <ft-element-list
         v-if="activeData.length > 0 && !isLoading"
         :data="activeData"
+        :use-channels-hidden-preference="false"
       />
       <ft-flex-box
         v-if="showLoadMoreButton"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Addresses #3744, for a feature introduced in #2849

## Description
Update following views to opt out of "Hide Videos From Channels", e.g. ignore channels to hide preference
- Channel
  Only reachable when user wants to view it explicitly, no point viewing the channel with all content hidden
- History
  Avoid unexpected false sense of absence when searching
- Subscription
  User subscribe for channels explicitly
- User playlist
  User add videos into user playlist(s) explicitly 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Mentioned views should still show content for channels added to "Hide Videos From Channels"
Other views (search, trending, popular, etc.) should still have stuff from channels in "Hide Videos From Channels" hidden

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
