### PR TITLE
Use video durations from the watch history for RSS

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -436,7 +436,13 @@ export default defineComponent({
 
       this.channelName = this.data.author ?? null
       this.channelId = this.data.authorId ?? null
-      this.duration = formatDurationAsTimestamp(this.data.lengthSeconds)
+
+      if (this.data.isRSS && this.historyIndex !== -1) {
+        this.duration = formatDurationAsTimestamp(this.historyCache[this.historyIndex].lengthSeconds)
+      } else {
+        this.duration = formatDurationAsTimestamp(this.data.lengthSeconds)
+      }
+
       this.description = this.data.description
       this.isLive = this.data.liveNow || this.data.lengthSeconds === 'undefined'
       this.isUpcoming = this.data.isUpcoming || this.data.premiere


### PR DESCRIPTION
# Use video durations from the watch history for RSS

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
closes #3672

## Description
Currently if you have more than 125 subscriptions in a profile or have manually enabled RSS for your subscriptions, you won't see any video durations, because they don't exist in the RSS feed. As we already store video durations in the watch history, we can use those for the RSS feeds when the video exists in the watch history.

This will not show the live status for videos, as they we don't store that in the history (videos that might have been live at the time they were marked as watched, might no longer be live now).

Unlike other things that interact with the history, which we disable when the `Remember History` setting is disabled, even if there is a history entry (e.g. restoring watch progress), I think it's fine to display durations even when the setting is disabled, as we are not changing the app behaviour just displaying useful information we have cached.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/f74af82e-a420-43b4-994a-1cbd2e76619b)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/bf63562d-c9f7-4059-afe8-f40103771f2b)

## Testing <!-- for code that is not small enough to be easily understandable -->

Preparation:
1. Ensure that the `Hide Videos on Watch` subscription setting is disabled.
2. If you don't have any items in the watch history (like me), enable the `Remember History` privacy setting and click on a few videos

Testing:
The shorts subscription feed always uses RSS (channel tab doesn't have published dates), so you can test with that or enable `Fetch Feeds from RSS` and check the videos and live feed.
Durations should show up for any video that has been watched, that isn't live.