### PR TITLE
Add custom toast event bus for Vue 3 compatiblity

### DIFF
--- a/src/renderer/components/ft-toast/ft-toast-events.js
+++ b/src/renderer/components/ft-toast/ft-toast-events.js
@@ -1,4 +1,2 @@
-import Vue from 'vue'
-
-const events = new Vue()
+const events = new EventTarget()
 export default events

--- a/src/renderer/components/ft-toast/ft-toast.js
+++ b/src/renderer/components/ft-toast/ft-toast.js
@@ -9,10 +9,10 @@ export default defineComponent({
     }
   },
   mounted: function () {
-    FtToastEvents.$on('toast-open', this.open)
+    FtToastEvents.addEventListener('toast-open', this.open)
   },
   beforeDestroy: function () {
-    FtToastEvents.$off('toast-open', this.open)
+    FtToastEvents.removeEventListener('toast-open', this.open)
   },
   methods: {
     performAction: function (index) {
@@ -25,7 +25,7 @@ export default defineComponent({
 
       toast.isOpen = false
     },
-    open: function (message, time, action) {
+    open: function ({ detail: { message, time, action } }) {
       const toast = { message: message, action: action || (() => { }), isOpen: false, timeout: null }
       toast.timeout = setTimeout(this.close, time || 3000, toast)
       setTimeout(() => { toast.isOpen = true })

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -189,7 +189,13 @@ export async function getFormatsFromHLSManifest(manifestUrl) {
 }
 
 export function showToast(message, time = null, action = null) {
-  FtToastEvents.$emit('toast-open', message, time, action)
+  FtToastEvents.dispatchEvent(new CustomEvent('toast-open', {
+    detail: {
+      message,
+      time,
+      action
+    }
+  }))
 }
 
 /**


### PR DESCRIPTION
# Add custom toast event bus for Vue 3 compatiblity

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Refactor

## Related issue
https://github.com/FreeTubeApp/FreeTube/projects/10#card-87323330

## Description
Vue 3 removes the global Vue `$on` and `$off` APIs which we currently use to trigger toasts. This pull request replaces our current way of triggering toasts, with a custom event bus built with [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) and [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent).

This is one of the changes we can do already without having to upgrade to Vue 3, so we'll have a little bit less to do when the time comes.

https://v3-migration.vuejs.org/breaking-changes/events-api.html

## Testing <!-- for code that is not small enough to be easily understandable -->
You can trigger toasts by setting and clearing the default Invidious instance.