### PR TITLE
Fix subscribe button being clipped on Channel page (mobile/tablet view)

### DIFF
--- a/src/renderer/components/ft-button/ft-button.css
+++ b/src/renderer/components/ft-button/ft-button.css
@@ -4,6 +4,7 @@
   font-size: 0.9rem;
   padding-block: 10px;
   padding-inline: 20px;
+  block-size: fit-content;
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
# Fix subscribe button being clipped on Channel page (mobile/tablet view)

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
None

## Description
Fixes mobile and tablet view of subscribe button.

## Screenshots <!-- If appropriate -->
Before:
![Screenshot_20230918_180308](https://github.com/FreeTubeApp/FreeTube/assets/84899178/b74d148b-536e-40da-9d7f-48ce5162abe2)

After:
![Screenshot_20230918_180355](https://github.com/FreeTubeApp/FreeTube/assets/84899178/3db55aad-cfcb-4fc2-9f09-1106dea7b0fa)


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open channel page
2. Set viewport width to ~<734px, when the subscribe button wraps over to the left side. Ensure button is full-height.

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0