### PR TITLE
Have Favorites icon always appear on favorited videos

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -52,6 +52,7 @@
         :title="$t('Video.Save Video')"
         :icon="['fas', 'star']"
         class="favoritesIcon"
+        :class="{ favorited: favoriteIconTheme === 'base favorite'}"
         :theme="favoriteIconTheme"
         :padding="appearance === `watchPlaylistItem` ? 5 : 6"
         :size="appearance === `watchPlaylistItem` ? 14 : 18"

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -306,6 +306,7 @@ $watched-transition-duration: 0.5s;
   }
 
   @media (hover: hover) {
+    .favoritesIcon.favorited,
     &:hover .favoritesIcon,
     &:hover .externalPlayerIcon,
     &:focus-within .favoritesIcon,


### PR DESCRIPTION
# Have Favorites icon always appear on favorited videos

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
addresses [this comment](https://github.com/FreeTubeApp/FreeTube/pull/3954#issuecomment-1711655664)

## Description
Updates such that "Favorites" icon is always visible on favorited videos, and does not need to be hovered to appear.

## Screenshots <!-- If appropriate -->
![Screenshot_20230909_103156](https://github.com/FreeTubeApp/FreeTube/assets/84899178/3c0743cb-b451-4dc1-bc09-ae61ae64ff8f)


## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0

## Additional context
This does not carve out an exception for the Playlists tab as suggested by @Gorrrg for the sake of keeping the behavior consistent. I think this is fine, but let me know if this is a major enough issue.
