### PR TITLE
local API: Add support for PageHeader hashtag header

### DIFF
--- a/src/renderer/views/Hashtag/Hashtag.js
+++ b/src/renderer/views/Hashtag/Hashtag.js
@@ -97,12 +97,26 @@ export default defineComponent({
     getLocalHashtag: async function(hashtag) {
       try {
         const hashtagData = await getHashtagLocal(hashtag)
-        this.hashtag = hashtagData.header.hashtag
-        this.videos = hashtagData.contents.contents.filter(item =>
-          item.type !== 'ContinuationItem'
-        ).map(item =>
-          parseLocalListVideo(item.content)
-        )
+
+        const header = hashtagData.header
+        if (header) {
+          switch (header.type) {
+            case 'HashtagHeader':
+              this.hashtag = header.hashtag.toString()
+              break
+            case 'PageHeader':
+              this.hashtag = header.content.title.text
+              break
+            default:
+              console.error(`Unknown hashtag header type: ${header.type}, falling back to query parameter.`)
+              this.hashtag = `#${hashtag}`
+          }
+        } else {
+          console.error(' Hashtag header missing, probably a layout change, falling back to query parameter.')
+          this.hashtag = `#${hashtag}`
+        }
+
+        this.videos = hashtagData.videos.map(parseLocalListVideo)
         this.apiUsed = 'local'
         this.hashtagContinuationData = hashtagData.has_continuation ? hashtagData : null
         this.isLoading = false
@@ -124,12 +138,8 @@ export default defineComponent({
 
     getLocalHashtagMore: async function() {
       try {
-        const continuation = await this.hashtagContinuationData.getContinuationData()
-        const newVideos = continuation.on_response_received_actions[0].contents.filter(item =>
-          item.type !== 'ContinuationItem'
-        ).map(item =>
-          parseLocalListVideo(item.content)
-        )
+        const continuation = await this.hashtagContinuationData.getContinuation()
+        const newVideos = continuation.videos.map(parseLocalListVideo)
         this.hashtagContinuationData = continuation.has_continuation ? continuation : null
         this.videos = this.videos.concat(newVideos)
       } catch (error) {


### PR DESCRIPTION
# local API: Add support for PageHeader hashtag header

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
MARKED AS DRAFT UNTIL #3895 IS MERGED

YouTube is A/B testing the PageHeader renderer, by the looks of it not just on the channel page (#3871), but also on the hashtag page.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/f48cd039-1328-49ac-b369-f8b9956aef14)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/b433836f-b028-4f18-aace-d28358f667b1)

## Testing <!-- for code that is not small enough to be easily understandable -->
As per usual with YouTube's A/B tests, they are tied to the visitor id, so they can be made to show up consistently by using visitor data with a visitor id, that got included in the A/B test.

Add this line to `createInnertube()` in `Innertube.create()` in `src/renderer/helpers/api/local.js`:
```js
visitor_data: 'Cgtta1lfM0V4enJQbCjzwv6mBg%3D%3D',
```

e.g. https://youtube.com/hashtag/shorts