### PR TITLE
Implement right-to-left interface

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -59,6 +59,6 @@
 
   .flexBox {
     margin-block-start: 60px;
-    margin-bottom: -75px;
+    margin-block-end: -75px;
   }
 }

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -12,16 +12,19 @@
 
 .routerView {
   flex: 1 1 0%;
-  margin: 18px 10px;
+  margin-block: 18px;
+  margin-inline: 10px;
 }
 
 .banner {
   width: 85%;
-  margin: 20px auto 0;
+  margin-block: 20px;
+  margin-inline: auto;
 }
 
 .banner-wrapper {
-  margin: 0 10px;
+  margin-block: 0;
+  margin-inline: 10px;
 }
 
 .flexBox {
@@ -45,16 +48,17 @@
 
 @media only screen and (max-width: 680px) {
   .routerView {
-    margin: 68px 8px 68px;
+    margin-block: 68px;
+    margin-inline: 8px;
   }
 
   .banner {
     width: 80%;
-    margin-top: 20px;
+    margin-block-start: 20px;
   }
 
   .flexBox {
-    margin-top: 60px;
+    margin-block-start: 60px;
     margin-bottom: -75px;
   }
 }

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -504,18 +504,17 @@ export default defineComponent({
     setWindowTitle: function() {
       if (this.windowTitle !== null) {
         document.title = this.windowTitle
-        const locale = this.$store.getters.getCurrentLocale
-        document.querySelector('html').lang = locale
-        if (locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi') {
-          document.querySelector('body').dir = 'rtl'
-        } else {
-          document.querySelector('body').dir = 'ltr'
-        }
       }
     },
 
     setLocale: function() {
       document.documentElement.setAttribute('lang', this.locale)
+      const locale = this.$store.getters.getCurrentLocale
+      if (locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi') {
+        document.body.dir = 'rtl'
+      } else {
+        document.body.dir = 'ltr'
+      }
     },
 
     /**

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -510,7 +510,7 @@ export default defineComponent({
     setLocale: function() {
       document.documentElement.setAttribute('lang', this.locale)
       const locale = this.$store.getters.getCurrentLocale
-      if (locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi') {
+      if (locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi' || locale === 'ku') {
         document.body.dir = 'rtl'
       } else {
         document.body.dir = 'ltr'

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -504,6 +504,13 @@ export default defineComponent({
     setWindowTitle: function() {
       if (this.windowTitle !== null) {
         document.title = this.windowTitle
+        const locale = this.$store.getters.getCurrentLocale
+        document.querySelector('html').lang = locale
+        if (locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi') {
+          document.querySelector('body').dir = 'rtl'
+        } else {
+          document.querySelector('body').dir = 'ltr'
+        }
       }
     },
 

--- a/src/renderer/components/channel-about/channel-about.css
+++ b/src/renderer/components/channel-about/channel-about.css
@@ -1,6 +1,6 @@
 .about {
   background-color: var(--card-bg-color);
-  margin-top: 0;
+  margin-block-start: 0;
   padding: 10px;
   position: relative;
   z-index: 1;

--- a/src/renderer/components/channel-about/channel-about.css
+++ b/src/renderer/components/channel-about/channel-about.css
@@ -34,7 +34,7 @@
 }
 
 .aboutDetails {
-  text-align: left;
+  text-align: start;
 }
 
 .aboutDetails th {

--- a/src/renderer/components/channel-about/channel-about.css
+++ b/src/renderer/components/channel-about/channel-about.css
@@ -38,5 +38,5 @@
 }
 
 .aboutDetails th {
-  padding-right: 10px;
+  padding-inline-end: 10px;
 }

--- a/src/renderer/components/experimental-settings/experimental-settings.css
+++ b/src/renderer/components/experimental-settings/experimental-settings.css
@@ -2,5 +2,5 @@
   text-align: center;
   font-weight: bold;
   padding-inline-start: 4%;
-  padding-right: 4%
+  padding-inline-end: 4%
 }

--- a/src/renderer/components/experimental-settings/experimental-settings.css
+++ b/src/renderer/components/experimental-settings/experimental-settings.css
@@ -1,6 +1,6 @@
 .experimental-warning {
   text-align: center;
   font-weight: bold;
-  padding-left: 4%;
+  padding-inline-start: 4%;
   padding-right: 4%
 }

--- a/src/renderer/components/ft-age-restricted/ft-age-restricted.scss
+++ b/src/renderer/components/ft-age-restricted/ft-age-restricted.scss
@@ -3,7 +3,8 @@
 
   h2 {
     background-color: var(--card-bg-color);
-    padding: 10px 0;
+    padding-block: 10px;
+    padding-inline: 0;
     text-align: center;
     width: 100%;
   }
@@ -12,7 +13,8 @@
     background-color: var(--card-bg-color);
     font-size: 10em;
     height: 100%;
-    padding: 20px 0;
+    padding-block: 20px;
+    padding-inline: 0;
     text-align: center;
     width: 100%;
   }

--- a/src/renderer/components/ft-button/ft-button.css
+++ b/src/renderer/components/ft-button/ft-button.css
@@ -37,7 +37,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  top: 0;
+  inset-block-start: 0;
   inset-inline-start: 0;
   pointer-events: none;
   background-image: radial-gradient(circle, #fff 10%, transparent 10.01%);

--- a/src/renderer/components/ft-button/ft-button.css
+++ b/src/renderer/components/ft-button/ft-button.css
@@ -2,7 +2,8 @@
   font-family: 'Roboto', sans-serif;
   min-width: 100px;
   font-size: 0.9rem;
-  padding: 10px 20px;
+  padding-block: 10px;
+  padding-inline: 20px;
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;

--- a/src/renderer/components/ft-button/ft-button.css
+++ b/src/renderer/components/ft-button/ft-button.css
@@ -38,7 +38,7 @@
   width: 100%;
   height: 100%;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   pointer-events: none;
   background-image: radial-gradient(circle, #fff 10%, transparent 10.01%);
   background-repeat: no-repeat;

--- a/src/renderer/components/ft-card/ft-card.css
+++ b/src/renderer/components/ft-card/ft-card.css
@@ -1,8 +1,7 @@
 .ft-card {
   background-color: var(--card-bg-color);
   margin: 8px;
-	padding: 16px;
-	padding-top: 3px;
-	padding-bottom: 16px;
+	padding-block: 3px 16px;
+  padding-inline: 16px;
   box-shadow: 0 1px 2px rgba(0,0,0,.1);
 }

--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
@@ -31,7 +31,7 @@
 
 .selected {
   position: absolute;
-  top: 10px;
+  inset-block-start: 10px;
   background-color: rgba(0, 0, 0, 0.5);
 }
 
@@ -39,7 +39,7 @@
   color: #EEEEEE;
   font-size: 25px;
   position: absolute;
-  top: 12px;
+  inset-block-start: 12px;
   inset-inline-start: 12px;
 }
 

--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
@@ -40,7 +40,7 @@
   font-size: 25px;
   position: absolute;
   top: 12px;
-  left: 12px;
+  inset-inline-start: 12px;
 }
 
 .channelName {

--- a/src/renderer/components/ft-community-poll/ft-community-poll.css
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.css
@@ -1,5 +1,5 @@
 .vote-count {
-  padding-bottom: 6px;
+  padding-block-end: 6px;
   font-size: smaller;
 }
 
@@ -16,7 +16,7 @@
   top: 8px;
   width: 10px;
 }
-  
+
 .filled-circle {
   border-radius: 50%;
   background-color: black;
@@ -32,11 +32,12 @@
   border-radius: 5px;
   border-style: solid;
   border-width: 2px;
-  padding: 5px 25px;
+  padding-block: 5px;
+  padding-inline: 25px;
 }
 
 .option {
-  padding-bottom: 10px;
+  padding-block-end: 10px;
 }
 
 .correct-option {

--- a/src/renderer/components/ft-community-poll/ft-community-poll.css
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.css
@@ -11,7 +11,7 @@
   display: block;
   float: left;
   height: 10px;
-  left: 5px;
+  inset-inline-start: 5px;
   position: relative;
   top: 8px;
   width: 10px;
@@ -22,7 +22,7 @@
   background-color: black;
   float: left;
   height: 6px;
-  left: 2px;
+  inset-inline-start: 2px;
   top: 2px;
   position: relative;
   width: 6px;

--- a/src/renderer/components/ft-community-poll/ft-community-poll.css
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.css
@@ -13,7 +13,7 @@
   height: 10px;
   inset-inline-start: 5px;
   position: relative;
-  top: 8px;
+  inset-block-start: 8px;
   width: 10px;
 }
 
@@ -23,7 +23,7 @@
   float: left;
   height: 6px;
   inset-inline-start: 2px;
-  top: 2px;
+  inset-block-start: 2px;
   position: relative;
   width: 6px;
 }

--- a/src/renderer/components/ft-community-poll/ft-community-poll.css
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.css
@@ -9,7 +9,7 @@
   border-style: solid;
   border-width: 2px;
   display: block;
-  float: left;
+  float: var(--float-left-ltr-rtl-value);
   height: 10px;
   inset-inline-start: 5px;
   position: relative;
@@ -20,7 +20,7 @@
 .filled-circle {
   border-radius: 50%;
   background-color: black;
-  float: left;
+  float: var(--float-left-ltr-rtl-value);
   height: 6px;
   inset-inline-start: 2px;
   inset-block-start: 2px;

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -56,7 +56,7 @@
   text-align: left;
 
   @media screen and (max-width: 680px) {
-    margin-left: 0;
+    margin-inline-start: 0;
     text-align: left;
   }
 
@@ -67,7 +67,7 @@
   }
 
   .likeCount {
-    margin-left: 5px;
+    margin-inline-start: 5px;
     margin-right: 6px;
   }
 }
@@ -91,7 +91,7 @@
   }
 
   .playlistText {
-    margin-left: 10px;
+    margin-inline-start: 10px;
     width: 50%;
     word-wrap: break-word;
 

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -22,7 +22,7 @@
   -webkit-border-radius: 50%;
   border-radius: 50%;
   height: 55px;
-  margin-right: 5px;
+  margin-inline-end: 5px;
   width: 55px;
 }
 
@@ -68,7 +68,7 @@
 
   .likeCount {
     margin-inline-start: 5px;
-    margin-right: 6px;
+    margin-inline-end: 6px;
   }
 }
 

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -32,12 +32,14 @@
   .authorName {
     font-size: 15px;
     font-weight: bold;
-    margin: 5px 6px 0 5px;
+    margin-block: 5px 0;
+    margin-inline: 5px 6px;
   }
 
   .publishedText {
     font-size: 15px;
-    margin: 5px 6px 0 5px;
+    margin-block: 5px 0;
+    margin-inline: 5px 6px;
   }
 }
 
@@ -51,7 +53,7 @@
   display: block;
   flex-direction: column;
   font-size: 15px;
-  margin-top: 4px;
+  margin-block-start: 4px;
   max-width: 210px;
   text-align: left;
 
@@ -78,7 +80,7 @@
   .videoThumbnail {
     display: flex;
     margin-bottom: auto;
-    margin-top: auto;
+    margin-block-start: auto;
     position: relative;
     width: fit-content;
 

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -55,11 +55,11 @@
   font-size: 15px;
   margin-block-start: 4px;
   max-width: 210px;
-  text-align: left;
+  text-align: start;
 
   @media screen and (max-width: 680px) {
     margin-inline-start: 0;
-    text-align: left;
+    text-align: start;
   }
 
   .likeBar {

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -65,7 +65,7 @@
   .likeBar {
     border-radius: 4px;
     height: 8px;
-    margin-bottom: 4px;
+    margin-block-end: 4px;
   }
 
   .likeCount {
@@ -79,7 +79,7 @@
 
   .videoThumbnail {
     display: flex;
-    margin-bottom: auto;
+    margin-block-end: auto;
     margin-block-start: auto;
     position: relative;
     width: fit-content;

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -111,7 +111,7 @@
       color: var(--primary-text-color);
       display: flex;
       font-size: small;
-      padding-top: 10px;
+      padding-block-start: 10px;
       text-decoration-line: none;
       width: 100%;
     }
@@ -128,5 +128,5 @@
 
 .ft-list-item.grid {
   min-height: 0 !important;
-  padding-bottom: 20px;
+  padding-block-end: 20px;
 }

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -134,7 +134,8 @@
 
   .listItemDivider {
     border-top: 1px solid var(--tertiary-text-color);
-    margin: 1px auto;
+    margin-block: 1px;
+    margin-inline: auto;
     // Too "visible" with current color
     opacity: 0.5;
     width: 95%;

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -99,11 +99,11 @@
   }
 
   &.top {
-    bottom: 45px;
+    inset-block-end 45px;
   }
 
   &.bottom {
-    top: 45px;
+    inset-block-start: 45px;
   }
 
   .list {
@@ -133,7 +133,7 @@
   }
 
   .listItemDivider {
-    border-top: 1px solid var(--tertiary-text-color);
+    border-block-start: 1px solid var(--tertiary-text-color);
     margin-block: 1px;
     margin-inline: auto;
     // Too "visible" with current color

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -115,7 +115,8 @@
   .listItem {
     cursor: pointer;
     margin: 0;
-    padding: 8px 10px;
+    padding-block: 8px;
+    padding-inline: 10px;
     transition: background 0.2s ease-out;
     white-space: nowrap;
 

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -99,7 +99,7 @@
   }
 
   &.top {
-    inset-block-end 45px;
+    inset-block-end: 45px;
   }
 
   &.bottom {

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -91,11 +91,11 @@
   z-index: 3;
 
   &.left {
-    right: calc(50% - 10px);
+    inset-inline-end: calc(50% - 10px);
   }
 
   &.right {
-    left: calc(50% - 10px);
+    inset-inline-start: calc(50% - 10px);
   }
 
   &.top {

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -26,7 +26,7 @@
 .ft-tag-box li>span {
   padding-top: 10px;
   padding-bottom: 10px;
-  padding-left: 10px;
+  padding-inline-start: 10px;
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-all;

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -24,8 +24,7 @@
 }
 
 .ft-tag-box li>span {
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-block: 10px;
   padding-inline-start: 10px;
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -44,7 +44,7 @@
 }
 
 :deep(.ft-input-component .ft-input) {
-  margin-top: 10px;
+  margin-block-start: 10px;
 }
 
 @media only screen and (max-width: 576px) {

--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -20,7 +20,7 @@
   margin: 5px;
   border-radius: 5px;
   display:flex;
-  float: left;
+  float: var(--float-left-ltr-rtl-value);
 }
 
 .ft-tag-box li>span {

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -153,7 +153,7 @@
   With arrow present means
   the text might get under the arrow with normal padding
    */
-  padding-right: calc(36px + 6px);
+  padding-inline-end: calc(36px + 6px);
 }
 
 .inputAction.enabled:hover {

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -183,7 +183,8 @@
   width: 100%;
   list-style: none;
   margin: 0;
-  padding: 5px 0;
+  padding-block: 5px;
+  padding-inline: 0;
   z-index: 10;
   border-radius: 0 0 5px 5px;
   word-wrap: break-word;

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -3,22 +3,22 @@
 }
 
 .ft-input-component.search.showClearTextButton {
-  padding-left: 30px;
+  padding-inline-start: 30px;
 }
 
 .ft-input-component.search.clearTextButtonVisible,
 .ft-input-component.search.showClearTextButton:focus-within {
-  padding-left: 0;
+  padding-inline-start: 0;
 }
 
 .ft-input-component.showClearTextButton:not(.search) .ft-input {
-  padding-left: 46px;
+  padding-inline-start: 46px;
 }
 
 /* Main search input */
 .clearTextButtonVisible.search .ft-input,
 .ft-input-component.search.showClearTextButton:focus-within .ft-input {
-  padding-left: 46px;
+  padding-inline-start: 46px;
 }
 
 .ft-input-component:focus-within .clearInputTextButton {

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -39,7 +39,7 @@
 .clearInputTextButton {
   position: absolute;
   top: 5px;
-  left: 0;
+  inset-inline-start: 0;
   /* To be higher than `.inputWrapper` */
   z-index: 1;
   margin-block: 0;
@@ -128,7 +128,7 @@
   margin-inline: 3px;
   padding: 10px;
   top: -8px;
-  right: 0;
+  inset-inline-end: 0;
   border-radius: 100%;
   color: var(--primary-text-color);
   /* this should look disabled by default */
@@ -196,7 +196,8 @@
 
 .list li {
   display: block;
-  padding: 0 15px;
+  padding-block: 0;
+  padding-inline: 15px;
   line-height: 2rem;
 }
 

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -38,7 +38,7 @@
 
 .clearInputTextButton {
   position: absolute;
-  top: 5px;
+  inset-block-start: 5px;
   inset-inline-start: 0;
   /* To be higher than `.inputWrapper` */
   z-index: 1;
@@ -69,7 +69,7 @@
 }
 
 .search .clearInputTextButton {
-  top: 12px;
+  inset-block-start: 12px;
 }
 
 .forceTextColor .clearInputTextButton {
@@ -88,7 +88,7 @@
   width: 100%;
   padding: 1rem;
   border: none;
-  margin-bottom: 10px;
+  margin-block-end: 10px;
   font-size: 16px;
   height: 45px;
   color: var(--secondary-text-color);
@@ -127,7 +127,7 @@
   margin-block: 0;
   margin-inline: 3px;
   padding: 10px;
-  top: -8px;
+  inset-block-start: -8px;
   inset-inline-end: 0;
   border-radius: 100%;
   color: var(--primary-text-color);

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -2,6 +2,15 @@
   position: relative;
 }
 
+ body[dir='rtl'] .ft-input-component.search.showClearTextButton .inputAction {
+  inset-inline-end: -30px;
+ }
+
+ body[dir='rtl'] .ft-input-component.search.clearTextButtonVisible .inputAction,
+ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inputAction {
+  inset-inline-end: 0;
+ }
+
 .ft-input-component.search.showClearTextButton {
   padding-inline-start: 30px;
 }

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -42,7 +42,8 @@
   left: 0;
   /* To be higher than `.inputWrapper` */
   z-index: 1;
-  margin: 0 3px;
+  margin-block: 0;
+  margin-inline: 3px;
   padding: 10px;
   border-radius: 100%;
   color: var(--primary-text-color);
@@ -123,7 +124,8 @@
 
 .inputAction {
   position: absolute;
-  margin: 0 3px;
+  margin-block: 0;
+  margin-inline: 3px;
   padding: 10px;
   top: -8px;
   right: 0;

--- a/src/renderer/components/ft-loader/ft-loader.css
+++ b/src/renderer/components/ft-loader/ft-loader.css
@@ -50,7 +50,7 @@
     border-radius: 50%;
     opacity: 0.6;
     position: absolute;
-    top: 0;
+    inset-block-start: 0;
     inset-inline-start: 0;
     background-color: var(--primary-color);
 

--- a/src/renderer/components/ft-loader/ft-loader.css
+++ b/src/renderer/components/ft-loader/ft-loader.css
@@ -51,7 +51,7 @@
     opacity: 0.6;
     position: absolute;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     background-color: var(--primary-color);
 
     -webkit-animation: sk-bounce 2.0s infinite ease-in-out;

--- a/src/renderer/components/ft-loader/ft-loader.css
+++ b/src/renderer/components/ft-loader/ft-loader.css
@@ -39,7 +39,8 @@
     width: 40px;
     height: 40px;
     position: relative;
-    margin: 100px auto;
+    margin-block: 100px;
+    margin-inline: auto;
 }
 
 .double-bounce1,

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.css
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.css
@@ -19,7 +19,7 @@
 }
 
 .message {
-  margin-right: 25px;
+  margin-inline-end: 25px;
   cursor: pointer;
 }
 

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.css
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.css
@@ -26,6 +26,6 @@
 .bannerIcon {
   position: absolute;
   top: 35%;
-  right: 10px;
+  inset-inline-end: 10px;
   cursor: pointer;
 }

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.css
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.css
@@ -25,7 +25,7 @@
 
 .bannerIcon {
   position: absolute;
-  top: 35%;
+  inset-block-start: 35%;
   inset-inline-end: 10px;
   cursor: pointer;
 }

--- a/src/renderer/components/ft-notification-banner/ft-notification-banner.css
+++ b/src/renderer/components/ft-notification-banner/ft-notification-banner.css
@@ -7,8 +7,8 @@
   */
   margin: 4px;
 	padding: 16px;
-	padding-top: 3px;
-	padding-bottom: 5px;
+  padding-block: 3px 5px;
+  padding-inline: 16px;
   box-shadow: 0 1px 2px rgba(0,0,0,.1);
   position: relative;
   cursor: pointer;

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
@@ -20,7 +20,8 @@
 .bubble {
   width: 70px;
   height: 70px;
-  margin: 20px auto 5px auto;
+  margin-block: 20px 5px;
+  margin-inline: auto;
   border-radius: 50%;
   -webkit-border-radius: 50%;
 }

--- a/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
+++ b/src/renderer/components/ft-profile-bubble/ft-profile-bubble.css
@@ -1,7 +1,8 @@
 .bubblePadding {
   width: 100px;
   height: 115px;
-  padding: 10px 10px 30px 10px;
+  padding-block: 10px 30px;
+  padding-inline: 10px;
   cursor: pointer;
   -webkit-transition: background 0.2s ease-out;
   -moz-transition: background 0.2s ease-out;
@@ -28,7 +29,8 @@
   font-size: 35px;
   line-height: 1em;
   text-align: center;
-  padding: 17.5px 0;
+  padding-block: 17.5px;
+  padding-inline: 0;
   user-select: none;
   -webkit-user-select: none;
 }

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.css
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.css
@@ -1,5 +1,5 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 15px;
+  margin-block: 0 15px;
+  margin-inline: auto;
 }

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -35,7 +35,8 @@
   font-size: 50px;
   line-height: 1em;
   text-align: center;
-  padding: 25px 0;
+  padding-block: 25px;
+  padding-inline: 0px;
   user-select: none;
   -webkit-user-select: none;
 }

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 15px;
+  margin-block: 0 15px;
+  margin-inline: auto;
 }
 
 .message {
@@ -18,8 +18,8 @@
 
 .colorOptions {
   max-width: 1000px;
-  margin: 0 auto;
-  margin-bottom: 30px;
+  margin-block: 0 30px;
+  margin-inline: auto;
 }
 
 .colorOption {

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.css
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.css
@@ -13,7 +13,7 @@
 }
 
 .bottomMargin {
-  margin-bottom: 30px;
+  margin-block-end: 30px;
 }
 
 .colorOptions {

--- a/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.css
+++ b/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 30px;
+  margin-block: 0 30px;
+  margin-inline: auto;
 }
 
 .selected {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -24,7 +24,7 @@
 .profileList {
   display: inline;
   position: absolute;
-  top: 60px;
+  inset-block-start: 60px;
   inset-inline-end: 10px;
   min-width: 250px;
   height: 400px;
@@ -58,7 +58,7 @@
 .profile .colorOption {
   float: left;
   position: relative;
-  bottom: 5px;
+  inset-block-end 5px;
   margin: 10px;
 }
 
@@ -78,6 +78,6 @@
 .profileSettings {
   float: right;
   position: absolute;
-  top: 10px;
+  inset-block-start: 10px;
   inset-inline-end: 5px;
 }

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -25,7 +25,7 @@
   display: inline;
   position: absolute;
   top: 60px;
-  right: 10px;
+  inset-inline-end: 10px;
   min-width: 250px;
   height: 400px;
   padding: 5px;
@@ -72,12 +72,12 @@
 .profileListTitle {
   position: absolute;
   margin: 0;
-  left: 10px;
+  inset-inline-start: 10px;
 }
 
 .profileSettings {
   float: right;
   position: absolute;
   top: 10px;
-  right: 5px;
+  inset-inline-end: 5px;
 }

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -56,7 +56,7 @@
 }
 
 .profile .colorOption {
-  float: left;
+  float: var(--float-left-ltr-rtl-value);
   position: relative;
   inset-block-end: 5px;
   margin: 10px;
@@ -76,7 +76,7 @@
 }
 
 .profileSettings {
-  float: right;
+  float: var(--float-right-ltr-rtl-value);
   position: absolute;
   inset-block-start: 10px;
   inset-inline-end: 5px;

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -58,7 +58,7 @@
 .profile .colorOption {
   float: left;
   position: relative;
-  inset-block-end 5px;
+  inset-block-end: 5px;
   margin: 10px;
 }
 

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -34,7 +34,7 @@
 }
 
 .profileWrapper {
-  margin-top: 60px;
+  margin-block-start: 60px;
   height: 340px;
   overflow-y: auto;
 }

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -66,7 +66,7 @@
   display: flex;
   align-items: center;
   height: 50px;
-  padding-right: 10px;
+  padding-inline-end: 10px;
 }
 
 .profileListTitle {

--- a/src/renderer/components/ft-progress-bar/ft-progress-bar.css
+++ b/src/renderer/components/ft-progress-bar/ft-progress-bar.css
@@ -1,7 +1,7 @@
 .progressBar {
   position: fixed;
   height: 3px;
-  bottom: 0px;
+  inset-block-end 0px;
   inset-inline-start: 0px;
   background-color: var(--primary-color);
   z-index: 1;

--- a/src/renderer/components/ft-progress-bar/ft-progress-bar.css
+++ b/src/renderer/components/ft-progress-bar/ft-progress-bar.css
@@ -2,7 +2,7 @@
   position: fixed;
   height: 3px;
   bottom: 0px;
-  left: 0px;
+  inset-inline-start: 0px;
   background-color: var(--primary-color);
   z-index: 1;
   transition: width 0.5s;

--- a/src/renderer/components/ft-progress-bar/ft-progress-bar.css
+++ b/src/renderer/components/ft-progress-bar/ft-progress-bar.css
@@ -1,7 +1,7 @@
 .progressBar {
   position: fixed;
   height: 3px;
-  inset-block-end 0px;
+  inset-block-end: 0px;
   inset-inline-start: 0px;
   background-color: var(--primary-color);
   z-index: 1;

--- a/src/renderer/components/ft-prompt/ft-prompt.css
+++ b/src/renderer/components/ft-prompt/ft-prompt.css
@@ -1,6 +1,6 @@
 .prompt {
   position: fixed;
-  top: 0px;
+  inset-block-start: 0px;
   inset-inline-start: 0px;
   width: 100vw;
   height: 100vh;

--- a/src/renderer/components/ft-prompt/ft-prompt.css
+++ b/src/renderer/components/ft-prompt/ft-prompt.css
@@ -1,7 +1,7 @@
 .prompt {
   position: fixed;
   top: 0px;
-  left: 0px;
+  inset-inline-start: 0px;
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.7);
@@ -24,7 +24,7 @@
   width: 95%;
   margin: 0;
   position: absolute;
-  left: 2.5%;
+  inset-inline-start: 2.5%;
   box-sizing: border-box;
 }
 

--- a/src/renderer/components/ft-prompt/ft-prompt.css
+++ b/src/renderer/components/ft-prompt/ft-prompt.css
@@ -15,7 +15,8 @@
 
 .promptCard.autosize {
   box-sizing: border-box;
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
   max-width: 95%;
 }
 

--- a/src/renderer/components/ft-radio-button/ft-radio-button.css
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.css
@@ -32,7 +32,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   color: var(--primary-color);
   position: absolute;
   top: 50%;
-  left: 0;
+  inset-inline-start: 0;
   width: 14px;
   height: 14px;
   margin-block-start: -9px;
@@ -47,7 +47,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   background-color: var(--primary-color);
   position: absolute;
   top: 50%;
-  left: 4px;
+  inset-inline-start: 4px;
   width: 10px;
   height: 10px;
   margin-block-start: -5px;
@@ -65,7 +65,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
 .pure-checkbox input[type="checkbox"] + label:after, .pure-radiobutton input[type="checkbox"] + label:after {
   background-color: transparent;
   top: 50%;
-  left: 4px;
+  inset-inline-start: 4px;
   width: 8px;
   height: 3px;
   margin-block-start: -4px;

--- a/src/renderer/components/ft-radio-button/ft-radio-button.css
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.css
@@ -35,7 +35,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   left: 0;
   width: 14px;
   height: 14px;
-  margin-top: -9px;
+  margin-block-start: -9px;
   border: 2px solid var(--primary-color);
   text-align: center;
   transition: all 0.4s ease;
@@ -50,7 +50,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   left: 4px;
   width: 10px;
   height: 10px;
-  margin-top: -5px;
+  margin-block-start: -5px;
   transform: scale(0);
   transform-origin: 50%;
   transition: transform 200ms ease-out;
@@ -68,7 +68,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   left: 4px;
   width: 8px;
   height: 3px;
-  margin-top: -4px;
+  margin-block-start: -4px;
   border-style: solid;
   border-width: 0 0 3px 3px;
   border-image: none;

--- a/src/renderer/components/ft-radio-button/ft-radio-button.css
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.css
@@ -23,7 +23,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   user-select: none;
   cursor: pointer;
   display: block;
-  margin-bottom: -20px;
+  margin-block-end: -20px;
 }
 
 .pure-checkbox input[type="checkbox"] + label:before, .pure-radiobutton input[type="checkbox"] + label:before, .pure-checkbox input[type="radio"] + label:before, .pure-radiobutton input[type="radio"] + label:before {
@@ -31,7 +31,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   content: '';
   color: var(--primary-color);
   position: absolute;
-  top: 50%;
+  inset-block-start: 50%;
   inset-inline-start: 0;
   width: 14px;
   height: 14px;
@@ -46,7 +46,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
   content: '';
   background-color: var(--primary-color);
   position: absolute;
-  top: 50%;
+  inset-block-start: 50%;
   inset-inline-start: 4px;
   width: 10px;
   height: 10px;
@@ -64,7 +64,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
 
 .pure-checkbox input[type="checkbox"] + label:after, .pure-radiobutton input[type="checkbox"] + label:after {
   background-color: transparent;
-  top: 50%;
+  inset-block-start: 50%;
   inset-inline-start: 4px;
   width: 8px;
   height: 3px;
@@ -103,5 +103,5 @@ borderscale {  50% {
 }
 
 .radioTitle {
-  margin-bottom: -20px;
+  margin-block-end: -20px;
 }

--- a/src/renderer/components/ft-radio-button/ft-radio-button.css
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.css
@@ -17,7 +17,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
 
 .pure-checkbox input[type="checkbox"] + label, .pure-radiobutton input[type="checkbox"] + label, .pure-checkbox input[type="radio"] + label, .pure-radiobutton input[type="radio"] + label {
   position: relative;
-  padding-left: 2em;
+  padding-inline-start: 2em;
   vertical-align: middle;
   -webkit-user-select: none;
   user-select: none;

--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -30,6 +30,6 @@
 
 @media only screen and (max-width: 600px) {
   .searchRadio {
-    border-right: 0;
+    border-inline-end: 0;
   }
 }

--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -24,7 +24,8 @@
 
 .radioFlexBox {
   max-width: 1000px;
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
 }
 
 @media only screen and (max-width: 600px) {

--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -3,7 +3,8 @@
   margin-inline-start: auto;
   margin-inline-end: auto;
 
-  padding: 20px 20px 70px 20px;
+  padding-block: 20px 70px;
+  padding-inline: 20px;
   max-height: 410px;
   overflow-y: auto;
 

--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -1,7 +1,7 @@
 .searchFilterInner {
   max-width: 800px;
   margin-inline-start: auto;
-  margin-right: auto;
+  margin-inline-end: auto;
 
   padding: 20px 20px 70px 20px;
   max-height: 410px;

--- a/src/renderer/components/ft-search-filters/ft-search-filters.css
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.css
@@ -1,6 +1,6 @@
 .searchFilterInner {
   max-width: 800px;
-  margin-left: auto;
+  margin-inline-start: auto;
   margin-right: auto;
 
   padding: 20px 20px 70px 20px;

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -68,12 +68,12 @@
 .iconSelect {
   position: absolute;
   top: 10px;
-  right: 15px;
+  inset-inline-end: 15px;
   /* Styling the down arrow */
   padding: 0;
   content: '';
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
+  border-inline-start: 6px solid transparent;
+  border-inline-end: 6px solid transparent;
   pointer-events: none;
   color: var(--tertiary-text-color);
 }
@@ -81,7 +81,7 @@
 .selectTooltip {
   position: absolute;
   top: -20px;
-  right: 17px;
+  inset-inline-end: 17px;
 }
 
 
@@ -90,7 +90,7 @@
   font-size: 18px;
   font-weight: normal;
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   top: 10px;
   transition: 0.2s ease all;
   color: var(--tertiary-text-color);
@@ -122,11 +122,11 @@
 }
 
 .select-bar:before {
-  left: 50%;
+  inset-inline-start: 50%;
 }
 
 .select-bar:after {
-  right: 50%;
+  inset-inline-end: 50%;
 }
 
 /* active state */
@@ -140,7 +140,7 @@
   height: 60%;
   width: 100px;
   top: 25%;
-  left: 0;
+  inset-inline-start: 0;
   pointer-events: none;
   opacity: 0.5;
 }

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -67,7 +67,7 @@
 
 .iconSelect {
   position: absolute;
-  top: 10px;
+  inset-block-start: 10px;
   inset-inline-end: 15px;
   /* Styling the down arrow */
   padding: 0;
@@ -80,7 +80,7 @@
 
 .selectTooltip {
   position: absolute;
-  top: -20px;
+  inset-block-start: -20px;
   inset-inline-end: 17px;
 }
 
@@ -91,7 +91,7 @@
   font-weight: normal;
   position: absolute;
   inset-inline-start: 0;
-  top: 10px;
+  inset-block-start: 10px;
   transition: 0.2s ease all;
   color: var(--tertiary-text-color);
 }
@@ -99,7 +99,7 @@
 /* active state */
 .select-text:focus ~ .select-label, .select-text:valid ~ .select-label {
   color: var(--accent-color);
-  top: -20px;
+  inset-block-start: -20px;
   transition: 0.2s ease all;
   font-size: 14px;
 }
@@ -115,7 +115,7 @@
   content: '';
   height: 2px;
   width: 0;
-  bottom: 1px;
+  inset-block-end 1px;
   position: absolute;
   background: var(--accent-color);
   transition: 0.2s ease all;
@@ -139,7 +139,7 @@
   position: absolute;
   height: 60%;
   width: 100px;
-  top: 25%;
+  inset-block-start: 25%;
   inset-inline-start: 0;
   pointer-events: none;
   opacity: 0.5;

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -60,7 +60,7 @@
   appearance: none;
   -webkit-appearance:none;
   text-overflow: ellipsis;
-  padding-right: 1.1rem;
+  padding-inline-end: 1.1rem;
 }
 
 .iconSelect {

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -24,7 +24,8 @@
 .select {
   position: relative;
   width: 200px;
-  padding: 0px 10px 10px 0;
+  padding-block: 0 10px;
+  padding-inline: 0 10px;
   margin-top: 30px;
 }
 
@@ -39,7 +40,8 @@
   background-color: transparent;
   color: var(--primary-text-color);
   width: 240px;
-  padding: 10px 10px 10px 0;
+  padding-block: 10px;
+  padding-inline: 0 10px;
   font-size: 18px;
   border-radius: 0;
   border: none;

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -115,7 +115,7 @@
   content: '';
   height: 2px;
   width: 0;
-  inset-block-end 1px;
+  inset-block-end: 1px;
   position: absolute;
   background: var(--accent-color);
   transition: 0.2s ease all;

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -162,6 +162,6 @@
 @media only screen and (max-width: 680px) {
   .select {
     padding: 0px;
-    margin-right: -15px;
-  }  
+    margin-inline-end: -15px;
+  }
 }

--- a/src/renderer/components/ft-select/ft-select.css
+++ b/src/renderer/components/ft-select/ft-select.css
@@ -26,7 +26,7 @@
   width: 200px;
   padding-block: 0 10px;
   padding-inline: 0 10px;
-  margin-top: 30px;
+  margin-block-start: 30px;
 }
 
 .disabled, .disabled + svg.iconSelect {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -41,7 +41,7 @@
 .sectionTitle {
   -webkit-user-select: none;
   user-select: none;
-  margin-left: 2%;
+  margin-inline-start: 2%;
 }
 
 :deep(.switchGrid) {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -44,6 +44,7 @@
   -webkit-user-select: none;
   user-select: none;
   margin-inline-start: 2%;
+  text-align: start;
 }
 
 :deep(.switchGrid) {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -93,7 +93,7 @@
 
     :deep(.switch-ctn.containsTooltip) {
       left: -10px;
-      margin-right: 5px;
+      margin-inline-end: 5px;
       padding: 0 10px;
     }
 

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -89,12 +89,12 @@
   .settingsSection {
     > div {
       :deep(.text.bottom) {
-        left: -85px;
+        inset-inline-start: -85px;
       }
     }
 
     :deep(.switch-ctn.containsTooltip) {
-      left: -10px;
+      inset-inline-start: -10px;
       margin-inline-end: 5px;
       padding-block: 0;
       padding-inline: 10px;
@@ -104,13 +104,13 @@
       > :deep(.tooltip) {
         display: inline-block;
         position: absolute;
-        right: -25px;
+        inset-inline-end: -25px;
         top: 12px;
       }
     }
 
     .settingsFlexStart460px :deep(.tooltip) {
-      right: 0;
+      inset-inline-end: 0;
       top: -2px;
     }
 

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -66,7 +66,7 @@
 :deep(.switchColumn) {
   display: flex;
   flex-direction: column;
-  justify-items: start;
+  align-items: start;
 }
 
 :deep(.center) {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -8,12 +8,13 @@
   }
 
   &[open] {
-    padding-bottom: 15px;
+    padding-block-end: 15px;
   }
 
   > div {
     box-sizing: border-box;
-    padding: 0 20px;
+    padding-block: 0;
+    padding-inline: 20px;
     width: 100%;
   }
 
@@ -94,7 +95,8 @@
     :deep(.switch-ctn.containsTooltip) {
       left: -10px;
       margin-inline-end: 5px;
-      padding: 0 10px;
+      padding-block: 0;
+      padding-inline: 10px;
     }
 
     :not(.select, .selectLabel) {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -29,7 +29,7 @@
   background-color: var(--primary-color);
   border: 0;
   height: 2px;
-  margin-top: -1px;
+  margin-block-start: -1px;
   width: 100%;
 }
 
@@ -114,7 +114,8 @@
     }
 
     :deep(.switch-ctn) {
-      margin: 10px 7px;
+      margin-block: 10px;
+      margin-inline: 7px;
     }
   }
 }

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -21,7 +21,7 @@
 
   > div:not(:last-child, .ft-flex-box) {
     @media only screen and (max-width: 800px) {
-      margin-bottom: 20px;
+      margin-block-end: 20px;
     }
   }
 }
@@ -105,13 +105,13 @@
         display: inline-block;
         position: absolute;
         inset-inline-end: -25px;
-        top: 12px;
+        inset-block-start: 12px;
       }
     }
 
     .settingsFlexStart460px :deep(.tooltip) {
       inset-inline-end: 0;
-      top: -2px;
+      inset-block-start: -2px;
     }
 
     :deep(.switch-ctn) {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -44,7 +44,6 @@
   -webkit-user-select: none;
   user-select: none;
   margin-inline-start: 2%;
-  text-align: start;
 }
 
 :deep(.switchGrid) {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -1,6 +1,7 @@
 .settingsSection {
   background-color: var(--card-bg-color);
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
   width: 85%;
 
   @media only screen and (max-width: 800px) {

--- a/src/renderer/components/ft-share-button/ft-share-button.scss
+++ b/src/renderer/components/ft-share-button/ft-share-button.scss
@@ -60,7 +60,7 @@
       background-size: cover;
       display: inline-block;
       height: 20px;
-      margin-right: 2px;
+      margin-inline-end: 2px;
       width: 20px;
 
       @at-root {

--- a/src/renderer/components/ft-share-button/ft-share-button.scss
+++ b/src/renderer/components/ft-share-button/ft-share-button.scss
@@ -9,7 +9,8 @@
     color: var(--primary-text-color);
     font-size: 18px;
     font-weight: bold;
-    margin: 4px 0 8px;
+    margin-block: 4px 8px;
+    margin-inline: 0;
   }
 
   .buttons {
@@ -24,7 +25,8 @@
   .divider {
     background: var(--tertiary-text-color);
     grid-row: span 3;
-    margin: 0 12px;
+    margin-block: 0;
+    margin-inline: 12px;
     width: 1px;
   }
 

--- a/src/renderer/components/ft-slider/ft-slider.css
+++ b/src/renderer/components/ft-slider/ft-slider.css
@@ -177,7 +177,8 @@
     margin: 17px 0;
     border: none;
     border-radius: 1px;
-    padding: 0 17px;
+    padding-block: 0;
+    padding-inline: 17px;
     width: 100%;
     height: 2px;
     background-color: transparent;

--- a/src/renderer/components/ft-slider/ft-slider.css
+++ b/src/renderer/components/ft-slider/ft-slider.css
@@ -1,251 +1,256 @@
 .pure-material-slider {
-    --pure-material-safari-helper1: var(--accent-color-opacity1);
-    --pure-material-safari-helper2: var(--accent-color-opacity2);
-    --pure-material-safari-helper3: var(--accent-color-opacity3);
-    --pure-material-safari-helper4: var(--accent-color-opacity4);
-    display: inline-block;
-    width: 380px;
-    color: rgba(var(--primary-text-color), 0.87);
-    font-family: var(--pure-material-font, "Roboto", "Segoe UI", BlinkMacSystemFont, system-ui, -apple-system);
-    font-size: 16px;
-    line-height: 1.5;
-    padding: 5px;
-    margin: 12px 8px;
+  --pure-material-safari-helper1: var(--accent-color-opacity1);
+  --pure-material-safari-helper2: var(--accent-color-opacity2);
+  --pure-material-safari-helper3: var(--accent-color-opacity3);
+  --pure-material-safari-helper4: var(--accent-color-opacity4);
+  display: inline-block;
+  width: 380px;
+  color: rgba(var(--primary-text-color), 0.87);
+  font-family: var(--pure-material-font, "Roboto", "Segoe UI", BlinkMacSystemFont, system-ui, -apple-system);
+  font-size: 16px;
+  line-height: 1.5;
+  padding: 5px;
+  margin-block: 12px;
+  margin-inline: 8px;
 }
 
 /* Input */
 .pure-material-slider > input {
-    -webkit-appearance: none;
-    position: relative;
-    top: 24px;
-    display: block;
-    margin: 0 0 -36px;
-    width: 100%;
-    height: 36px;
-    background-color: transparent;
-    cursor: pointer;
+  -webkit-appearance: none;
+  position: relative;
+  top: 24px;
+  display: block;
+  margin-block: 0 -36px;
+  margin-inline: 0;
+  width: 100%;
+  height: 36px;
+  background-color: transparent;
+  cursor: pointer;
 }
 
 /* Without Span */
 .pure-material-slider > input:last-child {
-    position: static;
-    margin: 0;
+  position: static;
+  margin: 0;
 }
 
 /* Span */
 .pure-material-slider > span {
-    display: inline-block;
-    margin-bottom: 36px;
+  display: inline-block;
+  margin-bottom: 36px;
 }
 
 /* Focus */
 .pure-material-slider > input:focus {
-    outline: none;
+  outline: none;
 }
 
 /* Disabled */
 .pure-material-slider > input:disabled {
-    cursor: default;
-    opacity: 0.38;
+  cursor: default;
+  opacity: 0.38;
 }
 
 .pure-material-slider > input:disabled + span {
-    opacity: 0.38;
+  opacity: 0.38;
 }
 
 /* Webkit | Track */
 .pure-material-slider > input::-webkit-slider-runnable-track {
-    margin: 17px 0;
-    border-radius: 1px;
-    width: 100%;
-    height: 2px;
-    background-color: var(--accent-color-opacity4);
+  margin-block: 17px;
+  margin-inline: 0;
+  border-radius: 1px;
+  width: 100%;
+  height: 2px;
+  background-color: var(--accent-color-opacity4);
 }
 
 /* Webkit | Thumb */
 .pure-material-slider > input::-webkit-slider-thumb {
-    appearance: none;
-    -webkit-appearance: none;
-    border: none;
-    border-radius: 50%;
-    height: 2px;
-    width: 2px;
-    background-color: var(--accent-color);
-    transform: scale(6, 6);
-    transition: box-shadow 0.2s;
+  appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  border-radius: 50%;
+  height: 2px;
+  width: 2px;
+  background-color: var(--accent-color);
+  transform: scale(6, 6);
+  transition: box-shadow 0.2s;
 }
 
 /* Webkit | Hover, Focus */
 .pure-material-slider:hover > input::-webkit-slider-thumb {
-    box-shadow: 0 0 0 2px var(--pure-material-safari-helper1);
+  box-shadow: 0 0 0 2px var(--pure-material-safari-helper1);
 }
 
 .pure-material-slider > input:focus::-webkit-slider-thumb {
-    box-shadow: 0 0 0 2px var(--pure-material-safari-helper2);
+  box-shadow: 0 0 0 2px var(--pure-material-safari-helper2);
 }
 
 .pure-material-slider:hover > input:focus::-webkit-slider-thumb {
-    box-shadow: 0 0 0 2px var(--pure-material-safari-helper3);
+  box-shadow: 0 0 0 2px var(--pure-material-safari-helper3);
 }
 
 /* Webkit | Active */
 .pure-material-slider > input:active::-webkit-slider-thumb {
-     box-shadow: 0 0 0 2px var(--pure-material-safari-helper4) !important;
+  box-shadow: 0 0 0 2px var(--pure-material-safari-helper4) !important;
 }
 
 /* Webkit | Disabled */
 .pure-material-slider > input:disabled::-webkit-slider-runnable-track {
-    background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
+  background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
 }
 
 .pure-material-slider > input:disabled::-webkit-slider-thumb {
-    background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
-    color: rgb(var(--pure-material-surface-rgb, 255, 255, 255)); /* Safari */
-    box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
-    transform: scale(4, 4);
+  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
+  color: rgb(var(--pure-material-surface-rgb, 255, 255, 255)); /* Safari */
+  box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
+  transform: scale(4, 4);
 }
 
 /* Moz | Track */
 .pure-material-slider > input::-moz-range-track {
-    margin: 17px 0;
-    border-radius: 1px;
-    width: 100%;
-    height: 2px;
-    background-color: var(--accent-color-opacity4);
+  margin-block: 0;
+  margin-auto: 17px;
+  border-radius: 1px;
+  width: 100%;
+  height: 2px;
+  background-color: var(--accent-color-opacity4);
 }
 
 /* Moz | Thumb */
 .pure-material-slider > input::-moz-range-thumb {
-    appearance: none;
-    -moz-appearance: none;
-    border: none;
-    border-radius: 50%;
-    height: 2px;
-    width: 2px;
-    background-color: var(--accent-color);
-    transform: scale(6, 6);
-    transition: box-shadow 0.2s;
+  appearance: none;
+  -moz-appearance: none;
+  border: none;
+  border-radius: 50%;
+  height: 2px;
+  width: 2px;
+  background-color: var(--accent-color);
+  transform: scale(6, 6);
+  transition: box-shadow 0.2s;
 }
 
 /* Moz | Progress */
 .pure-material-slider > input::-moz-range-progress {
-    border-radius: 1px;
-    height: 2px;
-    background-color: var(--accent-color);
+  border-radius: 1px;
+  height: 2px;
+  background-color: var(--accent-color);
 }
 
 /* Moz | Hover, Focus */
 .pure-material-slider:hover > input:hover::-moz-range-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity1);
+  box-shadow: 0 0 0 2px var(--accent-color-opacity1);
 }
 
 .pure-material-slider > input:focus::-moz-range-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity2);
+  box-shadow: 0 0 0 2px var(--accent-color-opacity2);
 }
 
 .pure-material-slider:hover > input:focus::-moz-range-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity3);
+  box-shadow: 0 0 0 2px var(--accent-color-opacity3);
 }
 
 /* Moz | Active */
 .pure-material-slider > input:active::-moz-range-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
+  box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
 }
 
 /* Moz | Disabled */
 .pure-material-slider > input:disabled::-moz-range-track {
-    background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
+  background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
 }
 
 .pure-material-slider > input:disabled::-moz-range-progress {
-    background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.87);
+  background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.87);
 }
 
 .pure-material-slider > input:disabled::-moz-range-thumb {
-    background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
-    box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
-    transform: scale(4, 4);
+  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
+  box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
+  transform: scale(4, 4);
 }
 
 .pure-material-slider > input::-moz-focus-outer {
-    border: none;
+  border: none;
 }
 
 /* MS | Track */
 .pure-material-slider > input::-ms-track {
-    box-sizing: border-box;
-    margin: 17px 0;
-    border: none;
-    border-radius: 1px;
-    padding-block: 0;
-    padding-inline: 17px;
-    width: 100%;
-    height: 2px;
-    background-color: transparent;
+  box-sizing: border-box;
+  margin-block: 17px;
+  margin-inline: 0;
+  border: none;
+  border-radius: 1px;
+  padding-block: 0;
+  padding-inline: 17px;
+  width: 100%;
+  height: 2px;
+  background-color: transparent;
 }
 
 .pure-material-slider > input::-ms-fill-lower {
-    border-radius: 1px;
-    height: 2px;
-    background-color: var(--accent-color);
+  border-radius: 1px;
+  height: 2px;
+  background-color: var(--accent-color);
 }
 
 /* MS | Progress */
 .pure-material-slider > input::-ms-fill-upper {
-    border-radius: 1px;
-    height: 2px;
-    background-color: var(--accent-color-opacity4);
+  border-radius: 1px;
+  height: 2px;
+  background-color: var(--accent-color-opacity4);
 }
 
 /* MS | Thumb */
 .pure-material-slider > input::-ms-thumb {
-    appearance: none;
-    margin: 0 17px;
-    border: none;
-    border-radius: 50%;
-    height: 2px;
-    width: 2px;
-    background-color: var(--accent-color);
-    transform: scale(6, 6);
-    transition: box-shadow 0.2s;
+  appearance: none;
+  margin: 0 17px;
+  border: none;
+  border-radius: 50%;
+  height: 2px;
+  width: 2px;
+  background-color: var(--accent-color);
+  transform: scale(6, 6);
+  transition: box-shadow 0.2s;
 }
 
 /* MS | Hover, Focus */
 .pure-material-slider:hover > input::-ms-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity1);
