### PR TITLE
Fix audio formats on long videos getting throttled

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -289,7 +289,7 @@ function runApp() {
     // InnerTube rejects requests if the referer isn't YouTube or empty
     const innertubeAndMediaRequestFilter = { urls: ['https://www.youtube.com/youtubei/*', 'https://*.googlevideo.com/videoplayback?*'] }
 
-    session.defaultSession.webRequest.onBeforeSendHeaders(innertubeAndMediaRequestFilter, ({ requestHeaders, url }, callback) => {
+    session.defaultSession.webRequest.onBeforeSendHeaders(innertubeAndMediaRequestFilter, ({ requestHeaders, url, resourceType }, callback) => {
       requestHeaders.Referer = 'https://www.youtube.com/'
       requestHeaders.Origin = 'https://www.youtube.com'
 
@@ -298,6 +298,38 @@ function runApp() {
       } else {
         // YouTube doesn't send the Content-Type header for the media requests, so we shouldn't either
         delete requestHeaders['Content-Type']
+      }
+
+      // YouTube throttles the adaptive formats if you request a chunk larger than 10MiB.
+      // For the DASH formats we are fine as video.js doesn't seem to ever request chunks that big.
+      // The legacy formats don't have any chunk size limits.
+      // For the audio formats we need to handle it ourselves, as the browser requests the entire audio file,
+      // which means that for most videos that are loger than 10 mins, we get throttled, as the audio track file sizes surpass that 10MiB limit.
+
+      // This code checks if the file is larger than the limit, by checking the `clen` query param,
+      // which YouTube helpfully populates with the content length for us.
+      // If it does surpass that limit, it then checks if the requested range is larger than the limit
+      // (seeking right at the end of the video, would result in a small enough range to be under the chunk limit)
+      // if that surpasses the limit too, it then limits the requested range to 10MiB, by setting the range to `start-${start + 10MiB}`.
+      if (resourceType === 'media' && url.includes('&mime=audio') && requestHeaders.Range) {
+        const TEN_MIB = 10 * 1024 * 1024
+
+        const contentLength = parseInt(new URL(url).searchParams.get('clen'))
+
+        if (contentLength > TEN_MIB) {
+          const [startStr, endStr] = requestHeaders.Range.split('=')[1].split('-')
+
+          const start = parseInt(startStr)
+
+          // handle open ended ranges like `0-` and `1234-`
+          const end = endStr.length === 0 ? contentLength : parseInt(endStr)
+
+          if (end - start > TEN_MIB) {
+            const newEnd = start + TEN_MIB
+
+            requestHeaders.Range = `bytes=${start}-${newEnd}`
+          }
+        }
       }
 
       // eslint-disable-next-line n/no-callback-literal


### PR DESCRIPTION
# Fix audio formats on long videos getting throttled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
YouTube throttles the adaptive formats when you request a chunk larger than 10MiB ([relevant yt-dlp line](https://github.com/yt-dlp/yt-dlp/blob/db7b054a6111ca387220d0eb87bf342f9c130eb8/yt_dlp/extractor/youtube.py#L3730)), for DASH that is not a problem, as videojs-http-streaming prefers to request tiny chunks instead of massive ones, but for the audio formats this is an issue. The audio only formats are handled by the browser/electron directly, which requests the range `0-` or `1234-0` if you seek, so the entire file. For short videos, ones under 10 minutes, this is not an issue, as the file sizes for the best audio quality are usually less than 10MiB but for long videos requesting the entire file, means going above that 10MiB threshold, meaning we get throttled.

This pull request works around the issue by intercepting the request in the main process and limiting the requested range to 10MiB. This thankfully works because YouTube returns HTTP 206 responses with the `Content-Range` header, which tells the browser, where the requested chunk is in the file, so the browser player doesn't care that we altered it's range. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range

Once we switch to shaka, we can use audio only DASH, to avoid the issue, which is something video.js doesn't support.
https://github.com/videojs/http-streaming/blob/de183c8f88189883eb62c146c983ddc75dda3377/docs/supported-features.md?plain=1#L139

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Set the default formats to audio
2. Set the preferred API to local
3. Open a long video (anything longer than 12mins should be affected by the throttling) e.g this WAN show live stream replay: https://youtu.be/rnIeknursww
4. With this change, it should load faster and also load quicker when you seek around.