### PR TITLE
Fix proxy settings test

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -724,10 +724,12 @@ function runApp() {
     session.defaultSession.setProxy({
       proxyRules: url
     })
+    session.defaultSession.closeAllConnections()
   })
 
   ipcMain.on(IpcChannels.DISABLE_PROXY, () => {
     session.defaultSession.setProxy({})
+    session.defaultSession.closeAllConnections()
   })
 
   ipcMain.on(IpcChannels.OPEN_EXTERNAL_LINK, (_, url) => {

--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -29,7 +29,8 @@ export default defineComponent({
     return {
       isLoading: false,
       dataAvailable: false,
-      proxyTestUrl: 'https://ipwho.is/',
+      proxyTestUrl: 'https://ipwho.is/?output=json&fields=ip,country,city,region',
+      proxyIp: '',
       proxyCountry: '',
       proxyRegion: '',
       proxyCity: '',
@@ -44,7 +45,8 @@ export default defineComponent({
         'https',
         'socks4',
         'socks5'
-      ]
+      ],
+      debounceEnableProxy: () => { }
     }
   },
   computed: {
@@ -64,7 +66,7 @@ export default defineComponent({
       return `${this.proxyProtocol}://${this.proxyHostname}:${this.proxyPort}`
     }
   },
-  mounted: function () {
+  created: function () {
     this.debounceEnableProxy = debounce(this.enableProxy, 200)
   },
   beforeDestroy: function () {
@@ -113,6 +115,12 @@ export default defineComponent({
 
     disableProxy: function () {
       ipcRenderer.send(IpcChannels.DISABLE_PROXY)
+
+      this.dataAvailable = false
+      this.proxyIp = ''
+      this.proxyCountry = ''
+      this.proxyRegion = ''
+      this.proxyCity = ''
     },
 
     testProxy: function () {


### PR DESCRIPTION
# Fix proxy settings test

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4108

## Description
The API we are using for the proxy test changed, now if you don't specifiy an IP or the output format, it redirects you to the docs page. This pull request adds the query parameter to set the output to JSON to make the test work again. (yes i also did some other small fixes)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Download the tor expert bundle (https://www.torproject.org/download/tor/)
2. Run the tor executable e.g. in windows `tor.exe | more`
3. Enable the proxy in FreeTube and set it to socks 5
4. Click test
5. It should show a different IP and location than your current one.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1