### PR TITLE
Fix single playlist view item index style

### DIFF
--- a/src/renderer/views/Playlist/Playlist.css
+++ b/src/renderer/views/Playlist/Playlist.css
@@ -25,13 +25,14 @@
 
 .playlistItem {
   display: grid;
-  grid-template-columns: max-content auto;
+  grid-template-columns: 30px 1fr;
   column-gap: 8px;
   align-items: center;
 }
 
 .videoIndex {
   color: var(--tertiary-text-color);
+  text-align: center;
 }
 
 .loadNextPageWrapper {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Single playlist view - item index got different width when number of digits changed
This make it have constant width (style from watch view playlist component)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/5a72160b-ee4a-422c-b73a-c2bd21402754)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/8772a7a6-3b54-4700-8416-24f347366270)

After
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/32ffaecf-8ba0-49b4-8707-8c2dae3bcd75)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/0d1f90eb-5747-4222-a0f5-6377e762e612)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Open random playlist with enough items (e.g. https://youtube.com/playlist?list=PL8mG-RkN2uTx9Er8AqFDnD6mFvje5fybs
- Scroll down to confirm style

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
Issue reported in https://github.com/PikachuEXE/FreeTube/discussions/49#discussioncomment-7308956

Also not sure if we should keep the gap (must consider the style when watched)