+  box-shadow: 0 0 0 2px var(--accent-color-opacity1);
 }
 
 .pure-material-slider > input:focus::-ms-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity2);
+  box-shadow: 0 0 0 2px var(--accent-color-opacity2);
 }
 
 .pure-material-slider:hover > input:focus::-ms-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity3);
+  box-shadow: 0 0 0 2px var(--accent-color-opacity3);
 }
 
 /* MS | Active */
 .pure-material-slider > input:active::-ms-thumb {
-    box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
+  box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
 }
 
 /* MS | Disabled */
 .pure-material-slider > input:disabled::-ms-fill-lower {
-    background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
+  background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
 }
 
 .pure-material-slider > input:disabled::-ms-fill-upper {
-    background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
-    opacity: 0.38;
+  background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.38);
+  opacity: 0.38;
 }
 
 .pure-material-slider > input:disabled::-ms-thumb {
-    background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
-    box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
-    transform: scale(4, 4);
+  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
+  box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
+  transform: scale(4, 4);
 }
 
 @media only screen and (max-width: 680px) {
-    .pure-material-slider {
-        width: 100%;
-    }
+  .pure-material-slider {
+    width: 100%;
+  }
 }

--- a/src/renderer/components/ft-slider/ft-slider.css
+++ b/src/renderer/components/ft-slider/ft-slider.css
@@ -164,7 +164,7 @@
 .pure-material-slider > input:disabled::-moz-range-progress {
   background-color: rgba(var(--pure-material-onsurface-rgb, 0, 0, 0), 0.87);
 }
