### PR TITLE
Fix Save icon blocking issue

### DIFF
--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -4,6 +4,7 @@
   justify-content: space-evenly;
   position: relative;
   user-select: none;
+  height: fit-content;
 }
 
 .iconButton {


### PR DESCRIPTION
# Fixed #3949 issue: Changed favorite/save button style

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #3949 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The user was not able to play the video by clicking right below the favorite or save button. Changed the styling for the saved button more specifically changed the height property of the button-container. Now after clicking on the part of the thumbnail below the Favorite/Star icon should open the video.


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="1312" alt="Screenshot 2023-08-26 at 7 12 59 PM" src="https://github.com/FreeTubeApp/FreeTube/assets/75901645/352959e1-136a-4684-8c02-4bc47534aaf7">
<img width="1312" alt="Screenshot 2023-08-26 at 7 13 05 PM" src="https://github.com/FreeTubeApp/FreeTube/assets/75901645/02e4f553-f4a0-4d9a-9c80-c5ec1d5ea6a6">
