### PR TITLE
Fix unnecessary error message display in toast when paused before video started playing on load

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -25,6 +25,13 @@ import {
 import { getProxyUrl } from '../../helpers/api/invidious'
 import store from '../../store'
 
+const EXPECTED_PLAY_RELATED_ERROR_MESSAGES = [
+  // This is thrown when `play()` called but user already viewing another page
+  'The play() request was interrupted by a new load request.',
+  // This is thrown when `pause()` called before video started playing on load
+  'The play() request was interrupted by a call to pause()',
+]
+
 // YouTube now throttles if you use the `Range` header for the DASH formats, instead of the range query parameter
 // videojs-http-streaming calls this hook everytime it makes a request,
 // so we can use it to convert the Range header into the range query parameter for the streaming URLs
@@ -1967,9 +1974,8 @@ export default defineComponent({
       }
       promise
         .catch(err => {
-          if (err.message.includes('The play() request was interrupted by a new load request.')) {
+          if (EXPECTED_PLAY_RELATED_ERROR_MESSAGES.some(msg => err.message.includes(msg))) {
             // Ignoring expected exception
-            // This is thrown when `play()` called but user already viewing another page
             // console.debug('Ignoring expected error')
             // console.debug(err)
             return


### PR DESCRIPTION


## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Caused by https://github.com/FreeTubeApp/FreeTube/pull/3775

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When viewing a video before video started playing on load (initial `play()` request)
If video is paused, the following error message is shown in toast:
`AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22`

This is unnecessary since there is no any broken behaviour and this error should be ignored like before

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before

https://github.com/FreeTubeApp/FreeTube/assets/1018543/4a40030c-1cc1-4428-9b5d-6b55ea2edc8d

After

https://github.com/FreeTubeApp/FreeTube/assets/1018543/094a2094-0b64-4c35-9002-7280554f8c3e



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Change simulated throttling setting to Fast/Slow 3G (easier to pause before initial play) (SC stolen from https://github.com/FreeTubeApp/FreeTube/pull/3825)
![throttling-setting](https://github.com/FreeTubeApp/FreeTube/assets/48293849/95b54e94-988d-4a90-88de-1cdf97e2d334)

- Enable `Autoplay Videos`
- Find random video to play
- Pause before it starts playing
- Confirm no toast message shown

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
