### PR TITLE
Search input keyboard focus enhancements

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -310,7 +310,7 @@ export default defineComponent({
         switch (event.key) {
           case 'D':
           case 'd':
-            this.$refs.topNav.focusSearch()
+            this.$refs.topNav.focusSearch(true)
             break
         }
       }
@@ -322,8 +322,15 @@ export default defineComponent({
         case 'l':
           if ((process.platform !== 'darwin' && event.ctrlKey) ||
             (process.platform === 'darwin' && event.metaKey)) {
-            this.$refs.topNav.focusSearch()
+            this.$refs.topNav.focusSearch(true)
           }
+          break
+        case '/':
+          if (!this.$refs.topNav.isSearchFocused()) {
+            // prevent entering slash character into input
+            event.preventDefault()
+          }
+          this.$refs.topNav.focusSearch(false)
           break
       }
     },

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -315,6 +315,14 @@ export default defineComponent({
       this.$refs.input.focus()
     },
 
+    isFocused() {
+      return document.activeElement === this.$refs.input
+    },
+
+    select() {
+      this.$refs.input.select()
+    },
+
     blur() {
       this.$refs.input.blur()
     },

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -205,10 +205,17 @@ export default defineComponent({
       this.showFilters = false
     },
 
-    focusSearch: function () {
+    focusSearch: function (select) {
       if (!this.hideSearchBar) {
         this.$refs.searchInput.focus()
+        if (select) {
+          this.$refs.searchInput.select()
+        }
       }
+    },
+
+    isSearchFocused: function () {
+      return this.$refs.searchInput.isFocused()
     },
 
     getSearchSuggestionsDebounce: function (query) {


### PR DESCRIPTION
# Search input keyboard focus enhancements

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Partially implements a feature requested in #2138

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Select text in search input when using Ctrl-L/Meta-L or Alt-D to focus search input.
This is the behavior of the combined address/search box of both Chrome and Firefox. I think it makes sense here because the search input in the application is essentially both an address box and a search box.
    
Add new Slash key shortcut to focus input without selecting text.
This does not select the text in the input, which matches the behavior of the YouTube web frontend.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
