### PR TITLE
Add a 15 second timeout for fetching the Invidious instances at startup

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -672,3 +672,35 @@ export function escapeHTML(untrusted) {
 export function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj))
 }
+
+/**
+ * Check if the `name` of the error is `TimeoutError` to know if the error was caused by a timeout or something else.
+ * @param {number} milliseconds
+ * @param {RequestInfo|URL} input
+ * @param {RequestInit=} init
+ */
+export async function fetchWithTimeout(milliseconds, input, init) {
+  const timeoutSignal = AbortSignal.timeout(milliseconds)
+
+  if (typeof init !== 'undefined') {
+    init.signal = timeoutSignal
+  } else {
+    init = {
+      signal: timeoutSignal
+    }
+  }
+
+  try {
+    return await fetch(input, init)
+  } catch (err) {
+    if (err.name === 'AbortError' && timeoutSignal.aborted) {
+      // According to the spec, fetch should use the original abort reason.
+      // Unfortunately chromium browsers always throw an AbortError, even when it was caused by a TimeoutError,
+      // so we need manually throw the original abort reason
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=1431720
+      throw timeoutSignal.reason
+    } else {
+      throw err
+    }
+  }
+}

--- a/static/invidious-instances.json
+++ b/static/invidious-instances.json
@@ -1,22 +1,10 @@
 [
   {
+    "url": "https://invidious.fdn.fr",
+    "cors": true
+  },
+  {
     "url": "https://vid.puffyan.us",
-    "cors": true
-  },
-  {
-    "url": "https://inv.riverside.rocks",
-    "cors": true
-  },
-  {
-    "url": "https://invidious.nerdvpn.de",
-    "cors": true
-  },
-  {
-    "url": "https://invidious.tiekoetter.com",
-    "cors": true
-  },
-  {
-    "url": "https://inv.bp.projectsegfau.lt",
     "cors": true
   },
   {
@@ -24,31 +12,7 @@
     "cors": true
   },
   {
-    "url": "https://yt.artemislena.eu",
-    "cors": true
-  },
-  {
-    "url": "https://inv.pistasjis.net",
-    "cors": true
-  },
-  {
-    "url": "https://invidious.sethforprivacy.com",
-    "cors": true
-  },
-  {
-    "url": "https://invidious.projectsegfau.lt",
-    "cors": true
-  },
-  {
-    "url": "https://invidious.baczek.me",
-    "cors": true
-  },
-  {
-    "url": "https://yt.funami.tech",
-    "cors": true
-  },
-  {
-    "url": "https://iv.ggtyler.dev",
+    "url": "https://inv.bp.projectsegfau.lt",
     "cors": true
   },
   {
@@ -56,7 +20,19 @@
     "cors": true
   },
   {
+    "url": "https://invidious.io.lol",
+    "cors": true
+  },
+  {
+    "url": "https://inv.tux.pizza",
+    "cors": true
+  },
+  {
     "url": "https://invidious.privacydev.net",
+    "cors": true
+  },
+  {
+    "url": "https://yt.artemislena.eu",
     "cors": true
   },
   {
@@ -64,11 +40,51 @@
     "cors": true
   },
   {
-    "url": "https://invidious.0011.lt",
+    "url": "https://onion.tube",
     "cors": true
   },
   {
-    "url": "https://inv.zzls.xyz",
+    "url": "https://yt.oelrichsgarcia.de",
+    "cors": true
+  },
+  {
+    "url": "https://invidious.protokolla.fi",
+    "cors": true
+  },
+  {
+    "url": "https://invidious.asir.dev",
+    "cors": true
+  },
+  {
+    "url": "https://iv.nboeck.de",
+    "cors": true
+  },
+  {
+    "url": "https://invidious.private.coffee",
+    "cors": true
+  },
+  {
+    "url": "https://iv.datura.network",
+    "cors": true
+  },
+  {
+    "url": "https://anontube.lvkaszus.pl",
+    "cors": true
+  },
+  {
+    "url": "https://inv.us.projectsegfau.lt",
+    "cors": true
+  },
+  {
+    "url": "https://invidious.perennialte.ch",
+    "cors": true
+  },
+  {
+    "url": "https://invidious.drgns.space",
+    "cors": true
+  },
+  {
+    "url": "https://invidious.einfachzocken.eu",
     "cors": true
   },
   {
@@ -76,11 +92,15 @@
     "cors": true
   },
   {
-    "url": "https://yt.floss.media",
-    "cors": false
+    "url": "https://invidious.no-logs.com",
+    "cors": true
   },
   {
-    "url": "https://invidious.nogafa.org",
+    "url": "https://yt.drgnz.club",
+    "cors": true
+  },
+  {
+    "url": "https://yt.cdaut.de",
     "cors": true
   },
   {
@@ -88,11 +108,7 @@
     "cors": true
   },
   {
-    "url": "https://invidious.esmailelbob.xyz",
-    "cors": true
-  },
-  {
-    "url": "https://invidious.snopyta.org",
+    "url": "https://inv.citw.lgbt",
     "cors": true
   }
 ]


### PR DESCRIPTION
# Add a 15 second timeout for fetching the Invidious instances at startup

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4223

## Description
When the Invidious instances API goes down, we want to fallback to our local copy of the instance list, unfortunately `fetch` waits for a really long time before it times out, unfortunately that means FreeTube sits on a blank screen at startup forever. I wasn't able to find an exact value for long chromium browsers wait, but the general consensus seems to be that it is a really long time.

To solve that issue, this pull request introduces a 15 second timeout for fetching the Invidious instances list before falling back to the local copy. I know 15 seconds seems quite a lot, but I wanted to make sure it wouldn't time out too early, even for people with the slowest proxies configured.

While we definitely shouldn't have the loading of the entire app dependant on a network request, refactoring all relevant parts is a lot more complicated. We would have to hide and deactivate certain functionality until the instance list is fetched, when you have the Invidious API selected and don't have a default instance configured. Top bar could be loaded but the search bar would have to be disabled, the side bar could be loaded but without the subscriptions list and with the popular icon hidden (also have to disable the popular keyboard shortcut), fetching subscriptions would have to be delayed until an instance is selected, etc etc.

We should probably setup a GitHub workflow that updates our list once a month, so it stays relatively up-to-date.

<details><summary>If you have a really slow proxy configured for your normal FreeTube use, firstly why??? secondly</summary>

![meme](https://github.com/FreeTubeApp/FreeTube/assets/48293849/ba405b26-d345-4ee9-b3b0-d61577dbf90a)

</details> 

## Testing <!-- for code that is not small enough to be easily understandable -->
Edit the timeout in the code to something short like 5ms, reload the FreeTube window with <kbd>CTRL</kbd>+<kbd>R</kbd> or <kbd>Command</kbd>+<kbd>R</kbd> and notice that the `Fetching the Invidious instance list timed out after 15 seconds. Falling back to local copy.` error shows up in the console. (you can try messing around with the throttling settings in the network dev tools if you want, but that was painfully slow for me, as it slows down the loading of FreeTube's own files too).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1