### PR TITLE
Fix: importing subscriptions with terminated channels

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -1035,10 +1035,9 @@ export default defineComponent({
         invidiousAPICall(subscriptionsPayload).then((response) => {
           resolve(response)
         }).catch((err) => {
-          console.error(err)
           const errorMessage = this.$t('Invidious API Error (Click to copy)')
-          showToast(`${errorMessage}: ${err.responseJSON.error}`, 10000, () => {
-            copyToClipboard(err.responseJSON.error)
+          showToast(`${errorMessage}: ${err}`, 10000, () => {
+            copyToClipboard(err)
           })
 
           if (process.env.IS_ELECTRON && this.backendFallback && this.backendPreference === 'invidious') {
@@ -1056,7 +1055,7 @@ export default defineComponent({
         const channel = await getLocalChannel(channelId)
 
         if (channel.alert) {
-          return undefined
+          return []
         }
 
         return {


### PR DESCRIPTION
# Fix: importing subscriptions with terminated channels

## Pull Request Type
- [x] Bugfix

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/3735

## Description
Import subscriptions when terminated channels found, etc.

## Testing 

See: https://github.com/FreeTubeApp/FreeTube/issues/3735#issuecomment-1642286050

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0

## Additional context
@efb4f5ff-1298-471a-8973-3d47447115dc I could not find the ` freetube-subscriptions.json` that you mentioned
