### PR TITLE
IV: Fix HtmlEncoded search suggestions

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -6,7 +6,7 @@ import FtProfileSelector from '../ft-profile-selector/ft-profile-selector.vue'
 import debounce from 'lodash.debounce'
 
 import { IpcChannels } from '../../../constants'
-import { openInternalPath } from '../../helpers/utils'
+import { decodeHTML, openInternalPath } from '../../helpers/utils'
 import { clearLocalSearchSuggestionsSession, getLocalSearchSuggestions } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
 
@@ -258,7 +258,7 @@ export default defineComponent({
       }
 
       invidiousAPICall(searchPayload).then((results) => {
-        this.searchSuggestionsDataList = results.suggestions
+        this.searchSuggestionsDataList = results.suggestions.map(suggestion => decodeHTML(suggestion))
       }).catch((err) => {
         console.error(err)
         if (process.env.IS_ELECTRON && this.backendFallback) {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -665,6 +665,17 @@ export function escapeHTML(untrusted) {
 }
 
 /**
+ * Decode an html encoded string (for when we're not displaying something as html)
+ * @param {string} htmlEncodedString
+ * @returns {string}
+ */
+export function decodeHTML(htmlEncodedString) {
+  const testDiv = document.createElement('div')
+  testDiv.innerHTML = htmlEncodedString
+  return testDiv.innerText
+}
+
+/**
  * Performs a deep copy of a javascript object
  * @param {Object} obj
  * @returns {Object}


### PR DESCRIPTION
# IV: Fix HtmlEncoded search suggestions

## Pull Request Type
- [x] Bugfix

## Description
The search suggestions for Invidious are html encoded so suggestions will be displayed like this when searching in Arabic + ( other languages):
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/b36132c0-1a01-43be-b4d1-6bef2d9c10c1)

This PR decodes the html so we can display the suggestions properly:
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/07ad2751-dbdf-4554-8700-97ad30044fe0)

## Testing 
- set invidious as primary api
- copy some arabic text from ar.yaml and paste it into the search bar
- look at suggestions

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1
