### PR TITLE
Fix `Scroll playback rate over video player` prevents page scrolling when not activated

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -855,14 +855,18 @@ export default defineComponent({
       }
     },
 
+    /**
+     * @param {WheelEvent} event
+     */
     mouseScrollPlaybackRate: function (event) {
       if (event.target && !event.currentTarget.querySelector('.vjs-menu:hover')) {
-        event.preventDefault()
-
         if (event.ctrlKey || event.metaKey) {
-          if (event.wheelDelta > 0) {
+          // Only stop page scrolling when Cmd/Ctrl pressed
+          event.preventDefault()
+
+          if (event.deltaY > 0) {
             this.changePlayBackRate(0.05)
-          } else if (event.wheelDelta < 0) {
+          } else if (event.deltaY < 0) {
             this.changePlayBackRate(-0.05)
           }
         }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Fixes https://github.com/FreeTubeApp/FreeTube/issues/3913

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fix `Scroll playback rate over video player` prevents page scrolling when not activated

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
See https://github.com/FreeTubeApp/FreeTube/issues/3913

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
