### PR TITLE
Add hide channel option directly to More Options menu

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -211,6 +211,10 @@ export default defineComponent({
               type: 'divider'
             },
             {
+              label: this.$t('Video.Hide Channel'),
+              value: 'hideChannel'
+            },
+            {
               label: this.$t('Video.Copy YouTube Channel Link'),
               value: 'copyYoutubeChannel'
             },
@@ -434,6 +438,9 @@ export default defineComponent({
         case 'openInvidiousChannel':
           openExternalLink(this.invidiousChannelUrl)
           break
+        case 'hideChannel':
+          this.hideChannel(this.channelName)
+          break
       }
     },
 
@@ -621,12 +628,21 @@ export default defineComponent({
       showToast(this.$t('Video.Video has been removed from your saved list'))
     },
 
+    hideChannel: function(channelName) {
+      const hiddenChannels = JSON.parse(this.$store.getters.getChannelsHidden)
+      hiddenChannels.push(channelName)
+      this.updateChannelsHidden(JSON.stringify(hiddenChannels))
+
+      showToast(this.$t('Channel Hidden', { channel: channelName }))
+    },
+
     ...mapActions([
       'openInExternalPlayer',
       'updateHistory',
       'removeFromHistory',
       'addVideo',
-      'removeVideo'
+      'removeVideo',
+      'updateChannelsHidden'
     ])
   }
 })

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -623,6 +623,7 @@ Video:
   Copy YouTube Channel Link: Copy YouTube Channel Link
   Open Channel in Invidious: Open Channel in Invidious
   Copy Invidious Channel Link: Copy Invidious Channel Link
+  Hide Channel: Hide Channel
   Views: Views
   Loop Playlist: Loop Playlist
   Shuffle Playlist: Shuffle Playlist
@@ -920,6 +921,7 @@ Starting download: 'Starting download of "{videoTitle}"'
 Downloading failed: 'There was an issue downloading "{videoTitle}"'
 Screenshot Success: Saved screenshot as "{filePath}"
 Screenshot Error: Screenshot failed. {error}
+Channel Hidden: Channel {channel} Hidden
 
 Hashtag:
   Hashtag: Hashtag


### PR DESCRIPTION
# Add hide channel option directly to More Options menu

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes https://github.com/FreeTubeApp/FreeTube/issues/3051

## Description

Piggybacks off the feature that was implemented in https://github.com/FreeTubeApp/FreeTube/pull/2849 to add an option directly to the "More Options" menu to hide a channel. Options will show up in the "Distraction Settings" afterwards and can be removed from there. 


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/b25e7148-fc41-457e-8089-390c4b101cc8)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

Selected the option in the context menu, the video is immediately filtered and a toast is thrown up to confirm it was hidden. Then I checked the "Distraction Settings" and confirmed the channel is there. 

## Desktop
<!-- Please complete the following information-->
- **OS:** Pop_OS
- **OS Version:** 22.04 LTS
- **FreeTube version:** 0.19.1

## Additional Info

I decided not to go with "Hide Recommendation" like mentioned in the original issue as there really isn't recommendations, just trending. 