### PR TITLE
Fix playlist item fetching for local API

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -4,7 +4,11 @@ import FtLoader from '../ft-loader/ft-loader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtListVideoLazy from '../ft-list-video-lazy/ft-list-video-lazy.vue'
 import { copyToClipboard, showToast } from '../../helpers/utils'
-import { getLocalPlaylist, parseLocalPlaylistVideo } from '../../helpers/api/local'
+import {
+  getLocalPlaylist,
+  parseLocalPlaylistVideo,
+  untilEndOfLocalPlayList,
+} from '../../helpers/api/local'
 import { invidiousGetPlaylistInfo } from '../../helpers/api/invidious'
 
 export default defineComponent({
@@ -327,21 +331,12 @@ export default defineComponent({
       if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious' || cachedPlaylist.continuationData === null) {
         this.playlistItems = cachedPlaylist.items
       } else {
-        const items = cachedPlaylist.items
-        let playlist = cachedPlaylist.continuationData
+        const videos = cachedPlaylist.items
+        await untilEndOfLocalPlayList(cachedPlaylist.continuationData, (p) => {
+          videos.push(...p.items.map(parseLocalPlaylistVideo))
+        }, { runCallbackOnceFirst: false })
 
-        do {
-          playlist = await playlist.getContinuation()
-
-          const parsedVideos = playlist.items.map(parseLocalPlaylistVideo)
-          items.push(...parsedVideos)
-
-          if (!playlist.has_continuation) {
-            playlist = null
-          }
-        } while (playlist !== null)
-
-        this.playlistItems = items
+        this.playlistItems = videos
       }
 
       this.isLoading = false
@@ -351,7 +346,7 @@ export default defineComponent({
       this.isLoading = true
 
       try {
-        let playlist = await getLocalPlaylist(this.playlistId)
+        const playlist = await getLocalPlaylist(this.playlistId)
 
         let channelName
 
@@ -368,14 +363,10 @@ export default defineComponent({
         this.channelName = channelName
         this.channelId = playlist.info.author?.id
 
-        const videos = playlist.items.map(parseLocalPlaylistVideo)
-
-        while (playlist.has_continuation) {
-          playlist = await playlist.getContinuation()
-
-          const parsedVideos = playlist.items.map(parseLocalPlaylistVideo)
-          videos.push(...parsedVideos)
-        }
+        const videos = []
+        await untilEndOfLocalPlayList(playlist, (p) => {
+          videos.push(...p.items.map(parseLocalPlaylistVideo))
+        })
 
         this.playlistItems = videos
 

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -76,6 +76,47 @@ export async function getLocalPlaylist(id) {
 }
 
 /**
+ * @param {Playlist} playlist
+ * @returns {Playlist|null} null when no valid playlist can be found (e.g. `empty continuation response`)
+ */
+export async function getLocalPlaylistContinuation(playlist) {
+  try {
+    return await playlist.getContinuation()
+  } catch (error) {
+    // Youtube can provide useless continuation data
+    if (!error.message.includes('Got empty continuation response.')) {
+      // Re-throw unhandled error
+      throw error
+    }
+
+    return null
+  }
+}
+
+/**
+ * Callback for adding two numbers.
+ *
+ * @callback untilEndOfLocalPlayListCallback
+ * @param {Playlist} playlist
+ */
+
+/**
+ * @param {Playlist} playlist
+ * @param {untilEndOfLocalPlayListCallback} callback
+ * @param {object} options
+ * @param {boolean} options.runCallbackOnceFirst
+ */
+export async function untilEndOfLocalPlayList(playlist, callback, options = { runCallbackOnceFirst: true }) {
+  if (options.runCallbackOnceFirst) { callback(playlist) }
+
+  while (playlist != null && playlist.has_continuation) {
+    playlist = await getLocalPlaylistContinuation(playlist)
+
+    if (playlist != null) { callback(playlist) }
+  }
+}
+
+/**
  * @param {string} location
  * @param {'default'|'music'|'gaming'|'movies'} tab
  * @param {import('youtubei.js').Mixins.TabbedFeed|null} instance

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -6,7 +6,11 @@ import PlaylistInfo from '../../components/playlist-info/playlist-info.vue'
 import FtListVideoLazy from '../../components/ft-list-video-lazy/ft-list-video-lazy.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
-import { getLocalPlaylist, parseLocalPlaylistVideo } from '../../helpers/api/local'
+import {
+  getLocalPlaylist,
+  getLocalPlaylistContinuation,
+  parseLocalPlaylistVideo,
+} from '../../helpers/api/local'
 import { extractNumberFromString } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 
@@ -188,12 +192,16 @@ export default defineComponent({
     getNextPageLocal: function () {
       this.isLoadingMore = true
 
-      this.continuationData.getContinuation().then((result) => {
-        const parsedVideos = result.items.map(parseLocalPlaylistVideo)
-        this.playlistItems = this.playlistItems.concat(parsedVideos)
+      getLocalPlaylistContinuation(this.continuationData).then((result) => {
+        if (result) {
+          const parsedVideos = result.items.map(parseLocalPlaylistVideo)
+          this.playlistItems = this.playlistItems.concat(parsedVideos)
 
-        if (result.has_continuation) {
-          this.continuationData = result
+          if (result.has_continuation) {
+            this.continuationData = result
+          } else {
+            this.continuationData = null
+          }
         } else {
           this.continuationData = null
         }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/4068 https://github.com/FreeTubeApp/FreeTube/issues/4086

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YT now sometimes returns useless continuation data which makes loading "next page" sometimes failed with error from `youtube.js`
We need to handle it somehow

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Example playlists/video with playlists to test
- https://www.youtube.com/watch?v=a52LaNBDV7Q&list=PL61FH1Fo4C7FPgWSYMaQj-OjWUB-buzUq
- https://youtube.com/playlist?list=PL61FH1Fo4C7FPgWSYMaQj-OjWUB-buzUq
- https://www.youtube.com/watch?v=MH2JHRBQ6ng&list=PLrBjj4brdIRzn3ja4BfqYUForg0p-p5wi (https://github.com/FreeTubeApp/FreeTube/issues/4068)
- https://www.youtube.com/watch?v=Ytkf3qZTj74&list=PLT1F2nOxLHOcmi_qi1BbY6axf5xLFEcit (https://github.com/FreeTubeApp/FreeTube/issues/4086)

### Watch video page, playlist component loading (normal)
- Watch a video with playlist **without** going to playlist view first (e.g. https://www.youtube.com/watch?v=a52LaNBDV7Q&list=PL61FH1Fo4C7FPgWSYMaQj-OjWUB-buzUq)
- Ensure no error, all items loaded

### Watch video page, playlist component loading (playlist cached)
- Watch a video with playlist **without** going to playlist view first (e.g. https://youtube.com/playlist?list=PL61FH1Fo4C7FPgWSYMaQj-OjWUB-buzUq)
- Ensure no error, all items loaded, **no duplicate**

### Playlist view
- Visit a playlist (e.g. https://youtube.com/playlist?list=PL61FH1Fo4C7FPgWSYMaQj-OjWUB-buzUq)
- Press load more, ensure no error shown
- No idea how to make it disappear on load without extra request

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
