### PR TITLE
Fix web throttling because of double deciphering

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -505,6 +505,7 @@ export default defineComponent({
             }
             this.adaptiveFormats = this.videoSourceList
 
+            /** @type {import('../../helpers/api/local').LocalFormat[]} */
             const formats = [...result.streaming_data.formats, ...result.streaming_data.adaptive_formats]
             this.downloadLinks = formats.map((format) => {
               const qualityLabel = format.quality_label ?? format.bitrate
@@ -521,7 +522,7 @@ export default defineComponent({
               }
 
               return {
-                url: format.url,
+                url: format.freeTubeUrl,
                 label: label
               }
             })
@@ -942,7 +943,7 @@ export default defineComponent({
     },
 
     /**
-     * @param {import('youtubei.js').Misc.Format[]} audioFormats
+     * @param {import('../../helpers/api/local').LocalFormat[]} audioFormats
      * @returns {AudioSource[]}
      */
     createLocalAudioSourceList: function (audioFormats) {
@@ -969,7 +970,7 @@ export default defineComponent({
         }
 
         return {
-          url: format.url,
+          url: format.freeTubeUrl,
           type: format.mime_type,
           label: 'Audio',
           qualityLabel: label


### PR DESCRIPTION
# Fix web throttling because of double deciphering

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3457 
partially #3738 (will create a separate pull request for the comments)

## Description
Finally figured out why DASH was getting throttled but audio only and the legacy formats were fine. Took multiple weeks and stabs in the dark but we finally solved it.

The cause was us deciphering the formats and overwriting the URL in the `Format` objects, to avoid having to decipher them in lots of places around FreeTube (e.g. downloads, audio only, legacy). Unfortunately when we generated the DASH manifest with toDash, YouTube.js deciphered the already deciphered formats again, causing the n-param to be correct everywhere but the DASH manifest.

I don't why we were completely fine without any throttling for months before that became an issue, all I can think is that YouTube made a change that resulted in the double deciphering becoming a problem.

As the web client is fine again, I'm removing the extra fetching of the android formats, so that we don't make excess requests. If we end up needing them again in the future, they can always be added back quite easily.

Thank you very much to @AudricV and @LuanRT for their help and putting up with me while we tried to figure out the issue! 🤗

## Testing <!-- for code that is not small enough to be easily understandable -->
Play videos on the local API without proxying with the DASH formats enabled. Additionally test some age restricted videos like this one mentioned in the issue https://youtu.be/rrSnnhe53ks or the videos in this playlist: https://www.youtube.com/playlist?list=PLze6c8Dxpjv4eaemhVXYLURZt3Pcrddw5