### PR TITLE
Localize proxy test info when possible

### DIFF
--- a/src/renderer/components/proxy-settings/proxy-settings.js
+++ b/src/renderer/components/proxy-settings/proxy-settings.js
@@ -29,7 +29,6 @@ export default defineComponent({
     return {
       isLoading: false,
       dataAvailable: false,
-      proxyTestUrl: 'https://ipwho.is/?output=json&fields=ip,country,city,region',
       proxyIp: '',
       proxyCountry: '',
       proxyRegion: '',
@@ -64,6 +63,24 @@ export default defineComponent({
     },
     proxyUrl: function () {
       return `${this.proxyProtocol}://${this.proxyHostname}:${this.proxyPort}`
+    },
+    lang: function() {
+      return this.$i18n.locale.replace('_', '-')
+    },
+    localeToUse: function() {
+      // locales found here: https://ipwhois.io/documentation
+      const supportedLangs = ['en', 'ru', 'de', 'es', 'pt-BR', 'fr', 'zh-CN', 'ja']
+      return supportedLangs.find(lang => {
+        return (this.lang === lang) || (this.lang.substring(0, 2) === lang.substring(0, 2))
+      })
+    },
+    proxyTestUrl: function() {
+      let proxyTestUrl = 'https://ipwho.is/?output=json&fields=ip,country,city,region'
+      if (this.localeToUse) {
+        proxyTestUrl += `&lang=${this.localeToUse}`
+      }
+
+      return proxyTestUrl
     }
   },
   created: function () {


### PR DESCRIPTION
# Localize proxy test info when possible

## Pull Request Type
- [x] Other - Localization

## Description
Currently we only get city, region and country name in English. This PR adds support for languages that are supported by the proxy test
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/687434ea-3ed3-4cc6-9376-f43ec191aa35)

## Testing 
- set locale to francais (French)
- set up proxy (ex: tor)
- click Test Button
- See info in French
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/40a55ce5-0150-4709-aad5-83f0e774e4b5)

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.19.1

