### PR TITLE
Fix outdated subscription cache clearing code when "Remove All Subscriptions / Profiles" performed

### DIFF
--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -110,7 +110,9 @@ export default defineComponent({
           }
         })
 
-        this.clearSubscriptionsCache()
+        this.clearSubscriptionVideosCache()
+        this.clearSubscriptionShortsCache()
+        this.clearSubscriptionLiveCache()
       }
     },
 
@@ -124,7 +126,9 @@ export default defineComponent({
       'updateProfile',
       'removeProfile',
       'updateActiveProfile',
-      'clearSubscriptionsCache',
+      'clearSubscriptionVideosCache',
+      'clearSubscriptionShortsCache',
+      'clearSubscriptionLiveCache',
     ])
   }
 })


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Bug introduced by #3725 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Saw this error in console while testing #3816

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/16c61a25-8f92-414e-9e25-1e4b0102b2b8)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Perform "Remove All Subscriptions / Profiles"
- Ensure no error in console

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
