### PR TITLE
Improve search filter accessibility

### DIFF
--- a/src/renderer/components/ft-radio-button/ft-radio-button.css
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.css
@@ -10,7 +10,7 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
 }
 
 .pure-checkbox input[type="checkbox"]:focus + label:before, .pure-radiobutton input[type="checkbox"]:focus + label:before, .pure-checkbox input[type="radio"]:focus + label:before, .pure-radiobutton input[type="radio"]:focus + label:before, .pure-checkbox input[type="checkbox"]:hover + label:before, .pure-radiobutton input[type="checkbox"]:hover + label:before, .pure-checkbox input[type="radio"]:hover + label:before, .pure-radiobutton input[type="radio"]:hover + label:before {
-  border-color: var(--primary-color);
+  border: 2px solid var(--accent-color-active);
 }
 
 .pure-checkbox input[type="checkbox"]:active + label:before, .pure-radiobutton input[type="checkbox"]:active + label:before, .pure-checkbox input[type="radio"]:active + label:before, .pure-radiobutton input[type="radio"]:active + label:before { transition-duration: 0s; }
@@ -83,6 +83,10 @@ pure-checkbox input[type="checkbox"], .pure-radiobutton input[type="checkbox"], 
 
 .pure-checkbox input[type="radio"]:checked + label:before, .pure-radiobutton input[type="radio"]:checked + label:before {
   animation: borderscale 300ms ease-in;
+}
+
+.pure-radiobutton input[type="radio"]:focus + label:after{
+  background-color: var(--accent-color-active);
 }
 
 .pure-checkbox input[type="radio"]:checked + label:after, .pure-radiobutton input[type="radio"]:checked + label:after { transform: scale(1); }

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue'
+import { defineComponent, nextTick } from 'vue'
 import { mapActions } from 'vuex'
 import FtInput from '../ft-input/ft-input.vue'
 import FtSearchFilters from '../ft-search-filters/ft-search-filters.vue'
@@ -271,6 +271,13 @@ export default defineComponent({
     toggleSearchContainer: function () {
       this.showSearchContainer = !this.showSearchContainer
       this.showFilters = false
+    },
+
+    toggleSearchFiltersDisplayed: function() {
+      this.showFilters = !this.showFilters
+      if (this.showFilters) {
+        nextTick(() => this.$refs.sortByRadio?.focus())
+      }
     },
 
     handleSearchFilterValueChanged: function (filterValueChanged) {

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -96,6 +96,11 @@
       box-shadow: 0 0 $effect-distance var(--text-with-main-color);
     }
   }
+
+  &.showFilters {
+    background-color: var(--primary-text-color);
+    color: var(--card-bg-color);
+  }
 }
 
 .side {

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -95,8 +95,8 @@
           :title="$t('Search Filters.Search Filters')"
           role="button"
           tabindex="0"
-          @click="showFilters = !showFilters"
-          @keydown.enter.prevent="showFilters = !showFilters"
+          @click="toggleSearchFiltersDisplayed"
+          @keydown.enter.prevent="toggleSearchFiltersDisplayed"
         />
       </div>
       <ft-search-filters

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -89,7 +89,7 @@
         />
         <font-awesome-icon
           class="navFilterIcon navIcon"
-          :class="{ filterChanged: searchFilterValueChanged }"
+          :class="{ filterChanged: searchFilterValueChanged, showFilters: showFilters }"
           :aria-pressed="showFilters"
           :icon="['fas', 'filter']"
           :title="$t('Search Filters.Search Filters')"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -90,7 +90,9 @@
         <font-awesome-icon
           class="navFilterIcon navIcon"
           :class="{ filterChanged: searchFilterValueChanged }"
+          :aria-pressed="showFilters"
           :icon="['fas', 'filter']"
+          :title="$t('Search Filters.Search Filters')"
           role="button"
           tabindex="0"
           @click="showFilters = !showFilters"


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
resolves [accessibility issue outlined here](https://github.com/FreeTubeApp/FreeTube/discussions/3972#discussioncomment-6853794), and other ones too
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Adds title and `aria-pressed` attribute to search filter icon, ensuring screenreaders will be aware of both what it is and when the filters are opened
- Programmatically applies focus to the search filter popup when opened from the icon button
- Updates radio button styling to show the `--accent-active-color` color on hover and focus, resolving issue where currently focused radio button is impossible to visually determine
- Updates filter button styling to appear visibly pressed when the filter popup is open

## Screenshots <!-- If appropriate -->
![Screenshot_20230829_215711](https://github.com/FreeTubeApp/FreeTube/assets/84899178/e55694d1-68f5-45ba-a607-5e9db14c86a8)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
    1. Confirm that the title "Search Filters" appears on hover of the filter icon.
    2. Click the filter icon. Verify that the icon styling has changed.
    3. Verify that the focus is now in the search filter popup.
    4. Verify that the currently focused or hovered radio button changes color to the `--accent-active-color`.
    5. Verify that the Search Filters icon appears has distinct styling when the search filters popup is open, and vice versa.

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0
