### PR TITLE
Fix local API comments for age-restricted videos

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -403,6 +403,17 @@ export default defineComponent({
           this.liveChat = null
         }
 
+        // region No comment detection
+        // For videos without any comment (comment disabled?)
+        // e.g. https://youtu.be/8NBSwDEf8a8
+        //
+        // `comments_entry_point_header` is null probably when comment disabled
+        // e.g. https://youtu.be/8NBSwDEf8a8
+        // However videos with comments enabled but have no comment
+        // are different (which is not detected here)
+        this.commentsEnabled = result.comments_entry_point_header != null
+        // endregion No comment detection
+
         // the bypassed result is missing some of the info that we extract in the code above
         // so we only overwrite the result here
         // we need the bypassed result for the streaming data and the subtitles
@@ -665,17 +676,6 @@ export default defineComponent({
             await this.createLocalStoryboardUrls(result.storyboards.boards.at(-1))
           }
         }
-
-        // region No comment detection
-        // For videos without any comment (comment disabled?)
-        // e.g. https://youtu.be/8NBSwDEf8a8
-        //
-        // `comments_entry_point_header` is null probably when comment disabled
-        // e.g. https://youtu.be/8NBSwDEf8a8
-        // However videos with comments enabled but have no comment
-        // are different (which is not detected here)
-        this.commentsEnabled = result.comments_entry_point_header != null
-        // endregion No comment detection
 
         this.isLoading = false
         this.updateTitle()


### PR DESCRIPTION
# Fix local API comments for age-restricted videos

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3738

## Description
As the bypassed response comes from an embed client, it doesn't have extras like comments and the watch next feed, so we need to check if the video has comments before switching to the bypassed result.

## Screenshots <!-- If appropriate -->

before:
![before, showing the "there are no comments available for this video" message](https://github.com/FreeTubeApp/FreeTube/assets/48293849/b0139b9b-693a-4565-be22-978f1e1fc53a)

after:
![afterwards, showing the "Click to View Comments" button](https://github.com/FreeTubeApp/FreeTube/assets/48293849/f6dadb19-9615-4417-a182-6ff4dca0066d)

## Testing <!-- for code that is not small enough to be easily understandable -->
Test some age restricted videos like this one mentioned in the issue https://youtu.be/rrSnnhe53ks or the videos in this playlist: https://www.youtube.com/playlist?list=PLze6c8Dxpjv4eaemhVXYLURZt3Pcrddw5