### PR TITLE
Fix playlists not showing up on artist topic channels with the local API

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1191,13 +1191,20 @@ export default defineComponent({
         // for the moment we just want the "Created Playlists" category that has all playlists in it
 
         if (playlistsTab.content_type_filters.length > 1) {
+          let viewId = '1'
+
+          // Artist topic channels don't have any created playlists, so we went to select the "Albums & Singles" category instead
+          if (this.channelName.endsWith('- Topic') && channel.metadata.music_artist_name) {
+            viewId = '50'
+          }
+
           /**
            * @type {import('youtubei.js').YTNodes.ChannelSubMenu}
            */
           const menu = playlistsTab.current_tab.content.sub_menu
           const createdPlaylistsFilter = menu.content_type_sub_menu_items.find(contentType => {
             const url = `https://youtube.com/${contentType.endpoint.metadata.url}`
-            return new URL(url).searchParams.get('view') === '1'
+            return new URL(url).searchParams.get('view') === viewId
           }).title
 
           playlistsTab = await playlistsTab.applyContentTypeFilter(createdPlaylistsFilter)


### PR DESCRIPTION
# Fix playlists not showing up on artist topic channels with the local API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently when you visit an artist topic channel e.g. `Rihanna - Topic` on the local API, the playlists tab will be empty. This is caused by those channels having the `Created Playlists` category despite not actually having any playlists that they own, instead we need to use the `Albums & Singles` category, which isn't empty and contains Album playlists, which aren't tied directly to any channel (playlist ID starts with `OL`).

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/fa2c0f78-1c03-43de-928c-9446ca483a6f)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/2c7250c6-29c5-4f9a-976a-e061960e7b0f)

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/channel/UCvWtix2TtWGe9kffqnwdaMw

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1