### PR TITLE
Make ft-channel-bubble an actual link when it is being used as one

### DIFF
--- a/src/renderer/components/channel-about/channel-about.js
+++ b/src/renderer/components/channel-about/channel-about.js
@@ -61,10 +61,5 @@ export default defineComponent({
     formattedViews: function () {
       return formatNumber(this.views)
     },
-  },
-  methods: {
-    goToChannel: function (id) {
-      this.$router.push({ path: `/channel/${id}` })
-    },
   }
 })

--- a/src/renderer/components/channel-about/channel-about.vue
+++ b/src/renderer/components/channel-about/channel-about.vue
@@ -90,10 +90,9 @@
         <ft-channel-bubble
           v-for="(channel, index) in relatedChannels"
           :key="index"
+          :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnailUrl"
-          role="link"
-          @click="goToChannel(channel.id)"
         />
       </ft-flex-box>
     </template>

--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
@@ -9,6 +9,8 @@
   align-items: center;
   gap: 16px;
   overflow: hidden;
+  color: inherit;
+  text-decoration: none;
   -webkit-transition: background 0.2s ease-out;
   -moz-transition: background 0.2s ease-out;
   -o-transition: background 0.2s ease-out;

--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.js
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.js
@@ -1,9 +1,12 @@
 import { defineComponent } from 'vue'
-import { sanitizeForHtmlId } from '../../helpers/accessibility'
 
 export default defineComponent({
   name: 'FtChannelBubble',
   props: {
+    channelId: {
+      type: String,
+      required: true
+    },
     channelName: {
       type: String,
       required: true
@@ -24,15 +27,12 @@ export default defineComponent({
   },
   computed: {
     sanitizedId: function() {
-      return 'channelBubble' + sanitizeForHtmlId(this.channelName)
+      return 'channelBubble' + this.channelId
     }
   },
   methods: {
     handleClick: function (event) {
       if (event instanceof KeyboardEvent) {
-        if (event.target.getAttribute('role') === 'link' && event.key !== 'Enter') {
-          return
-        }
         event.preventDefault()
       }
 

--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.vue
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.vue
@@ -1,6 +1,26 @@
 <template>
-  <div
+  <router-link
+    v-if="!showSelected"
     class="bubblePadding"
+    :aria-labelledby="sanitizedId"
+    :to="`/channel/${channelId}`"
+  >
+    <img
+      class="bubble"
+      :src="channelThumbnail"
+      alt=""
+    >
+    <div
+      :id="sanitizedId"
+      class="channelName"
+    >
+      {{ channelName }}
+    </div>
+  </router-link>
+  <div
+    v-else
+    class="bubblePadding"
+    role="button"
     tabindex="0"
     :aria-labelledby="sanitizedId"
     @click="handleClick"

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.vue
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.vue
@@ -12,10 +12,10 @@
           v-for="(channel, index) in subscriptions"
           :key="index"
           :ref="`channel-${index}`"
+          :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
           :show-selected="true"
-          role="button"
           @click="handleChannelClick(index)"
         />
       </ft-flex-box>

--- a/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.vue
+++ b/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.vue
@@ -21,10 +21,10 @@
           v-for="(channel, index) in channels"
           :key="index"
           :ref="`all-channels-${index}`"
+          :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
           :show-selected="true"
-          role="button"
           @click="handleChannelClick(index)"
         />
       </ft-flex-box>

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.js
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.js
@@ -77,10 +77,6 @@ export default defineComponent({
     document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
-    goToChannel: function (id) {
-      this.$router.push({ path: `/channel/${id}` })
-    },
-
     increaseLimit: function () {
       this.dataLimit += 100
       sessionStorage.setItem('subscriptionLimit', this.dataLimit)

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.vue
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.vue
@@ -14,7 +14,6 @@
           :channel-name="channel.name"
           :channel-id="channel.id"
           :channel-thumbnail="channel.thumbnail"
-          @click="goToChannel(channel.id)"
         />
       </ft-flex-box>
     </div>


### PR DESCRIPTION
# Make ft-channel-bubble an actual link when it is being used as one

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
The channel bubble component is used in 4 places, twice for channel selection on the profile edit page and as links on the channel about tab for the featured channels and errored channels on the subscriptions page. Currently we just set the role of the element to link (`role="link"`) but it doesn't act like other links in FreeTube, right, middle and control/command clicking does nothing.

This pull request replaces the `role="link"` in favour of using router-links, that way they behave as expected, meaning you can control/command and middle click on them to open the channel in a new window and right clicking brings up the context menu that allows you to copy the link or open it in a new window.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that selecting and deselecting still work on the profile edit page, in both the "Subscriptions List" and "Other Channels" sections.

Check that the channel bubbles on the about tab of channels act as links, so clicking on them still takes you to the channel but also that the context menu with the copy link and open in new window entries show up.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0
