### PR TITLE
Fix raw HTML in video descriptions

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.vue
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.vue
@@ -53,9 +53,8 @@
       <p
         v-if="listType !== 'grid'"
         class="description"
-      >
-        {{ description }}
-      </p>
+        v-html="description"
+      />
     </div>
   </div>
 </template>

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -120,9 +120,8 @@
       <p
         v-if="listType !== 'grid' && appearance === 'result'"
         class="description"
-      >
-        {{ description }}
-      </p>
+        v-html="description"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Fix raw HTML in video descriptions

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3945

## Description
Updates channel and video descriptions to use `v-html` instead of passing the text as-is, thus resolving issues with links, etc. being displayed as raw HTML.

## Screenshots

Before:
![Screenshot_20230825_231837](https://github.com/FreeTubeApp/FreeTube/assets/84899178/aea803a6-2e71-473d-bdfb-5c488d9a1033)

After:
![Screenshot_20230825_231926](https://github.com/FreeTubeApp/FreeTube/assets/84899178/d4de83c6-0333-4f2b-ba72-c1a7a71918c0)

## Desktop
 - OS: OpenSUSE Tumbleweed
 -  OS Version: 2023xxxx
 - FreeTube version: 0.19.0

