### PR TITLE
Handle channel URL resolve redirects in the local API

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -238,6 +238,17 @@ export async function getLocalChannelId(url) {
 
     if (navigationEndpoint.metadata.page_type === 'WEB_PAGE_TYPE_CHANNEL') {
       return navigationEndpoint.payload.browseId
+    } else if (navigationEndpoint.metadata.page_type === 'WEB_PAGE_TYPE_UNKNOWN' && navigationEndpoint.payload.url?.startsWith('https://www.youtube.com/')) {
+      // handle redirects like https://www.youtube.com/@wanderbots, which resolves to https://www.youtube.com/Wanderbots, which we need to resolve again
+
+      // while we could just have this function recursively call itself, YouTube should only ever redirect once, so if they do it multiple times, we should assume something is wrong
+      const secondNavigationEndpoint = await innertube.resolveURL(navigationEndpoint.payload.url)
+
+      if (secondNavigationEndpoint.metadata.page_type === 'WEB_PAGE_TYPE_CHANNEL') {
+        return secondNavigationEndpoint.payload.browseId
+      } else {
+        return null
+      }
     } else {
       return null
     }


### PR DESCRIPTION
# Handle channel URL resolve redirects in the local API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4199

## Description
For some channels instead of returning the channel ID when we resolve the URL, it returns another channel URL. This pull requests adds handling for that by resolving the returned URL too.

This only addresses the local API, for Invidious this has to be handled in their URL resolving API endpoint (it returns an HTTP 400 error when it encounters the redirect).

## Testing <!-- for code that is not small enough to be easily understandable -->
https://www.youtube.com/@wanderbots

Before it will show the error page saying the channel doesn't exist, afterwards it should show the channel page.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1