### PR TITLE
Improve performance of the watch history handling

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -54,8 +54,8 @@ export default defineComponent({
     allPlaylists: function () {
       return this.$store.getters.getAllPlaylists
     },
-    historyCache: function () {
-      return this.$store.getters.getHistoryCache
+    historyCacheSorted: function () {
+      return this.$store.getters.getHistoryCacheSorted
     },
     exportSubscriptionsPromptNames: function () {
       const exportFreeTube = this.$t('Settings.Data Settings.Export FreeTube')
@@ -825,7 +825,7 @@ export default defineComponent({
     },
 
     exportHistory: async function () {
-      const historyDb = this.historyCache.map((historyEntry) => {
+      const historyDb = this.historyCacheSorted.map((historyEntry) => {
         return JSON.stringify(historyEntry)
       }).join('\n') + '\n'
       const dateStr = getTodayDateStrLocalTimezone()

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -76,8 +76,8 @@ export default defineComponent({
     }
   },
   computed: {
-    historyCache: function () {
-      return this.$store.getters.getHistoryCache
+    historyEntry: function () {
+      return this.$store.getters.getHistoryCacheById[this.id]
     },
 
     listType: function () {
@@ -313,12 +313,6 @@ export default defineComponent({
       }
     },
 
-    historyIndex: function() {
-      return this.historyCache.findIndex((video) => {
-        return video.videoId === this.id
-      })
-    },
-
     playlistIdFinal: function () {
       if (this.playlistId) {
         return this.playlistId
@@ -327,12 +321,8 @@ export default defineComponent({
       // Get playlist ID from history ONLY if option enabled
       if (!this.showVideoWithLastViewedPlaylist) { return }
       if (!this.saveVideoHistoryWithLastViewedPlaylist) { return }
-      const historyIndex = this.historyIndex
-      if (historyIndex === -1) {
-        return undefined
-      }
 
-      return this.historyCache[historyIndex].lastViewedPlaylistId
+      return this.historyEntry?.lastViewedPlaylistId
     },
 
     currentLocale: function () {
@@ -348,7 +338,7 @@ export default defineComponent({
     }
   },
   watch: {
-    historyIndex() {
+    historyEntry() {
       this.checkIfWatched()
     },
   },
@@ -451,8 +441,8 @@ export default defineComponent({
       this.channelName = this.data.author ?? null
       this.channelId = this.data.authorId ?? null
 
-      if (this.data.isRSS && this.historyIndex !== -1) {
-        this.duration = formatDurationAsTimestamp(this.historyCache[this.historyIndex].lengthSeconds)
+      if (this.data.isRSS && typeof this.historyEntry !== 'undefined') {
+        this.duration = formatDurationAsTimestamp(this.historyEntry.lengthSeconds)
       } else {
         this.duration = formatDurationAsTimestamp(this.data.lengthSeconds)
       }
@@ -538,22 +528,25 @@ export default defineComponent({
     },
 
     checkIfWatched: function () {
-      const historyIndex = this.historyIndex
+      const historyEntry = this.historyEntry
 
-      if (historyIndex !== -1) {
+      if (typeof historyEntry !== 'undefined') {
         this.watched = true
         if (this.saveWatchedProgress) {
           // For UX consistency, no progress reading if writing disabled
-          this.watchProgress = this.historyCache[historyIndex].watchProgress
+          this.watchProgress = historyEntry.watchProgress
         }
 
-        if (this.historyCache[historyIndex].published !== '') {
-          const videoPublished = this.historyCache[historyIndex].published
+        if (historyEntry.published !== '') {
+          const videoPublished = historyEntry.published
           const videoPublishedDate = new Date(videoPublished)
           this.publishedText = videoPublishedDate.toLocaleDateString()
         } else {
           this.publishedText = ''
         }
+      } else {
+        this.watched = false
+        this.watchProgress = 0
       }
     },
 

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -38,14 +38,10 @@ export function updateVideoListAfterProcessing(videos) {
   }
 
   if (store.getters.getHideWatchedSubs) {
-    const historyCache = store.getters.getHistoryCache
+    const historyCacheById = store.getters.getHistoryCacheById
 
     videoList = videoList.filter((video) => {
-      const historyIndex = historyCache.findIndex((x) => {
-        return x.videoId === video.videoId
-      })
-
-      return historyIndex === -1
+      return !Object.hasOwn(historyCacheById, video.videoId)
     })
   }
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -469,7 +469,8 @@ const customActions = {
           break
 
         case SyncEvents.GENERAL.DELETE_ALL:
-          commit('setHistoryCache', [])
+          commit('setHistoryCacheSorted', [])
+          commit('setHistoryCacheById', {})
           break
 
         default:

--- a/src/renderer/views/History/History.js
+++ b/src/renderer/views/History/History.js
@@ -28,15 +28,15 @@ export default defineComponent({
     }
   },
   computed: {
-    historyCache: function () {
-      return this.$store.getters.getHistoryCache
+    historyCacheSorted: function () {
+      return this.$store.getters.getHistoryCacheSorted
     },
 
     fullData: function () {
-      if (this.historyCache.length < this.dataLimit) {
-        return this.historyCache
+      if (this.historyCacheSorted.length < this.dataLimit) {
+        return this.historyCacheSorted
       } else {
-        return this.historyCache.slice(0, this.dataLimit)
+        return this.historyCacheSorted.slice(0, this.dataLimit)
       }
     }
   },
@@ -59,7 +59,7 @@ export default defineComponent({
 
     this.activeData = this.fullData
 
-    if (this.activeData.length < this.historyCache.length) {
+    if (this.activeData.length < this.historyCacheSorted.length) {
       this.showLoadMoreButton = true
     } else {
       this.showLoadMoreButton = false
@@ -85,14 +85,14 @@ export default defineComponent({
     filterHistory: function() {
       if (this.query === '') {
         this.activeData = this.fullData
-        if (this.activeData.length < this.historyCache.length) {
+        if (this.activeData.length < this.historyCacheSorted.length) {
           this.showLoadMoreButton = true
         } else {
           this.showLoadMoreButton = false
         }
       } else {
         const lowerCaseQuery = this.query.toLowerCase()
-        const filteredQuery = this.historyCache.filter((video) => {
+        const filteredQuery = this.historyCacheSorted.filter((video) => {
           if (typeof (video.title) !== 'string' || typeof (video.author) !== 'string') {
             return false
           } else {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -123,8 +123,8 @@ export default defineComponent({
     }
   },
   computed: {
-    historyCache: function () {
-      return this.$store.getters.getHistoryCache
+    historyEntry: function () {
+      return this.$store.getters.getHistoryCacheById[this.videoId]
     },
     rememberHistory: function () {
       return this.$store.getters.getRememberHistory
@@ -1040,9 +1040,7 @@ export default defineComponent({
     },
 
     checkIfWatched: function () {
-      const historyIndex = this.historyCache.findIndex((video) => {
-        return video.videoId === this.videoId
-      })
+      const historyEntry = this.historyEntry
 
       if (!this.isLive) {
         if (this.timestamp) {
@@ -1053,9 +1051,9 @@ export default defineComponent({
           } else {
             this.$refs.videoPlayer.player.currentTime(this.timestamp)
           }
-        } else if (this.saveWatchedProgress && historyIndex !== -1) {
+        } else if (this.saveWatchedProgress && typeof historyEntry !== 'undefined') {
           // For UX consistency, no progress reading if writing disabled
-          const watchProgress = this.historyCache[historyIndex].watchProgress
+          const watchProgress = this.historyEntry.watchProgress
 
           if (watchProgress < (this.videoLengthSeconds - 10)) {
             this.$refs.videoPlayer.player.currentTime(watchProgress)
@@ -1066,8 +1064,8 @@ export default defineComponent({
       if (this.rememberHistory) {
         if (this.timestamp) {
           this.addToHistory(this.timestamp)
-        } else if (historyIndex !== -1) {
-          this.addToHistory(this.historyCache[historyIndex].watchProgress)
+        } else if (typeof historyEntry !== 'undefined') {
+          this.addToHistory(this.historyEntry.watchProgress)
         } else {
           this.addToHistory(0)
         }


### PR DESCRIPTION
# Improve performance of the watch history handling

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Performance Improvement

## Related issue
closes #3796

## Description
Currently all watch history interactions go through a chronologically sorted list, which is great for the history page, so that it displays items in the right order, but less than ideal if you need to check if a video is watched. For most users this will likely never be a problem, but for users like the ones in the issue, that have gigantic watch histories (32k+), this means that video lists and especially the subscriptions page, slow down.

This pull request introduces an additional history object, this time it is an object (vuex doesn't support [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)s) with the video ids as the keys. This should allow for almost instant lookups, which should speed up video lists and any other place that accesses the watch history to check an entry exist and read properties from them.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that history handling still works as expected:
- Watch history and watch progress get saved and restored on the next playback (well the watch progress might not get restored, as it is now fast enough that it might try to do it before the video is loaded, yes it's a race condition that I am fully aware of, using a link with a timestamp doesn't work either if you have no history)
- Adding and removing and item from the history should live update it's state in a second window
- Watch history page still works
- Exporting history still works
- The hide watched items on the subscription page setting still works

@Nemo157 @apatheticslacker @StrangestNoob
As none of the devs have a large enough history to encounter any performance problems, it would be really helpful if you could test this pull request and check if it solves the problem for you. (Ideally all 3 of you, but mainly @Nemo157 as you opened the bug report).

Here is a test build you 3 can download, so that you don't have to set up a development environment to test it: https://github.com/absidue/FreeTube/actions/runs/6136849377

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0