### PR TITLE
Make certain controls non-selectable / non-draggable

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -26,6 +26,8 @@
 
 .flexBox {
   display: block;
+  user-select: all;
+  -webkit-user-select: all;
 }
 
 #changeLogText {

--- a/src/renderer/components/ft-flex-box/ft-flex-box.css
+++ b/src/renderer/components/ft-flex-box/ft-flex-box.css
@@ -2,4 +2,6 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: space-evenly;
+  user-select: none;
+  -webkit-user-select: none;
 }

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -3,6 +3,8 @@
   flex-flow: row wrap;
   justify-content: space-evenly;
   position: relative;
+
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -84,6 +86,7 @@
   list-style-type: none;
   position: absolute;
   text-align: center;
+  -webkit-user-select: none;
   user-select: none;
   z-index: 3;
 

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -97,6 +97,8 @@
 
 .ft-input-component ::-webkit-input-placeholder {
   color: var(--tertiary-text-color);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .forceTextColor .ft-input {

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
@@ -29,6 +29,8 @@
   line-height: 1em;
   text-align: center;
   padding: 17.5px 0;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .profileName {

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -36,6 +36,8 @@
   line-height: 1em;
   text-align: center;
   padding: 25px 0;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 @media only screen and (max-width: 680px) {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -17,6 +17,8 @@
   font-size: 20px;
   line-height: 1em;
   text-align: center;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .profileList {

--- a/src/renderer/components/ft-radio-button/ft-radio-button.css
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.css
@@ -19,6 +19,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   position: relative;
   padding-left: 2em;
   vertical-align: middle;
+  -webkit-user-select: none;
   user-select: none;
   cursor: pointer;
   display: block;

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -39,6 +39,17 @@
 }
 
 .sectionTitle {
+  /* iOS Safari */
+  -webkit-touch-callout: none;
+  /* Safari */
+  -webkit-user-select: none;
+  /* Konqueror HTML */
+  /* Firefox */
+  -moz-user-select: none;
+  /* Internet Explorer/Edge */
+  -ms-user-select: none;
+  /* Non-prefixed version, currently supported by Chrome and Opera */
+  user-select: none;
   margin-left: 2%;
 }
 

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -39,16 +39,7 @@
 }
 
 .sectionTitle {
-  /* iOS Safari */
-  -webkit-touch-callout: none;
-  /* Safari */
   -webkit-user-select: none;
-  /* Konqueror HTML */
-  /* Firefox */
-  -moz-user-select: none;
-  /* Internet Explorer/Edge */
-  -ms-user-select: none;
-  /* Non-prefixed version, currently supported by Chrome and Opera */
   user-select: none;
   margin-left: 2%;
 }

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -12,6 +12,8 @@
   transition-property: width;
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .inner {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -43,6 +43,7 @@
   position: relative;
   padding: 5px;
   min-height: 35px;
+  -webkit-user-drag: none;
 }
 
 .moreOption {

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -61,6 +61,7 @@
     color: gray;
     opacity: 0.5;
     pointer-events: none;
+    -webkit-user-select: none;
     user-select: none;
   }
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1091,17 +1091,10 @@ body.vjs-full-window {
   cursor: pointer;
   padding: 0;
   margin: 0 0.45em 0 0.45em;
-  /* iOS Safari */
-  -webkit-touch-callout: none;
-  /* Safari */
+
   -webkit-user-select: none;
-  /* Konqueror HTML */
-  /* Firefox */
-  -moz-user-select: none;
-  /* Internet Explorer/Edge */
-  -ms-user-select: none;
-  /* Non-prefixed version, currently supported by Chrome and Opera */
   user-select: none;
+
   background-color: #73859f;
   background-color: rgba(115, 133, 159, 0.5);
 }


### PR DESCRIPTION
# Make certain controls non-selectable / non-draggable

## Pull Request Type
- [x] Feature Implementation

## Related issue
closes #1048

## Description
Updates certain controls to be non-selectable (i.e., highlightable) and non-draggable so as to avoid the irksome user experience it can cause. 

Elements made non-draggable:
- everything in the `side-nav`

Elements made non-selectable:
-  everything in the `side-nav`
- `ft-flex-box`
- `ft-input` placeholders
- Settings section headers
- profile icons

Incidentally, this PR also removes inapplicable or otherwise unneeded prefixes for `user-select`.

## Screenshots 

Screenshots of pressing `Ctrl+A` on FreeTube:

Before:

![Screenshot_20230826_005539](https://github.com/FreeTubeApp/FreeTube/assets/84899178/18dedd19-62ca-4342-9fb7-081d8d04f01d)
![Screenshot_20230826_005527](https://github.com/FreeTubeApp/FreeTube/assets/84899178/0c9bf4e9-ed0c-49cb-9ed8-6c7cb3062459)


After:

![Screenshot_20230826_005317](https://github.com/FreeTubeApp/FreeTube/assets/84899178/57235557-f23c-49b6-9248-a751e2f4c05f)
![Screenshot_20230826_005352](https://github.com/FreeTubeApp/FreeTube/assets/84899178/8acd8d87-f266-4da2-a826-0af141694e84)


## Testing 
Tested by trying to drag and select the elements mentioned above, as well as going through their normal usage after the change.

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0
