### PR TITLE
Enable Persian language (Farsi)

### DIFF
--- a/static/locales/activeLocales.json
+++ b/static/locales/activeLocales.json
@@ -13,6 +13,7 @@
   "es-MX",
   "et",
   "eu",
+  "fa",
   "fi",
   "fr-FR",
   "gl",


### PR DESCRIPTION
# Enable Persian language (Farsi)

## Pull Request Type
- [x] Other - enable translated locale

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/3970#issuecomment-1698592731

## Description
Enable Farsi to be used in the app

## Screenshots
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/de1ef188-ac12-43d7-8dcd-e5072e13acea)

## Testing
See Persian in the drop down of language setting

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0