### PR TITLE
Include hide comment photos setting

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -50,7 +50,10 @@ export default defineComponent({
     hideComments: function () {
       return this.$store.getters.getHideComments
     },
-    hideLiveStreams: function() {
+    hideCommentPhotos: function () {
+      return this.$store.getters.getHideCommentPhotos
+    },
+    hideLiveStreams: function () {
       return this.$store.getters.getHideLiveStreams
     },
     hideUpcomingPremieres: function () {
@@ -62,31 +65,31 @@ export default defineComponent({
     hideChapters: function () {
       return this.$store.getters.getHideChapters
     },
-    hideFeaturedChannels: function() {
+    hideFeaturedChannels: function () {
       return this.$store.getters.getHideFeaturedChannels
     },
-    hideChannelShorts: function() {
+    hideChannelShorts: function () {
       return this.$store.getters.getHideChannelShorts
     },
-    hideChannelPlaylists: function() {
+    hideChannelPlaylists: function () {
       return this.$store.getters.getHideChannelPlaylists
     },
-    hideChannelPodcasts: function() {
+    hideChannelPodcasts: function () {
       return this.$store.getters.getHideChannelPodcasts
     },
-    hideChannelReleases: function() {
+    hideChannelReleases: function () {
       return this.$store.getters.getHideChannelReleases
     },
-    hideChannelCommunity: function() {
+    hideChannelCommunity: function () {
       return this.$store.getters.getHideChannelCommunity
     },
-    hideSubscriptionsVideos: function() {
+    hideSubscriptionsVideos: function () {
       return this.$store.getters.getHideSubscriptionsVideos
     },
-    hideSubscriptionsShorts: function() {
+    hideSubscriptionsShorts: function () {
       return this.$store.getters.getHideSubscriptionsShorts
     },
-    hideSubscriptionsLive: function() {
+    hideSubscriptionsLive: function () {
       return this.$store.getters.getHideSubscriptionsLive
     },
     showDistractionFreeTitles: function () {
@@ -111,7 +114,7 @@ export default defineComponent({
 
       this.updateHideRecommendedVideos(value)
     },
-    handleChannelsHidden: function(value) {
+    handleChannelsHidden: function (value) {
       this.updateChannelsHidden(JSON.stringify(value))
     },
 
@@ -130,6 +133,7 @@ export default defineComponent({
       'updateDefaultTheatreMode',
       'updateHideVideoDescription',
       'updateHideComments',
+      'updateHideCommentPhotos',
       'updateHideLiveStreams',
       'updateHideUpcomingPremieres',
       'updateHideSharingActions',

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -166,6 +166,12 @@
           :default-value="hideComments"
           @change="updateHideComments"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.Distraction Free Settings.Hide Comment Photos')"
+          :compact="true"
+          :default-value="hideCommentPhotos"
+          @change="updateHideCommentPhotos"
+        />
       </div>
     </div>
     <h4

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -53,6 +53,22 @@
   -webkit-border-radius: 200px;
 }
 
+.commentThumbnailHidden {
+  float: left;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 60px;
+  height: 60px;
+  font-size: 20px;
+  line-height: 1em;
+  text-transform: capitalize;
+  color: rgb(0 0 0);
+  background-color: rgb(235 160 172);
+  border-radius: 50%;
+  -webkit-border-radius: 50%;
+}
+
 .commentAuthorWrapper {
   font-weight: bold;
   font-size: 14px;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -59,6 +59,10 @@ export default defineComponent({
       return this.$store.getters.getHideCommentLikes
     },
 
+    hideCommentPhotos: function () {
+      return this.$store.getters.getHideCommentPhotos
+    },
+
     commentAutoLoadEnabled: function () {
       return this.$store.getters.getCommentAutoLoadEnabled
     },
@@ -81,7 +85,7 @@ export default defineComponent({
       return (this.sortNewest) ? 'newest' : 'top'
     },
 
-    observeVisibilityOptions: function() {
+    observeVisibilityOptions: function () {
       if (!this.commentAutoLoadEnabled) { return false }
       if (!this.videoPlayerReady) { return false }
 
@@ -106,11 +110,11 @@ export default defineComponent({
       }
     },
 
-    canPerformInitialCommentLoading: function() {
+    canPerformInitialCommentLoading: function () {
       return this.commentData.length === 0 && !this.isLoading && !this.showComments
     },
 
-    canPerformMoreCommentLoading: function() {
+    canPerformMoreCommentLoading: function () {
       return this.commentData.length > 0 && !this.isLoading && this.showComments && this.nextPageToken
     },
   },

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -62,11 +62,20 @@
           :to="`/channel/${comment.authorLink}`"
           tabindex="-1"
         >
-          <img
-            :src="comment.authorThumb"
-            alt=""
-            class="commentThumbnail"
-          >
+          <template v-if="!hideCommentPhotos">
+            <img
+              :src="comment.authorThumb"
+              alt=""
+              class="commentThumbnail"
+            >
+          </template>
+          <template v-else>
+            <div
+              class="commentThumbnailHidden"
+            >
+              {{ comment.author.substr(1, 1) }}
+            </div>
+          </template>
         </router-link>
         <p
           v-if="comment.isPinned"
@@ -163,16 +172,19 @@
             :key="replyIndex"
             class="comment"
           >
-            <router-link
-              :to="`/channel/${reply.authorLink}`"
-              tabindex="-1"
-            >
+            <template v-if="!hideCommentPhotos">
               <img
-                :src="reply.authorThumb"
-                class="commentThumbnail"
+                :src="comment.authorThumb"
                 alt=""
+                class="commentThumbnail"
               >
-            </router-link>
+            </template>
+            <template v-else>
+              <img
+                alt=""
+                class="commentThumbnailHidden"
+              >
+            </template>
             <p class="commentAuthorWrapper">
               <router-link
                 class="commentAuthor"

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -172,19 +172,25 @@
             :key="replyIndex"
             class="comment"
           >
-            <template v-if="!hideCommentPhotos">
-              <img
-                :src="comment.authorThumb"
-                alt=""
-                class="commentThumbnail"
-              >
-            </template>
-            <template v-else>
-              <img
-                alt=""
-                class="commentThumbnailHidden"
-              >
-            </template>
+            <router-link
+              :to="`/channel/${reply.authorLink}`"
+              tabindex="-1"
+            >
+              <template v-if="!hideCommentPhotos">
+                <img
+                  :src="reply.authorThumb"
+                  alt=""
+                  class="commentThumbnail"
+                >
+              </template>
+              <template v-else>
+                <div
+                  class="commentThumbnailHidden"
+                >
+                  {{ reply.author.substr(1, 1) }}
+                </div>
+              </template>
+            </router-link>
             <p class="commentAuthorWrapper">
               <router-link
                 class="commentAuthor"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -199,6 +199,7 @@ const state = {
   hideChannelShorts: false,
   hideChannelSubscriptions: false,
   hideCommentLikes: false,
+  hideCommentPhotos: false,
   hideComments: false,
   hideFeaturedChannels: false,
   channelsHidden: '[]',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -344,6 +344,7 @@ Settings:
     Hide Active Subscriptions: Hide Active Subscriptions
     Hide Video Description: Hide Video Description
     Hide Comments: Hide Comments
+    Hide Comment Photos: Hide Comment Photos
     Display Titles Without Excessive Capitalisation: Display Titles Without Excessive Capitalisation
     Hide Live Streams: Hide Live Streams
     Hide Upcoming Premieres: Hide Upcoming Premieres

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -408,6 +408,7 @@ Settings:
     Distraction Free Settings: Distraction Free Settings
     Hide Playlists: Hide Playlists
     Hide Comments: Hide comments
+    Hide Comment Photos: Hide Comment Photos
     Hide Video Description: Hide video description
     Hide Live Streams: Hide live streams
     Hide Upcoming Premieres: Hide Upcoming Premieres


### PR DESCRIPTION
# Include hide comment photos setting

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #3919 

## Description
Adds toggle switch to Settings>Distraction Free Settings>Watch Page>Hide Comment Photos
Essentially hides profile pictures in comments, replaces it with the default background color of the FreeTube profile on the top right and the first character of the commenter's username.

Livestream chat isn't affected, not sure to touch it or not.

## Screenshots <!-- If appropriate -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/01bbaee3-da33-415d-8d5e-c6cf3e29d101)

Replaces this
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/fe1c23ec-79b7-4509-b2e9-e5143a66e76b)
with
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/463f75e9-a915-4ee6-b00c-b6a666982d23)


## Testing <!-- for code that is not small enough to be easily understandable -->
Looked through a couple of videos and it seemed fine

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2
- **FreeTube version:**

## Additional context
Same query with [this PR](https://github.com/FreeTubeApp/FreeTube/pull/3938) about the i18n stuff.
