### PR TITLE
Fix in subscription view, restoring last tab is bugged when visible tabs do not include tab to be restored

### DIFF
--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -111,7 +111,8 @@ export default defineComponent({
       if (this.visibleTabs.includes(tab)) {
         this.currentTab = tab
       } else {
-        this.currentTab = null
+        // First visible tab or no tab
+        this.currentTab = this.visibleTabs.length > 0 ? this.visibleTabs[0] : null
       }
     },
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Found this issue maybe when testing https://github.com/FreeTubeApp/FreeTube/pull/3973 (but not related)

## Description
When switching to subscription view, last tab view tab would be restored
But if visible tabs does not contain last tab, it should restore to 1st visible tab, but it displayed as no tab selected instead

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Switch to sub view
- Select tab that can be hidden (short/live/community)
- Go to setting and hide the tab selected
- Switch back & confirm first tab selected
- Go to setting and hide all
- Switch back & confirm "empty message"
- Go to setting and show all
- Switch back & confirm first tab selected

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
