### PR TITLE
Fix styling for Channel page on desktop view

### DIFF
--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -98,21 +98,18 @@
   gap: 32px;
   padding-block: .3em;
   padding-inline: 0;
-  flex-direction: column;
   flex-wrap: nowrap;
 }
 
 .tabs {
   display: flex;
   flex: 0 1 33%;
-  flex-wrap: wrap;
 }
 
 .tab {
   padding: 15px;
   font-size: 15px;
   cursor: pointer;
-  flex: 1 1 0%;
   align-self: flex-end;
   text-align: center;
   color: var(--tertiary-text-color);
@@ -205,6 +202,10 @@
   .tabs {
     flex: 1 1 0;
     flex-wrap: wrap;
+  }
+
+  .tab {
+    flex: 1 1 0%;
   }
 
   #communityPanel {


### PR DESCRIPTION
# Fix styling for Channel page on desktop view

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
[See comment](https://github.com/FreeTubeApp/FreeTube/pull/4061#issuecomment-1734034555)

## Description
Fixes search bar wrapping onto separate height, and channel tabs taking full width, on desktop view.


## Screenshots <!-- If appropriate -->
![Screenshot_20231007_180926](https://github.com/FreeTubeApp/FreeTube/assets/84899178/7a365d8c-57c2-4e32-a684-f35b92c5b843)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Go to channel page for a given video on desktop view. Confirm that search bar is on the same height, and tabs are not taking full width.

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0
