### PR TITLE
Wrap channel tabs as soon as there isn't enough screen space

### DIFF
--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -202,7 +202,6 @@
 
   .tabs {
     flex: 1 1 0;
-    flex-wrap: wrap;
   }
 
   .tab {

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -103,7 +103,8 @@
 
 .tabs {
   display: flex;
-  flex: 0 1 33%;
+  flex: 0 1 66%;
+  flex-wrap: wrap;
 }
 
 .tab {


### PR DESCRIPTION
# Wrap channel tabs as soon as there isn't enough screen space

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Currently, at certain breakpoints, the channel page is pushed down one full screen length. This is because the channel tabs are not wrapping until `800px`. This PR aims to address this issue by making the channel tabs `flex-wrap` by default.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
|before|after|
|--|--|
|![before-1](https://github.com/FreeTubeApp/FreeTube/assets/106682128/6f1c153d-954e-4615-8364-3b154ae19c98)|![after-1](https://github.com/FreeTubeApp/FreeTube/assets/106682128/b7facdb2-a6f2-42d6-9438-d046d2a293c5)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open a channel with a lot of channel tabs (ex: https://www.youtube.com/channel/UChRV-sCl5Fma4qm_hFpDKBQ)
2. Reduce the page width
3. Ensure the page doesn't suddenly shift down 1 entire screen length

## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 3c0ed260c108241d63cbe8228f3440a1ed6f2eda
