### PR TITLE
Fix/improve community post list styling

### DIFF
--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.js
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.js
@@ -7,7 +7,7 @@ export default defineComponent({
       type: Boolean,
       required: true
     },
-    usingFtCardWrapper: {
+    useFtCardWrapper: {
       type: Boolean,
       default: false
     }

--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.js
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.js
@@ -6,6 +6,10 @@ export default defineComponent({
     grid: {
       type: Boolean,
       required: true
+    },
+    usingFtCardWrapper: {
+      type: Boolean,
+      default: false
     }
   }
 })

--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.scss
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.scss
@@ -10,4 +10,19 @@
     display: grid;
     grid-gap: 4px;
   }
+
+  &.card {
+    position: relative;
+    width: 85%;
+    margin-block: 0 20px;
+    margin-inline: auto;
+    box-sizing: border-box;
+
+    .ft-card {
+      margin-inline: 0;
+      margin-block: 0 16px;
+      max-width: 850px;
+      padding-block-end: 3px;
+    }
+  }
 }

--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.scss
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.scss
@@ -22,7 +22,7 @@
       margin-inline: 0;
       margin-block: 0 16px;
       max-width: 850px;
-      padding-block-end: 3px;
+      padding-block-end: 6px;
     }
   }
 }

--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.vue
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.vue
@@ -4,7 +4,7 @@
     :class="{
       grid: grid,
       list: !grid,
-      card: usingFtCardWrapper
+      card: useFtCardWrapper
     }"
   >
     <slot />

--- a/src/renderer/components/ft-auto-grid/ft-auto-grid.vue
+++ b/src/renderer/components/ft-auto-grid/ft-auto-grid.vue
@@ -3,7 +3,8 @@
     class="ft-auto-grid"
     :class="{
       grid: grid,
-      list: !grid
+      list: !grid,
+      card: usingFtCardWrapper
     }"
   >
     <slot />

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -3,22 +3,6 @@
 
 $community-thumbnail-side-width: 65px;
 
-.outside {
-  margin: auto;
-
-  &.list {
-    width: 100%;
-  }
-
-  &.grid {
-    width: 40%;
-  }
-
-  @media screen and (max-width: 768px) {
-    width: 100%;
-  }
-}
-
 .ft-list-post {
   box-sizing: border-box;
 }
