### PR TITLE
IV: Show channel handle in search results

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -1,6 +1,7 @@
 import { defineComponent } from 'vue'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { formatNumber } from '../../helpers/utils'
+import { parseLocalSubscriberCount } from '../../helpers/api/local'
 
 export default defineComponent({
   name: 'FtListChannel',
@@ -21,6 +22,8 @@ export default defineComponent({
       channelName: '',
       subscriberCount: 0,
       videoCount: '',
+      parsedSubscriberCount: '',
+      parsedVideoCount: '',
       handle: null,
       description: ''
     }
@@ -53,12 +56,17 @@ export default defineComponent({
 
       this.channelName = this.data.name
       this.id = this.data.id
-      this.subscriberCount = this.data.subscribers != null ? this.data.subscribers.replace(/ subscriber(s)?/, '') : null
+      this.subscriberCount = null
+      if (this.data.subscribers != null) {
+        this.subscriberCount = parseLocalSubscriberCount(this.data.subscribers.replace(/ subscriber(s)?/, ''))
+        this.parsedSubscriberCount = formatNumber(this.subscriberCount)
+      }
 
       if (this.data.videos === null) {
         this.videoCount = 0
       } else {
-        this.videoCount = formatNumber(this.data.videos)
+        this.videoCount = this.data.videos
+        this.parsedVideoCount = formatNumber(this.data.videos)
       }
 
       if (this.data.handle) {
@@ -76,8 +84,16 @@ export default defineComponent({
 
       this.channelName = this.data.author
       this.id = this.data.authorId
-      this.subscriberCount = formatNumber(this.data.subCount)
-      this.videoCount = formatNumber(this.data.videoCount)
+      this.subscriberCount = this.data.subCount
+      this.parsedSubscriberCount = formatNumber(this.subscriberCount)
+      this.handle = this.data.channelHandle
+      if (this.handle != null) {
+        this.videoCount = null
+      } else {
+        this.videoCount = this.data.videoCount
+        this.parsedVideoCount = formatNumber(this.videoCount)
+      }
+
       this.description = this.data.description
     }
   }

--- a/src/renderer/components/ft-list-channel/ft-list-channel.vue
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.vue
@@ -29,7 +29,9 @@
           v-if="subscriberCount !== null && !hideChannelSubscriptions"
           class="subscriberCount"
         >
-          {{ subscriberCount }} subscribers -
+          {{ parsedSubscriberCount }}
+          <template v-if="subscriberCount === 1">{{ $t("Channel.Subscriber") }}</template>
+          <template v-else>{{ $t("Channel.Subscribers") }}</template> -
         </span>
         <router-link
           v-if="handle !== null"
@@ -42,7 +44,9 @@
           v-else
           class="videoCount"
         >
-          {{ videoCount }} videos
+          {{ parsedVideoCount }}
+          <template v-if="videoCount === 1">{{ $t("Channel.Videos.Video") }}</template>
+          <template v-else>{{ $t("Channel.Videos.Videos") }}</template>
         </span>
       </div>
       <p

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -533,6 +533,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: This channel is age-restricted and currently cannot be viewed in FreeTube.
   Channel Tabs: Channel Tabs
   Videos:
+    Video: Video
     Videos: Videos
     This channel does not currently have any videos: This channel does not currently
       have any videos


### PR DESCRIPTION
# IV: Show channel handle in search results

## Pull Request Type
- [x] Feature Implementation

## Related issue
Video Count for channels is almost always 0 (it might always be 0)

## Description
Display the channel handle when it exists + fix missing translations for ft-list-channel


## Testing
- Use Invidious API
- Search 'MrBeast'
- See channel handle instead of video count for the Mr Beast channel

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0

## Additional context
Releis on https://github.com/iv-org/invidious/pull/3994 to be merged
