### PR TITLE
Make constants imported from @fortawesome/free-solid-svg-icons ordered by name again

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -26,6 +26,8 @@ import {
   faExchangeAlt,
   faExclamationCircle,
   faExternalLinkAlt,
+  faEye,
+  faEyeSlash,
   faFileDownload,
   faFileVideo,
   faFilter,
@@ -57,8 +59,6 @@ import {
   faTimes,
   faTimesCircle,
   faUsers,
-  faEye,
-  faEyeSlash,
 } from '@fortawesome/free-solid-svg-icons'
 import {
   faBitcoin,
@@ -94,6 +94,8 @@ library.add(
   faExchangeAlt,
   faExclamationCircle,
   faExternalLinkAlt,
+  faEye,
+  faEyeSlash,
   faFileDownload,
   faFileVideo,
   faFilter,
@@ -125,8 +127,6 @@ library.add(
   faTimes,
   faTimesCircle,
   faUsers,
-  faEye,
-  faEyeSlash,
 
   // brand icons
   faGithub,


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
"Issue" introduced by https://github.com/FreeTubeApp/FreeTube/pull/3865

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When I try to merge `development` into my playlist branch
I found duplicate icon constant entries due to new constants added in https://github.com/FreeTubeApp/FreeTube/pull/3865 not ordered properly
This PR fixes it

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Look at code diff is enough

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
None needed

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
