### PR TITLE
Keep download folder path when changing to 'ask for download path' and back

### DIFF
--- a/src/renderer/components/download-settings/download-settings.js
+++ b/src/renderer/components/download-settings/download-settings.js
@@ -21,7 +21,6 @@ export default defineComponent({
   },
   data: function () {
     return {
-      askForDownloadPath: false,
       downloadBehaviorValues: [
         'download',
         'open'
@@ -31,6 +30,9 @@ export default defineComponent({
   computed: {
     downloadPath: function() {
       return this.$store.getters.getDownloadFolderPath
+    },
+    askForDownloadPath: function() {
+      return this.$store.getters.getAskForDownloadFolderPath
     },
     downloadBehaviorNames: function () {
       return [
@@ -42,15 +44,9 @@ export default defineComponent({
       return this.$store.getters.getDownloadBehavior
     }
   },
-  mounted: function () {
-    this.askForDownloadPath = this.downloadPath === ''
-  },
   methods: {
     handleDownloadingSettingChange: function (value) {
-      this.askForDownloadPath = value
-      if (value === true) {
-        this.updateDownloadFolderPath('')
-      }
+      this.updateAskForDownloadFolderPath(value)
     },
     chooseDownloadingFolder: async function() {
       // only use with electron
@@ -62,6 +58,7 @@ export default defineComponent({
       this.updateDownloadFolderPath(folder.filePaths[0])
     },
     ...mapActions([
+      'updateAskForDownloadFolderPath',
       'updateDownloadFolderPath',
       'updateDownloadBehavior'
     ])

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -283,6 +283,7 @@ const state = {
   videoPlaybackRateMouseScroll: false,
   videoSkipMouseScroll: false,
   videoPlaybackRateInterval: 0.25,
+  askForDownloadFolderPath: true,
   downloadFolderPath: '',
   downloadBehavior: 'download',
   enableScreenshot: false,

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -125,9 +125,10 @@ const actions = {
 
     const fileName = `${replaceFilenameForbiddenChars(title)}.${extension}`
     const errorMessage = i18n.t('Downloading failed', { videoTitle: title })
+    const askFolderPath = rootState.settings.askForDownloadFolderPath
     let folderPath = rootState.settings.downloadFolderPath
 
-    if (folderPath === '') {
+    if (askFolderPath) {
       const options = {
         defaultPath: fileName,
         filters: [


### PR DESCRIPTION
# Keep download folder path when changing to 'ask for download path' and back

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes https://github.com/FreeTubeApp/FreeTube/issues/4035

## Description
Keeps a flag to ask for download path instead of checking if it's an empty string

## Testing 
Tried switching between the toggles and different folder paths on several videos.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11
- **OS Version:** 22H2
- **FreeTube version:**
