### PR TITLE
Make landing page configurable

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -111,6 +111,10 @@ export default defineComponent({
       return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
     },
 
+    landingPage: function() {
+      return '/' + this.$store.getters.getLandingPage
+    },
+
     externalLinkOpeningPromptNames: function () {
       return [
         this.$t('Yes'),
@@ -136,7 +140,7 @@ export default defineComponent({
     $route () {
       // react to route changes...
       // Hide top nav filter panel on page change
-      this.$refs.topNav.hideFilters()
+      this.$refs.topNav?.hideFilters()
     }
   },
   created () {
@@ -178,7 +182,13 @@ export default defineComponent({
       })
 
       this.$router.afterEach((to, from) => {
-        this.$refs.topNav.navigateHistory()
+        this.$refs.topNav?.navigateHistory()
+      })
+
+      this.$router.onReady(() => {
+        if (this.$router.currentRoute.path !== this.landingPage && this.landingPage !== '/subscriptions') {
+          this.$router.push({ path: this.landingPage })
+        }
       })
     })
   },

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -27,20 +27,6 @@ export default defineComponent({
         'invidious',
         'local'
       ],
-      defaultPageNames: [
-        'Subscriptions',
-        'Trending',
-        'Most Popular',
-        'Playlists',
-        'History'
-      ],
-      defaultPageValues: [
-        'subscriptions',
-        'trending',
-        'mostPopular',
-        'playlists',
-        'history'
-      ],
       viewTypeValues: [
         'grid',
         'list'
@@ -74,6 +60,17 @@ export default defineComponent({
     },
     checkForBlogPosts: function () {
       return this.$store.getters.getCheckForBlogPosts
+    },
+    defaultPages: function () {
+      // filter out default '/' route and routes with params
+      return this.$router.getRoutes().filter((route, i) => i !== 0 && !route.path.includes(':'))
+    },
+    defaultPageNames: function () {
+      return this.defaultPages.map((route) => this.$t(route.meta.title))
+    },
+    defaultPageValues: function () {
+      // avoid Vue parsing issues by excluding '/' from path values
+      return this.defaultPages.map((route) => route.path.substring(1))
     },
     backendPreference: function () {
       return this.$store.getters.getBackendPreference

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -43,7 +43,6 @@
         @change="handlePreferredApiBackend"
       />
       <ft-select
-        v-if="false"
         :placeholder="$t('Settings.General Settings.Default Landing Page')"
         :value="landingPage"
         :select-names="defaultPageNames"

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -22,6 +22,7 @@ const router = new Router({
   routes: [
     {
       path: '/',
+      name: 'default',
       meta: {
         title: 'Subscriptions.Subscriptions'
       },
@@ -29,6 +30,7 @@ const router = new Router({
     },
     {
       path: '/subscriptions',
+      name: 'subscriptions',
       meta: {
         title: 'Subscriptions.Subscriptions'
       },
@@ -36,13 +38,63 @@ const router = new Router({
     },
     {
       path: '/subscribedchannels',
+      name: 'subscribedChannels',
       meta: {
         title: 'Channels.Title'
       },
       component: SubscribedChannels
     },
     {
+      path: '/trending',
+      name: 'trending',
+      meta: {
+        title: 'Trending.Trending'
+      },
+      component: Trending
+    },
+    {
+      path: '/popular',
+      name: 'popular',
+      meta: {
+        title: 'Most Popular'
+      },
+      component: Popular
+    },
+    {
+      path: '/userplaylists',
+      name: 'userPlaylists',
+      meta: {
+        title: 'User Playlists.Your Playlists'
+      },
+      component: UserPlaylists
+    },
+    {
+      path: '/history',
+      name: 'history',
+      meta: {
+        title: 'History.History'
+      },
+      component: History
+    },
+    {
+      path: '/settings',
+      name: 'settings',
+      meta: {
+        title: 'Settings.Settings'
+      },
+      component: Settings
+    },
+    {
+      path: '/about',
+      name: 'about',
+      meta: {
+        title: 'About.About'
+      },
+      component: About
+    },
+    {
       path: '/settings/profile',
+      name: 'profileSettings',
       meta: {
         title: 'Profile.Profile Settings'
       },
@@ -63,49 +115,6 @@ const router = new Router({
         title: 'Profile.Edit Profile'
       },
       component: ProfileEdit
-    },
-    {
-      path: '/trending',
-      meta: {
-        title: 'Trending.Trending'
-      },
-      component: Trending
-    },
-    {
-      path: '/popular',
-      meta: {
-        title: 'Most Popular'
-      },
-      component: Popular
-    },
-    {
-      path: '/userplaylists',
-      meta: {
-        title: 'User Playlists.Your Playlists'
-      },
-      component: UserPlaylists
-    },
-    {
-      path: '/history',
-      name: 'history',
-      meta: {
-        title: 'History.History'
-      },
-      component: History
-    },
-    {
-      path: '/settings',
-      meta: {
-        title: 'Settings.Settings'
-      },
-      component: Settings
-    },
-    {
-      path: '/about',
-      meta: {
-        title: 'About.About'
-      },
-      component: About
     },
     {
       path: '/search/:query',


### PR DESCRIPTION
# Make landing page configurable

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #183 
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
Implements setting to customize your landing page on startup. Only includes routes without params. Also slightly reorders routes to closer match the more logical order of how they appear in the application and adds `name` properties to a handful (not used here, but nice to have handy).

## Screenshots <!-- If appropriate -->
![Screenshot_20231021_011521](https://github.com/FreeTubeApp/FreeTube/assets/84899178/733cb35b-4ad6-4d48-8b59-996a40fe0f16)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Go to General Settings and change the default landing page. Confirm that it is populated correctly with a default value.
- Change to one of the values. Restart application -- not just refresh (i.e., NOT CTRL+R) -- and ensure page is used as starting page. Repeat for all values.

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.0
