### PR TITLE
Work around context menus in the devtools being displayed behind the window

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -170,6 +170,10 @@ function runApp() {
   app.commandLine.appendSwitch('enable-file-cookies')
   app.commandLine.appendSwitch('ignore-gpu-blacklist')
 
+  // Work around for context menus in the devtools being displayed behind the window
+  // https://github.com/electron/electron/issues/38790
+  app.commandLine.appendSwitch('disable-features', 'WidgetLayering')
+
   // command line switches need to be added before the app ready event first
   // that means we can't use the normal settings system as that is asynchronous,
   // doing it synchronously ensures that we add it before the event fires


### PR DESCRIPTION
# Work around context menus in the devtools being displayed behind the window

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/electron/electron/issues/38790

## Description
Currently Electron has a bug that makes the context menus in the dev tools show behind the devtools window, making them useless. This pull requests introduces the workaround suggested in the Electron issue, so that we get our context menus back.

## Screenshots <!-- If appropriate -->
The electron issue has screenshots.

## Testing <!-- for code that is not small enough to be easily understandable -->
Right click in the devtools window, if the menu shows up with this pull request it works :)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1