### PR TITLE
Fix the layout of the hashtag page

### DIFF
--- a/src/renderer/views/Hashtag/Hashtag.css
+++ b/src/renderer/views/Hashtag/Hashtag.css
@@ -11,9 +11,14 @@
 .getNextPage:hover, .getNextPage:focus {
   background-color: var(--side-nav-hover-color);
 }
+
 .card {
-  box-sizing: border-box;
   margin: 0 auto 20px;
-  position: relative;
   width: 85%;
+}
+
+@media only screen and (max-width: 680px) {
+  .card {
+    width: 90%;
+  }
 }

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -4,39 +4,36 @@
       v-if="isLoading"
       :fullscreen="true"
     />
-    <div v-else>
-      <ft-card>
-        <h3>{{ hashtag }}</h3>
-        <div
-          class="elementList"
+    <ft-card
+      v-else
+      class="card"
+    >
+      <h3>{{ hashtag }}</h3>
+      <ft-element-list
+        v-if="videos.length > 0"
+        :data="videos"
+      />
+      <ft-flex-box
+        v-else
+      >
+        <p
+          class="message"
         >
-          <ft-element-list
-            v-if="videos.length > 0"
-            :data="videos"
-          />
-          <ft-flex-box
-            v-else-if="videos.length === 0"
-          >
-            <p
-              class="message"
-            >
-              {{ $t("Hashtag.This hashtag does not currently have any videos") }}
-            </p>
-          </ft-flex-box>
-        </div>
-        <div
-          v-if="showFetchMoreButton"
-          class="getNextPage"
-          role="button"
-          tabindex="0"
-          @click="handleFetchMore"
-          @keydown.space.prevent="handleFetchMore"
-          @keydown.enter.prevent="handleFetchMore"
-        >
-          <font-awesome-icon :icon="['fas', 'search']" /> {{ $t("Search Filters.Fetch more results") }}
-        </div>
-      </ft-card>
-    </div>
+          {{ $t("Hashtag.This hashtag does not currently have any videos") }}
+        </p>
+      </ft-flex-box>
+      <div
+        v-if="showFetchMoreButton"
+        class="getNextPage"
+        role="button"
+        tabindex="0"
+        @click="handleFetchMore"
+        @keydown.space.prevent="handleFetchMore"
+        @keydown.enter.prevent="handleFetchMore"
+      >
+        <font-awesome-icon :icon="['fas', 'search']" /> {{ $t("Search Filters.Fetch more results") }}
+      </div>
+    </ft-card>
   </div>
 </template>
 <script src="./Hashtag.js" />


### PR DESCRIPTION
# Fix the layout of the hashtag page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the hashtag page takes up the entire width of the window, going against the layout used for the rest of the app, which is 90% on narrow screens and 80% for everything else. This pull request aligns the layout with other pages in FreeTube.

I recommend turning on the "Hide Whitespace" option in the pull request UI while reviewing this pull request, so that you can tell what the changes are, without the indentation changes getting highlighted.

## Screenshots <!-- If appropriate -->

![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/1db22f24-9425-4b24-a2a7-b26e37fa38ff)

![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/deba514d-0361-4a4d-8f67-088d02f85b71)

## Testing <!-- for code that is not small enough to be easily understandable -->
#shorts hashtag https://youtube.com/hashtag/shorts

If you get the page header error on the local API, just navigate back and forward until it disappears, there is already a change in YouTube.js to support the new header, but we need to wait for it to be released in an update on their side, before we can add support on our side.