### PR TITLE
local API: Add support for PageHeader channel header

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -595,6 +595,25 @@ export default defineComponent({
             tags.push(...badges)
             break
           }
+          case 'PageHeader': {
+            // example: YouTube Gaming (an A/B test at the time of writing)
+            // https://www.youtube.com/channel/UCOpNcN46UbXVtpKMrmU4Abg
+
+            /**
+             * @type {import('youtubei.js').YTNodes.PageHeader}
+             */
+            const header = channel.header
+
+            channelName = header.content.title.text
+            channelThumbnailUrl = header.content.image.image[0].url
+            channelId = this.id
+
+            break
+          }
+        }
+
+        if (channelThumbnailUrl.startsWith('//')) {
+          channelThumbnailUrl = `https:${channelThumbnailUrl}`
         }
 
         this.channelName = channelName


### PR DESCRIPTION
# local API: Add support for PageHeader channel header

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue


## Description
<!-- Please write a clear and concise description of what the pull request does. -->

## Testing <!-- for code that is not small enough to be easily understandable -->

Add this line to `createInnertube()` in `src/renderer/helpers/api/local.js`:
```js

YouTube Gaming: https://www.youtube.com/channel/UCOpNcN46UbXVtpKMrmU4Abg
YouTube Live: https://www.youtube.com/channel/UC4R8DWoMoI7CAwX8_LjQHig