### PR TITLE
Fix localization of counts

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -1,6 +1,7 @@
 import { defineComponent } from 'vue'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { formatNumber } from '../../helpers/utils'
+import { parseLocalSubscriberCount } from '../../helpers/api/local'
 
 export default defineComponent({
   name: 'FtListChannel',
@@ -20,7 +21,9 @@ export default defineComponent({
       thumbnail: '',
       channelName: '',
       subscriberCount: 0,
-      videoCount: '',
+      videoCount: 0,
+      formattedSubscriberCount: '',
+      formattedVideoCount: '',
       handle: null,
       description: ''
     }
@@ -53,13 +56,15 @@ export default defineComponent({
 
       this.channelName = this.data.name
       this.id = this.data.id
-      this.subscriberCount = this.data.subscribers != null ? this.data.subscribers.replace(/ subscriber(s)?/, '') : null
-
-      if (this.data.videos === null) {
-        this.videoCount = 0
+      if (this.data.subscribers != null) {
+        this.subscriberCount = parseLocalSubscriberCount(this.data.subscribers.replace(/ subscriber(s)?/, ''))
+        this.formattedSubscriberCount = formatNumber(this.subscriberCount)
       } else {
-        this.videoCount = formatNumber(this.data.videos)
+        this.subscriberCount = null
       }
+
+      this.videoCount = this.data.videos ?? 0
+      this.formattedVideoCount = formatNumber(this.videoCount)
 
       if (this.data.handle) {
         this.handle = this.data.handle
@@ -76,8 +81,10 @@ export default defineComponent({
 
       this.channelName = this.data.author
       this.id = this.data.authorId
-      this.subscriberCount = formatNumber(this.data.subCount)
-      this.videoCount = formatNumber(this.data.videoCount)
+      this.subscriberCount = this.data.subCount
+      this.videoCount = this.data.videoCount
+      this.formattedVideoCount = formatNumber(this.data.videoCount)
+      this.formattedSubscriberCount = formatNumber(this.data.subCount)
       this.description = this.data.description
     }
   }

--- a/src/renderer/components/ft-list-channel/ft-list-channel.vue
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.vue
@@ -34,7 +34,7 @@
           v-if="subscriberCount !== null && !hideChannelSubscriptions"
           class="subscriberCount"
         >
-          {{ subscriberCount }} subscribers -
+          {{ $tc('Global.Counts.Subscriber Count', subscriberCount, {count: formattedSubscriberCount}) }}
         </span>
         <router-link
           v-if="handle !== null"
@@ -47,7 +47,7 @@
           v-else
           class="videoCount"
         >
-          {{ videoCount }} videos
+          {{ $tc('Global.Counts.Video Count', videoCount, {count: formattedVideoCount}) }}
         </span>
       </div>
       <p

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -90,9 +90,7 @@
           <span>{{ channelName }}</span>
         </router-link>
         <template v-if="!isLive && !isUpcoming && !isPremium && !hideViews">
-          <span class="viewCount"><template v-if="channelId !== null"> •</template> {{ parsedViewCount }} </span>
-          <span v-if="viewCount === 1">{{ $t("Video.View").toLowerCase() }}</span>
-          <span v-else>{{ $t("Video.Views").toLowerCase() }}</span>
+          <span class="viewCount"><template v-if="channelId !== null"> •</template>{{ $tc('Global.Counts.View Count', viewCount, {count: parsedViewCount}) }}</span>
         </template>
         <span
           v-if="uploadedTime !== '' && !isLive && !inHistory"
@@ -105,7 +103,7 @@
         <span
           v-if="isLive && !hideViews"
           class="viewCount"
-        > • {{ parsedViewCount }} {{ $t("Video.Watching").toLowerCase() }}</span>
+        > • {{ $tc('Global.Counts.Watching Count', viewCount, {count: parsedViewCount}) }}</span>
       </div>
       <ft-icon-button
         class="optionsButton"

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -199,7 +199,8 @@ export default defineComponent({
       if (this.hideVideoViews) {
         return null
       }
-      return formatNumber(this.viewCount) + ` ${this.$t('Video.Views').toLowerCase()}`
+
+      return this.$tc('Global.Counts.View Count', this.viewCount, { count: formatNumber(this.viewCount) })
     },
 
     dateString: function () {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -46,7 +46,7 @@ export function calculatePublishedDate(publishedText) {
 
 export function toLocalePublicationString ({ publishText, isLive = false, isUpcoming = false, isRSS = false }) {
   if (isLive) {
-    return '0' + i18n.t('Video.Watching')
+    return i18n.tc('Global.Counts.Watching Count', 0, { count: 0 })
   } else if (isUpcoming || publishText === null) {
     // the check for null is currently just an inferring of knowledge, because there is no other possibility left
     return `${i18n.t('Video.Published.Upcoming')}: ${publishText}`

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -52,9 +52,7 @@
                 v-if="subCount !== null && !hideChannelSubscriptions"
                 class="channelSubCount"
               >
-                {{ formattedSubCount }}
-                <span v-if="subCount === 1">{{ $t("Channel.Subscriber") }}</span>
-                <span v-else>{{ $t("Channel.Subscribers") }}</span>
+                {{ $tc('Global.Counts.Subscriber Count', subCount, { count: formattedSubCount }) }}
               </p>
             </div>
           </div>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -45,6 +45,12 @@ Global:
   Videos: Videos
   Shorts: Shorts
   Live: Live
+  Counts:
+    Video Count: 1 video | {count} videos
+    Channel Count: 1 channel | {count} channels
+    Subscriber Count: 1 subscriber | {count} subscribers
+    View Count: 1 view | {count} views
+    Watching Count: 1 watching | {count} watching
 
 # Search Bar
 Search / Go to URL: Search / Go to URL


### PR DESCRIPTION
# Fix localization of counts

## Pull Request Type
- [x] Bugfix

## Related issue
See: https://github.com/FreeTubeApp/FreeTube/pull/3970#issuecomment-1697564131

## Description
Use TC to properly handle plurals of view count, subscriber count, channel count, etc.

## Testing 
Test the following on both local and invidious api (remember to clear search cache if searching the same thing)
- view a channel in search, look at subscriber and video count (ex: search `the replacements - topic`)
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/8bbdc797-f191-4a89-aba3-4827edbb9126)
- view a video on search, look at view count
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/fc852569-8cd1-427e-bfdd-4c29ff9db6eb)
- click on a video, look at view count
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/a550a5b6-d96d-4431-a805-087de84b3002)
- look at the subscribers count on a channel page
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/ae83f751-1fe8-4c16-a5e2-286321b0a8c8)

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0