### PR TITLE
Truncate title of playlist in queue window

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -1,4 +1,10 @@
-.playlistTitle, .channelName {
+.playlistTitle {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.playlistTitleLink, .channelName {
   text-decoration: none;
   color: inherit;
 }

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
@@ -6,9 +6,12 @@
     <div
       v-else
     >
-      <h3>
+      <h3
+        class="playlistTitle"
+        :title="`${playlistTitle}`"
+      >
         <router-link
-          class="playlistTitle"
+          class="playlistTitleLink"
           :to="`/playlist/${playlistId}`"
         >
           {{ playlistTitle }}


### PR DESCRIPTION
# Truncate title of playlist in queue window

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes https://github.com/FreeTubeApp/FreeTube/issues/4131

## Description
All the spacing in `watch-video-playlist` works nicely if the title fits in 1 line. Decided to truncate it like how YouTube does it:
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/d1ae5c94-3e7d-4853-a4b3-53ecf90d15e0)


## Screenshots <!-- If appropriate -->

Full title can be shown on hover:
![Untitled](https://github.com/FreeTubeApp/FreeTube/assets/19561469/1d6db4e4-f6d9-400e-b25d-295f53fc8034)


https://github.com/FreeTubeApp/FreeTube/assets/19561469/d19f8258-ec2b-4a2b-8048-c45c45373779

https://github.com/FreeTubeApp/FreeTube/assets/19561469/fa0105f6-2712-4ee7-b604-ea9d8897aa0b


## Testing <!-- for code that is not small enough to be easily understandable -->
Tried several playlists:
- https://www.youtube.com/playlist?list=PLHh55M_Kq4OApWScZyPl5HhgsTJS9MZ6M
- https://www.youtube.com/playlist?list=PL61FH1Fo4C7FPgWSYMaQj-OjWUB-buzUq
- https://www.youtube.com/playlist?list=PL1Uej7CYD92axHrYkxV4MgD86weobZ0bT
- https://www.youtube.com/playlist?list=PLmWSpSS_VIZrVrqWT4z9KSYnDB9pJRLlU
- https://www.youtube.com/playlist?list=PLHoyRoIJhvUPlVxA9HsTfJalB2SZh7-fk

and resized the window a couple of times seeing if it breaks anything

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2
- **FreeTube version:**
