### PR TITLE
SponsorBlock: video id hash length to 4

### DIFF
--- a/src/renderer/helpers/sponsorblock.js
+++ b/src/renderer/helpers/sponsorblock.js
@@ -11,7 +11,7 @@ async function getVideoHash(videoId) {
     .join('')
 }
 export async function sponsorBlockSkipSegments(videoId, categories) {
-  const videoIdHashPrefix = await getVideoHash(videoId)
+  const videoIdHashPrefix = (await getVideoHash(videoId)).substring(0, 4)
   const requestUrl = `${store.getters.getSponsorBlockUrl}/api/skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
 
   try {


### PR DESCRIPTION
# SponsorBlock: video id hash length to 4

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
n/a

## Description
Use only 4 characters for the hash to improve privacy, see:
https://wiki.sponsor.ajay.app/w/API_Docs#GET_/api/skipSegments/:sha256HashPrefix
<!-- Please write a clear and concise description of what the pull request does. -->

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:Linux**
- **OS Version:6.5.7**
- **FreeTube version:0.19.1**

## Additional context
<!-- Add any other context about the pull request here. -->
allows support for https://github.com/TeamPiped/sponsorblock-mirror/
