### PR TITLE
Cleanup some template conditionals

### DIFF
--- a/src/renderer/components/download-settings/download-settings.vue
+++ b/src/renderer/components/download-settings/download-settings.vue
@@ -11,35 +11,38 @@
         @change="updateDownloadBehavior"
       />
     </ft-flex-box>
-    <ft-flex-box
+    <template
       v-if="downloadBehavior === 'download'"
-      class="settingsFlexStart500px"
     >
-      <ft-toggle-switch
-        :label="$t('Settings.Download Settings.Ask Download Path')"
-        :default-value="askForDownloadPath"
-        @change="handleDownloadingSettingChange"
-      />
-    </ft-flex-box>
-    <ft-flex-box
-      v-if="!askForDownloadPath && downloadBehavior === 'download'"
-    >
-      <ft-input
-        class="folderDisplay"
-        :placeholder="downloadPath"
-        :show-action-button="false"
-        :show-label="false"
-        :disabled="true"
-      />
-    </ft-flex-box>
-    <ft-flex-box
-      v-if="!askForDownloadPath && downloadBehavior === 'download'"
-    >
-      <ft-button
-        :label="$t('Settings.Download Settings.Choose Path')"
-        @click="chooseDownloadingFolder"
-      />
-    </ft-flex-box>
+      <ft-flex-box
+        class="settingsFlexStart500px"
+      >
+        <ft-toggle-switch
+          :label="$t('Settings.Download Settings.Ask Download Path')"
+          :default-value="askForDownloadPath"
+          @change="handleDownloadingSettingChange"
+        />
+      </ft-flex-box>
+      <template
+        v-if="!askForDownloadPath"
+      >
+        <ft-flex-box>
+          <ft-input
+            class="folderDisplay"
+            :placeholder="downloadPath"
+            :show-action-button="false"
+            :show-label="false"
+            :disabled="true"
+          />
+        </ft-flex-box>
+        <ft-flex-box>
+          <ft-button
+            :label="$t('Settings.Download Settings.Choose Path')"
+            @click="chooseDownloadingFolder"
+          />
+        </ft-flex-box>
+      </template>
+    </template>
   </ft-settings-section>
 </template>
 

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -70,23 +70,25 @@
           :label="$t('Profile.Create Profile')"
           @click="saveProfile"
         />
-        <ft-button
-          v-if="!isNew"
-          :label="$t('Profile.Update Profile')"
-          @click="saveProfile"
-        />
-        <ft-button
-          v-if="!isNew"
-          :label="$t('Profile.Make Default Profile')"
-          @click="setDefaultProfile"
-        />
-        <ft-button
-          v-if="!isMainProfile && !isNew"
-          :label="$t('Profile.Delete Profile')"
-          text-color="var(--text-with-main-color)"
-          background-color="var(--primary-color)"
-          @click="openDeletePrompt"
-        />
+        <template
+          v-else
+        >
+          <ft-button
+            :label="$t('Profile.Update Profile')"
+            @click="saveProfile"
+          />
+          <ft-button
+            :label="$t('Profile.Make Default Profile')"
+            @click="setDefaultProfile"
+          />
+          <ft-button
+            v-if="!isMainProfile"
+            :label="$t('Profile.Delete Profile')"
+            text-color="var(--text-with-main-color)"
+            background-color="var(--primary-color)"
+            @click="openDeletePrompt"
+          />
+        </template>
       </ft-flex-box>
     </ft-card>
     <ft-prompt

--- a/src/renderer/components/proxy-settings/proxy-settings.vue
+++ b/src/renderer/components/proxy-settings/proxy-settings.vue
@@ -9,7 +9,7 @@
         @change="handleUpdateProxy"
       />
     </ft-flex-box>
-    <div
+    <template
       v-if="useProxy"
     >
       <ft-flex-box>
@@ -72,7 +72,7 @@
           {{ $t('Settings.Proxy Settings.City') }}: {{ proxyCity }}
         </p>
       </div>
-    </div>
+    </template>
   </ft-settings-section>
 </template>
 

--- a/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
+++ b/src/renderer/components/sponsor-block-settings/sponsor-block-settings.vue
@@ -15,7 +15,7 @@
         @change="handleUpdateUseDeArrowTitles"
       />
     </ft-flex-box>
-    <div
+    <template
       v-if="useSponsorBlock || useDeArrowTitles"
     >
       <ft-flex-box
@@ -46,7 +46,7 @@
           :category-name="category"
         />
       </ft-flex-box>
-    </div>
+    </template>
   </ft-settings-section>
 </template>
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -62,16 +62,16 @@
         role="tabpanel"
       />
       <subscriptions-shorts
-        v-if="currentTab === 'shorts'"
+        v-else-if="currentTab === 'shorts'"
         id="subscriptionsPanel"
         role="tabpanel"
       />
       <subscriptions-live
-        v-if="currentTab === 'live'"
+        v-else-if="currentTab === 'live'"
         id="subscriptionsPanel"
         role="tabpanel"
       />
-      <p v-if="currentTab === null">
+      <p v-else-if="currentTab === null">
         {{ $t("Subscriptions.All Subscription Tabs Hidden", {
           subsection: $t('Settings.Distraction Free Settings.Sections.Subscriptions Page'),
           settingsSection: $t('Settings.Distraction Free Settings.Distraction Free Settings')


### PR DESCRIPTION
# Cleanup some template conditionals

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Performance improvement

## Description
Changes some `v-if`s to `v-if-else`, swaps some `div`s to `template` when they don't contribute to the layout and are just used as wrappers for the `v-if` and adds some `template` wrappers to replace consecutive identical `v-if`s.

I didn't make any changes to the community posts (could be changed to `v-else-if`) to avoid conflicts with #3865.

Probably won't make a big difference but it should slighty improve performance, as it avoids extra unnecessary divs getting created and if-else-if is faster than if-if, because it doesn't have to check both conditions if the first one succeeds.

## Testing <!-- for code that is not small enough to be easily understandable -->
This is just to confirm that it still behaves the same as before.

1. Check that changing the download behaviour in the download setting still makes it toggle the elements below it
2. Check that the edit and new profile screens still look the same
3. Check that toggling the use proxy setting shows and hides the proxy configuration
4. Check that the correct tabs show up on the subscriptions page, depending on your distraction free settings
5. If the dearrow titles or sponsor block settings are enabled you should see the sponsor block URL box