### PR TITLE
Parse IV search urls

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -324,7 +324,7 @@ const actions = {
 
     const typePatterns = new Map([
       ['playlist', /^(\/playlist\/?|\/embed(\/?videoseries)?)$/],
-      ['search', /^\/results\/?$/],
+      ['search', /^\/results|search\/?$/],
       ['hashtag', hashtagPattern],
       ['channel', channelPattern]
     ])
@@ -359,12 +359,21 @@ const actions = {
       }
 
       case 'search': {
-        if (!url.searchParams.has('search_query')) {
+        let searchQuery = null
+        if (url.searchParams.has('search_query')) {
+          // https://www.youtube.com/results?search_query={QUERY}
+          searchQuery = url.searchParams.get('search_query')
+        }
+        if (url.searchParams.has('q')) {
+          // https://redirect.invidious.io/search?q={QUERY}
+          searchQuery = url.searchParams.get('q')
+        }
+        if (searchQuery == null) {
           throw new Error('Search: "search_query" field not found')
         }
 
-        const searchQuery = url.searchParams.get('search_query')
         url.searchParams.delete('search_query')
+        url.searchParams.delete('q')
 
         const searchSettings = state.searchSettings
         const query = {


### PR DESCRIPTION
# Parse IV search urls

## Pull Request Type
- [x] Bugfix

## Related issue
I found this issue while testing #3846

## Description
FreeTube was not properly parsing IV urls. 

## Testing
enter `https://yt.artemislena.eu/search?q=hi` into the FreeTube search bar

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.18.0
