### PR TITLE
Add missing Electron guards after #4230

### DIFF
--- a/src/renderer/helpers/channels.js
+++ b/src/renderer/helpers/channels.js
@@ -46,7 +46,7 @@ export async function findChannelTagInfo(id, backendOptions) {
   if (!/UC\S{22}/.test(id)) return { invalidId: true }
   try {
     const channel = await findChannelById(id, backendOptions)
-    if (process.env.IS_ELECTRON || backendOptions.preference === 'invidious') {
+    if (!process.env.IS_ELECTRON || backendOptions.preference === 'invidious') {
       if (channel.invalid) return { invalidId: true }
       return {
         preferredName: channel.author,


### PR DESCRIPTION
# Add missing Electron guards after #4230

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
#4230

## Description
This pull request adds Electron guards, like we have in other places in FreeTube, around the local API calls that were added in #4230, as the local API doesn't exist for the web build. As we don't actively maintain or release an official web build, I wouldn't expect new contributors to know about the build time guards that we add around local API stuff.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that hidding a channel by id works properly on the local API in the Electron build, to make sure that I didn't mess up the logic.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1