### PR TITLE
Fix local API empty search results loading forever

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -411,7 +411,8 @@ function handleSearchResponse(response) {
 
   return {
     results,
-    continuationData: response.has_continuation ? response : null
+    // check the length of the results, as there can be continuations for things that we've filtered out, which we don't want
+    continuationData: response.has_continuation && results.length > 0 ? response : null
   }
 }
 

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -114,10 +114,6 @@ export default defineComponent({
       try {
         const { results, continuationData } = await getLocalSearchResults(payload.query, payload.searchSettings, this.showFamilyFriendlyOnly)
 
-        if (results.length === 0) {
-          return
-        }
-
         this.apiUsed = 'local'
 
         this.shownResults = results


### PR DESCRIPTION
# Fix local API empty search results loading forever

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3349

## Description
Currently when you search for something that doesn't return any results the search page loads forever, this pull request fixes that.

## Testing <!-- for code that is not small enough to be easily understandable -->
Search for something that doesn't return any results e.g. `####` check that it shows and empty results page instead of loading forever.