### PR TITLE
Add external player support for Clapper

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -147,6 +147,6 @@
           "playlistReverse": null,
           "playlistShuffle": null,
           "playlistLoop": null
-      }
-  }
+        }
+    }
 ]

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -130,5 +130,23 @@
             "playlistShuffle": null,
             "playlistLoop": null
         }
-    }
+    },
+    {
+      "name": "Clapper",
+      "nameTranslationKey": "Settings.External Player Settings.Players.Clapper.Name",
+      "value": "clapper",
+      "cmdArguments": {
+          "defaultExecutable": "clapper",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": false,
+          "videoUrl": "",
+          "playlistUrl": null,
+          "startOffset": null,
+          "playbackRate": null,
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": null,
+          "playlistLoop": null
+      }
+  }
 ]


### PR DESCRIPTION
# Add external player support for Clapper

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #3914 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Adds support for opening videos using the Clapper media player. Clapper does not expose any commandline parameters and does not support opening playlists.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![clapper](https://github.com/FreeTubeApp/FreeTube/assets/17594477/b8caf8cf-8fba-4f23-978c-d64f7cb89443)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

Only tested the flatpak build in a Debian VM due to gstreamer hell with the regular packages across multiple distros, but the executable is correct so should work if you have a working gstreamer setup that can parse Youtube URLs.

## Desktop
<!-- Please complete the following information-->
- **OS:** Debian
- **OS Version:** 12 
- **FreeTube version:** v0.19.0 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
