### PR TITLE
Update top nav bar icon to remove focus state style

### DIFF
--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -54,11 +54,6 @@
 
   @include top-nav-is-colored {
     color: var(--text-with-main-color);
-
-    &:hover,
-    &:focus {
-      background-color: var(--primary-color-hover);
-    }
   }
 
   &.fa-arrow-left,
@@ -69,10 +64,13 @@
     user-select: none;
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     background-color: var(--side-nav-hover-color);
     transition: background 0.2s ease-in;
+
+    @include top-nav-is-colored {
+      background-color: var(--primary-color-hover);
+    }
   }
 
   &:active {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/3067

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fix "navigation bar icons are still being highlighted after click"

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Tabbing into the button remain highlighted
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/f41fd0c4-6226-438a-8754-8862b8cebd76)

No highlight after clicking the button

https://github.com/FreeTubeApp/FreeTube/assets/1018543/03416d7b-8259-4dd3-b4ab-a411bd7aa0d9



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Click top nav button(s)
- Ensure they are no longer highlighted after cursor moved away

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
