### PR TITLE
Add subscribed icon to comments

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -118,7 +118,6 @@
 }
 
 .commentSubscribedIcon {
-  content: url("../../../../_icons/iconColorSmall.png");
   height: 10px;
   width: 10px;
   margin-left: 0.25em;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -117,6 +117,14 @@
   height: 14px;
 }
 
+.commentSubscribedIcon {
+  content: url("../../../../_icons/iconColorSmall.png");
+  height: 10px;
+  width: 10px;
+  margin-left: 0.25em;
+  margin-right: 0.25em;
+}
+
 .commentLikeCount {
   font-size: 11px;
   margin-left: 70px;

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -117,6 +117,10 @@ export default defineComponent({
     canPerformMoreCommentLoading: function () {
       return this.commentData.length > 0 && !this.isLoading && this.showComments && this.nextPageToken
     },
+
+    subscriptions: function() {
+      return this.$store.getters.getActiveProfile.subscriptions
+    }
   },
   mounted: function () {
     // region No comment detection

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -109,9 +109,9 @@
           >
           <img
             v-if="subscriptions.find((channel) => channel.id === comment.authorId)"
-            :src="comment.memberIconUrl"
             :title="$t('Comments.Subscribed')"
             :aria-label="$t('Comments.Subscribed')"
+            src="../../../../_icons/iconColorSmall.png"
             class="commentSubscribedIcon"
             alt=""
           >

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -107,6 +107,14 @@
             class="commentMemberIcon"
             alt=""
           >
+          <img
+            v-if="subscriptions.find((channel) => channel.id === comment.authorId)"
+            :src="comment.memberIconUrl"
+            :title="$t('Comments.Subscribed')"
+            :aria-label="$t('Comments.Subscribed')"
+            class="commentSubscribedIcon"
+            alt=""
+          >
           <span class="commentDate">
             {{ comment.time }}
           </span>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -808,6 +808,7 @@ Comments:
   No more comments available: No more comments available
   Pinned by: Pinned by
   Member: Member
+  Subscribed: Subscribed
   Hearted: Hearted
 Up Next: Up Next
 


### PR DESCRIPTION
# Add subscribed icon to comments

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
Closes https://github.com/FreeTubeApp/FreeTube/issues/1823

## Description
Adds a freetube icon as suggested beside a comment author's username for whomever the current profile is subscribed to

## Screenshots <!-- If appropriate -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/5a24a71b-3d65-4e72-bf8b-329c1e047909)
Top shows what it would look like if the verified icon is to be added in the future.

## Testing <!-- for code that is not small enough to be easily understandable -->
https://youtu.be/KgmV2GaN-J0
Subbing/unsubbing works fine, icon updates accordingly.
Changing profiles in a video also updates the icons accordingly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
