### PR TITLE
Fix buttons intersecting on Subscribed Channels tab

### DIFF
--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.css
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.css
@@ -1,6 +1,7 @@
-.subscribeButton {
+.subscribeButton.btn {
   align-self: center;
   block-size: 50%;
   margin-block-end: 10px;
   min-inline-size: 150px;
+  white-space: initial;
 }


### PR DESCRIPTION
# Fix buttons intersecting on Subscribed Channels tab

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
None

## Description
Fixes buttons on the Subscribed Channels tab intersecting in many languages. In all languages where this issue occurs, there are multiple words in the Unsubscribe button label text, which causes the buttons to intersect. This change has the words wrap in such cases and updates the default behavior for all `ft-subscribe-button`s for future-proofing. As a result, this wrapping behavior goes into effect on other instances of `ft-subscribe-button` when the button would otherwise overflow to outside of the container (e.g., the subscribe button on the Channel page on very small viewport widths), but this is desired behavior in those cases.

## Screenshots <!-- If appropriate -->

Before:
![Screenshot_20230918_182239](https://github.com/FreeTubeApp/FreeTube/assets/84899178/9c6ebcee-b3ba-4d34-a17e-dea14aec4d86)

After:
![Screenshot_20230918_182221](https://github.com/FreeTubeApp/FreeTube/assets/84899178/46632ae1-c3bd-41d1-b783-6a19a355985b)


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Change locale to a language with multiple words in the "Unsubsribe" button label text (e.g., `Svenska` / Swedish)
2. Navigate to Channels tab
3. See normal behavior

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0
