### PR TITLE
Update external-player-map.json: Add basic support for external SMPlayer

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -58,5 +58,23 @@
             "playlistShuffle": "--mpv-shuffle",
             "playlistLoop": "--mpv-loop-playlist"
         }
+    },
+      {
+        "name": "SMPlayer",
+        "nameTranslationKey": "Settings.External Player Settings.Players.SMPlayer.Name",
+        "value": "smplayer",
+        "cmdArguments": {
+            "defaultExecutable": "smplayer",
+            "defaultCustomArguments": null,
+            "supportsYtdlProtocol": true,
+            "videoUrl": "",
+            "playlistUrl": "",
+            "startOffset": null,
+            "playbackRate": null,
+            "playlistIndex": null,
+            "playlistReverse": null,
+            "playlistShuffle": null,
+            "playlistLoop": null
+        }
     }
 ]


### PR DESCRIPTION
# Add basic functionality to open videos in SMPlayer


<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #2231 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds basic functionality to open videos in SMPlayer.

Adding more parameters (e.g., startOffset or speed) is not possible at this time as SMPlayer expects different formatting compared to what FreeTube currently passes through.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Testing has been done on Windows 11 x64 only.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** v0.18.0-nightly-3109

## Additional context
<!-- Add any other context about the pull request here. -->
