### PR TITLE
Fix error when clicking on the current quality in the DASH quality selector

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1711,6 +1711,9 @@ export default defineComponent({
       const VjsButton = videojs.getComponent('Button')
       class dashQualitySelector extends VjsButton {
         handleClick(event) {
+          if (!event.target.classList.contains('quality-item') && !event.target.classList.contains('vjs-menu-item-text')) {
+            return
+          }
           const selectedQuality = event.target.innerText
           const bitrate = selectedQuality === 'auto' ? 'auto' : parseInt(event.target.attributes.bitrate.value)
           setDashQualityLevel(bitrate)


### PR DESCRIPTION
# Fix error when clicking on the current quality in the DASH quality selector

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #3543

## Description
Fixes the error that happens if you click on the DASH quality selector but don't click on one of the available qualities. The proper fix would be to use a video.js menu instead of creating one with our own HTML, but this fix works for now.

See issue for the original error and a video of it happening.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open a video
2. Select the DASH formats
3. Click the current quality in the quality selector, the button that is always visible, that you have to hover over to open the drop up.
4. Check that it doesn't produce an error like before.

Also test that changing qualities still works.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1

## Additional context
The proper fix would be to use a video.js menu element instead of creating our own one with raw HTML but that doesn't seem worth changing now.