### PR TITLE
Rounded channel thumbnails

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.scss
+++ b/src/renderer/components/ft-list-video/ft-list-video.scss
@@ -1,5 +1,1 @@
 @use '../../scss-partials/_ft-list-item';
-
-.thumbnailLink:hover {
-  outline: 3px solid var(--side-nav-hover-color);
-}

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -62,11 +62,13 @@
       >
         {{ $t("Video.Watched") }}
       </div>
-      <div
-        v-if="watched"
-        class="watchedProgressBar"
-        :style="{width: progressPercentage + '%'}"
-      />
+      <div class="watchedProgressBarContainer">
+        <div
+          v-if="watched"
+          class="watchedProgressBar"
+          :style="{width: progressPercentage + '%'}"
+        />
+      </div>
     </div>
     <div class="info">
       <router-link

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -92,6 +92,8 @@ $watched-transition-duration: 0.5s;
     }
 
     .thumbnailImage {
+      border-radius: 12px;
+
       @include is-sidebar-item {
         height: 75px;
       }
@@ -150,6 +152,11 @@ $watched-transition-duration: 0.5s;
       margin-right: 3px;
       margin-top: 3px;
       opacity: $thumbnail-overlay-opacity;
+    }
+
+    .watchedProgressBarContainer {
+      width: calc(100% - 24px);
+      margin: auto;
     }
 
     .watchedProgressBar {
@@ -296,6 +303,13 @@ $watched-transition-duration: 0.5s;
       font-size: 13px;
       margin-top: 8px;
     }
+  }
+}
+
+.thumbnailImage {
+  border-radius: 12px;
+  &:hover {
+    box-shadow: 0 0 0 3px var(--side-nav-hover-color);
   }
 }
 


### PR DESCRIPTION
# Rounded Channel Thumbnails

## Pull Request Type
- [x] Feature Implementation

## Related issue
related to #1452 

## Description
This change adds the sleek rounded thumbnail look. It also updates the outline to be rounded, as well as the watch progress bar to cover the now-shortened bottom side. I am open to alternative suggestions for how we should handle the watch progress bar (this has the left and right sides clipped so as to avoid floating above the rounded edges. One alternative would be only rounding the top left and right.

## Screenshots 

Screenshots of the rounded channel thumbnails:
![Screenshot_20230826_010910](https://github.com/FreeTubeApp/FreeTube/assets/84899178/cc2e958f-313e-4254-bdbc-42e3333fcc1f)
![Screenshot_20230826_011824](https://github.com/FreeTubeApp/FreeTube/assets/84899178/080a34d6-41d8-4c53-9b4f-e191b1502ed5)


If enough reviewers prefer this one, I can push a different version that only make the top left and right appear rounded:
![Screenshot_20230826_011611](https://github.com/FreeTubeApp/FreeTube/assets/84899178/c4e46456-0e4c-4dbc-9caf-203bb40c6a91)
![Screenshot_20230826_011757](https://github.com/FreeTubeApp/FreeTube/assets/84899178/b5d674c3-c693-433f-ab04-8a7d395234c4)

## Testing
Tested in card and list view with hover, focus, active, and watched styling.

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0
