### PR TITLE
Fix author for album playlists on the playlist page

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -21,7 +21,7 @@ export default defineComponent({
       title: '',
       channelThumbnail: '',
       channelName: '',
-      channelId: '',
+      channelId: null,
       videoCount: 0,
       viewCount: 0,
       lastUpdated: '',

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -41,6 +41,7 @@
       class="channelShareWrapper"
     >
       <router-link
+        v-if="channelId"
         class="playlistChannel"
         :to="`/channel/${channelId}`"
       >
@@ -55,6 +56,16 @@
           {{ channelName }}
         </h3>
       </router-link>
+      <div
+        v-else
+        class="playlistChannel"
+      >
+        <h3
+          class="channelName"
+        >
+          {{ channelName }}
+        </h3>
+      </div>
 
       <ft-share-button
         v-if="!hideSharingActions"

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -92,7 +92,7 @@ export default defineComponent({
           viewCount: extractNumberFromString(result.info.views),
           videoCount: extractNumberFromString(result.info.total_items),
           lastUpdated: result.info.last_updated ?? '',
-          channelName: result.info.author?.name ?? '',
+          channelName: result.info.author?.name ?? result.info.subtitle,
           channelThumbnail: result.info.author?.best_thumbnail?.url ?? '',
           channelId: result.info.author?.id,
           infoSource: 'local'


### PR DESCRIPTION
# Fix author for album playlists on the playlist page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
With the addition of the releases tab, it is now a lot easier to stumble across the auto-generated album playlists, previously you would only get them if you copied a link from YouTube Music. Unlike normal playlists, these album playlists don't belong to a channel, so the playlist page doesn't contain any author information for them (no name, id, link, avatar), instead it has a subtitle in this format: `{artist/artists separated by commas} • Album`.

This pull request adds support for those playlists in the local API, so it will now show the subtitle instead of a blank link with the channel ID `undefined` (before the latest YouTube.js update that added support for them it would say `N/A` instead). This doesn't show any text for the Invidious API as that currently doesn't return it, but it does avoid it generating the `undefined` link.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/0e851534-f965-45c8-9d44-6ffaba8ed81d)

after (local API):
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/f8afcebe-6003-46a6-b1d2-89c33fd5aeba)

## Testing <!-- for code that is not small enough to be easily understandable -->

Example playlists:
One artist: https://www.youtube.com/playlist?list=OLAK5uy_lM3m05hKVY9vbzZH5lJpVKZKUQ-v_iTz4
Two artists: https://www.youtube.com/playlist?list=OLAK5uy_mYnfMbIG74obySLdWtKKGj_MJ-YZqVTu0