### PR TITLE
Add updated video resolution to auto selector

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1789,17 +1789,15 @@ export default defineComponent({
           button.title = 'Select Quality'
           button.innerHTML = beginningHtml + qualityHtml + endingHtml
 
-          let autoQualityLabel = ''
+          let autoQualityLabel = 'auto'
           if (currentAdaptiveFormat) {
             autoQualityLabel += ` ${currentAdaptiveFormat.qualityLabel}`
-          } else {
+          } else if (autoResolution !== '') {
             autoQualityLabel += ` ${autoResolution.split('x')[1]}p`
           }
 
           // For default auto, it may select a resolution before generating the quality buttons
-          button.querySelector('#vjs-current-quality').innerText = defaultIsAuto
-            ? `auto${autoQualityLabel}`
-            : currentQualityLabel
+          button.querySelector('#vjs-current-quality').innerText = defaultIsAuto ? autoQualityLabel : currentQualityLabel
 
           return button.children[0]
         }

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -136,6 +136,7 @@ export default defineComponent({
       autoQuality: '',
       autoResolution: '',
       autoBitrate: '',
+      autoMimeType: '',
       autoFPS: 0,
       using60Fps: false,
       activeSourceList: [],
@@ -488,6 +489,7 @@ export default defineComponent({
               return format.bitrate === newQualityLevel.bitrate
             })
             if (adaptiveFormat) {
+              this.autoMimeType = adaptiveFormat.mimeType
               this.currentAdaptiveFormat = adaptiveFormat
               qualityLabel = `auto ${adaptiveFormat.qualityLabel}`
             } else {
@@ -1185,6 +1187,7 @@ export default defineComponent({
         this.autoResolution = this.selectedResolution
         this.autoFPS = this.selectedFPS
         this.autoBitrate = this.selectedBitrate
+        this.autoMimeType = this.selectedMimeType
 
         this.selectedResolution = 'auto'
         this.selectedFPS = 'auto'
@@ -1993,18 +1996,20 @@ export default defineComponent({
       const droppedFrames = this.playerStats.videoPlaybackQuality.droppedVideoFrames
       const totalFrames = this.playerStats.videoPlaybackQuality.totalVideoFrames
       const frames = `${droppedFrames} / ${totalFrames}`
-      const resolution = this.selectedResolution === 'auto' ? 'auto' : `${this.selectedResolution}@${this.selectedFPS}fps`
+      const resolution = this.selectedResolution === 'auto' ? `${this.autoResolution}@${this.autoFPS}fps (auto)` : `${this.selectedResolution}@${this.selectedFPS}fps`
       const playerDimensions = `${this.playerStats.playerDimensions.width}x${this.playerStats.playerDimensions.height}`
+      const bitrate = this.selectedBitrate === 'auto' ? `${this.autoBitrate} (auto)` : this.selectedBitrate
+      const mimeType = this.selectedMimeType === 'auto' ? `${this.autoMimeType} (auto)` : this.selectedMimeType
       const statsArray = [
         [this.$t('Video.Stats.Video ID'), this.videoId],
         [this.$t('Video.Stats.Resolution'), resolution],
         [this.$t('Video.Stats.Player Dimensions'), playerDimensions],
-        [this.$t('Video.Stats.Bitrate'), this.selectedBitrate],
+        [this.$t('Video.Stats.Bitrate'), bitrate],
         [this.$t('Video.Stats.Volume'), volume],
         [this.$t('Video.Stats.Bandwidth'), bandwidth],
         [this.$t('Video.Stats.Buffered'), buffered],
         [this.$t('Video.Stats.Dropped / Total Frames'), frames],
-        [this.$t('Video.Stats.Mimetype'), this.selectedMimeType]
+        [this.$t('Video.Stats.Mimetype'), mimeType]
       ]
       let listContentHTML = ''
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -678,10 +678,9 @@ body.vjs-full-window {
 .vjs-quality-level-value {
   width: 100%;
   height: 100%;
-}
-
-.vjs-quality-level-value span {
-  line-height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .vjs-quality-level-value:hover + .vjs-quality-level-menu {


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #3837

## Description
Include current video resolution in quality selector and misc info in video statistics

## Screenshots <!-- If appropriate -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/277e2f1d-363d-4924-b9c1-1f8e364b827c)
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/da8f5eb7-f3c3-4bda-a3f1-a3875a3b6c55)

## Testing
Tried on >=30 videos and seemed fine, with both quality default to auto and manual resolutions.
Doesn't break livestreams.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2
- **FreeTube version:**