### PR TITLE
Miscellaneous improvements to settings page styling

### DIFF
--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -2,16 +2,35 @@
   <ft-settings-section
     :title="$t('Settings.Data Settings.Data Settings')"
   >
+    <h4 class="groupTitle">
+      {{ $t('Subscriptions.Subscriptions') }}
+    </h4>
     <ft-flex-box>
       <ft-button
         :label="$t('Settings.Data Settings.Import Subscriptions')"
         @click="importSubscriptions"
       />
+      <ft-flex-box>
+        <ft-button
+          :label="$t('Settings.Data Settings.Manage Subscriptions')"
+          @click="openProfileSettings"
+        />
+      </ft-flex-box>
       <ft-button
         :label="$t('Settings.Data Settings.Export Subscriptions')"
         @click="showExportSubscriptionsPrompt = true"
       />
     </ft-flex-box>
+    <ft-flex-box>
+      <p>
+        <a href="https://docs.freetubeapp.io/usage/importing-subscriptions/">
+          {{ $t("Settings.Data Settings.How do I import my subscriptions?") }}
+        </a>
+      </p>
+    </ft-flex-box>
+    <h4 class="groupTitle">
+      {{ $t('History.History') }}
+    </h4>
     <ft-flex-box>
       <ft-button
         :label="$t('Settings.Data Settings.Import History')"
@@ -22,19 +41,9 @@
         @click="exportHistory"
       />
     </ft-flex-box>
-    <ft-flex-box>
-      <p>
-        <a href="https://docs.freetubeapp.io/usage/importing-subscriptions/">
-          {{ $t("Settings.Data Settings.How do I import my subscriptions?") }}
-        </a>
-      </p>
-    </ft-flex-box>
-    <ft-flex-box>
-      <ft-button
-        :label="$t('Settings.Data Settings.Manage Subscriptions')"
-        @click="openProfileSettings"
-      />
-    </ft-flex-box>
+    <h4 class="groupTitle">
+      {{ $t('Playlists') }}
+    </h4>
     <ft-flex-box>
       <ft-button
         :label="$t('Settings.Data Settings.Import Playlists')"

--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -100,6 +100,7 @@
   padding: 1rem;
   border: none;
   margin-block-end: 10px;
+  margin-block-start: 10px;
   font-size: 16px;
   block-size: 45px;
   color: var(--secondary-text-color);

--- a/src/renderer/components/privacy-settings/privacy-settings.vue
+++ b/src/renderer/components/privacy-settings/privacy-settings.vue
@@ -43,20 +43,14 @@
     <ft-flex-box>
       <ft-button
         :label="$t('Settings.Privacy Settings.Clear Search Cache')"
-        text-color="var(--text-with-main-color)"
-        background-color="var(--primary-color)"
         @click="showSearchCachePrompt = true"
       />
       <ft-button
         :label="$t('Settings.Privacy Settings.Remove Watch History')"
-        text-color="var(--text-with-main-color)"
-        background-color="var(--primary-color)"
         @click="showRemoveHistoryPrompt = true"
       />
       <ft-button
         :label="$t('Settings.Privacy Settings.Remove All Subscriptions / Profiles')"
-        text-color="var(--text-with-main-color)"
-        background-color="var(--primary-color)"
         @click="showRemoveSubscriptionsPrompt = true"
       />
     </ft-flex-box>


### PR DESCRIPTION
# Miscellaneous improvements to settings page styling

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [X] Other

Some styling and organization improvements I noticed while working on a different issue 

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description


I've noticed some inconsistencies when going through the settings, or some things I think can be organized better. I've tried to capture the low hanging fruit here. I've enumerated all changes in the screenshots.  

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

### Inconsistent Buttons

All buttons used the default coloring, the privacy buttons were the only buttons on the settings page which used a custom color, this brings it in line with all other buttons on the page.

| Before         | After     |
|--------------|-----------|
|![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/8179ff1a-f6e9-4bca-b900-fbbc938d0013) | ![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/2f61d126-dc76-41de-86c1-a3559baff431) |

### Organize Data Settings By Type

Just a more clean layout I think.

| Before         | After     |
|--------------|-----------|
|![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/bde5859c-e382-4fcf-bea5-16e2e3ac5719) | ![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/2f01fdf5-2a9a-465e-a315-71ce9dc0620e) |

### Fix Search Spacing

The search already had a bottom 10px border, added a top one as well, which makes labels appear less crowded. 

| Before         | After     |
|--------------|-----------|
|![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/e4008fbf-ba77-43f4-b6d0-07ee11d8b43a)| ![image](https://github.com/FreeTubeApp/FreeTube/assets/30714020/d7f157b8-7423-44f8-bcec-3daa03e94171) |

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

Only visual changes were made

## Desktop
<!-- Please complete the following information-->
- **OS:** Pop_OS
- **OS Version:** 22.04 LTS
- **FreeTube version:** 0.19.1

## Additional context
<!-- Add any other context about the pull request here. -->
