### PR TITLE
Fix focus not showing on channel page tabs and in prompts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -70,6 +70,11 @@ const SyncEvents = {
   }
 }
 
+// https://v2.vuejs.org/v2/api/#provide-inject
+const Injectables = {
+  SHOW_OUTLINES: 'showOutlines'
+}
+
 // Utils
 const MAIN_PROFILE_ID = 'allChannels'
 
@@ -77,5 +82,6 @@ export {
   IpcChannels,
   DBActions,
   SyncEvents,
+  Injectables,
   MAIN_PROFILE_ID
 }

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -10,7 +10,7 @@ import FtButton from './components/ft-button/ft-button.vue'
 import FtToast from './components/ft-toast/ft-toast.vue'
 import FtProgressBar from './components/ft-progress-bar/ft-progress-bar.vue'
 import { marked } from 'marked'
-import { IpcChannels } from '../constants'
+import { Injectables, IpcChannels } from '../constants'
 import packageDetails from '../../package.json'
 import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 
@@ -29,6 +29,11 @@ export default defineComponent({
     FtButton,
     FtToast,
     FtProgressBar
+  },
+  provide: function () {
+    return {
+      [Injectables.SHOW_OUTLINES]: this.showOutlines
+    }
   },
   data: function () {
     return {
@@ -493,6 +498,15 @@ export default defineComponent({
       if (this.windowTitle !== null) {
         document.title = this.windowTitle
       }
+    },
+
+    /**
+     * provided to all child components, see `provide` near the top of this file
+     * after injecting it, they can show outlines during keyboard navigation
+     * e.g. cycling through tabs with the arrow keys
+     */
+    showOutlines: function () {
+      this.hideOutlines = false
     },
 
     ...mapMutations([

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -40,7 +40,6 @@
         <RouterView
           ref="router"
           class="routerView"
-          @showOutlines="hideOutlines = false"
         />
       <!-- </keep-alive> -->
       </transition>

--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -2,6 +2,7 @@ import { defineComponent } from 'vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
+import { Injectables } from '../../../constants'
 import { sanitizeForHtmlId } from '../../helpers/accessibility'
 
 export default defineComponent({
@@ -10,6 +11,9 @@ export default defineComponent({
     'ft-card': FtCard,
     'ft-flex-box': FtFlexBox,
     'ft-button': FtButton
+  },
+  inject: {
+    showOutlines: Injectables.SHOW_OUTLINES
   },
   props: {
     label: {
@@ -77,7 +81,8 @@ export default defineComponent({
         index = 0
       }
       if (index >= 0 && index < this.promptButtons.length) {
-        this.promptButtons[index].focus({ focusVisible: true })
+        this.promptButtons[index].focus()
+        this.showOutlines()
       }
     },
     // close on escape key and unfocus

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -32,6 +32,7 @@ import {
   parseLocalListVideo,
   parseLocalSubscriberCount
 } from '../../helpers/api/local'
+import { Injectables } from '../../../constants'
 
 export default defineComponent({
   name: 'Channel',
@@ -46,6 +47,9 @@ export default defineComponent({
     'ft-share-button': FtShareButton,
     'ft-subscribe-button': FtSubscribeButton,
     'channel-about': ChannelAbout
+  },
+  inject: {
+    showOutlines: Injectables.SHOW_OUTLINES
   },
   data: function () {
     return {
@@ -1724,7 +1728,8 @@ export default defineComponent({
             : this.tabInfoValues[(index + 1) % this.tabInfoValues.length]
 
           const tabNode = document.getElementById(`${tab}Tab`)
-          tabNode.focus({ focusVisible: true })
+          tabNode.focus()
+          this.showOutlines()
           return
         }
       }
@@ -1732,7 +1737,8 @@ export default defineComponent({
       // `newTabNode` can be `null` when `tab` === "search"
       const newTabNode = document.getElementById(`${tab}Tab`)
       this.currentTab = tab
-      newTabNode?.focus({ focusVisible: true })
+      newTabNode?.focus()
+      this.showOutlines()
     },
 
     newSearch: function (query) {

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -6,6 +6,7 @@ import SubscriptionsShorts from '../../components/subscriptions-shorts/subscript
 
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
+import { Injectables } from '../../../constants'
 
 export default defineComponent({
   name: 'Subscriptions',
@@ -15,6 +16,9 @@ export default defineComponent({
     'subscriptions-shorts': SubscriptionsShorts,
     'ft-card': FtCard,
     'ft-flex-box': FtFlexBox
+  },
+  inject: {
+    showOutlines: Injectables.SHOW_OUTLINES
   },
   data: function () {
     return {
@@ -102,7 +106,7 @@ export default defineComponent({
         const visibleTabs = this.visibleTabs
 
         if (visibleTabs.length === 1) {
-          this.$emit('showOutlines')
+          this.showOutlines()
           return
         }
 
@@ -121,7 +125,7 @@ export default defineComponent({
         }
 
         this.$refs[visibleTabs[index]].focus()
-        this.$emit('showOutlines')
+        this.showOutlines()
       }
     }
   }

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -8,6 +8,7 @@ import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import { copyToClipboard, showToast } from '../../helpers/utils'
 import { getLocalTrending } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
+import { Injectables } from '../../../constants'
 
 export default defineComponent({
   name: 'Trending',
@@ -17,6 +18,9 @@ export default defineComponent({
     'ft-element-list': FtElementList,
     'ft-icon-button': FtIconButton,
     'ft-flex-box': FtFlexBox
+  },
+  inject: {
+    showOutlines: Injectables.SHOW_OUTLINES
   },
   data: function () {
     return {
@@ -74,7 +78,7 @@ export default defineComponent({
       if (!event.altKey) {
         event.preventDefault()
         this.$refs[tab].focus()
-        this.$emit('showOutlines')
+        this.showOutlines()
       }
     },
 


### PR DESCRIPTION
# Fix focus not showing on channel page tabs and in prompts

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
When using the arrow keys to cycle through tabs on the channel pages or buttons in prompts, the focus outlines would not show up until the tab key was pressed. We have a gobal handler for the tab key that shows the outlines.

The `focusVisible` option that was being passed to the `focus` function, only exists in Firefox, so it was doing nothing in FreeTube.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#browser_compatibility

This pull request switches the channel page tabs and prompt buttons to use the same approach used on the trending and subscriptions page, notifying the top App component to unhide the outlines. As prompts can exist at any level in the component hiearchy, I decided to use `provide` and `inject` which allows a parent component to expose variables to all of it's child components, regardless of how deep they are in the hierarchy, compared to `props` and `emit` which can only be used for direct parent and child communication.

https://v2.vuejs.org/v2/api/#provide-inject

The Vue 3 docs about it, have some better explainations and diagrams than the Vue 2 ones: https://vuejs.org/guide/components/provide-inject.html

## Screenshots <!-- If appropriate -->

![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/c5113180-b713-4f87-9299-a874c00235b3)

![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/272198f6-2869-4c96-a342-b69129edc608)

## Testing <!-- for code that is not small enough to be easily understandable -->
Channel page:

1. Open the channel page
2. Click on a tab
3. Start cylcing through tabs with the left and right arrow keys

Prompts:
1. In the theme settings toggle the `Disable Smooth Scrolling` switch
2. Cycle through the buttons with the left and right arrow keys