### PR TITLE
Fix playlists for external players with no index support

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -585,7 +585,12 @@ const actions = {
         }
       }
 
-      args.push(`${cmdArgs.playlistUrl}https://youtube.com/playlist?list=${payload.playlistId}`)
+      // If the player supports opening playlists but not indexes, send only the video URL if an index is specified
+      if (cmdArgs.playlistIndex == null && payload.playlistIndex != null && payload.playlistId !== '') {
+        args.push(`${cmdArgs.videoUrl}https://youtube.com/watch?v=${payload.videoId}`)
+      } else {
+        args.push(`${cmdArgs.playlistUrl}https://youtube.com/playlist?list=${payload.playlistId}`)
+      }
     } else {
       if (payload.playlistId != null && payload.playlistId !== '' && !ignoreWarnings) {
         showExternalPlayerUnsupportedActionToast(externalPlayer, 'opening playlists')


### PR DESCRIPTION
# Fix playlists for external players with playlist but no index support

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The current logic doesn't consider external players that have support for playlists but not playlist indexes enabled, leading to entire playlists being sent to the external player when a single video is opened from within a playlist.

This adds an additional check to only send the video URL for these players when a playlist with an index is specified, for all other players or if no index is specified the playlist URL will be sent.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** v0.18.0-nightly-3148

## Additional context
<!-- Add any other context about the pull request here. -->
