### PR TITLE
Sort list of external players

### DIFF
--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -21,9 +21,20 @@ export default defineComponent({
   computed: {
     externalPlayerNames: function () {
       const fallbackNames = this.$store.getters.getExternalPlayerNames
-      const nameTranslationKeys = this.$store.getters.getExternalPlayerNameTranslationKeys
+      const nameTranslationKeys = this.$store.getters.getExternalPlayerNameTranslationKeys.map((translationKey, idx) => this.$te(translationKey) ? this.$t(translationKey) : fallbackNames[idx])
 
-      return nameTranslationKeys.map((translationKey, idx) => this.$te(translationKey) ? this.$t(translationKey) : fallbackNames[idx])
+      // Sort list of external players alphabetically & case-insensitive and keep the default 'None' in the first index
+      const nameTranslationKeysSorted = [...nameTranslationKeys]
+
+      nameTranslationKeysSorted.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+
+      const playerNone = nameTranslationKeys[0]
+      const playerNoneIndex = nameTranslationKeysSorted.indexOf(playerNone)
+
+      nameTranslationKeysSorted.splice(playerNoneIndex, 1)
+      nameTranslationKeysSorted.unshift(playerNone)
+
+      return nameTranslationKeysSorted
     },
     externalPlayerValues: function () {
       return this.$store.getters.getExternalPlayerValues


### PR DESCRIPTION
# Sort list of external players

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
As more players get added, the list should be sorted for better UX. This PR sorts the elements before display and keeps the default entry for no external player at the top.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![{4A13AAC2-618E-41ED-B76D-6BE209D6D40C}](https://github.com/FreeTubeApp/FreeTube/assets/17594477/b43a53cb-c223-4cbd-b93a-cdc5afe6a12f)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Has been checked by opening the settings and it works as designed.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** v0.19.0

## Additional context
<!-- Add any other context about the pull request here. -->

Due to the way this setting appears to be saved, changing the order will mix up previously existing configurations and users would have to go back into the settings and set their preferred player again.
I can't really think of an elegant and simple way to avoid this. If you do, I'm all ears and happy to make changes.

If you feel that breaking this setting is too much, I'd understand. But I do believe it's necessary in the long run to keep the list from becoming too unwieldy.