### PR TITLE
Show error message in most popular page when instance does not support it

### DIFF
--- a/src/renderer/views/Popular/Popular.js
+++ b/src/renderer/views/Popular/Popular.js
@@ -5,6 +5,7 @@ import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 
 import { invidiousAPICall } from '../../helpers/api/invidious'
+import { copyToClipboard, showToast } from '../../helpers/utils'
 
 export default defineComponent({
   name: 'Popular',
@@ -28,7 +29,7 @@ export default defineComponent({
   mounted: function () {
     document.addEventListener('keydown', this.keyboardShortcutHandler)
 
-    this.shownResults = this.popularCache
+    this.shownResults = this.popularCache || []
     if (!this.shownResults || this.shownResults.length < 1) {
       this.fetchPopularInfo()
     }
@@ -47,7 +48,11 @@ export default defineComponent({
       this.isLoading = true
       const result = await invidiousAPICall(searchPayload)
         .catch((err) => {
-          console.error(err)
+          const errorMessage = this.$t('Invidious API Error (Click to copy)')
+          showToast(`${errorMessage}: ${err}`, 10000, () => {
+            copyToClipboard(err)
+          })
+          return undefined
         })
 
       if (!result) {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Fixes https://github.com/FreeTubeApp/FreeTube/issues/3495

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
In popular tab when fetching remote info, when IV instance used does not support it there is no error message
This PR adds one

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/d9cb7a65-2f69-4b77-86a3-16d9579861c4)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Set `https://invidious.nerdvpn.de/` as IV instance
- Navigate to most popular page
- Ensure error message shown

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