-
+O
 .pure-material-slider > input:disabled::-moz-range-thumb {
   background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
   box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
@@ -205,7 +205,8 @@
 /* MS | Thumb */
 .pure-material-slider > input::-ms-thumb {
   appearance: none;
-  margin: 0 17px;
+  margin-block: 0;
+  margin-inline: 17px;
   border: none;
   border-radius: 50%;
   height: 2px;

--- a/src/renderer/components/ft-slider/ft-slider.css
+++ b/src/renderer/components/ft-slider/ft-slider.css
@@ -18,7 +18,7 @@
 .pure-material-slider > input {
   -webkit-appearance: none;
   position: relative;
-  top: 24px;
+  inset-block-start: 24px;
   display: block;
   margin-block: 0 -36px;
   margin-inline: 0;
@@ -37,7 +37,7 @@
 /* Span */
 .pure-material-slider > span {
   display: inline-block;
-  margin-bottom: 36px;
+  margin-block-end: 36px;
 }
 
 /* Focus */

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.scss
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.scss
@@ -1,6 +1,7 @@
 .sponsorBlockCategory {
   margin-top: 30px;
-  padding: 0 10px;
+  padding-block: 0;
+  padding-inline: 10px;
 
   @media only screen and (max-width: 680px) {
     width: 100%;

--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.scss
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.scss
@@ -1,5 +1,5 @@
 .sponsorBlockCategory {
-  margin-top: 30px;
+  margin-block-start: 30px;
   padding-block: 0;
   padding-inline: 10px;
 

--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.css
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.css
@@ -1,6 +1,6 @@
 .subscribeButton {
   align-self: center;
   height: 50%;
-  margin-bottom: 10px;
+  margin-block-end: 10px;
   min-width: 150px;
 }

--- a/src/renderer/components/ft-toast/ft-toast.css
+++ b/src/renderer/components/ft-toast/ft-toast.css
@@ -1,6 +1,6 @@
 .toast-holder {
   position: fixed;
-  left: 50vw;
+  inset-inline-start: 50vw;
   transform: translate(-50%, 0);
   bottom: 50px;
   z-index: 1;

--- a/src/renderer/components/ft-toast/ft-toast.css
+++ b/src/renderer/components/ft-toast/ft-toast.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset-inline-start: 50vw;
   transform: translate(-50%, 0);
-  inset-block-end 50px;
+  inset-block-end: 50px;
   z-index: 1;
   display: flex;
   flex-direction: column;

--- a/src/renderer/components/ft-toast/ft-toast.css
+++ b/src/renderer/components/ft-toast/ft-toast.css
@@ -2,7 +2,7 @@
   position: fixed;
   inset-inline-start: 50vw;
   transform: translate(-50%, 0);
-  bottom: 50px;
+  inset-block-end 50px;
   z-index: 1;
   display: flex;
   flex-direction: column;

--- a/src/renderer/components/ft-toast/ft-toast.css
+++ b/src/renderer/components/ft-toast/ft-toast.css
@@ -1,7 +1,7 @@
 .toast-holder {
   position: fixed;
   inset-inline-start: 50vw;
-  transform: translate(-50%, 0);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 0);
   inset-block-end: 50px;
   z-index: 1;
   display: flex;

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
@@ -1,7 +1,8 @@
 /* Thanks to Guus Lieben for the Material Design Switch */
 
 .switch-ctn {
-  margin: 20px 16px;
+  margin-block: 20px;
+  margin-inline: 16px;
   position: relative;
 
   &.compact {

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
@@ -23,7 +23,8 @@
   cursor: pointer;
   display: inline-block;
   font-weight: 500;
-  padding: 12px 0 12px 44px;
+  padding-block: 12px;
+  padding-inline: 44px 0;
   position: relative;
   text-align: left;
 

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
@@ -27,7 +27,7 @@
   padding-block: 12px;
   padding-inline: 44px 0;
   position: relative;
-  text-align: left;
+  text-align: start;
 
   &::before,
   &::after {

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
@@ -66,7 +66,7 @@
 
     .switch-input:checked + & {
       background-color: var(--accent-color);
-      transform: translate(80%, -50%);
+      transform: translate(calc(80% * var(--horizontal-directionality-coefficient)), -50%);
     }
 
     .switch-input:disabled + & {

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
@@ -15,7 +15,7 @@
   height: 20px;
   inset-inline-start: -3px;
   position: absolute;
-  top: calc(50% - 3px);
+  inset-block-start: calc(50% - 3px);
   transform: translate(0, -50%);
   width: 34px;
 }
@@ -35,7 +35,7 @@
     margin: 0;
     outline: 0;
     position: absolute;
-    top: 50%;
+    inset-block-start: 50%;
     transform: translate(0, -50%);
     transition: all 0.3s ease;
   }

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.scss
@@ -13,7 +13,7 @@
 .switch-input {
   appearance: none;
   height: 20px;
-  left: -3px;
+  inset-inline-start: -3px;
   position: absolute;
   top: calc(50% - 3px);
   transform: translate(0, -50%);
@@ -44,7 +44,7 @@
     background-color: #9e9e9e;
     border-radius: 8px;
     height: 14px;
-    left: 1px;
+    inset-inline-start: 1px;
     width: 34px;
 
     .switch-input:checked + & {
@@ -61,7 +61,7 @@
     border-radius: 50%;
     box-shadow: 0 3px 1px -2px rgb(0 0 0 / 14%), 0 2px 2px 0 rgb(0 0 0 / 9.8%), 0 1px 5px 0 rgb(0 0 0 / 8.4%);
     height: 20px;
-    left: 0;
+    inset-inline-start: 0;
     width: 20px;
 
     .switch-input:checked + & {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -77,7 +77,7 @@
 
 .text.right {
   left: 100%;
-  margin-left: 1em;
+  margin-inline-start: 1em;
   top: 50%;
   -webkit-transform: translate(-1em, -50%);
   transform: translate(-1em, -50%);

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -53,7 +53,7 @@
 }
 
 .text.bottom {
-  margin-top: 1em;
+  margin-block-start: 1em;
   top: 100%;
   left: 50%;
   -webkit-transform: translate(-50%, -1em);
@@ -61,7 +61,7 @@
 }
 
 .text.bottom-left {
-  margin-top: 1em;
+  margin-block-start: 1em;
   top: 100%;
   left: -100px;
   -webkit-transform: translate(-50%, -1em);

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -19,8 +19,8 @@
 .button:hover + .text.bottom-left,
 .button:focus + .text.top,
 .button:hover + .text.top {
-  -webkit-transform: translate(-50%, 0);
-  transform: translate(-50%, 0);
+  -webkit-transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 0);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 0);
 }
 
 .button:focus + .text.left,
@@ -56,8 +56,8 @@
   margin-block-start: 1em;
   inset-block-start: 100%;
   inset-inline-start: 50%;
-  -webkit-transform: translate(-50%, -1em);
-  transform: translate(-50%, -1em);
+  -webkit-transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), -1em);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), -1em);
 }
 
 .text.bottom-left {
@@ -65,31 +65,31 @@
   inset-block-start: 100%;
   inset-inline-start: -100px;
   -webkit-transform: translate(-50%, -1em);
-  transform: translate(-50%, -1em);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), -1em);
 }
 
 .text.left {
   margin-inline-end:1em;
   inset-inline-end: 100%;
   inset-block-start: 50%;
-  -webkit-transform: translate(1em, -50%);
-  transform: translate(1em, -50%);
+  -webkit-transform: translate(calc(1em * var(--horizontal-directionality-coefficient)), -50%);
+  transform: translate(calc(1em * var(--horizontal-directionality-coefficient)), -50%);
 }
 
 .text.right {
   inset-inline-start: 100%;
   margin-inline-start: 1em;
   inset-block-start: 50%;
-  -webkit-transform: translate(-1em, -50%);
-  transform: translate(-1em, -50%);
+  -webkit-transform: translate(calc(-1em * var(--horizontal-directionality-coefficient)), -50%);
+  transform: translate(calc(-1em * var(--horizontal-directionality-coefficient)), -50%);
 }
 
 .text.top {
   inset-block-end: 100%;
   inset-inline-start: 50%;
   margin-block-end: 1em;
-  -webkit-transform: translate(-50%, 1em);
-  transform: translate(-50%, 1em);
+  -webkit-transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 1em);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 1em);
 }
 
 .tooltip {

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -55,7 +55,7 @@
 .text.bottom {
   margin-block-start: 1em;
   top: 100%;
-  left: 50%;
+  inset-inline-start: 50%;
   -webkit-transform: translate(-50%, -1em);
   transform: translate(-50%, -1em);
 }
@@ -63,21 +63,21 @@
 .text.bottom-left {
   margin-block-start: 1em;
   top: 100%;
-  left: -100px;
+  inset-inline-start: -100px;
   -webkit-transform: translate(-50%, -1em);
   transform: translate(-50%, -1em);
 }
 
 .text.left {
   margin-inline-end:1em;
-  right: 100%;
+  inset-inline-end: 100%;
   top: 50%;
   -webkit-transform: translate(1em, -50%);
   transform: translate(1em, -50%);
 }
 
 .text.right {
-  left: 100%;
+  inset-inline-start: 100%;
   margin-inline-start: 1em;
   top: 50%;
   -webkit-transform: translate(-1em, -50%);
@@ -86,7 +86,7 @@
 
 .text.top {
   bottom: 100%;
-  left: 50%;
+  inset-inline-start: 50%;
   margin-bottom: 1em;
   -webkit-transform: translate(-50%, 1em);
   transform: translate(-50%, 1em);

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -85,7 +85,7 @@
 }
 
 .text.top {
-  inset-block-end 100%;
+  inset-block-end: 100%;
   inset-inline-start: 50%;
   margin-block-end: 1em;
   -webkit-transform: translate(-50%, 1em);

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -54,7 +54,7 @@
 
 .text.bottom {
   margin-block-start: 1em;
-  top: 100%;
+  inset-block-start: 100%;
   inset-inline-start: 50%;
   -webkit-transform: translate(-50%, -1em);
   transform: translate(-50%, -1em);
@@ -62,7 +62,7 @@
 
 .text.bottom-left {
   margin-block-start: 1em;
-  top: 100%;
+  inset-block-start: 100%;
   inset-inline-start: -100px;
   -webkit-transform: translate(-50%, -1em);
   transform: translate(-50%, -1em);
@@ -71,7 +71,7 @@
 .text.left {
   margin-inline-end:1em;
   inset-inline-end: 100%;
-  top: 50%;
+  inset-block-start: 50%;
   -webkit-transform: translate(1em, -50%);
   transform: translate(1em, -50%);
 }
@@ -79,15 +79,15 @@
 .text.right {
   inset-inline-start: 100%;
   margin-inline-start: 1em;
-  top: 50%;
+  inset-block-start: 50%;
   -webkit-transform: translate(-1em, -50%);
   transform: translate(-1em, -50%);
 }
 
 .text.top {
-  bottom: 100%;
+  inset-block-end 100%;
   inset-inline-start: 50%;
-  margin-bottom: 1em;
+  margin-block-end: 1em;
   -webkit-transform: translate(-50%, 1em);
   transform: translate(-50%, 1em);
 }

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -68,7 +68,7 @@
 }
 
 .text.left {
-  margin-right:1em;
+  margin-inline-end:1em;
   right: 100%;
   top: 50%;
   -webkit-transform: translate(1em, -50%);

--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -41,7 +41,8 @@
   max-width: max-content;
   min-width: 15em;
   opacity: 0;
-  padding: 10px 8px;
+  padding-block: 10px;
+  padding-inline: 8px;
   pointer-events: none;
   position: absolute;
   text-align: center;

--- a/src/renderer/components/ft-video-player/ft-video-player.css
+++ b/src/renderer/components/ft-video-player/ft-video-player.css
@@ -22,7 +22,7 @@
 
 :deep(.chapterMarker) {
   height: 100%;
-  top: 0;
+  inset-block-start: 0;
   width: 2px;
   z-index: 2;
   background-color: #000;

--- a/src/renderer/components/player-settings/player-settings.scss
+++ b/src/renderer/components/player-settings/player-settings.scss
@@ -5,7 +5,8 @@
 .screenshotFolderContainer {
   align-items: center;
   column-gap: 1rem;
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
   width: 95%;
 
   .screenshotFolderLabel,

--- a/src/renderer/components/player-settings/player-settings.scss
+++ b/src/renderer/components/player-settings/player-settings.scss
@@ -18,6 +18,6 @@
   .screenshotFilenamePatternInput,
   .screenshotFilenamePatternExample {
     flex-grow: 1;
-    margin-top: 10px;
+    margin-block-start: 10px;
   }
 }

--- a/src/renderer/components/playlist-info/playlist-info.scss
+++ b/src/renderer/components/playlist-info/playlist-info.scss
@@ -45,7 +45,7 @@
 
 .channelThumbnail {
   border-radius: 200px;
-  float: left;
+  float: var(--float-left-ltr-rtl-value);
   width: 40px;
 }
 

--- a/src/renderer/components/playlist-info/playlist-info.scss
+++ b/src/renderer/components/playlist-info/playlist-info.scss
@@ -21,7 +21,7 @@
 }
 
 .playlistTitle {
-  margin-bottom: 0.1em;
+  margin-block-end: 0.1em;
 }
 
 .playlistDescription {

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -53,7 +53,8 @@
   .navOption, .closed .navOption {
     width: 70px;
     height: 40px;
-    padding: 10px 0px;
+    padding-block: 10px;
+    padding-inline: 0;
   }
 
   .navLabel {

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -57,7 +57,7 @@
   }
 
   .navLabel {
-    margin-left: 0px;
+    margin-inline-start: 0px;
     width: 100%;
     text-align: center;
     left: 0px;
@@ -65,7 +65,7 @@
   }
 
   .navIcon {
-    margin-left: 0px;
+    margin-inline-start: 0px;
     width: 100%;
     display: block;
     margin-top: 0.5em;

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -28,7 +28,7 @@
 .moreOptionContainer {
   position: fixed;
   background-color: var(--side-nav-color);
-  inset-block-end 60px;
+  inset-block-end: 60px;
   width: 70px;
   z-index: 0;
   -webkit-box-shadow: 3px -3px 5px 0px rgba(0,0,0,0.2);
@@ -45,7 +45,7 @@
     margin-block-start: 0px;
     height: 60px;
     width: 100%;
-    inset-block-end 0px;
+    inset-block-end: 0px;
     inset-block-start: auto;
     overflow-y: inherit;
   }

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -42,7 +42,7 @@
   }
 
   .sideNav, .closed {
-    margin-top: 0px;
+    margin-block-start: 0px;
     height: 60px;
     width: 100%;
     bottom: 0px;
@@ -69,7 +69,7 @@
     margin-inline-start: 0px;
     width: 100%;
     display: block;
-    margin-top: 0.5em;
+    margin-block-start: 0.5em;
   }
 
   .moreOption {

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -28,7 +28,7 @@
 .moreOptionContainer {
   position: fixed;
   background-color: var(--side-nav-color);
-  bottom: 60px;
+  inset-block-end 60px;
   width: 70px;
   z-index: 0;
   -webkit-box-shadow: 3px -3px 5px 0px rgba(0,0,0,0.2);
@@ -45,8 +45,8 @@
     margin-block-start: 0px;
     height: 60px;
     width: 100%;
-    bottom: 0px;
-    top: auto;
+    inset-block-end 0px;
+    inset-block-start: auto;
     overflow-y: inherit;
   }
 

--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.css
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.css
@@ -61,7 +61,7 @@
     margin-inline-start: 0px;
     width: 100%;
     text-align: center;
-    left: 0px;
+    inset-inline-start: 0px;
     font-size: 11px;
   }
 

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -124,7 +124,8 @@
 
 .closed .navOption {
   width: 100%;
-  padding: 5px 0px;
+  padding-block: 5px;
+  padding-inline: 0;
 }
 
 .closed .navIcon {
@@ -149,7 +150,8 @@
 .closed .navChannel {
   width: 100%;
   height: 45px;
-  padding: 5px 0px;
+  padding-block: 5px;
+  padding-inline: 0;
 }
 
 .closed .thumbnailContainer {
@@ -200,8 +202,8 @@
     width: 70px;
     height: 40px;
     padding: 0px;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-block-start: 10px;
+    padding-block-end: 10px;
   }
 
   .navLabel {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -4,7 +4,7 @@
   width: 200px;
   overflow-x: hidden;
   position: sticky;
-  left: 0;
+  inset-inline-start: 0;
   top: 60px;
   z-index: 3;
   box-shadow: 1px -1px 1px -1px var(--primary-shadow-color);
@@ -115,7 +115,7 @@
 .refreshIcon {
   position: absolute;
   top: 20px;
-  right: 20px;
+  inset-inline-end: 20px;
 }
 
 .closed .refreshIcon {
@@ -142,7 +142,7 @@
   margin-inline-start: 0px;
   width: 100%;
   text-align: center;
-  left: 0px;
+  inset-inline-start: 0px;
   font-size: 11px;
   margin-block-end: 0em;
 }
@@ -178,7 +178,7 @@
 
   .sideNav {
     position: fixed;
-    left: 0;
+    inset-inline-start: 0;
     bottom: 0;
 
     display: flex;
@@ -211,7 +211,7 @@
     margin-inline-start: 0px;
     width: 100%;
     text-align: center;
-    left: 0px;
+    inset-inline-start: 0px;
     font-size: 11px;
   }
 

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -184,7 +184,7 @@
   .topNavOption {
     margin-top: 0px;
     padding-inline-start: 10px;
-    padding-right: 10px;
+    padding-inline-end: 10px;
   }
 
   .sideNav, .closed {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -158,7 +158,8 @@
   position: static;
   display: block;
   float: none;
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
   top: 0px;
   -ms-transform: none;
   transform: none;

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -36,7 +36,7 @@
 }
 
 .topNavOption {
-  margin-top: 10px;
+  margin-block-start: 10px;
 }
 
 .navOption, .navChannel {
@@ -184,13 +184,13 @@
   }
 
   .topNavOption {
-    margin-top: 0px;
+    margin-block-start: 0px;
     padding-inline-start: 10px;
     padding-inline-end: 10px;
   }
 
   .sideNav, .closed {
-    margin-top: 0px;
+    margin-block-start: 0px;
     height: 60px;
     width: 100%;
     bottom: 0px;

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -65,18 +65,18 @@
 }
 
 .navIcon {
-  margin-left: 10px;
+  margin-inline-start: 10px;
 }
 
 .navOption .navLabel {
-  margin-left: 40px;
+  margin-inline-start: 40px;
   overflow: hidden;
   word-break: break-word;
 }
 
 .navChannel .navLabel {
   overflow: hidden;
-  margin-left: 40px;
+  margin-inline-start: 40px;
   word-break: break-word;
   font-size: 12px;
 }
@@ -128,7 +128,7 @@
 }
 
 .closed .navIcon {
-  margin-left: 0px;
+  margin-inline-start: 0px;
   width: 100%;
   display: block;
   margin-bottom: 0px;
@@ -138,7 +138,7 @@
 }
 
 .closed .navLabel {
-  margin-left: 0px;
+  margin-inline-start: 0px;
   width: 100%;
   text-align: center;
   left: 0px;
@@ -205,7 +205,7 @@
   }
 
   .navLabel {
-    margin-left: 0px;
+    margin-inline-start: 0px;
     width: 100%;
     text-align: center;
     left: 0px;

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -179,7 +179,7 @@
   .sideNav {
     position: fixed;
     inset-inline-start: 0;
-    inset-block-end 0;
+    inset-block-end: 0;
 
     display: flex;
   }
@@ -194,7 +194,7 @@
     margin-block-start: 0px;
     height: 60px;
     width: 100%;
-    inset-block-end 0px;
+    inset-block-end: 0px;
     inset-block-start: auto;
     overflow-y: hidden;
   }

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -183,7 +183,7 @@
 
   .topNavOption {
     margin-top: 0px;
-    padding-left: 10px;
+    padding-inline-start: 10px;
     padding-right: 10px;
   }
 

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -72,6 +72,7 @@
   margin-inline-start: 40px;
   overflow: hidden;
   word-break: break-word;
+  text-align: start;
 }
 
 .navChannel .navLabel {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -72,7 +72,6 @@
   margin-inline-start: 40px;
   overflow: hidden;
   word-break: break-word;
-  text-align: start;
 }
 
 .navChannel .navLabel {

--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -5,7 +5,7 @@
   overflow-x: hidden;
   position: sticky;
   inset-inline-start: 0;
-  top: 60px;
+  inset-block-start: 60px;
   z-index: 3;
   box-shadow: 1px -1px 1px -1px var(--primary-shadow-color);
   background-color: var(--side-nav-color);
@@ -85,7 +85,7 @@
   width: 35px;
   margin: 0;
   position: absolute;
-  top: 50%;
+  inset-block-start: 50%;
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
 }
@@ -114,7 +114,7 @@
 
 .refreshIcon {
   position: absolute;
-  top: 20px;
+  inset-block-start: 20px;
   inset-inline-end: 20px;
 }
 
@@ -132,7 +132,7 @@
   margin-inline-start: 0px;
   width: 100%;
   display: block;
-  margin-bottom: 0px;
+  margin-block-end: 0px;
 }
 .closed .navIconExpand{
   height:1.3em;
@@ -160,7 +160,7 @@
   float: none;
   margin-block: 0;
   margin-inline: auto;
-  top: 0px;
+  inset-block-start: 0px;
   -ms-transform: none;
   transform: none;
   margin-block-start: 0.3em;
@@ -179,7 +179,7 @@
   .sideNav {
     position: fixed;
     inset-inline-start: 0;
-    bottom: 0;
+    inset-block-end 0;
 
     display: flex;
   }
@@ -194,8 +194,8 @@
     margin-block-start: 0px;
     height: 60px;
     width: 100%;
-    bottom: 0px;
-    top: auto;
+    inset-block-end 0px;
+    inset-block-start: auto;
     overflow-y: hidden;
   }
 

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
@@ -10,7 +10,7 @@
 
 .floatingTopButton {
   position: fixed;
-  top: 70px;
+  inset-block-start: 70px;
   inset-inline-end: 10px;
 }
 

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
@@ -11,7 +11,7 @@
 .floatingTopButton {
   position: fixed;
   top: 70px;
-  right: 10px;
+  inset-inline-end: 10px;
 }
 
 @media only screen and (max-width: 350px) {

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .message {

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -54,6 +54,15 @@ export default defineComponent({
       return this.$store.getters.getCurrentInvidiousInstance
     },
 
+    currentLocale: function () {
+      return this.$store.getters.getCurrentLocale
+    },
+
+    isDirectionLtr: function() {
+      const locale = this.currentLocale
+      return !(locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi')
+    },
+
     backendFallback: function () {
       return this.$store.getters.getBackendFallback
     },
@@ -280,8 +289,8 @@ export default defineComponent({
     navigateHistory: function () {
       if (!this.isForwardOrBack) {
         this.historyIndex = window.history.length
-        this.$refs.historyArrowBack.classList.remove('fa-arrow-left')
-        this.$refs.historyArrowForward.classList.add('fa-arrow-right')
+        this.$refs.historyArrowBack.classList.remove('arrowBackwardDisabled')
+        this.$refs.historyArrowForward.classList.add('arrowForwardDisabled')
       } else {
         this.isForwardOrBack = false
       }
@@ -293,9 +302,9 @@ export default defineComponent({
 
       if (this.historyIndex > 1) {
         this.historyIndex--
-        this.$refs.historyArrowForward.classList.remove('fa-arrow-right')
+        this.$refs.historyArrowForward.classList.remove('arrowForwardDisabled')
         if (this.historyIndex === 1) {
-          this.$refs.historyArrowBack.classList.add('fa-arrow-left')
+          this.$refs.historyArrowBack.classList.add('arrowBackwardDisabled')
         }
       }
     },
@@ -306,10 +315,10 @@ export default defineComponent({
 
       if (this.historyIndex < window.history.length) {
         this.historyIndex++
-        this.$refs.historyArrowBack.classList.remove('fa-arrow-left')
+        this.$refs.historyArrowBack.classList.remove('arrowBackwardDisabled')
 
         if (this.historyIndex === window.history.length) {
-          this.$refs.historyArrowForward.classList.add('fa-arrow-right')
+          this.$refs.historyArrowForward.classList.add('arrowForwardDisabled')
         }
       }
     },

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -25,6 +25,8 @@ export default defineComponent({
       searchFilterValueChanged: false,
       historyIndex: 1,
       isForwardOrBack: false,
+      isArrowBackwardDisabled: true,
+      isArrowForwardDisabled: true,
       searchSuggestionsDataList: [],
       lastSuggestionQuery: ''
     }
@@ -289,8 +291,8 @@ export default defineComponent({
     navigateHistory: function () {
       if (!this.isForwardOrBack) {
         this.historyIndex = window.history.length
-        this.$refs.historyArrowBack.classList.remove('arrowBackwardDisabled')
-        this.$refs.historyArrowForward.classList.add('arrowForwardDisabled')
+        this.isArrowBackwardDisabled = false
+        this.isArrowForwardDisabled = true
       } else {
         this.isForwardOrBack = false
       }
@@ -302,9 +304,9 @@ export default defineComponent({
 
       if (this.historyIndex > 1) {
         this.historyIndex--
-        this.$refs.historyArrowForward.classList.remove('arrowForwardDisabled')
+        this.isArrowForwardDisabled = false
         if (this.historyIndex === 1) {
-          this.$refs.historyArrowBack.classList.add('arrowBackwardDisabled')
+          this.isArrowBackwardDisabled = true
         }
       }
     },
@@ -315,10 +317,10 @@ export default defineComponent({
 
       if (this.historyIndex < window.history.length) {
         this.historyIndex++
-        this.$refs.historyArrowBack.classList.remove('arrowBackwardDisabled')
+        this.isArrowBackwardDisabled = false
 
         if (this.historyIndex === window.history.length) {
-          this.$refs.historyArrowForward.classList.add('arrowForwardDisabled')
+          this.isArrowForwardDisabled = true
         }
       }
     },

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -62,7 +62,7 @@ export default defineComponent({
 
     isDirectionLtr: function() {
       const locale = this.currentLocale
-      return !(locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi')
+      return !(locale === 'ar' || locale === 'fa' || locale === 'he' || locale === 'ur' || locale === 'yi' || locale === 'ku')
     },
 
     backendFallback: function () {

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -56,8 +56,8 @@
     color: var(--text-with-main-color);
   }
 
-  &.fa-arrow-left,
-  &.fa-arrow-right {
+  &.arrowBackwardDisabled,
+  &.arrowForwardDisabled {
     color: gray;
     opacity: 0.5;
     pointer-events: none;

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -102,7 +102,8 @@
   align-items: center;
   display: flex;
   gap: 3px;
-  margin: 0 6px;
+  margin-block: 0;
+  margin-inline: 6px;
 
   &.profiles {
     justify-content: flex-end;
@@ -198,14 +199,16 @@
 
   .searchFilters {
     left: 0;
-    margin: 10px 20px 20px 220px;
+    margin-block: 10px 20px;
+    margin-inline: 220px 20px;
     position: absolute;
     right: 0;
     transition: margin 150ms ease-in-out;
 
     @media only screen and (max-width: 680px) {
       left: 0;
-      margin: 95px 10px 0;
+      margin-block: 95px 0;
+      margin-inline: 10px;
       right: 0;
     }
   }

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -14,10 +14,10 @@
   box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
   display: flex;
   height: 60px;
-  left: 0;
+  inset-inline-start: 0;
   line-height: 60px;
   position: sticky;
-  right: 0;
+  inset-inline-end: 0;
   top: 0;
   width: 100%;
   z-index: 4;
@@ -182,9 +182,9 @@
 
     @media only screen and (max-width: 680px) {
       background-color: var(--side-nav-color);
-      left: 0;
+      inset-inline-start: 0;
       position: fixed;
-      right: 0;
+      inset-inline-end: 0;
       top: 60px;
 
       @include top-nav-is-colored {
@@ -198,18 +198,18 @@
   }
 
   .searchFilters {
-    left: 0;
+    inset-inline-start: 0;
     margin-block: 10px 20px;
     margin-inline: 220px 20px;
     position: absolute;
-    right: 0;
+    inset-inline-end: 0;
     transition: margin 150ms ease-in-out;
 
     @media only screen and (max-width: 680px) {
-      left: 0;
+      inset-inline-start: 0;
       margin-block: 95px 0;
       margin-inline: 10px;
-      right: 0;
+      inset-inline-end: 0;
     }
   }
 }

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -18,7 +18,7 @@
   line-height: 60px;
   position: sticky;
   inset-inline-end: 0;
-  top: 0;
+  inset-block-start: 0;
   width: 100%;
   z-index: 4;
 
@@ -158,7 +158,7 @@
       height: 40px;
       margin-inline-start: 5px;
       position: relative;
-      top: -3px;
+      inset-block-start: -3px;
       width: 100px;
 
       @media only screen and (max-width: 680px) {
@@ -185,7 +185,7 @@
       inset-inline-start: 0;
       position: fixed;
       inset-inline-end: 0;
-      top: 60px;
+      inset-block-start: 60px;
 
       @include top-nav-is-colored {
         background-color: var(--primary-color-hover);

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -124,7 +124,8 @@
     align-items: center;
     cursor: pointer;
     display: flex;
-    padding: 0 25px 0 10px;
+    padding-block: 0;
+    padding-inline: 10px 25px;
 
     &:active {
       background-color: var(--tertiary-text-color);

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -87,7 +87,7 @@
 .navFilterIcon {
   $effect-distance: 10px;
 
-  margin-left: $effect-distance;
+  margin-inline-start: $effect-distance;
 
   &.filterChanged {
     box-shadow: 0 0 $effect-distance var(--primary-color);
@@ -154,7 +154,7 @@
       background-repeat: no-repeat;
       background-size: 100px;
       height: 40px;
-      margin-left: 5px;
+      margin-inline-start: 5px;
       position: relative;
       top: -3px;
       width: 100px;

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -15,8 +15,8 @@
       />
       <font-awesome-icon
         ref="historyArrowBack"
-        class="navBackIcon navIcon fa-arrow-left"
-        :icon="['fas', 'arrow-left']"
+        class="navIcon arrowBackwardDisabled"
+        :icon="['fas', isDirectionLtr ? 'arrow-left' : 'arrow-right']"
         role="button"
         tabindex="0"
         :title="backwardText"
@@ -25,8 +25,8 @@
       />
       <font-awesome-icon
         ref="historyArrowForward"
-        class="navForwardIcon navIcon fa-arrow-right"
-        :icon="['fas', 'arrow-right']"
+        class="navIcon arrowForwardDisabled"
+        :icon="['fas', isDirectionLtr ? 'arrow-right' : 'arrow-left']"
         role="button"
         tabindex="0"
         :title="forwardText"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -14,8 +14,9 @@
         @keydown.enter.prevent="toggleSideNav"
       />
       <font-awesome-icon
-        ref="historyArrowBack"
-        class="navIcon arrowBackwardDisabled"
+        :aria-disabled="isArrowBackwardDisabled"
+        class="navIcon"
+        :class="{ arrowBackwardDisabled: isArrowBackwardDisabled}"
         :icon="['fas', isDirectionLtr ? 'arrow-left' : 'arrow-right']"
         role="button"
         tabindex="0"
@@ -24,8 +25,9 @@
         @keydown.enter.prevent="historyBack"
       />
       <font-awesome-icon
-        ref="historyArrowForward"
-        class="navIcon arrowForwardDisabled"
+        :aria-disabled="isArrowForwardDisabled"
+        class="navIcon"
+        :class="{ arrowForwardDisabled: isArrowForwardDisabled}"
         :icon="['fas', isDirectionLtr ? 'arrow-right' : 'arrow-left']"
         role="button"
         tabindex="0"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -56,6 +56,7 @@
       <div
         v-if="!hideHeaderLogo"
         class="logo"
+        dir="ltr"
         role="link"
         tabindex="0"
         :title="$t('Subscriptions.Subscriptions')"

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.css
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.css
@@ -76,7 +76,8 @@
 .chapterTimestamp {
   grid-area: timestamp;
   align-self: flex-start;
-  padding: 3px 4px;
+  padding-block: 3px;
+  padding-inline: 4px;
   border-radius: 5px;
   background-color: var(--accent-color);
   color: var(--text-with-accent-color);

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.css
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.css
@@ -3,7 +3,7 @@
 }
 
 .chaptersTitle {
-  margin-top: 10px;
+  margin-block-start: 10px;
   margin-bottom: 0;
   cursor: pointer;
 }
@@ -13,7 +13,7 @@
 }
 
 .chaptersWrapper {
-  margin-top: 15px;
+  margin-block-start: 15px;
   max-height: 250px;
   overflow-y: scroll;
   display: flex;

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.css
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.css
@@ -30,7 +30,7 @@
 }
 
 .chaptersChevron.open {
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 .chapter {

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.css
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.css
@@ -4,7 +4,7 @@
 
 .chaptersTitle {
   margin-block-start: 10px;
-  margin-bottom: 0;
+  margin-block-end: 0;
   cursor: pointer;
 }
 

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -27,7 +27,7 @@
 }
 
 .commentSort {
-  float: right;
+  float: var(--float-right-ltr-rtl-value);
 }
 
 .comment {
@@ -43,7 +43,7 @@
 }
 
 .commentThumbnail {
-  float: left;
+  float: var(--float-left-ltr-rtl-value);
   width: 60px;
   height: 60px;
   border-radius: 200px;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -115,7 +115,7 @@
 
 .commentHeartBadgeImg {
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   width: 15px;
   height: 15px;
   border-radius: 50%;
@@ -124,7 +124,7 @@
 
 .commentHeartBadgeWhite {
   position: absolute;
-  left: 9px;
+  inset-inline-start: 9px;
   bottom: 1px;
   width: 11px;
   height: 11px;
@@ -134,7 +134,7 @@
 .commentHeartBadgeRed {
   position: absolute;
   color: var(--red-500);
-  left: 10px;
+  inset-inline-start: 10px;
   bottom: 2px;
   width: 9px;
   height: 9px;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -54,7 +54,7 @@
   font-weight: bold;
   font-size: 14px;
   margin-inline-start: 68px;
-  margin-top: 0px;
+  margin-block-start: 0px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -73,7 +73,7 @@
 .commentText {
   white-space: pre-wrap;
   font-size: 14px;
-  margin-top: -10px;
+  margin-block-start: -10px;
   margin-inline-start: 70px;
   word-wrap: break-word;
 }
@@ -101,7 +101,7 @@
 .commentLikeCount {
   font-size: 11px;
   margin-inline-start: 70px;
-  margin-top: 0px;
+  margin-block-start: 0px;
 }
 
 .commentHeartBadge {

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -56,7 +56,7 @@
 .commentAuthorWrapper {
   font-weight: bold;
   font-size: 14px;
-  margin-left: 68px;
+  margin-inline-start: 68px;
   margin-top: 0px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -77,7 +77,7 @@
   white-space: pre-wrap;
   font-size: 14px;
   margin-top: -10px;
-  margin-left: 70px;
+  margin-inline-start: 70px;
   word-wrap: break-word;
 }
 .commentPinned {
@@ -85,25 +85,25 @@
   font-size: 12px;
   margin-block-end: 0;
   margin-block-start: 0;
-  margin-left: 68px;
+  margin-inline-start: 68px;
   margin-bottom: 5px;
 }
 
 .commentDate {
   font-weight: normal;
-  margin-left: 5px;
+  margin-inline-start: 5px;
   font-size: 12px;
 }
 
 .commentMemberIcon {
-  margin-left: 5px;
+  margin-inline-start: 5px;
   width: 14px;
   height: 14px;
 }
 
 .commentLikeCount {
   font-size: 11px;
-  margin-left: 70px;
+  margin-inline-start: 70px;
   margin-top: 0px;
 }
 
@@ -112,7 +112,7 @@
   position: relative;
   width: 25px;
   height: 20px;
-  margin-left: 10px;
+  margin-inline-start: 10px;
   margin-bottom: -7px;
 }
 
@@ -146,18 +146,18 @@
 
 .commentMoreReplies {
   font-size: 11px;
-  margin-left: 5px;
+  margin-inline-start: 5px;
   text-decoration: underline;
   cursor: pointer;
   color: var(--title-color);
 }
 
 .commentReplies {
-  margin-left: 30px;
+  margin-inline-start: 30px;
 }
 
 .showMoreReplies {
-  margin-left: 30px;
+  margin-inline-start: 30px;
   font-size: 15px;
   cursor: pointer;
   text-decoration: underline;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -83,7 +83,7 @@
   margin-block-end: 0;
   margin-block-start: 0;
   margin-inline-start: 68px;
-  margin-bottom: 5px;
+  margin-block-end: 5px;
 }
 
 .commentDate {
@@ -110,7 +110,7 @@
   width: 25px;
   height: 20px;
   margin-inline-start: 10px;
-  margin-bottom: -7px;
+  margin-block-end: -7px;
 }
 
 .commentHeartBadgeImg {
@@ -125,7 +125,7 @@
 .commentHeartBadgeWhite {
   position: absolute;
   inset-inline-start: 9px;
-  bottom: 1px;
+  inset-block-end 1px;
   width: 11px;
   height: 11px;
   z-index: 1;
@@ -135,7 +135,7 @@
   position: absolute;
   color: var(--red-500);
   inset-inline-start: 10px;
-  bottom: 2px;
+  inset-block-end 2px;
   width: 9px;
   height: 9px;
   z-index: 2;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -125,7 +125,7 @@
 .commentHeartBadgeWhite {
   position: absolute;
   inset-inline-start: 9px;
-  inset-block-end 1px;
+  inset-block-end: 1px;
   width: 11px;
   height: 11px;
   z-index: 1;
@@ -135,7 +135,7 @@
   position: absolute;
   color: var(--red-500);
   inset-inline-start: 10px;
-  inset-block-end 2px;
+  inset-block-end: 2px;
   width: 9px;
   height: 9px;
   z-index: 2;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -1,5 +1,6 @@
 .card {
-  padding: 0 16px;
+  padding-block: 0;
+  padding-inline: 16px;
 }
 
 .getCommentsTitle,
@@ -9,8 +10,7 @@
 }
 
 .getCommentsTitle {
-  padding-bottom: 8px;
-  padding-top: 8px;
+  padding-block: 8px;
   text-align: center;
   text-decoration: underline;
   cursor: pointer;
@@ -18,15 +18,12 @@
 }
 
 .noCommentMsg {
-  padding-top: 1em;
-  padding-bottom: 1em;
-
+  padding-block: 1em;
   text-align: center;
 }
 
 .commentsTitle {
-  padding-bottom: 1em;
-  padding-top: 1em;
+  padding-block: 1em;
 }
 
 .commentSort {
@@ -65,7 +62,7 @@
 .commentOwner {
   background-color: var(--scrollbar-color);
   border-radius: 10px;
-  padding: 0 10px;
+  padding-inline: 10px;
 }
 
 .commentAuthor {
@@ -164,7 +161,7 @@
 }
 
 .getMoreComments {
-  padding-bottom: 1em;
+  padding-block-end: 1em;
 
   text-align: center;
   text-decoration: underline;

--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -38,7 +38,7 @@
     margin-inline-start: 6px;
     position: relative;
     text-decoration: inherit;
-    top: -2px;
+    inset-block-start: -2px;
   }
 
   .subscribeButton {
@@ -91,7 +91,7 @@
   .likeBar {
     border-radius: 4px;
     height: 8px;
-    margin-bottom: 4px;
+    margin-block-end: 4px;
   }
 
   .likeCount {

--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -112,8 +112,8 @@
     justify-content: flex-start;
 
     :deep(.iconDropdown) {
-      left: calc(50% - 20px);
-      right: auto;
+      inset-inline-start: calc(50% - 20px);
+      inset-inline-end: auto;
     }
   }
 }

--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -36,7 +36,7 @@
     color: inherit;
     cursor: pointer;
     display: block;
-    margin-left: 6px;
+    margin-inline-start: 6px;
     position: relative;
     text-decoration: inherit;
     top: -2px;
@@ -44,7 +44,7 @@
 
   .subscribeButton {
     font-size: 14px;
-    margin-left: 6px;
+    margin-inline-start: 6px;
     margin-top: 6px;
     padding: 6px;
   }
@@ -78,13 +78,13 @@
   display: flex;
   flex-direction: column;
   font-size: 16px;
-  margin-left: auto;
+  margin-inline-start: auto;
   margin-top: 4px;
   max-width: 210px;
   text-align: right;
 
   @media screen and (max-width: 680px) {
-    margin-left: 0;
+    margin-inline-start: 0;
     text-align: left;
   }
 
@@ -105,7 +105,7 @@
   margin-top: 16px;
 
   .option:not(:first-child) {
-    margin-left: 4px;
+    margin-inline-start: 4px;
   }
 
   @media screen and (max-width: 680px) {

--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -53,10 +53,10 @@
 .datePublished {
   color: var(--secondary-text-color);
   font-size: 15px;
-  text-align: right;
+  text-align: end;
 
   @media screen and (max-width: 680px) {
-    text-align: left;
+    text-align: start;
   }
 }
 
@@ -81,11 +81,11 @@
   margin-inline-start: auto;
   margin-block-start: 4px;
   max-width: 210px;
-  text-align: right;
+  text-align: end;
 
   @media screen and (max-width: 680px) {
     margin-inline-start: 0;
-    text-align: left;
+    text-align: start;
   }
 
   .likeBar {

--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -13,10 +13,9 @@
   display: block;
   font-size: 22px;
   font-weight: normal;
-  margin: 0 0 24px;
+  margin-block: 0 24px;
+  margin-inline: 0;
   margin-block-end: 1em;
-  margin-inline-end: 0;
-  margin-inline-start: 0;
   word-break: break-word;
 }
 
@@ -45,7 +44,7 @@
   .subscribeButton {
     font-size: 14px;
     margin-inline-start: 6px;
-    margin-top: 6px;
+    margin-block-start: 6px;
     padding: 6px;
   }
 }
@@ -62,14 +61,15 @@
 }
 
 .viewCount {
-  margin: 18px 0 0;
+  margin-block: 18px 0;
+  margin-inline: 0;
 }
 
 .datePublished {
   margin: 4px 0 0;
 
   @media screen and (max-width: 680px) {
-    margin-top: 16px;
+    margin-block-start: 16px;
   }
 }
 
@@ -79,7 +79,7 @@
   flex-direction: column;
   font-size: 16px;
   margin-inline-start: auto;
-  margin-top: 4px;
+  margin-block-start: 4px;
   max-width: 210px;
   text-align: right;
 
@@ -102,7 +102,7 @@
 .videoOptions {
   display: flex;
   justify-content: flex-end;
-  margin-top: 16px;
+  margin-block-start: 16px;
 
   .option:not(:first-child) {
     margin-inline-start: 4px;

--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -28,7 +28,7 @@
   .channelThumbnail {
     border-radius: 50%;
     cursor: pointer;
-    margin-right: 10px;
+    margin-inline-end: 10px;
     width: 56px;
   }
 
@@ -95,7 +95,7 @@
   }
 
   .likeCount {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 }
 

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -31,7 +31,8 @@
 
 :deep(.liveChatEmoji) {
   vertical-align: middle;
-  margin: 0 2px;
+  margin-block: 0;
+  margin-inline: 2px;
 }
 
 .errorIcon {
@@ -69,12 +70,12 @@
 
 .superChatContent {
   margin-inline-start: 32px;
-  margin-top: -25px;
+  margin-block-start: -25px;
   color: var(--text-with-main-color);
 }
 
 .superChat .channelThumbnail {
-  margin-top: 3px;
+  margin-block-start: 3px;
   margin-inline-start: 3px;
   height: 25px;
 }
@@ -120,7 +121,7 @@
   grid-template-columns: auto;
   margin-inline-start: 5%;
   margin-inline-end: 5%;
-  margin-top: 25px;
+  margin-block-start: 25px;
   margin-bottom: 10px;
   background-color: var(--primary-color);
   border-radius: 5px;
@@ -129,7 +130,7 @@
 }
 
 .upperSuperChatMessage {
-  margin-top: -15px;
+  margin-block-start: -15px;
   width: 100%;
   height: 55px;
   background-color: var(--primary-color-hover);
@@ -140,7 +141,7 @@
 .upperSuperChatMessage .channelThumbnail {
   width: 45px;
   margin-inline-start: 10px;
-  margin-top: 5px;
+  margin-block-start: 5px;
 }
 
 .upperSuperChatMessage .channelName {
@@ -176,7 +177,7 @@
 }
 
 .chatContent {
-  margin-top: 5px;
+  margin-block-start: 5px;
   margin-bottom: 2px;
   font-size: 12px;
   word-wrap: break-word;

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -59,7 +59,7 @@
   padding: 1px;
   padding-right: 10px;
   margin-inline-start: 2px;
-  margin-right: 2px;
+  margin-inline-end: 2px;
   height: 30px;
   cursor: pointer;
   background-color: var(--primary-color);
@@ -120,7 +120,7 @@
   width: 90%;
   grid-template-columns: auto;
   margin-inline-start: 5%;
-  margin-right: 5%;
+  margin-inline-end: 5%;
   margin-top: 25px;
   margin-bottom: 10px;
   background-color: var(--primary-color);
@@ -198,7 +198,7 @@
 }
 
 .owner {
-  margin-right: 2px;
+  margin-inline-end: 2px;
   background-color: var(--primary-color);
   color: var(--text-with-main-color);
 }

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -58,7 +58,7 @@
   display: inline-block;
   padding: 1px;
   padding-right: 10px;
-  margin-left: 2px;
+  margin-inline-start: 2px;
   margin-right: 2px;
   height: 30px;
   cursor: pointer;
@@ -68,14 +68,14 @@
 }
 
 .superChatContent {
-  margin-left: 32px;
+  margin-inline-start: 32px;
   margin-top: -25px;
   color: var(--text-with-main-color);
 }
 
 .superChat .channelThumbnail {
   margin-top: 3px;
-  margin-left: 3px;
+  margin-inline-start: 3px;
   height: 25px;
 }
 
@@ -88,7 +88,7 @@
   width: 100%;
   height: 415px;
   position: absolute;
-  margin-left: -16px;
+  margin-inline-start: -16px;
   padding-right: 32px;
   bottom: -15px;
   cursor: auto;
@@ -119,7 +119,7 @@
 .superChatMessage {
   width: 90%;
   grid-template-columns: auto;
-  margin-left: 5%;
+  margin-inline-start: 5%;
   margin-right: 5%;
   margin-top: 25px;
   margin-bottom: 10px;
@@ -140,7 +140,7 @@
 
 .upperSuperChatMessage .channelThumbnail {
   width: 45px;
-  margin-left: 10px;
+  margin-inline-start: 10px;
   margin-top: 5px;
 }
 
@@ -149,20 +149,20 @@
   opacity: 0.7;
   position: absolute;
   top: -20px;
-  margin-left: 65px;
+  margin-inline-start: 65px;
 }
 
 .upperSuperChatMessage .donationAmount {
   color: var(--text-with-main-color);
   font-weight: bold;
-  margin-left: 65px;
+  margin-inline-start: 65px;
   position: absolute;
   top: 0px;
 }
 
 .superChatMessage .chatMessage {
   color: var(--text-with-main-color);
-  margin-left: 20px;
+  margin-inline-start: 20px;
 }
 
 .liveChatComments {

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -91,7 +91,7 @@
   position: absolute;
   margin-inline-start: -16px;
   padding-inline-end: 32px;
-  bottom: -15px;
+  inset-block-end -15px;
   cursor: auto;
   z-index: 1;
 }
@@ -122,7 +122,7 @@
   margin-inline-start: 5%;
   margin-inline-end: 5%;
   margin-block-start: 25px;
-  margin-bottom: 10px;
+  margin-block-end: 10px;
   background-color: var(--primary-color);
   border-radius: 5px;
   -webkit-border-radius: 5px;
@@ -148,7 +148,7 @@
   color: var(--text-with-main-color);
   opacity: 0.7;
   position: absolute;
-  top: -20px;
+  inset-block-start: -20px;
   margin-inline-start: 65px;
 }
 
@@ -157,7 +157,7 @@
   font-weight: bold;
   margin-inline-start: 65px;
   position: absolute;
-  top: 0px;
+  inset-block-start: 0px;
 }
 
 .superChatMessage .chatMessage {
@@ -178,7 +178,7 @@
 
 .chatContent {
   margin-block-start: 5px;
-  margin-bottom: 2px;
+  margin-block-end: 2px;
   font-size: 12px;
   word-wrap: break-word;
 }
@@ -213,7 +213,7 @@
   height: 35px;
   position: absolute;
   inset-inline-start: 45%;
-  bottom: 20px;
+  inset-block-end 20px;
   cursor: pointer;
   border-radius: 200px;
   -webkit-border-radius: 200px;
@@ -231,5 +231,5 @@
   color: var(--text-with-accent-color);
   font-size: 22px;
   position: relative;
-  top: 0.45rem;
+  inset-block-start: 0.45rem;
 }

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -91,7 +91,7 @@
   position: absolute;
   margin-inline-start: -16px;
   padding-inline-end: 32px;
-  inset-block-end -15px;
+  inset-block-end: -15px;
   cursor: auto;
   z-index: 1;
 }
@@ -213,7 +213,7 @@
   height: 35px;
   position: absolute;
   inset-inline-start: 45%;
-  inset-block-end 20px;
+  inset-block-end: 20px;
   cursor: pointer;
   border-radius: 200px;
   -webkit-border-radius: 200px;

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -57,7 +57,7 @@
 .superChat {
   display: inline-block;
   padding: 1px;
-  padding-right: 10px;
+  padding-inline-end: 10px;
   margin-inline-start: 2px;
   margin-inline-end: 2px;
   height: 30px;
@@ -89,7 +89,7 @@
   height: 415px;
   position: absolute;
   margin-inline-start: -16px;
-  padding-right: 32px;
+  padding-inline-end: 32px;
   bottom: -15px;
   cursor: auto;
   z-index: 1;
@@ -186,7 +186,7 @@
 .channelName {
   color: var(--tertiary-text-color);
   font-weight: bold;
-  padding-right: 5px;
+  padding-inline-end: 5px;
 }
 
 .member {

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -109,8 +109,7 @@
 
 .comment {
   width: 100%;
-  padding-top: 5px;
-  padding-bottom: 7px;
+  padding-block: 5px 7px;
   display: grid;
   grid-template-columns: min-content auto;
   gap: 5px;

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -212,7 +212,7 @@
   width: 35px;
   height: 35px;
   position: absolute;
-  left: 45%;
+  inset-inline-start: 45%;
   bottom: 20px;
   cursor: pointer;
   border-radius: 200px;

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -16,7 +16,7 @@
 }
 
 .playlistProgressBar {
-  margin-left: 10px;
+  margin-inline-start: 10px;
   /* > In order to let ::-webkit-progress-value take effect, appearance needs to be set to none on the <progress> element. */
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-progress-value */
   appearance: none;
@@ -89,7 +89,7 @@
 }
 
 .videoInfo {
-  margin-left: 30px;
+  margin-inline-start: 30px;
   position: relative;
   bottom: 7px;
 }

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -6,12 +6,12 @@
 .channelName {
   font-size: 15px;
   position: relative;
-  inset-block-end 15px;
+  inset-block-end: 15px;
 }
 
 .playlistIndex {
   position: relative;
-  inset-block-end 15px;
+  inset-block-end: 15px;
   color: var(--tertiary-text-color);
 }
 
@@ -91,5 +91,5 @@
 .videoInfo {
   margin-inline-start: 30px;
   position: relative;
-  inset-block-end 7px;
+  inset-block-end: 7px;
 }

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -6,12 +6,12 @@
 .channelName {
   font-size: 15px;
   position: relative;
-  bottom: 15px;
+  inset-block-end 15px;
 }
 
 .playlistIndex {
   position: relative;
-  bottom: 15px;
+  inset-block-end 15px;
   color: var(--tertiary-text-color);
 }
 
@@ -67,7 +67,7 @@
 }
 
 .playlistItem:not(:last-child) {
-  margin-bottom: 8px;
+  margin-block-end: 8px;
 }
 
 .playlistItem:hover {
@@ -91,5 +91,5 @@
 .videoInfo {
   margin-inline-start: 30px;
   position: relative;
-  bottom: 7px;
+  inset-block-end 7px;
 }

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -38,7 +38,7 @@
 .playlistIcon {
   font-size: 20px;
   padding: 10px;
-  margin-top: -25px;
+  margin-block-start: -25px;
   cursor: pointer;
   border-radius: 50%;
   color: var(--tertiary-text-color);

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -122,7 +122,8 @@ $watched-transition-duration: 0.5s;
       font-size: 15px;
       justify-self: right;
       line-height: 1.2;
-      margin: 0 4px 4px 0;
+      margin-block: 0 4px;
+      margin-inline: 0 4px;
       opacity: $thumbnail-overlay-opacity;
       padding-block: 3px;
       padding-inline: 4px;
@@ -150,7 +151,7 @@ $watched-transition-duration: 0.5s;
       font-size: 17px;
       justify-self: right;
       margin-inline-end: 3px;
-      margin-top: 3px;
+      margin-block-start: 3px;
       height: fit-content;
     }
 
@@ -229,7 +230,7 @@ $watched-transition-duration: 0.5s;
     .infoLine {
       font-size: 14px;
       grid-area: infoLine;
-      margin-top: 5px;
+      margin-block-start: 5px;
       overflow-wrap: anywhere;
 
       @include is-sidebar-item {
@@ -296,7 +297,7 @@ $watched-transition-duration: 0.5s;
 
     .infoLine {
       font-size: 13px;
-      margin-top: 8px;
+      margin-block-start: 8px;
     }
   }
 

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -143,7 +143,7 @@ $watched-transition-duration: 0.5s;
       align-self: flex-end;
       font-size: 17px;
       justify-self: left;
-      margin-bottom: 4px;
+      margin-block-end: 4px;
       margin-inline-start: 4px;
     }
 
@@ -284,7 +284,7 @@ $watched-transition-duration: 0.5s;
 
     .videoThumbnail,
     .channelThumbnail {
-      margin-bottom: 12px;
+      margin-block-end: 12px;
 
       .thumbnailImage {
         width: 100%;

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -142,7 +142,7 @@ $watched-transition-duration: 0.5s;
       font-size: 17px;
       justify-self: left;
       margin-bottom: 4px;
-      margin-left: 4px;
+      margin-inline-start: 4px;
     }
 
     .favoritesIcon {

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -148,7 +148,7 @@ $watched-transition-duration: 0.5s;
     .favoritesIcon {
       font-size: 17px;
       justify-self: right;
-      margin-right: 3px;
+      margin-inline-end: 3px;
       margin-top: 3px;
       height: fit-content;
     }
@@ -260,13 +260,13 @@ $watched-transition-duration: 0.5s;
 
     @include is-sidebar-item {
       .videoThumbnail {
-        margin-right: 10px;
+        margin-inline-end: 10px;
       }
     }
 
     .videoThumbnail,
     .channelThumbnail {
-      margin-right: 20px;
+      margin-inline-end: 20px;
     }
 
     .channelThumbnail {

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -124,7 +124,8 @@ $watched-transition-duration: 0.5s;
       line-height: 1.2;
       margin: 0 4px 4px 0;
       opacity: $thumbnail-overlay-opacity;
-      padding: 3px 4px;
+      padding-block: 3px;
+      padding-inline: 4px;
       pointer-events: none;
 
       @include is-watch-playlist-item {
@@ -278,7 +279,7 @@ $watched-transition-duration: 0.5s;
     display: flex;
     flex-direction: column;
     min-height: 230px;
-    padding-bottom: 20px;
+    padding-block-end: 20px;
 
     .videoThumbnail,
     .channelThumbnail {

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -232,6 +232,7 @@ $watched-transition-duration: 0.5s;
       grid-area: infoLine;
       margin-block-start: 5px;
       overflow-wrap: anywhere;
+      text-align: start;
 
       @include is-sidebar-item {
         font-size: 12px;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -921,7 +921,7 @@ body {
 }
 
 .rightAligned {
-  text-align: right;
+  text-align: end;
 }
 
 a:link {

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -925,7 +925,7 @@ body {
   --red-500: #f44336;
 }
 
-body p, body a, body h2, body h3 {
+body p, body a, body h2, body h3, body li {
   text-align: start;
 }
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -903,6 +903,18 @@
   --accent-color-opacity4: rgba(180,190,254,0.24);
 }
 
+body[dir='ltr'] {
+  --ltr-or-rtl: ltr;
+  --float-left-ltr-rtl-value: left;
+  --float-right-ltr-rtl-value: right;
+}
+
+body[dir='rtl'] {
+  --ltr-or-rtl: rtl;
+  --float-left-ltr-rtl-value: right;
+  --float-right-ltr-rtl-value: left;
+}
+
 body {
   margin: 0;
   min-height: 100vh;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -905,12 +905,14 @@
 
 body[dir='ltr'] {
   --ltr-or-rtl: ltr;
+  --horizontal-directionality-coefficient: 1;
   --float-left-ltr-rtl-value: left;
   --float-right-ltr-rtl-value: right;
 }
 
 body[dir='rtl'] {
   --ltr-or-rtl: rtl;
+  --horizontal-directionality-coefficient: -1;
   --float-left-ltr-rtl-value: right;
   --float-right-ltr-rtl-value: left;
 }

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -925,7 +925,7 @@ body {
   --red-500: #f44336;
 }
 
-body p, body a {
+body p, body a, body h2, body h3 {
   text-align: start;
 }
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -925,6 +925,10 @@ body {
   --red-500: #f44336;
 }
 
+body p, body a {
+  text-align: start;
+}
+
 #app {
   color: var(--primary-text-color);
   background-color: var(--bg-color);

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -376,8 +376,8 @@
   font-size: inherit;
   line-height: inherit;
   list-style-position: outside;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
+  margin-left: 0;
+  margin-right: 0;
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -596,7 +596,7 @@ body.vjs-full-window {
   top: 50%;
   left: 50%;
   margin-top: -0.81666em;
-  margin-inline-start: -1.5em;
+  margin-left: -1.5em;
 }
 
 .video-js:hover .vjs-big-play-button,
@@ -1113,7 +1113,7 @@ body.vjs-full-window {
 }
 .video-js .vjs-volume-control {
   cursor: pointer;
-  margin-inline-end: 1em;
+  margin-right: 1em;
   display: flex;
 }
 
@@ -1127,7 +1127,7 @@ body.vjs-full-window {
   opacity: 0;
   width: 1px;
   height: 1px;
-  margin-inline-start: -1px;
+  margin-left: -1px;
 }
 
 .video-js .vjs-volume-tooltip {
@@ -1146,7 +1146,7 @@ body.vjs-full-window {
 .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-horizontal, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-horizontal {
   width: 5em;
   height: 3em;
-  margin-inline-end: 0;
+  margin-right: 0;
 }
 .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-vertical, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-vertical {
   left: -3.5em;
@@ -1313,8 +1313,8 @@ body.vjs-full-window {
   flex: none;
   display: inline-flex;
   height: 100%;
-  padding-inline-start: 0.5em;
-  padding-inline-end: 0.5em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
   font-size: 1em;
   line-height: 3em;
   width: auto;
@@ -1337,7 +1337,7 @@ body.vjs-full-window {
 }
 
 .vjs-seek-to-live-control .vjs-icon-placeholder {
-  margin-inline-end: 0.5em;
+  margin-right: 0.5em;
   color: #888;
 }
 
@@ -1351,8 +1351,8 @@ body.vjs-full-window {
   line-height: 3.7em;
   min-width: 2em;
   width: auto;
-  padding-inline-start: 0em;
-  padding-inline-end: 0em;
+  padding-left: 0em;
+  padding-right: 0em;
 }
 
 .vjs-live .vjs-time-control {
@@ -1729,7 +1729,7 @@ video::-webkit-media-text-track-display {
   }
 }
 .vjs-track-setting > select {
-  margin-inline-end: 1em;
+  margin-right: 1em;
   margin-bottom: 0.5em;
 }
 
@@ -1785,7 +1785,7 @@ video::-webkit-media-text-track-display {
 }
 
 .vjs-track-settings-controls .vjs-default-button {
-  margin-inline-end: 1em;
+  margin-right: 1em;
 }
 
 @media print {
@@ -1925,7 +1925,7 @@ video::-webkit-media-text-track-display {
 }
 
 .video-js .vjs-time-control.vjs-current-time {
-    margin-inline-start: 1em
+    margin-left: 1em
 }
 
 .video-js .vjs-time-control .vjs-current-time-display,.video-js .vjs-time-control .vjs-duration-display {
@@ -2017,13 +2017,13 @@ video::-webkit-media-text-track-display {
 }
 
 .video-js.vjs-live .vjs-live-control {
-    margin-inline-start: 1em
+    margin-left: 1em
 }
 
 .video-js .vjs-big-play-button {
     top: 50%;
     left: 50%;
-    margin-inline-start: -1em;
+    margin-left: -1em;
     margin-top: -1em;
     width: 2em;
     height: 2em;

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1313,7 +1313,7 @@ body.vjs-full-window {
   flex: none;
   display: inline-flex;
   height: 100%;
-  padding-left: 0.5em;
+  padding-inline-start: 0.5em;
   padding-right: 0.5em;
   font-size: 1em;
   line-height: 3em;
@@ -1351,7 +1351,7 @@ body.vjs-full-window {
   line-height: 3.7em;
   min-width: 2em;
   width: auto;
-  padding-left: 0em;
+  padding-inline-start: 0em;
   padding-right: 0em;
 }
 

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -376,7 +376,7 @@
   font-size: inherit;
   line-height: inherit;
   list-style-position: outside;
-  margin-left: 0;
+  margin-inline-start: 0;
   margin-right: 0;
   margin-top: 0;
   margin-bottom: 0;
@@ -596,7 +596,7 @@ body.vjs-full-window {
   top: 50%;
   left: 50%;
   margin-top: -0.81666em;
-  margin-left: -1.5em;
+  margin-inline-start: -1.5em;
 }
 
 .video-js:hover .vjs-big-play-button,
@@ -1127,7 +1127,7 @@ body.vjs-full-window {
   opacity: 0;
   width: 1px;
   height: 1px;
-  margin-left: -1px;
+  margin-inline-start: -1px;
 }
 
 .video-js .vjs-volume-tooltip {
@@ -1925,7 +1925,7 @@ video::-webkit-media-text-track-display {
 }
 
 .video-js .vjs-time-control.vjs-current-time {
-    margin-left: 1em
+    margin-inline-start: 1em
 }
 
 .video-js .vjs-time-control .vjs-current-time-display,.video-js .vjs-time-control .vjs-duration-display {
@@ -2017,13 +2017,13 @@ video::-webkit-media-text-track-display {
 }
 
 .video-js.vjs-live .vjs-live-control {
-    margin-left: 1em
+    margin-inline-start: 1em
 }
 
 .video-js .vjs-big-play-button {
     top: 50%;
     left: 50%;
-    margin-left: -1em;
+    margin-inline-start: -1em;
     margin-top: -1em;
     width: 2em;
     height: 2em;

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -1314,7 +1314,7 @@ body.vjs-full-window {
   display: inline-flex;
   height: 100%;
   padding-inline-start: 0.5em;
-  padding-right: 0.5em;
+  padding-inline-end: 0.5em;
   font-size: 1em;
   line-height: 3em;
   width: auto;
@@ -1352,7 +1352,7 @@ body.vjs-full-window {
   min-width: 2em;
   width: auto;
   padding-inline-start: 0em;
-  padding-right: 0em;
+  padding-inline-end: 0em;
 }
 
 .vjs-live .vjs-time-control {

--- a/src/renderer/videoJS.css
+++ b/src/renderer/videoJS.css
@@ -377,7 +377,7 @@
   line-height: inherit;
   list-style-position: outside;
   margin-inline-start: 0;
-  margin-right: 0;
+  margin-inline-end: 0;
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -1113,7 +1113,7 @@ body.vjs-full-window {
 }
 .video-js .vjs-volume-control {
   cursor: pointer;
-  margin-right: 1em;
+  margin-inline-end: 1em;
   display: flex;
 }
 
@@ -1146,7 +1146,7 @@ body.vjs-full-window {
 .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-horizontal, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-horizontal {
   width: 5em;
   height: 3em;
-  margin-right: 0;
+  margin-inline-end: 0;
 }
 .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-vertical, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-vertical {
   left: -3.5em;
@@ -1337,7 +1337,7 @@ body.vjs-full-window {
 }
 
 .vjs-seek-to-live-control .vjs-icon-placeholder {
-  margin-right: 0.5em;
+  margin-inline-end: 0.5em;
   color: #888;
 }
 
@@ -1729,7 +1729,7 @@ video::-webkit-media-text-track-display {
   }
 }
 .vjs-track-setting > select {
-  margin-right: 1em;
+  margin-inline-end: 1em;
   margin-bottom: 0.5em;
 }
 
@@ -1785,7 +1785,7 @@ video::-webkit-media-text-track-display {
 }
 
 .vjs-track-settings-controls .vjs-default-button {
-  margin-right: 1em;
+  margin-inline-end: 1em;
 }
 
 @media print {

--- a/src/renderer/views/About/About.scss
+++ b/src/renderer/views/About/About.scss
@@ -1,6 +1,6 @@
 .card {
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
   width: 85%;
 
   @media only screen and (max-width: 680px) {
@@ -25,7 +25,8 @@
   display: grid;
   grid-gap: 16px;
   grid-template-columns: 1fr 1fr;
-  margin: 80px auto;
+  margin-block: 80;
+  margin-inline: auto;
   max-width: 860px;
 
   @media only screen and (max-width: 650px) {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -61,7 +61,7 @@
 
 .channelSubCount {
   color: var(--tertiary-text-color);
-  top: 50px;
+  inset-block-start: 50px;
   inset-inline-start: 120px;
 }
 
@@ -109,18 +109,18 @@
   align-self: flex-end;
   text-align: center;
   color: var(--tertiary-text-color);
-  border-bottom: 3px solid transparent;
+  border-block-end: 3px solid transparent;
 }
 
 .tab:hover,
 .tab:focus {
   font-weight: bold;
-  border-bottom: 3px solid var(--tertiary-text-color);
+  border-block-end: 3px solid var(--tertiary-text-color);
 }
 
 .selectedTab {
   color: var(--primary-text-color);
-  border-bottom: 3px solid var(--primary-color);
+  border-block-end: 3px solid var(--primary-color);
   font-weight: bold;
   box-sizing: border-box;
 }

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -62,7 +62,7 @@
 .channelSubCount {
   color: var(--tertiary-text-color);
   top: 50px;
-  left: 120px;
+  inset-inline-start: 120px;
 }
 
 .channelInfoActionsContainer {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -75,13 +75,13 @@
 
 .channelSearch {
   width: 220px;
-  margin-left: auto;
+  margin-inline-start: auto;
   align-self: flex-end;
   flex: 1 1 0%;
 }
 
 .sortSelect {
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .channelInfoTabs {
@@ -171,7 +171,7 @@
 
 .ft-community-image {
   display: block;
-  margin-left: auto;
+  margin-inline-start: auto;
   margin-right: auto;
 }
 

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -177,7 +177,7 @@
 
 .community-post-container {
   padding-inline-start: 30%;
-  padding-right: 30%;
+  padding-inline-end: 30%;
 }
 
 @media only screen and (max-width: 800px) {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -153,7 +153,7 @@
   display: flex;
   justify-content: center;
   flex-direction: column;
-  padding-left: 1em;
+  padding-inline-start: 1em;
 }
 
 .channelLineContainer h1,
@@ -176,7 +176,7 @@
 }
 
 .community-post-container {
-  padding-left: 30%;
+  padding-inline-start: 30%;
   padding-right: 30%;
 }
 

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -1,7 +1,8 @@
 .card {
   position: relative;
   width: 85%;
-  margin: 0 auto 20px;
+  margin-block: 0 20px;
+  margin-inline: auto;
   box-sizing: border-box;
 }
 
@@ -28,7 +29,7 @@
 .channelInfoContainer {
   position: relative;
   background-color: var(--card-bg-color);
-  margin-top: 10px;
+  margin-block-start: 10px;
   padding-block: 0;
   padding-inline: 16px;
 }
@@ -125,12 +126,12 @@
 }
 
 .channelSearch {
-  margin-top: 10px;
+  margin-block-start: 10px;
   max-width: 250px;
 }
 
 .elementListLoading {
-  margin-top: 200px;
+  margin-block-start: 200px;
 }
 
 .message {
@@ -144,7 +145,7 @@
   line-height: 45px;
   text-align: center;
   cursor: pointer;
-  margin-top: 16px;
+  margin-block-start: 16px;
 }
 
 .thumbnailContainer {
@@ -197,6 +198,6 @@
     overflow-x: scroll;
   }
   #communityPanel {
-    margin-top: 1rem;
+    margin-block-start: 1rem;
   }
 }

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -29,7 +29,8 @@
   position: relative;
   background-color: var(--card-bg-color);
   margin-top: 10px;
-  padding: 0 16px;
+  padding-block: 0;
+  padding-inline: 16px;
 }
 
 .channelInfo {
@@ -40,7 +41,7 @@
 }
 
 .channelInfoHasError {
-  padding-bottom: 10px;
+  padding-block-end: 10px;
 }
 
 .channelThumbnail {
@@ -90,7 +91,8 @@
   height: auto;
   justify-content: unset;
   gap: 32px;
-  padding: .3em 0;
+  padding-block: .3em;
+  padding-inline: 0;
 }
 
 .tabs {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -172,7 +172,7 @@
 .ft-community-image {
   display: block;
   margin-inline-start: auto;
-  margin-right: auto;
+  margin-inline-end: auto;
 }
 
 .community-post-container {

--- a/src/renderer/views/Hashtag/Hashtag.css
+++ b/src/renderer/views/Hashtag/Hashtag.css
@@ -5,7 +5,7 @@
   line-height: 45px;
   text-align: center;
   cursor: pointer;
-  margin-top: 16px;
+  margin-block-start: 16px;
 }
 
 .getNextPage:hover, .getNextPage:focus {
@@ -13,7 +13,8 @@
 }
 
 .card {
-  margin: 0 auto 20px;
+  margin-block: 0 20px;
+  margin-inline: auto;
   width: 85%;
 }
 

--- a/src/renderer/views/History/History.css
+++ b/src/renderer/views/History/History.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .message {

--- a/src/renderer/views/Playlist/Playlist.css
+++ b/src/renderer/views/Playlist/Playlist.css
@@ -10,7 +10,7 @@
   overflow-y: auto;
   padding: 10px;
   position: sticky;
-  top: 96px;
+  inset-block-start: 96px;
   width: 30%;
 }
 
@@ -41,7 +41,7 @@
 
 :deep(.videoThumbnail) {
   margin-block-start: auto;
-  margin-bottom: auto;
+  margin-block-end: auto;
 }
 
 :deep(.thumbnailImage) {
@@ -56,7 +56,7 @@
   .playlistInfo {
     box-sizing: border-box;
     position: relative;
-    top: 0;
+    inset-block-start: 0;
     height: auto;
     width: 100%;
   }

--- a/src/renderer/views/Playlist/Playlist.css
+++ b/src/renderer/views/Playlist/Playlist.css
@@ -40,7 +40,7 @@
 }
 
 :deep(.videoThumbnail) {
-  margin-top: auto;
+  margin-block-start: auto;
   margin-bottom: auto;
 }
 

--- a/src/renderer/views/Playlist/Playlist.css
+++ b/src/renderer/views/Playlist/Playlist.css
@@ -6,7 +6,7 @@
   background-color: var(--card-bg-color);
   box-sizing: border-box;
   height: calc(100vh - 132px);
-  margin-right: 1em;
+  margin-inline-end: 1em;
   overflow-y: auto;
   padding: 10px;
   position: sticky;

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .floatingTopButton {

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -7,7 +7,7 @@
 .floatingTopButton {
   position: fixed;
   top: 70px;
-  right: 10px;
+  inset-inline-end: 10px;
 }
 
 @media only screen and (max-width: 350px) {

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -6,7 +6,7 @@
 
 .floatingTopButton {
   position: fixed;
-  top: 70px;
+  inset-block-start: 70px;
   inset-inline-end: 10px;
 }
 

--- a/src/renderer/views/ProfileSettings/ProfileSettings.css
+++ b/src/renderer/views/ProfileSettings/ProfileSettings.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .message {
@@ -10,8 +10,8 @@
 
 .profileList {
   max-width: 1000px;
-  margin: 0 auto;
-  margin-bottom: 10px;
+  margin-block: 0 10px;
+  margin-inline: auto;
 }
 
 @media only screen and (max-width: 680px) {

--- a/src/renderer/views/Search/Search.css
+++ b/src/renderer/views/Search/Search.css
@@ -14,8 +14,8 @@
 
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 @media only screen and (max-width: 680px) {

--- a/src/renderer/views/Search/Search.css
+++ b/src/renderer/views/Search/Search.css
@@ -5,7 +5,7 @@
   line-height: 45px;
   text-align: center;
   cursor: pointer;
-  margin-top: 16px;
+  margin-block-start: 16px;
 }
 
 .getNextPage:hover, .getNextPage:focus {

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -1,7 +1,8 @@
 hr {
   height: 2px;
   width: 85%;
-  margin: 0 auto;
+  margin-block: 0;
+  margin-inline: auto;
   border: 0;
   background-color: var(--scrollbar-color-hover);
 }

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.css
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.css
@@ -9,7 +9,7 @@
 }
 
 .count {
-  margin-top: 1rem;
+  margin-block-start: 1rem;
 }
 
 .channels {
@@ -17,7 +17,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr) );
   gap: 2.5rem;
-  margin-top: 2rem;
+  margin-block-start: 2rem;
 }
 
 .channel {

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.css
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .message {

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.css
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.css
@@ -52,7 +52,8 @@
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  padding: 0 4px;
+  padding-block: 0;
+  padding-inline: 4px;
 }
 
 .unsubscribeContainer {

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .message {

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -12,15 +12,15 @@
   width: 100%;
   margin-block-start: -3px;
   color: var(--tertiary-text-color);
-  margin-bottom: 10px;
+  margin-block-end: 10px;
 }
 
 .selectedTab {
-  border-bottom: 3px solid var(--primary-color);
+  border-block-end: 3px solid var(--primary-color);
   color: var(--primary-text-color);
   font-weight: bold;
   box-sizing: border-box;
-  margin-bottom: -3px;
+  margin-block-end: -3px;
 }
 
 .tab {

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -10,7 +10,7 @@
 
 .subscriptionTabs {
   width: 100%;
-  margin-top: -3px;
+  margin-block-start: -3px;
   color: var(--tertiary-text-color);
   margin-bottom: 10px;
 }

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -14,7 +14,7 @@
   width: 100%;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr 1fr;
-  margin-top: -3px;
+  margin-block-start: -3px;
   color: var(--tertiary-text-color);
   margin-bottom: 10px;
 }

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -7,7 +7,7 @@
 .floatingTopButton {
   position: fixed;
   top: 70px;
-  right: 10px;
+  inset-inline-end: 10px;
 }
 
 .trendingInfoTabs {

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .floatingTopButton {

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -6,7 +6,7 @@
 
 .floatingTopButton {
   position: fixed;
-  top: 70px;
+  inset-block-start: 70px;
   inset-inline-end: 10px;
 }
 
@@ -16,15 +16,15 @@
   grid-template-columns: 1fr 1fr 1fr 1fr;
   margin-block-start: -3px;
   color: var(--tertiary-text-color);
-  margin-bottom: 10px;
+  margin-block-end: 10px;
 }
 
 .selectedTab {
-  border-bottom: 3px solid var(--primary-color);
+  border-block-end: 3px solid var(--primary-color);
   color: var(--primary-text-color);
   font-weight: bold;
   box-sizing: border-box;
-  margin-bottom: -3px;
+  margin-block-end: -3px;
 }
 
 .tab {

--- a/src/renderer/views/UserPlaylists/UserPlaylists.css
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.css
@@ -1,7 +1,7 @@
 .card {
   width: 85%;
-  margin: 0 auto;
-  margin-bottom: 60px;
+  margin-block: 0 60px;
+  margin-inline: auto;
 }
 
 .message {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -64,7 +64,7 @@
         position: absolute;
 
         .premiereIcon {
-          float: left;
+          float: var(--float-left-ltr-rtl-value);
           font-size: 25px;
           margin-block: 0;
           margin-inline: 12px;

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -54,7 +54,7 @@
         align-items: center;
         background-color: rgb(0 0 0 / 80%);
         border-radius: 5px;
-        inset-block-end 12px;
+        inset-block-end: 12px;
         color: #fff;
         display: flex;
         height: 60px;

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -54,7 +54,7 @@
         align-items: center;
         background-color: rgb(0 0 0 / 80%);
         border-radius: 5px;
-        bottom: 12px;
+        inset-block-end 12px;
         color: #fff;
         display: flex;
         height: 60px;
@@ -122,7 +122,7 @@
   .watchVideoPlaylist {
     :deep(.videoThumbnail) {
       margin-block-start: auto;
-      margin-bottom: auto;
+      margin-block-end: auto;
     }
     @media (max-width: 768px) {
       height: auto;
@@ -161,7 +161,7 @@
 
     .infoAreaSticky {
       position: sticky;
-      top: 76px;
+      inset-block-start: 76px;
     }
   }
 }

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -58,7 +58,7 @@
         color: #fff;
         display: flex;
         height: 60px;
-        left: 12px;
+        inset-inline-start: 12px;
         padding-block: 0;
         padding-inline: 12px;
         position: absolute;

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -58,7 +58,8 @@
         display: flex;
         height: 60px;
         left: 12px;
-        padding: 0 12px;
+        padding-block: 0;
+        padding-inline: 12px;
         position: absolute;
 
         .premiereIcon {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -36,7 +36,8 @@
     grid-area: video;
 
     .videoAreaMargin {
-      margin: 0 0 16px;
+      margin-block: 0 16px;
+      margin-inline: 0;
     }
 
     .videoPlayer {
@@ -65,11 +66,13 @@
         .premiereIcon {
           float: left;
           font-size: 25px;
-          margin: 0 12px;
+          margin-block: 0;
+          margin-inline: 12px;
         }
 
         .premiereText {
-          margin: 0 12px;
+          margin-block: 0;
+          margin-inline: 12px;
           min-width: 200px;
 
           .premiereTextTimestamp {
@@ -83,7 +86,8 @@
 
   .watchVideo {
     grid-column: 1;
-    margin: 0 0 16px;
+    margin-block: 0 16px;
+    margin-inline: 0;
   }
 
   .infoArea {
@@ -106,7 +110,8 @@
   .watchVideoPlaylist,
   .watchVideoSidebar,
   .theatrePlaylist {
-    margin: 0 8px 16px;
+    margin-block: 0 16px;
+    margin-inline: 8px;
   }
 
   .watchVideoSidebar,
@@ -116,7 +121,7 @@
 
   .watchVideoPlaylist {
     :deep(.videoThumbnail) {
-      margin-top: auto;
+      margin-block-start: auto;
       margin-bottom: auto;
     }
     @media (max-width: 768px) {
@@ -126,10 +131,12 @@
 
   .watchVideoRecommendations,
   .theatreRecommendations {
-    margin: 0 0 16px;
+    margin-block: 0 16px;
+    margin-inline: 0;
 
     @media only screen and (min-width: 901px) {
-      margin: 0 8px 16px;
+      margin-block: 0 16px;
+      margin-inline: 8px;
     }
   }
 
@@ -149,7 +156,7 @@
 
   @media only screen and (min-width: 901px) {
     .infoArea {
-      scroll-margin-top: 76px;
+      scroll-margin-block-start: 76px;
     }
 
     .infoAreaSticky {


### PR DESCRIPTION
# Implement right-to-left interface

Co-authored by @ChunkyProgrammer
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
closes #1550

## Description

At a high level, this PR updates the interface of FreeTube to accommodate the proper patterns for right-to-left languages throughout the entire app. This PR looks quite large, and it is, but >80-85% of the changes are migrating CSS properties to their 1:1 directionality-agnostic equivalents.

Implementation-wise:
- **Doesn't touch VideoJS.css**
- Replaces `margin-left` / `-right` with `margin-inline-start` / `-end` & `margin-top` / `-bottom` with `margin-block-start` / `-end`
- Replaces `padding-left` / `-right` with `padding-inline-start` / `end` & `padding-top` / `-bottom` with `padding-block-start` / `-end`
- Replaces `left`/`right` with `inset-inline-start`/`-end` & `top`/`bottom` with `inset-block-start`/`-end`
- Replaces `border-left*`/`border-right*` with `border-inset-start`/`-end` & `border-top*`/`border-bottom*` with `border-block-start`/`-end`
- Replaces `text-align: left`/`right` with `text-align: start`/`end`
- Custom: replaces `float: left`/`right` with two CSS variables (because [`float: inline-start`/`-end` is still experimental in Chrome](https://developer.mozilla.org/en-US/docs/Web/CSS/float))
- Custom: modifies `transform()` x values to conditionally be inverted by multiplying them with a CSS variable of 1 or -1 based on language directionality (090f392)
- Custom styling was needed/added in one place (`ft-input.css` to fix an emergent issue with the search bar `magnifying-glass` icon positioning on languages with right-to-left directionality
- Fixes settings switches not being aligned when the locale has right-to-left directionality
- Updates arrow keys when the current locale has right-to-left directionality such that left arrow is the "history forward" arrow, and right arrow is the "history backward" arrow
- Refactors the arrow key logic to use class binding to resolve emergent bug with history arrows showing as disabled when changing the locale to one with different directionality. It's also better practice than whatever the original implementer was doing (me, in 2021, to be clear)

## Screenshots <!-- If appropriate -->

![Screenshot_20230829_022443](https://github.com/FreeTubeApp/FreeTube/assets/84899178/644aef02-97b8-459c-8073-99177a26c8ea)
![Screenshot_20230829_022536](https://github.com/FreeTubeApp/FreeTube/assets/84899178/e6288a77-d17a-4715-97ea-622086a1ee1d)
![Screenshot_20230829_022631](https://github.com/FreeTubeApp/FreeTube/assets/84899178/b55b40eb-a1cb-44cc-808d-c7a9eb2e8319)
![Screenshot_20230829_022711](https://github.com/FreeTubeApp/FreeTube/assets/84899178/a51b0d0b-1681-4d36-8fb5-bc596718828a)

<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->

### Test Plan
- Under General Settings, set locale to one with right-to-left directionality (e.g., Arabic / العربية )
- Check that sliders in, e.g., Player Settings, are right-to-left
- Check that switches/toggles in, e.g., Player Settings, are right-to-left
- Check that tooltips in, e.g., Player Settings, open correctly
- Check that arrow navigation works correctly by going forward one route, then going back (left = forward, right = back)
- Check that labels left-aligned in ltr languages are right-aligned (e.g., side-nav labels, video titles, search results, `ft-input` placeholders, comments sections, the labels in the profile sections)
- Check that rtl directionality and styling is maintained after Ctrl+R
- (Optional) Prepend `true ||` to `v-if` statements on lines 17 and 21 of `App.vue` to show & validate updates banner is rtl

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0

## Future Action Items
### Add linter requiring use of directionality-neutral CSS properties
To maintain a usable right-to-left interface, we must ensure that the directionality-agnostic property names listed above are used in all cases going forward (with maybe the sole exception of `videoJS.css`).

### Ongoing Localization Problem
We currently use string concatenation of data and an i18n label in many places in the code (e.g., "v0.19.0 Beta" on the About page, "5,000 views" on video lists. This is not the way to do this, because many languages order those values differently. This will need to be addressed in a separate PR given that this is more of a localization problem, but I thought it would mention it specifically because languages with right-to-left directionality are most notably affected. 

### Enhancement: Switch left-to-right direction in `ft-input`s and their search results based on whether the text typed is in `ltr` or `rtl` language.

### To RTL language users
 let us know if you are having any issues with directionality in the video player or any other part of FreeTube!