### PR TITLE
Fix empty channels showing up as errored with RSS

### DIFF
--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -216,6 +216,17 @@ export default defineComponent({
         const response = await fetch(feedUrl)
 
         if (response.status === 404) {
+          // playlists don't exist if the channel was terminated but also if it doesn't have the tab,
+          // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
+
+          const response2 = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
+            method: 'HEAD'
+          })
+
+          if (response2.status === 404) {
+            this.errorChannels.push(channel)
+          }
+
           return []
         }
 

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -157,6 +157,17 @@ export default defineComponent({
         const response = await fetch(feedUrl)
 
         if (response.status === 404) {
+          // playlists don't exist if the channel was terminated but also if it doesn't have the tab,
+          // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
+
+          const response2 = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
+            method: 'HEAD'
+          })
+
+          if (response2.status === 404) {
+            this.errorChannels.push(channel)
+          }
+
           return []
         }
 

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
@@ -14,10 +14,6 @@
   right: 10px;
 }
 
-.channelBubble {
-  display: inline-block;
-}
-
 @media only screen and (max-width: 350px) {
   .floatingTopButton {
     position: absolute

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.vue
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.vue
@@ -14,7 +14,6 @@
           :channel-name="channel.name"
           :channel-id="channel.id"
           :channel-thumbnail="channel.thumbnail"
-          class="channelBubble"
           @click="goToChannel(channel.id)"
         />
       </div>

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -216,7 +216,17 @@ export default defineComponent({
         const response = await fetch(feedUrl)
 
         if (response.status === 404) {
-          this.errorChannels.push(channel)
+          // playlists don't exist if the channel was terminated but also if it doesn't have the tab,
+          // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
+
+          const response2 = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channel.id}`, {
+            method: 'HEAD'
+          })
+
+          if (response2.status === 404) {
+            this.errorChannels.push(channel)
+          }
+
           return []
         }
 


### PR DESCRIPTION
# Fix empty channels showing up as errored with RSS

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3800

## Description
As we switched from the channel RSS feeds to the playlist ones, we also need to update the logic to handle empty and terminated channels. For empty channels the channel RSS feed returns an empty feed and only 404s if the channel doesn't exist e.g. it was terminated, unfortunately YouTube only creates the auto-generated playlists if the channel has the relevant tabs/content of that type, so it will 404 even if the channel still exists. To ensure that we only show errors for actually terminated and deleted channels, this pull request will fire off a HEAD request to the channel RSS feed if the playlist one 404s, that way we can supress the playlist 404s if they aren't actual errors.

I also took the opportunity to fix the CSS for the errored channels section.

This only addresses the local API, Invidious with RSS won't show any errors, even for terminated channels, due to https://github.com/iv-org/invidious/issues/4021

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/a2aa3e24-b390-4a9c-ad67-6b2aa9b6acbc)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/eff427a6-d7bc-4eae-bb64-1b861aec3527)

## Testing <!-- for code that is not small enough to be easily understandable -->
For testing purposes I've made a profiles database with 3 channels:
* A working channel: Linus Tech Tips
* An empty channel: on of the ones listed in #3800
* A terminated channel: taken from the test cases in #3143 and manually edited into the file, as we purposely prevent subscribing to terminated channels

1. Download this file and rename it to `profiles.db` [profiles.txt](https://github.com/FreeTubeApp/FreeTube/files/12207446/profiles.txt)
2. Close the dev version of FreeTube entirely (on macOS remember to quit it too, on windows and linux you just need to close all windows)
3. Backup your existing dev profiles database if you want to
4. Place the downloaded one in the correct location on the file system **do not import it in the app, as that won't import the terminated channel**, on Windows in dev that is `%appdata%\Electron\profiles.db`
5. Launch the dev version of FreeTube (`yarn dev` or `yarn run dev`)
6. Set the preferred API to the local one
7. Enable Fetch feeds from RSS
8. Refresh each subscription tab and check that it only shows the terminated channel in the errored channels list