### PR TITLE
Fix watch page video published time parsing

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -322,7 +322,8 @@ export default defineComponent({
           channelId: this.channelId
         })
 
-        this.videoPublished = new Date(result.page[0].microformat.publish_date.replace('-', '/')).getTime()
+        // `result.page[0].microformat.publish_date` example value: `2023-08-12T08:59:59-07:00`
+        this.videoPublished = new Date(result.page[0].microformat.publish_date).getTime()
 
         if (result.secondary_info?.description.runs) {
           try {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Fixes #4104

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
See related issue

YT seems to return new value for published time now

before: `2023-10-05`
now: `2023-10-05T13:00:07-07:00`

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After fix
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/b72b50cf-dda7-480c-bfc0-cb49dec482d0)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
See #4104

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
