### PR TITLE
Normalize ft-list-item grid height

### DIFF
--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -283,6 +283,7 @@ $watched-transition-duration: 0.5s;
     flex-direction: column;
     min-height: 230px;
     padding-block-end: 20px;
+    height: 91.46%;
 
     .videoThumbnail,
     .channelThumbnail {


### PR DESCRIPTION
# Normalize ft-list-item grid height

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
N/A

## Description
Makes all grid elements' inner ft-list-items have an equal height. The main this affects is that video elements with `class="watched"` don't jump up and down in relative heights.

## Screenshots <!-- If appropriate -->
Before:

![Screenshot_20230913_184201](https://github.com/FreeTubeApp/FreeTube/assets/84899178/0ca8d9e0-ab1b-4e6f-bf57-6288b23195fb)

After:

![Screenshot_20230913_184330](https://github.com/FreeTubeApp/FreeTube/assets/84899178/7121b723-d999-49f0-9b3c-21d821f1f793)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0

## Additional context
[Sometimes it's the small stuff that counts!](https://en.wikipedia.org/wiki/Pareto_principle)