### PR TITLE
Improve responsiveness in playlist sidebar when one word channel names are long

### DIFF
--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -228,6 +228,7 @@ $watched-transition-duration: 0.5s;
       font-size: 14px;
       grid-area: infoLine;
       margin-top: 5px;
+      overflow-wrap: anywhere;
 
       @include is-sidebar-item {
         font-size: 12px;

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -111,6 +111,9 @@
   .watchVideoSidebar,
   .watchVideoPlaylist {
     height: 500px;
+    @media (max-width: 768px) {
+      height: auto;
+    }
   }
 
   .watchVideoRecommendations,

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -106,15 +106,18 @@
   .watchVideoSidebar,
   .theatrePlaylist {
     margin: 0 8px 16px;
-    :deep(.videoThumbnail) {
-      margin-top: auto;
-      margin-bottom: auto;
-    }
   }
 
   .watchVideoSidebar,
   .watchVideoPlaylist {
     height: 500px;
+  }
+
+  .watchVideoPlaylist {
+    :deep(.videoThumbnail) {
+      margin-top: auto;
+      margin-bottom: auto;
+    }
     @media (max-width: 768px) {
       height: auto;
     }

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -106,6 +106,10 @@
   .watchVideoSidebar,
   .theatrePlaylist {
     margin: 0 8px 16px;
+    :deep(.videoThumbnail) {
+      margin-top: auto;
+      margin-bottom: auto;
+    }
   }
 
   .watchVideoSidebar,


### PR DESCRIPTION
# Improve responsiveness in playlist sidebar when one word channel names are long

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
When there is a channel name that is very long and contains no spaces, it can cause the page to overflow. This PR addresses this by adding the `overflow-wrap: anywhere;` style to `.infoLine`. Additionally, in fixing the overflow, I noticed that video thumbnails in the playlist sidebar were not vertically centered in the `Watch` view like they are in the `Playlist` view, so I adjusted that too so it would look more aligned with the vertically centered video index.

## Screenshots <!-- If appropriate -->
overflow:
|before|after|
|--|--|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/8b293264-3032-41bb-bf68-8bd3f3cef453)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/190a5534-00bc-4494-9ab3-4627781d97f5)|

vertical centering:
|before|after|
|--|--|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/351e2d82-2725-437e-b1d3-765861ca8005)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/848dfb34-6e42-45fc-ab44-e70960f06064)|

_(for reference on vertical centering, this is the playlist view)_
<img src="https://github.com/FreeTubeApp/FreeTube/assets/106682128/899794a2-13b3-4e4f-b4c3-6e5e08a11708" width="200" />



## Testing <!-- for code that is not small enough to be easily understandable -->
1. Reduce your window width to 400px or below
2. Navigate to a playlist containing videos where the author has a long, one-word channel name (ex: https://youtube.com/playlist?list=PLABS9rhwbrHm-hHQ-aoH0USFaloHC5ehN)
3. Make sure the page doesn't overflow and that everything looks alright

## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 8c03a465e306a9b7e49081898432b29c69bfc347

