### PR TITLE
Add basic support for PotPlayer, MPC-HC, MPC-BE

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -529,7 +529,10 @@ const actions = {
 
     if (payload.watchProgress > 0 && payload.watchProgress < payload.videoLength - 10) {
       if (typeof cmdArgs.startOffset === 'string') {
-        if (cmdArgs.startOffset.endsWith('=')) {
+        if (cmdArgs.defaultExecutable.startsWith('mpc')) {
+          // For mpc-hc and mpc-be, which require startOffset to be in milliseconds
+          args.push(cmdArgs.startOffset, (Math.trunc(payload.watchProgress) * 1000))
+        } else if (cmdArgs.startOffset.endsWith('=')) {
           // For players using `=` in arguments
           // e.g. vlc --start-time=xxxxx
           args.push(`${cmdArgs.startOffset}${payload.watchProgress}`)

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -6,42 +6,6 @@
         "cmdArguments": null
     },
     {
-        "name": "mpv",
-        "nameTranslationKey": "Settings.External Player Settings.Players.mpv.Name",
-        "value": "mpv",
-        "cmdArguments": {
-            "defaultExecutable": "mpv",
-            "defaultCustomArguments": null,
-            "supportsYtdlProtocol": true,
-            "videoUrl": "",
-            "playlistUrl": "",
-            "startOffset": "--start=",
-            "playbackRate": "--speed=",
-            "playlistIndex": "--playlist-start=",
-            "playlistReverse": null,
-            "playlistShuffle": "--shuffle",
-            "playlistLoop": "--loop-playlist"
-        }
-    },
-    {
-        "name": "VLC",
-        "nameTranslationKey": "Settings.External Player Settings.Players.VLC.Name",
-        "value": "vlc",
-        "cmdArguments": {
-            "defaultExecutable": "vlc",
-            "defaultCustomArguments": null,
-            "supportsYtdlProtocol": false,
-            "videoUrl": "",
-            "playlistUrl": null,
-            "startOffset": "--start-time=",
-            "playbackRate": "--rate=",
-            "playlistIndex": null,
-            "playlistReverse": null,
-            "playlistShuffle": "--random",
-            "playlistLoop": "--loop"
-        }
-    },
-    {
         "name": "iina",
         "nameTranslationKey": "Settings.External Player Settings.Players.iina.Name",
         "value": "iina",
@@ -57,6 +21,60 @@
             "playlistReverse": null,
             "playlistShuffle": "--mpv-shuffle",
             "playlistLoop": "--mpv-loop-playlist"
+        }
+    },
+    {
+      "name": "MPC-BE",
+      "nameTranslationKey": "Settings.External Player Settings.Players.MPC-BE.Name",
+      "value": "mpc-be",
+      "cmdArguments": {
+          "defaultExecutable": "mpc-be64",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": true,
+          "videoUrl": "",
+          "playlistUrl": "",
+          "startOffset": "/start",
+          "playbackRate": null,
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": null,
+          "playlistLoop": null
+      }
+  },
+    {
+      "name": "MPC-HC",
+      "nameTranslationKey": "Settings.External Player Settings.Players.MPC-HC.Name",
+      "value": "mpc-hc",
+      "cmdArguments": {
+          "defaultExecutable": "mpc-hc64",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": true,
+          "videoUrl": "",
+          "playlistUrl": "",
+          "startOffset": "/start",
+          "playbackRate": null,
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": null,
+          "playlistLoop": null
+      }
+  },
+    {
+        "name": "mpv",
+        "nameTranslationKey": "Settings.External Player Settings.Players.mpv.Name",
+        "value": "mpv",
+        "cmdArguments": {
+            "defaultExecutable": "mpv",
+            "defaultCustomArguments": null,
+            "supportsYtdlProtocol": true,
+            "videoUrl": "",
+            "playlistUrl": "",
+            "startOffset": "--start=",
+            "playbackRate": "--speed=",
+            "playlistIndex": "--playlist-start=",
+            "playlistReverse": null,
+            "playlistShuffle": "--shuffle",
+            "playlistLoop": "--loop-playlist"
         }
     },
       {
@@ -76,5 +94,23 @@
             "playlistShuffle": null,
             "playlistLoop": null
         }
-    }
+    },
+    {
+      "name": "VLC",
+      "nameTranslationKey": "Settings.External Player Settings.Players.VLC.Name",
+      "value": "vlc",
+      "cmdArguments": {
+          "defaultExecutable": "vlc",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": false,
+          "videoUrl": "",
+          "playlistUrl": null,
+          "startOffset": "--start-time=",
+          "playbackRate": "--rate=",
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": "--random",
+          "playlistLoop": "--loop"
+      }
+  }
 ]

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -77,6 +77,24 @@
             "playlistLoop": "--loop-playlist"
         }
     },
+    {
+      "name": "PotPlayer",
+      "nameTranslationKey": "Settings.External Player Settings.Players.PotPlayer.Name",
+      "value": "potplayer",
+      "cmdArguments": {
+          "defaultExecutable": "potplayermini64",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": false,
+          "videoUrl": "",
+          "playlistUrl": null,
+          "startOffset": "/seek=",
+          "playbackRate": null,
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": null,
+          "playlistLoop": null
+      }
+  },
       {
         "name": "SMPlayer",
         "nameTranslationKey": "Settings.External Player Settings.Players.SMPlayer.Name",


### PR DESCRIPTION
# Add basic support for PotPlayer, MPC-HC, MPC-BE

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #3614 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR adds basic external player functionality for PotPlayer, MPC-HC and MPC-BE.
It also sorts the list alphabetically, because UX.

Note that MPC-HC requires yt-dlp or similar to be present.
It will also fail to properly play back videos with a startOffset if the resolution is > 1080p (audio will play, video will be black). Unfortunately the default limit (View > Options > Advanced > YDLMaxHeight) MPC-HC ships with is 1440p.
**Feedback desired on whether startOffset should stay enabled given the current state.**

Note that MPC-BE requires yt-dlp or similar to be present and enabled in order to parse playlists.

Note that both MPC-HC and MPC-BE require #3797 to fix playback from within playlists.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** v0.18.0-nightly-3148

## Additional context
<!-- Add any other context about the pull request here. -->
