### PR TITLE
Fix handling of DeArrow titles

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -1,6 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 import i18n from '../../i18n/index'
+import { set as vueSet } from 'vue'
 
 import { IpcChannels } from '../../../constants'
 import { pathExists } from '../../helpers/filesystem'
@@ -58,8 +59,8 @@ const getters = {
     return state.sessionSearchHistory
   },
 
-  getDeArrowCache: (state) => (videoId) => {
-    return state.deArrowCache[videoId]
+  getDeArrowCache: (state) => {
+    return state.deArrowCache
   },
 
   getPopularCache () {
@@ -639,7 +640,9 @@ const mutations = {
     const sameVideo = state.deArrowCache[payload.videoId]
 
     if (!sameVideo) {
-      state.deArrowCache[payload.videoId] = payload
+      // setting properties directly doesn't trigger watchers in Vue 2,
+      // so we need to use Vue's set function
+      vueSet(state.deArrowCache, payload.videoId, payload)
     }
   },
 


### PR DESCRIPTION
# Fix handling of DeArrow titles

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
PR that added the DeArrow titles: #3688

## Description
This pull request addresses two issues with the current DeArrow titles implementation:
1. The titles should only be modified at display time, so that they disappear when you disable the dearrow titles setting, the current implementation unfortunately stores them in the watch history and playlists databases if the video is favourited or marked as watched from an ft-list-video component, so they stay modified even when the setting is disabled
2. The current implementation results in the data display being delayed until the dearrow title was fetched, that means that the components got rendered empty first and then recreated with the data when the title was fetched, not only causing extra component updates but also meaning that people with slow connections would see empty components until the API requests are done. (see screenshot below)

This pull request addresses the first issue by only overriding the title in the `displayTitle` computed property, instead of overriding the `title` property that is among other things used for the mark as watched button.

It addresses the second issue by switching the component creation back to being synchronous and fetching the DeArrow title asynchronously, if the setting is enabled and the video isn't listed in the cache. This approach means that if the DeArrow titles setting is disabled or the video exists in the cache, the initial component render is completely synchronous without any updates (we can use the cached title during the initial render). If the setting is enabled and the video doesn't exist in the cache, the initial render will stay synchronous using the original data, once the API response is complete only the components that have a modified title get rerendered.
So on slow connections instead of seeing nothing first, you will now see the original data and then the display title will be replaced once that API has responded.

## Screenshots
Empty component
![rendering_issue](https://github.com/FreeTubeApp/FreeTube/assets/48293849/92be0f50-ec61-4bae-a53f-4e363516719d)

Simulated throttling setting
![throttling-setting](https://github.com/FreeTubeApp/FreeTube/assets/48293849/95b54e94-988d-4a90-88de-1cdf97e2d334)

## Testing <!-- for code that is not small enough to be easily understandable -->
### Testing the worst case rendering scenario

1. Make sure that the DeArrow titles setting is disabled because we want to start with an empty cache
2. Load your subscriptions if they aren't already loaded (make sure you have a channel that has clickbate titles e.g. Linus Tech Tips)
3. In the same window, switch to the settings tab and enable the DeArrow titles setting
4. In the network tab in the devtools set the throttling option to the "Slow 3G" preset (see screenshot)
5. Switch back to the subscriptions tab
6. With this pull request you should see the components render straight away, with the titles gradually getting replaced with the DeArrow ones where available.
Without this pull request you will see empty components and then they will start rendering in when the DeArrow API responses arrive, even components without a replacement title will suffer from the issue.

### Testing that the modified titles don't get stored

1. Enable the DeArrow titles setting
2. In the 3 dots menu next to a video with a modified title, click "Mark as Watched"
3. In the history tab, check that the video is shown with the modified title
4. Disable the DeArrow titles setting
5. In the history tab, check that the video is shown with the original title