### PR TITLE
Avoid extending the VueRouter class as it won't exist in Vue 3

### DIFF
--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -16,41 +16,9 @@ import Channel from '../views/Channel/Channel.vue'
 import Watch from '../views/Watch/Watch.vue'
 import Hashtag from '../views/Hashtag/Hashtag.vue'
 
-class CustomRouter extends Router {
-  push(location) {
-    // only navigates if the location is not identical to the current location
+Vue.use(Router)
 
-    const currentQueryUSP = new URLSearchParams(router.currentRoute.query)
-    let newPath = ''
-    let newQueryUSP = new URLSearchParams()
-
-    if (typeof location === 'string') {
-      if (location.includes('?')) {
-        const urlParts = location.split('?')
-        newPath = urlParts[0]
-        newQueryUSP = new URLSearchParams(urlParts[1])
-      } else {
-        newPath = location
-        // newQueryUSP already empty
-      }
-    } else {
-      newPath = location.path
-      newQueryUSP = new URLSearchParams(location.query)
-    }
-
-    const pathsAreDiff = router.currentRoute.path !== newPath
-    // Comparing `URLSearchParams` objects directly will always be different
-    const queriesAreDiff = newQueryUSP.toString() !== currentQueryUSP.toString()
-
-    if (pathsAreDiff || queriesAreDiff) {
-      return super.push(location)
-    }
-  }
-}
-
-Vue.use(CustomRouter)
-
-const router = new CustomRouter({
+const router = new Router({
   routes: [
     {
       path: '/',
@@ -187,5 +155,37 @@ const router = new CustomRouter({
     })
   }
 })
+
+const originalPush = router.push.bind(router)
+
+router.push = (location) => {
+  // only navigates if the location is not identical to the current location
+
+  const currentQueryUSP = new URLSearchParams(router.currentRoute.query)
+  let newPath = ''
+  let newQueryUSP = new URLSearchParams()
+
+  if (typeof location === 'string') {
+    if (location.includes('?')) {
+      const urlParts = location.split('?')
+      newPath = urlParts[0]
+      newQueryUSP = new URLSearchParams(urlParts[1])
+    } else {
+      newPath = location
+      // newQueryUSP already empty
+    }
+  } else {
+    newPath = location.path
+    newQueryUSP = new URLSearchParams(location.query)
+  }
+
+  const pathsAreDiff = router.currentRoute.path !== newPath
+  // Comparing `URLSearchParams` objects directly will always be different
+  const queriesAreDiff = newQueryUSP.toString() !== currentQueryUSP.toString()
+
+  if (pathsAreDiff || queriesAreDiff) {
+    return originalPush(location)
+  }
+}
 
 export default router


### PR DESCRIPTION
# Avoid extending the VueRouter class as it won't exist in Vue 3

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Refactor

## Related issue
https://github.com/FreeTubeApp/FreeTube/projects/10#card-87323330

## Description
This is another one of my Vue 3 preparation pull requests, making changes that we can already do, to reduce the amount of changes we'll have to do and review, when we do the actual Vue 3 migration.

The vue-router version compatible with Vue 3 no longer uses a VueRouter class, instead it has a [`createRouter`](https://router.vuejs.org/api/#createRouter) function, which creates the router object based on the values you passed to the function. As the class no longer exists, we won't be able to extend it anymore, so this pull request overwrites the push function after the router is created, which should be compatible with the object returned by the `createRouter` function.

Scroll behaviour changed in vue-router 4, but that isn't something we can change yet, as it will have to be done as part of the migration: https://router.vuejs.org/guide/migration/#scrollBehavior-changes

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Navigate around FreeTube
2. Spam click the FreeTube logo in the nav bar and make sure that the NavigationDuplicated error doesn't show up
The logo still uses a click handler with router.push, so it would trigger that NavigationDuplicated error, without the special handler, which should still work with this refactor

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.0