### PR TITLE
local API: Support Post Live DVR videos

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -80,6 +80,7 @@ export default defineComponent({
       liveChat: null,
       isLiveContent: false,
       isUpcoming: false,
+      isPostLiveDvr: false,
       upcomingTimestamp: null,
       upcomingTimeLeft: null,
       activeFormat: 'legacy',
@@ -353,6 +354,7 @@ export default defineComponent({
         this.isLive = !!result.basic_info.is_live
         this.isUpcoming = !!result.basic_info.is_upcoming
         this.isLiveContent = !!result.basic_info.is_live_content
+        this.isPostLiveDvr = !!result.basic_info.is_post_live_dvr
 
         const subCount = !result.secondary_info.owner.subscriber_count.isEmpty() ? parseLocalSubscriberCount(result.secondary_info.owner.subscriber_count.text) : NaN
 
@@ -418,7 +420,7 @@ export default defineComponent({
           result = bypassedResult
         }
 
-        if (this.isLive && !this.isUpcoming) {
+        if ((this.isLive || this.isPostLiveDvr) && !this.isUpcoming) {
           try {
             const formats = await getFormatsFromHLSManifest(result.streaming_data.hls_manifest_url)
 
@@ -452,6 +454,8 @@ export default defineComponent({
           this.showDashPlayer = false
           this.activeFormat = 'legacy'
           this.activeSourceList = this.videoSourceList
+          this.audioSourceList = null
+          this.dashSrc = null
         } else if (this.isUpcoming) {
           const upcomingTimestamp = result.basic_info.start_timestamp
 
@@ -1124,11 +1128,11 @@ export default defineComponent({
     },
 
     enableDashFormat: function () {
-      if (this.activeFormat === 'dash' || this.isLive) {
+      if (this.activeFormat === 'dash') {
         return
       }
 
-      if (this.dashSrc === null) {
+      if (this.dashSrc === null || this.isLive || this.isPostLiveDvr) {
         showToast(this.$t('Change Format.Dash formats are not available for this video'))
         return
       }


### PR DESCRIPTION
# local API: Support Post Live DVR videos

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Related issue
closes #3582

## Description
Just after a live stream has ended, before it has been processed into a normal video, it is still in the live stream format of self intialising DASH segments. YouTube uses self-initialising segments for their live stream DASH, which is in the DASH spec but highly discouraged by the interoperability guidelines, so video.js doesn't support them. That's why we can't use DASH for the live streams but also means we can't use it for videos in the Post Live DVR state, instead we can treat them like currently live streams and use the provided HLS manifest.

This pull request only adds support for the local API, as Invidious doesn't tell us when a video has the `isPostLiveDvr` flag set.

## Testing <!-- for code that is not small enough to be easily understandable -->

As you might be testing this days or weeks later, any Post Live DVR videos I would link to, would have been processed into normal videos by then. Instead I made a script that will find a video in the Post Live DVR state for you, so you can test this pull request, without having to find one yourself.

1. Download this script [find-post-live-dvr.txt](https://github.com/FreeTubeApp/FreeTube/files/12323142/find-post-live-dvr.txt)
2. Change the extension to `.mjs`
3. Place in your FreeTube dev directory (it uses YouTube.js, so placing it there means you don't have to install YouTube.js separately)
4. Run it with `node find-post-live-dvr.mjs`
5. It will print out the first Post Live DVR video it finds in the "Recent Live Streams" section on https://youtube.com/live, it tries various geolocations until it finds one, although in my testing it usually already found one in the first or second geolocation it tries.

Try watching the video with the local API, you should be able watch and seek around, compared to previously where it would either load endlessly or show a player UI that is ended but doesn't allow you to seek back so you could watch anything.