### PR TITLE
Make certain controls non-selectable / non-draggable - Part II

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -26,8 +26,8 @@
 
 .flexBox {
   display: block;
-  user-select: all;
-  -webkit-user-select: all;
+  user-select: unset;
+  --webkit-user-select: unset;
 }
 
 #changeLogText {

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -85,6 +85,8 @@ $watched-transition-duration: 0.5s;
     .inner {
       grid-column: 1;
       grid-row: 1;
+      user-select: none;
+      -webkit-user-select: none;
     }
 
     .thumbnailLink {
@@ -304,6 +306,8 @@ $watched-transition-duration: 0.5s;
 .live,
 .upcoming {
   text-transform: uppercase;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 // we use h3 for semantic reasons but don't want to keep the h3 style


### PR DESCRIPTION
# Make certain controls non-selectable / non-draggable - Part II

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
[See comment](https://github.com/FreeTubeApp/FreeTube/pull/3947#issuecomment-1694778435)

## Description
A previous PR making certain controls non-selectable / non-draggable was thwarted by my inclusion of a `user-select: all` to unset instead of a `user-select: unset`. This resolves the issue.

## Testing <!-- for code that is not small enough to be easily understandable -->
Tested on video page and other views

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0

