### PR TITLE
Fix playlist view on the watch page not reacting to playlist changes

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -129,6 +129,15 @@ export default defineComponent({
         nextTick(() => this.scrollToCurrentVideo())
       }
     },
+    playlistId: function (newVal, oldVal) {
+      if (oldVal !== newVal) {
+        if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
+          this.getPlaylistInformationInvidious()
+        } else {
+          this.getPlaylistInformationLocal()
+        }
+      }
+    }
   },
   mounted: function () {
     const cachedPlaylist = this.$store.getters.getCachedPlaylist


### PR DESCRIPTION
# Fix playlist view on the watch page not reacting to playlist changes

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/3895#issuecomment-1684875711

## Description
Currently the playlist view on the watch page doesn't react to the playlist changing, when you jump directly from one playlist to another one, without leaving the watch page in between.

This bug exists because unlike the other components on the watch page, the playlist view stays mounted when the video changes, this is to avoid refetching the playlist for every video in the same playlist.

## Screenshots <!-- If appropriate -->
Screenshot from the comment:
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/c245c2dd-edf9-4f25-a067-618a9a2a715c)

## Testing <!-- for code that is not small enough to be easily understandable -->
Paste the first playlist URL into the search bar, afterwards the second one, the playlist view on the watch page should update to the second playlist instead of continuing to show the first one.

playlist 1: https://www.youtube.com/watch?v=xEyR5dCQs60&list=PLa4zmfXkL4P2khNoEOGA8NEOgFwHIWGIX

playlist 2: https://www.youtube.com/watch?v=HUlR6zQjTmw&list=PLa4zmfXkL4P0UaXti2bPFpsyi3K_IE0rB