### PR TITLE
Fix focus disappearing when visiting the settings

### DIFF
--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -48,7 +48,7 @@ export default defineComponent({
       return this.$store.getters.getSettingsPassword
     }
   },
-  mounted: function () {
+  created: function () {
     if (this.settingsPassword === '') {
       this.unlocked = true
     }


### PR DESCRIPTION
# Fix focus disappearing when visiting the settings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4021 

## Description
Currently the settings page is first rendered with the password dialog, which focuses the password input and then immediately rerendered without it, if you don't have a password, which unset the focus. This is caused by the default value for `settingsUnlocked` being `true` and us only setting it to `false` when the `mounted` hook fires, changing to the created hook fixes the issue, as that fires before Vue does any rendering. The created hook fires after the component instance is created, the mounted hook fires after the component has been mounted into the DOM (html elements created, event listeners registered etc).

## Testing <!-- for code that is not small enough to be easily understandable -->
0. Make sure you don't have a settings password set.
1. Click on the settings icon in the side bar
2. Press tab
3. The focus should be on the history icon

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0