### PR TITLE
Fix duplicate content updates run on channel switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.25",
     "postcss-scss": "^4.0.6",
-    "prettier": "^3.0.0",
+    "prettier": "^2.8.8",
     "rimraf": "^5.0.1",
     "sass": "^1.63.6",
     "sass-loader": "^13.3.2",

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -104,7 +104,9 @@ export default defineComponent({
       playlistSelectValues: [
         'newest',
         'last'
-      ]
+      ],
+
+      autoRefreshOnSortByChangeEnabled: false,
     }
   },
   computed: {
@@ -257,6 +259,9 @@ export default defineComponent({
         return
       }
 
+      // Disable auto refresh on sort value change during state reset
+      this.autoRefreshOnSortByChangeEnabled = false
+
       this.id = this.$route.params.id
       this.searchPage = 2
       this.relatedChannels = []
@@ -296,14 +301,20 @@ export default defineComponent({
       this.showShareMenu = true
       this.errorMessage = ''
 
+      // Re-enable auto refresh on sort value change AFTER update done
       if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
         this.getChannelInfoInvidious()
+        this.autoRefreshOnSortByChangeEnabled = true
       } else {
-        this.getChannelLocal()
+        this.getChannelLocal().finally(() => {
+          this.autoRefreshOnSortByChangeEnabled = true
+        })
       }
     },
 
     videoSortBy () {
+      if (!this.autoRefreshOnSortByChangeEnabled) { return }
+
       this.isElementListLoading = true
       this.latestVideos = []
       switch (this.apiUsed) {
@@ -319,6 +330,8 @@ export default defineComponent({
     },
 
     shortSortBy() {
+      if (!this.autoRefreshOnSortByChangeEnabled) { return }
+
       this.isElementListLoading = true
       this.latestShorts = []
       switch (this.apiUsed) {
@@ -334,6 +347,8 @@ export default defineComponent({
     },
 
     liveSortBy () {
+      if (!this.autoRefreshOnSortByChangeEnabled) { return }
+
       this.isElementListLoading = true
       this.latestLive = []
       switch (this.apiUsed) {
@@ -349,6 +364,8 @@ export default defineComponent({
     },
 
     playlistSortBy () {
+      if (!this.autoRefreshOnSortByChangeEnabled) { return }
+
       this.isElementListLoading = true
       this.latestPlaylists = []
       this.playlistContinuationData = null
@@ -382,10 +399,14 @@ export default defineComponent({
       return
     }
 
+    // Enable auto refresh on sort value change AFTER initial update done
     if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
       this.getChannelInfoInvidious()
+      this.autoRefreshOnSortByChangeEnabled = true
     } else {
-      this.getChannelLocal()
+      this.getChannelLocal().finally(() => {
+        this.autoRefreshOnSortByChangeEnabled = true
+      })
     }
   },
   methods: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6635,15 +6635,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-"prettier@^1.18.2 || ^2.0.0":
+"prettier@^1.18.2 || ^2.0.0", prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Fixes https://github.com/FreeTubeApp/FreeTube/issues/3287

Includes changes from https://github.com/FreeTubeApp/FreeTube/pull/3761 otherwise it can't be tested

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When switching channel in channel view
There can 2 patch of updates run
1 by `$route` watcher (A)
1 by sort by value watchers (B)

So there are errors for updates run by A due to state being prepared for switched channel (in N)
This PR disable B when A is running

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- View one channel with all 4: video, live, short, playlist, e.g. https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw
S
- Switch to every tab and change sorting (so sort by values in state all become non default)
- Switch to another channel
- Ensure no error in console, no issue like https://github.com/FreeTubeApp/FreeTube/issues/3287

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
