### PR TITLE
Fix comment author focus outline being broken

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -70,8 +70,7 @@
   font-weight: bold;
   font-size: 14px;
   margin-inline-start: 68px;
-  margin-block-start: 0px;
-  overflow: hidden;
+  margin-block-start: 0;
   text-overflow: ellipsis;
 }
 
@@ -94,10 +93,10 @@
   margin-inline-start: 70px;
   word-wrap: break-word;
 }
+
 .commentPinned {
   font-weight: normal;
   font-size: 12px;
-  margin-block-end: 0;
   margin-block-start: 0;
   margin-inline-start: 68px;
   margin-block-end: 5px;
@@ -127,7 +126,7 @@
 .commentLikeCount {
   font-size: 11px;
   margin-inline-start: 70px;
-  margin-block-start: 0px;
+  margin-block-start: 0;
 }
 
 .commentHeartBadge {
@@ -188,7 +187,6 @@
 
 .getMoreComments {
   padding-block-end: 1em;
-
   text-align: center;
   text-decoration: underline;
   cursor: pointer;


### PR DESCRIPTION
# Fix comment author focus outline being broken

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
fixes #4025 

## Description
Fixes the focus outline not wrapping around the comment author, turns out the culprit was `overflow: none` on the `.commentAuthorWrapper` class. I also fixed some of the issues that stylelint was pointing out in the file.

## Screenshots <!-- If appropriate -->

before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/2bc7ea68-33c6-419d-bb70-351d047133f5)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/ee7e8767-2c75-4053-9713-bd9acfeb7992)

## Testing <!-- for code that is not small enough to be easily understandable -->
Tab through the comments and check that the outline around the comment author names displays correctly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0