### PR TITLE
Default theatre mode no sidebar

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -240,7 +240,7 @@ export default defineComponent({
   mounted: function () {
     this.videoId = this.$route.params.id
     this.activeFormat = this.defaultVideoFormat
-    this.useTheatreMode = this.defaultTheatreMode
+    this.useTheatreMode = this.defaultTheatreMode && this.theatrePossible
 
     this.checkIfPlaylist()
     this.checkIfTimestamp()

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -3,17 +3,7 @@
 }
 
 @mixin theatre-mode-template {
-  grid-template:  'video video video' auto
-                  'info info sidebar' auto
-                  'info info sidebar' auto / 1fr 1fr 1fr;
-
-  // When there is no sidebar (but the empty container element still exists)
-  // The info element need to be expanded with following rule(s)
-  @at-root .videoLayout.noSidebar {
-    grid-template:  'video video video' auto
-                    'info info info'    auto
-                    'info info info'    auto / 1fr 1fr 1fr;
-  }
+  grid-template: 'video video video' auto 'info info sidebar' auto 'info info sidebar' auto / 1fr 1fr 1fr;
 }
 
 @mixin single-column-template {


### PR DESCRIPTION
# Default theatre mode no sidebar

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3923
#3931 (original pull request)

## Description
This pull request aims to fix the same issue as the original pull request did, but does so without enforcing a 3 colum layout on the loading icon (see screenshot).

## Screenshots <!-- If appropriate -->
![off-centre-loading-icon](https://github.com/FreeTubeApp/FreeTube/assets/48293849/01395592-4979-4ebd-b9c2-443274736983)

## Testing <!-- for code that is not small enough to be easily understandable -->
**Loading icon:**
1. Turn the "Hide Recommended Videos" distraction free setting
2. Open a video without a playlist (we don't want a side bar)
3. The loading icon should be centred

**Original test cases:**

Check that the layout looks correct and that enabling theatre mode by default still works when it should.

1. "Hide Recommended Videos" ON / "Enable Theatre Mode by Default" ON
2. "Hide Recommended Videos" ON / "Enable Theatre Mode by Default" OFF
3. "Hide Recommended Videos" OFF / "Enable Theatre Mode by Default" ON
4. "Hide Recommended Videos" OFF / "Enable Theatre Mode by Default" OFF

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0 nightly (621cc279385f5f37db63643de3f8182930b10b6e)