### PR TITLE
Move hideOutlines to the utils store instead of using provide/inject

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -70,11 +70,6 @@ const SyncEvents = {
   }
 }
 
-// https://v2.vuejs.org/v2/api/#provide-inject
-const Injectables = {
-  SHOW_OUTLINES: 'showOutlines'
-}
-
 // Utils
 const MAIN_PROFILE_ID = 'allChannels'
 
@@ -82,6 +77,5 @@ export {
   IpcChannels,
   DBActions,
   SyncEvents,
-  Injectables,
   MAIN_PROFILE_ID
 }

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -10,7 +10,7 @@ import FtButton from './components/ft-button/ft-button.vue'
 import FtToast from './components/ft-toast/ft-toast.vue'
 import FtProgressBar from './components/ft-progress-bar/ft-progress-bar.vue'
 import { marked } from 'marked'
-import { Injectables, IpcChannels } from '../constants'
+import { IpcChannels } from '../constants'
 import packageDetails from '../../package.json'
 import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 
@@ -30,15 +30,9 @@ export default defineComponent({
     FtToast,
     FtProgressBar
   },
-  provide: function () {
-    return {
-      [Injectables.SHOW_OUTLINES]: this.showOutlines
-    }
-  },
   data: function () {
     return {
       dataReady: false,
-      hideOutlines: true,
       showUpdatesBanner: false,
       showBlogBanner: false,
       showReleaseNotes: false,
@@ -58,6 +52,9 @@ export default defineComponent({
   computed: {
     showProgressBar: function () {
       return this.$store.getters.getShowProgressBar
+    },
+    outlinesHidden: function () {
+      return this.$store.getters.getOutlinesHidden
     },
     isLocaleRightToLeft: function () {
       return this.locale === 'ar' || this.locale === 'fa' || this.locale === 'he' ||
@@ -291,7 +288,7 @@ export default defineComponent({
     activateKeyboardShortcuts: function () {
       document.addEventListener('keydown', this.handleKeyboardShortcuts)
       document.addEventListener('mousedown', () => {
-        this.hideOutlines = true
+        this.hideOutlines()
       })
     },
 
@@ -316,7 +313,7 @@ export default defineComponent({
       }
       switch (event.key) {
         case 'Tab':
-          this.hideOutlines = false
+          this.showOutlines()
           break
         case 'L':
         case 'l':
@@ -517,15 +514,6 @@ export default defineComponent({
       }
     },
 
-    /**
-     * provided to all child components, see `provide` near the top of this file
-     * after injecting it, they can show outlines during keyboard navigation
-     * e.g. cycling through tabs with the arrow keys
-     */
-    showOutlines: function () {
-      this.hideOutlines = false
-    },
-
     ...mapMutations([
       'setInvidiousInstancesList'
     ]),
@@ -542,7 +530,9 @@ export default defineComponent({
       'setupListenersToSyncWindows',
       'updateBaseTheme',
       'updateMainColor',
-      'updateSecColor'
+      'updateSecColor',
+      'showOutlines',
+      'hideOutlines'
     ])
   }
 })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -3,7 +3,7 @@
     v-if="dataReady"
     id="app"
     :class="{
-      hideOutlines: hideOutlines,
+      hideOutlines: outlinesHidden,
       isLocaleRightToLeft: isLocaleRightToLeft
     }"
   >

--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -1,8 +1,8 @@
 import { defineComponent } from 'vue'
+import { mapActions } from 'vuex'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
-import { Injectables } from '../../../constants'
 import { sanitizeForHtmlId } from '../../helpers/accessibility'
 
 export default defineComponent({
@@ -11,9 +11,6 @@ export default defineComponent({
     'ft-card': FtCard,
     'ft-flex-box': FtFlexBox,
     'ft-button': FtButton
-  },
-  inject: {
-    showOutlines: Injectables.SHOW_OUTLINES
   },
   props: {
     label: {
@@ -101,6 +98,10 @@ export default defineComponent({
         const direction = (e.key === 'ArrowLeft') ? -1 : 1
         this.focusItem(parseInt(currentIndex) + direction)
       }
-    }
+    },
+
+    ...mapActions([
+      'showOutlines'
+    ])
   }
 })

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -19,6 +19,7 @@ import {
 
 const state = {
   isSideNavOpen: false,
+  outlinesHidden: true,
   sessionSearchHistory: [],
   popularCache: null,
   trendingCache: {
@@ -49,6 +50,10 @@ const state = {
 const getters = {
   getIsSideNavOpen () {
     return state.isSideNavOpen
+  },
+
+  getOutlinesHidden() {
+    return state.outlinesHidden
   },
 
   getCurrentVolume () {
@@ -117,6 +122,14 @@ const getters = {
 }
 
 const actions = {
+  showOutlines({ commit }) {
+    commit('setOutlinesHidden', false)
+  },
+
+  hideOutlines({ commit }) {
+    commit('setOutlinesHidden', true)
+  },
+
   async downloadMedia({ rootState }, { url, title, extension, fallingBackPath }) {
     if (!process.env.IS_ELECTRON) {
       openExternalLink(url)
@@ -631,6 +644,10 @@ const actions = {
 const mutations = {
   toggleSideNav (state) {
     state.isSideNavOpen = !state.isSideNavOpen
+  },
+
+  setOutlinesHidden(state, value) {
+    state.outlinesHidden = value
   },
 
   setShowProgressBar (state, value) {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -32,7 +32,6 @@ import {
   parseLocalListVideo,
   parseLocalSubscriberCount
 } from '../../helpers/api/local'
-import { Injectables } from '../../../constants'
 
 export default defineComponent({
   name: 'Channel',
@@ -47,9 +46,6 @@ export default defineComponent({
     'ft-share-button': FtShareButton,
     'ft-subscribe-button': FtSubscribeButton,
     'channel-about': ChannelAbout
-  },
-  inject: {
-    showOutlines: Injectables.SHOW_OUTLINES
   },
   data: function () {
     return {
@@ -1870,6 +1866,7 @@ export default defineComponent({
     },
 
     ...mapActions([
+      'showOutlines',
       'updateSubscriptionDetails'
     ])
   }

--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -1,4 +1,5 @@
 import { defineComponent } from 'vue'
+import { mapActions } from 'vuex'
 
 import SubscriptionsVideos from '../../components/subscriptions-videos/subscriptions-videos.vue'
 import SubscriptionsLive from '../../components/subscriptions-live/subscriptions-live.vue'
@@ -7,7 +8,6 @@ import SubscriptionsCommunity from '../../components/subscriptions-community/sub
 
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
-import { Injectables } from '../../../constants'
 
 export default defineComponent({
   name: 'Subscriptions',
@@ -18,9 +18,6 @@ export default defineComponent({
     'subscriptions-community': SubscriptionsCommunity,
     'ft-card': FtCard,
     'ft-flex-box': FtFlexBox
-  },
-  inject: {
-    showOutlines: Injectables.SHOW_OUTLINES
   },
   data: function () {
     return {
@@ -148,6 +145,10 @@ export default defineComponent({
         this.$refs[visibleTabs[index]].focus()
         this.showOutlines()
       }
-    }
+    },
+
+    ...mapActions([
+      'showOutlines'
+    ])
   }
 })

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -1,4 +1,5 @@
 import { defineComponent } from 'vue'
+import { mapActions } from 'vuex'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
@@ -8,7 +9,6 @@ import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import { copyToClipboard, showToast } from '../../helpers/utils'
 import { getLocalTrending } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
-import { Injectables } from '../../../constants'
 
 export default defineComponent({
   name: 'Trending',
@@ -18,9 +18,6 @@ export default defineComponent({
     'ft-element-list': FtElementList,
     'ft-icon-button': FtIconButton,
     'ft-flex-box': FtFlexBox
-  },
-  inject: {
-    showOutlines: Injectables.SHOW_OUTLINES
   },
   data: function () {
     return {
@@ -191,6 +188,10 @@ export default defineComponent({
           }
           break
       }
-    }
+    },
+
+    ...mapActions([
+      'showOutlines'
+    ])
   }
 })


### PR DESCRIPTION
# Move hideOutlines to the utils store instead of using provide/inject

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Refactor/Cleanup

## Related issue
#3850 (original pull request)

## Description
In #3850 I decided to use Vue's provide/inject pattern to allow all components to show and hide outlines, while that seemed like a good idea at the time, I've since decided that it makes more sense to use the store for that, as we don't use provide/inject for anything else in FreeTube.

## Testing <!-- for code that is not small enough to be easily understandable -->
### Showing outlines
1. Press <kbd>TAB</kbd> anywhere in FreeTube
2. Inside prompts and tabs (channel, trending, subscriptions) press the left and right arrow keys

### Hiding outlines
Click anywhere

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1