### PR TITLE
Fix watch page breaking when subscriber count is missing

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -357,7 +357,7 @@ export default defineComponent({
         this.isUpcoming = !!result.basic_info.is_upcoming
         this.isLiveContent = !!result.basic_info.is_live_content
 
-        const subCount = parseLocalSubscriberCount(result.secondary_info.owner.subscriber_count.text)
+        const subCount = !result.secondary_info.owner.subscriber_count.isEmpty() ? parseLocalSubscriberCount(result.secondary_info.owner.subscriber_count.text) : NaN
 
         if (!isNaN(subCount)) {
           this.channelSubscriptionCountText = formatNumber(subCount, subCount >= 10000 ? { notation: 'compact' } : undefined)
@@ -713,7 +713,7 @@ export default defineComponent({
 
           this.videoTitle = result.title
           this.videoViewCount = result.viewCount
-          this.channelSubscriptionCountText = result.subCountText || 'FT-0'
+          this.channelSubscriptionCountText = isNaN(result.subCountText) ? '' : result.subCountText
           if (this.hideVideoLikesAndDislikes) {
             this.videoLikeCount = null
             this.videoDislikeCount = null


### PR DESCRIPTION
# Fix watch page breaking when subscriber count is missing

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
YouTube is removing subscriber counts for auto-generated channels like the topic ones. Currently the watch page always expects there to be a subscriber count with the local API

## Testing <!-- for code that is not small enough to be easily understandable -->
(Invidious returning 403s for the music streams when proxying is disabled is a separate issue, guessing youtube doesn't like the IP of the machine requesting the watch page and the machine requesting the streams being different for music videos)
topic channel video: https://youtu.be/pcWRMvNufA
LTT video: https://youtu.be/0EtgwIajVqs