### PR TITLE
Add external player support for Baka, Celluloid & Haruna

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -148,5 +148,59 @@
           "playlistShuffle": null,
           "playlistLoop": null
         }
+    },
+    {
+      "name": "Baka-MPlayer",
+      "nameTranslationKey": "Settings.External Player Settings.Players.Baka-MPlayer.Name",
+      "value": "baka-mplayer",
+      "cmdArguments": {
+          "defaultExecutable": "baka-mplayer",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": false,
+          "videoUrl": "",
+          "playlistUrl": null,
+          "startOffset": null,
+          "playbackRate": null,
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": null,
+          "playlistLoop": null
+        }
+    },
+    {
+      "name": "Celluloid",
+      "nameTranslationKey": "Settings.External Player Settings.Players.Celluloid.Name",
+      "value": "celluloid",
+      "cmdArguments": {
+          "defaultExecutable": "celluloid",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": false,
+          "videoUrl": "",
+          "playlistUrl": "",
+          "startOffset": "--mpv-start=",
+          "playbackRate": "--mpv-speed=",
+          "playlistIndex": "--mpv-playlist-start=",
+          "playlistReverse": null,
+          "playlistShuffle": "--mpv-shuffle",
+          "playlistLoop": "--mpv-loop-playlist"
+        }
+    },
+    {
+      "name": "Haruna",
+      "nameTranslationKey": "Settings.External Player Settings.Players.Haruna.Name",
+      "value": "haruna",
+      "cmdArguments": {
+          "defaultExecutable": "haruna",
+          "defaultCustomArguments": null,
+          "supportsYtdlProtocol": false,
+          "videoUrl": "",
+          "playlistUrl": "",
+          "startOffset": null,
+          "playbackRate": null,
+          "playlistIndex": null,
+          "playlistReverse": null,
+          "playlistShuffle": null,
+          "playlistLoop": null
+        }
     }
 ]


### PR DESCRIPTION
# Add external player support for Baka, Celluloid & Haruna

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #3990

## Description
Adds basic support for Baka & Haruna and extended support for Celluloid

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

Haruna and Celluloid have been fully tested, all options should work. Baka does not appear to be in active development anymore and requires replacing mpv and youtube-dl on Windows to even work, and it segfaults for me in Linux.
If someone can confirm it works for them, I'll leave it in, otherwise I'll remove it.

## Desktop
<!-- Please complete the following information-->
- **OS:** openSUSE Tumbleweed
- **OS Version:** 20230921-2505.1
- **FreeTube version:** 0.19
