### PR TITLE
Revert "Bump prettier from 2.8.8 to 3.0.0 (#3758)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.25",
     "postcss-scss": "^4.0.6",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "sass": "^1.63.6",
     "sass-loader": "^13.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6635,15 +6635,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-"prettier@^1.18.2 || ^2.0.0":
+"prettier@^1.18.2 || ^2.0.0", prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This reverts commit f77ae6da165df3ec11cf226631f0e589484f5923.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reverts https://github.com/FreeTubeApp/FreeTube/pull/3758

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Strange syntax errors start appearing after the upgrade
Cannot find any fix yet, better just revert the upgrade first

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/49fd774b-01f8-430b-afaf-d14f334230cc)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
`yarn dev`

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