@@ -138,7 +122,6 @@ $community-thumbnail-side-width: 65px;
 
 .ft-list-item.grid {
   min-height: 0 !important;
-  padding-bottom: 20px;
 }
 
 .ft-list-item.list {

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -1,9 +1,19 @@
 /* stylelint-disable property-no-vendor-prefix */
 @use '../../scss-partials/_ft-list-item';
 
+$community-thumbnail-side-width: 65px;
+
 .outside {
   margin: auto;
-  width: 40%;
+
+  &.list {
+    width: 100%;
+  }
+
+  &.grid {
+    width: 40%;
+  }
+
   @media screen and (max-width: 768px) {
     width: 100%;
   }
@@ -129,4 +139,22 @@
 .ft-list-item.grid {
   min-height: 0 !important;
   padding-bottom: 20px;
+}
+
+.ft-list-item.list {
+  flex-wrap: wrap;
+  justify-content: space-between;
+
+  > :not(.author-div) {
+    margin-inline-start: $community-thumbnail-side-width;
+    flex-basis: 100%;
+  }
+
+  .author-div {
+    height: 24px;
+  }
+
+  .postText {
+    margin-block-start: 6px;
+  }
 }

--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -22,20 +22,23 @@ $community-thumbnail-side-width: 65px;
 
 .author-div {
   display: flex;
+  margin-block-start: -16px;
 
   .authorName {
     font-size: 15px;
     font-weight: bold;
-    margin: 5px 6px 0 5px;
+    margin-block-end: 6px;
   }
 
   .publishedText {
     font-size: 15px;
-    margin: 5px 6px 0 5px;
+    margin-inline: 5px 6px;
+    margin-block-end: 6px;
   }
 }
 
 .postText {
+  margin-block-start: 0;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
@@ -120,24 +123,9 @@ $community-thumbnail-side-width: 65px;
   }
 }
 
-.ft-list-item.grid {
-  min-height: 0 !important;
-}
-
-.ft-list-item.list {
-  flex-wrap: wrap;
+.ft-list-item.grid, .ft-list-item.list {
+  flex-direction: row;
   justify-content: space-between;
-
-  > :not(.author-div) {
-    margin-inline-start: $community-thumbnail-side-width;
-    flex-basis: 100%;
-  }
-
-  .author-div {
-    height: 24px;
-  }
-
-  .postText {
-    margin-block-start: 6px;
-  }
+  gap: 10px;
+  padding-block-end: 0;
 }

--- a/src/renderer/components/ft-community-post/ft-community-post.vue
+++ b/src/renderer/components/ft-community-post/ft-community-post.vue
@@ -5,86 +5,90 @@
     :appearance="appearance"
     :class="{ list: listType === 'list', grid: listType === 'grid' }"
   >
-    <div
-      class="author-div"
-    >
+    <div>
       <img
         v-if="authorThumbnails.length > 0"
         :src="getBestQualityImage(authorThumbnails)"
         class="communityThumbnail"
         alt=""
       >
+    </div>
+    <div>
+      <div
+        class="author-div"
+      >
+        <p
+          class="authorName"
+        >
+          {{ author }}
+        </p>
+        <p
+          class="publishedText"
+        >
+          {{ publishedText }}
+        </p>
+      </div>
       <p
-        class="authorName"
-      >
-        {{ author }}
-      </p>
-      <p
-        class="publishedText"
-      >
-        {{ publishedText }}
-      </p>
-    </div>
-    <p
-      class="postText"
-      v-html="postText"
-    />
-    <tiny-slider
-      v-if="type === 'multiImage' && postContent.content.length > 0"
-      v-bind="tinySliderOptions"
-      class="slider"
-    >
-      <img
-        v-for="(img, index) in postContent.content"
-        :key="index"
-        :src="getBestQualityImage(img)"
-        class="communityImage tns-lazy-img"
-        alt=""
-      >
-    </tiny-slider>
-    <div
-      v-if="type === 'image' && postContent.content.length > 0"
-    >
-      <img
-        :src="getBestQualityImage(postContent.content)"
-        class="communityImage"
-        alt=""
-      >
-    </div>
-    <div
-      v-if="type === 'video'"
-    >
-      <ft-list-video
-        :data="data.postContent.content"
-        appearance=""
+        class="postText"
+        v-html="postText"
       />
-    </div>
-    <div
-      v-if="type === 'poll' || type === 'quiz'"
-    >
-      <ft-community-poll :data="postContent" />
-    </div>
-    <div
-      v-if="type === 'playlist'"
-      class="playlistWrapper"
-    >
-      <ft-list-playlist
-        :data="postContent.content"
-        :appearance="appearance"
-      />
-    </div>
-    <div
-      class="bottomSection"
-    >
-      <span class="likeCount"><font-awesome-icon
-        class="thumbs-up-icon"
-        :icon="['fas', 'thumbs-up']"
-      /> {{ voteCount }}</span>
-      <span class="commentCount">
-        <font-awesome-icon
-          class="comment-count-icon"
-          :icon="['fas', 'comment']"
-        /> {{ commentCount }}</span>
+      <tiny-slider
+        v-if="type === 'multiImage' && postContent.content.length > 0"
+        v-bind="tinySliderOptions"
+        class="slider"
+      >
+        <img
+          v-for="(img, index) in postContent.content"
+          :key="index"
+          :src="getBestQualityImage(img)"
+          class="communityImage tns-lazy-img"
+          alt=""
+        >
+      </tiny-slider>
+      <div
+        v-if="type === 'image' && postContent.content.length > 0"
+      >
+        <img
+          :src="getBestQualityImage(postContent.content)"
+          class="communityImage"
+          alt=""
+        >
+      </div>
+      <div
+        v-if="type === 'video'"
+      >
+        <ft-list-video
+          :data="data.postContent.content"
+          appearance=""
+        />
+      </div>
+      <div
+        v-if="type === 'poll' || type === 'quiz'"
+      >
+        <ft-community-poll :data="postContent" />
+      </div>
+      <div
+        v-if="type === 'playlist'"
+        class="playlistWrapper"
+      >
+        <ft-list-playlist
+          :data="postContent.content"
+          :appearance="appearance"
+        />
+      </div>
+      <div
+        class="bottomSection"
+      >
+        <span class="likeCount"><font-awesome-icon
+          class="thumbs-up-icon"
+          :icon="['fas', 'thumbs-up']"
+        /> {{ voteCount }}</span>
+        <span class="commentCount">
+          <font-awesome-icon
+            class="comment-count-icon"
+            :icon="['fas', 'comment']"
+          /> {{ commentCount }}</span>
+      </div>
     </div>
   </div>
 </template>

--- a/src/renderer/components/ft-element-list/ft-element-list.js
+++ b/src/renderer/components/ft-element-list/ft-element-list.js
@@ -26,6 +26,10 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    usingFtCardWrapper: {
+      type: Boolean,
+      default: false
+    }
   },
   computed: {
     listType: function () {

--- a/src/renderer/components/ft-element-list/ft-element-list.js
+++ b/src/renderer/components/ft-element-list/ft-element-list.js
@@ -26,7 +26,7 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
-    usingFtCardWrapper: {
+    useFtCardWrapper: {
       type: Boolean,
       default: false
     }

--- a/src/renderer/components/ft-element-list/ft-element-list.vue
+++ b/src/renderer/components/ft-element-list/ft-element-list.vue
@@ -1,6 +1,7 @@
 <template>
   <ft-auto-grid
     :grid="displayValue !== 'list'"
+    :usingFtCardWrapper = usingFtCardWrapper
   >
     <ft-list-lazy-wrapper
       v-for="(result, index) in data"
@@ -11,6 +12,7 @@
       :layout="displayValue"
       :show-video-with-last-viewed-playlist="showVideoWithLastViewedPlaylist"
       :use-channels-hidden-preference="useChannelsHiddenPreference"
+      :using-ft-card-wrapper="usingFtCardWrapper"
     />
   </ft-auto-grid>
 </template>

--- a/src/renderer/components/ft-element-list/ft-element-list.vue
+++ b/src/renderer/components/ft-element-list/ft-element-list.vue
@@ -1,7 +1,7 @@
 <template>
   <ft-auto-grid
     :grid="displayValue !== 'list'"
-    :usingFtCardWrapper = usingFtCardWrapper
+    :use-ft-card-wrapper="useFtCardWrapper"
   >
     <ft-list-lazy-wrapper
       v-for="(result, index) in data"
@@ -12,7 +12,7 @@
       :layout="displayValue"
       :show-video-with-last-viewed-playlist="showVideoWithLastViewedPlaylist"
       :use-channels-hidden-preference="useChannelsHiddenPreference"
-      :using-ft-card-wrapper="usingFtCardWrapper"
+      :use-ft-card-wrapper="useFtCardWrapper"
     />
   </ft-auto-grid>
 </template>

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
@@ -39,7 +39,7 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
-    usingFtCardWrapper: {
+    useFtCardWrapper: {
       type: Boolean,
       default: false,
     }

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.js
@@ -3,6 +3,7 @@ import FtListVideo from '../ft-list-video/ft-list-video.vue'
 import FtListChannel from '../ft-list-channel/ft-list-channel.vue'
 import FtListPlaylist from '../ft-list-playlist/ft-list-playlist.vue'
 import FtCommunityPost from '../ft-community-post/ft-community-post.vue'
+import FtCard from '../ft-card/ft-card.vue'
 
 export default defineComponent({
   name: 'FtListLazyWrapper',
@@ -10,7 +11,8 @@ export default defineComponent({
     'ft-list-video': FtListVideo,
     'ft-list-channel': FtListChannel,
     'ft-list-playlist': FtListPlaylist,
-    'ft-community-post': FtCommunityPost
+    'ft-community-post': FtCommunityPost,
+    'ft-card': FtCard
   },
   props: {
     data: {
@@ -37,6 +39,10 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    usingFtCardWrapper: {
+      type: Boolean,
+      default: false,
+    }
   },
   data: function () {
     return {

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="usingFtCardWrapper ? 'ft-card' : 'div'"
+  <component :is="useFtCardWrapper ? 'ft-card' : 'div'"
     v-if="showResult"
     v-observe-visibility="firstScreen ? false : {
       callback: onVisibilityChanged,

--- a/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
+++ b/src/renderer/components/ft-list-lazy-wrapper/ft-list-lazy-wrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <component :is="usingFtCardWrapper ? 'ft-card' : 'div'"
     v-if="showResult"
     v-observe-visibility="firstScreen ? false : {
       callback: onVisibilityChanged,
@@ -35,7 +35,7 @@
         :data="data"
       />
     </template>
-  </div>
+  </component>
 </template>
 
 <script src="./ft-list-lazy-wrapper.js" />

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -220,7 +220,7 @@
       v-if="(!isLoading && !errorMessage && (isFamilyFriendly || !showFamilyFriendlyOnly)) && !hideChannelCommunity && currentTab === 'community' && latestCommunityPosts.length > 0"
       id="communityPanel"
       :data="latestCommunityPosts"
-      :using-ft-card-wrapper="true"
+      :use-ft-card-wrapper="true"
       :use-channels-hidden-preference="false"
       role="tabpanel"
       aria-labelledby="communityTab"

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -216,6 +216,16 @@
         </ft-flex-box>
       </div>
     </ft-card>
+    <ft-element-list
+      v-if="(!isLoading && !errorMessage && (isFamilyFriendly || !showFamilyFriendlyOnly)) && !hideChannelCommunity && currentTab === 'community' && latestCommunityPosts.length > 0"
+      id="communityPanel"
+      :data="latestCommunityPosts"
+      :using-ft-card-wrapper="true"
+      :use-channels-hidden-preference="false"
+      role="tabpanel"
+      aria-labelledby="communityTab"
+      display="list"
+    />
     <ft-card
       v-if="!isLoading && !errorMessage && (isFamilyFriendly || !showFamilyFriendlyOnly)"
       class="card"
@@ -368,15 +378,6 @@
             {{ $t("Channel.Playlists.This channel does not currently have any playlists") }}
           </p>
         </ft-flex-box>
-        <ft-element-list
-          v-if="!hideChannelCommunity && currentTab === 'community'"
-          id="communityPanel"
-          :data="latestCommunityPosts"
-          :use-channels-hidden-preference="false"
-          role="tabpanel"
-          aria-labelledby="communityTab"
-          display="list"
-        />
         <ft-flex-box
           v-if="!hideChannelCommunity && currentTab === 'community' && latestCommunityPosts.length === 0"
         >


### PR DESCRIPTION
# Improve community post styling & fix list styling

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3984

## Description
Fixes community post styling on the list view (as in, is legible and actually pretty). Wraps each community post in its own ft-card for list and grid views, and equalizes the list and grid views (given that there does not seem to be a good way to actually display community posts in a grid).

## Screenshots <!-- If appropriate -->
![Screenshot_20230902_021401](https://github.com/FreeTubeApp/FreeTube/assets/84899178/1bc00fdb-8485-415a-9727-436ddce34784)
![localhost_9080_(iPad Air)](https://github.com/FreeTubeApp/FreeTube/assets/84899178/ed21006a-0e2b-454e-ada9-0edaf9a01d8d)
![localhost_9080_(iPhone 12 Pro)](https://github.com/FreeTubeApp/FreeTube/assets/84899178/00fe4e77-c63e-4a11-826d-8ba79aea6f43)

## Testing <!-- for code that is not small enough to be easily understandable -->
1, Under General Settings, set Video View Type to "List"
2. [Navigate to this channel](https://www.youtube.com/channel/UCgwv23FVv3lqh567yagXfNg)
3. Navigate to the Community tab
4. Ensure that view appears correctly
5. Check with smaller device size (Chrome devtool)
6. Repeat for Grid view
7. Check with smaller device size (Chrome devtool)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** Tumbleweed
- **FreeTube version:** 0.19.0
