### PR TITLE
Add images to community polls

### DIFF
--- a/src/renderer/components/ft-community-poll/ft-community-poll.css
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.css
@@ -11,9 +11,7 @@
   display: block;
   float: var(--float-left-ltr-rtl-value);
   block-size: 10px;
-  inset-inline-start: 5px;
   position: relative;
-  inset-block-start: 8px;
   inline-size: 10px;
 }
 
@@ -29,30 +27,45 @@
 }
 
 .option-text {
-  border-radius: 5px;
-  border-style: solid;
-  border-width: 2px;
-  padding-block: 5px;
-  padding-inline: 25px;
+  margin-inline-start: 10px;
 }
 
 .option {
+  display: flex;
+  align-items: center;
   padding-block-end: 10px;
+  border-radius: 5px;
+  border-style: solid;
+  border-width: 1px;
+  padding-block: 5px;
+  padding-inline-start: 10px;
+  margin-block-end: 10px;
+}
+
+.option > img {
+  margin-inline-start: 10px;
+  block-size: 125px;
 }
 
 .correct-option {
+  border-color: #78da71;
+  border-width: 2px;
+}
+
+.correct-option .filled-circle {
   background-color: #78da71;
 }
 
 .incorrect-option {
-  background-color: #dd4e4e;
+  border-color: #dd4e4e;
+  border-width: 2px;
 }
 
-.reveal-answer  {
-  text-align: center;
+.reveal-answer {
+  justify-content: center;
   cursor: pointer;
 }
 
-.reveal-answer:hover > .option-text, .reveal-answer:focus > .option-text {
+.reveal-answer:hover, .reveal-answer:focus {
   background-color: var(--side-nav-hover-color)
 }

--- a/src/renderer/components/ft-community-poll/ft-community-poll.js
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.js
@@ -18,5 +18,11 @@ export default defineComponent({
     formattedVotes: function () {
       return formatNumber(this.data.totalVotes)
     },
+  },
+  methods: {
+    // Use smallest as it's resized to 125px anyways and they're usually all larger than that
+    findSmallestPollImage: function (images) {
+      return images.reduce((prev, img) => (img.height < prev.height) ? img : prev, images[0]).url
+    }
   }
 })

--- a/src/renderer/components/ft-community-poll/ft-community-poll.vue
+++ b/src/renderer/components/ft-community-poll/ft-community-poll.vue
@@ -13,13 +13,13 @@
       <div
         v-if="data.type === 'quiz'"
         class="option quiz-option"
+        :class="revealAnswer && choice.isCorrect ? 'correct-option' : ''"
       >
         <span class="empty-circle">
           <span :class="revealAnswer && choice.isCorrect ? 'filled-circle' : ''" />
         </span>
         <div
           class="option-text"
-          :class="revealAnswer && choice.isCorrect ? 'correct-option' : ''"
         >
           {{ choice.text }}
         </div>
@@ -29,6 +29,11 @@
         class="option poll-option"
       >
         <span class="empty-circle" />
+        <img
+          v-if="choice.image"
+          :src="findSmallestPollImage(choice.image)"
+          alt=""
+        >
         <div class="option-text">
           {{ choice.text }}
         </div>


### PR DESCRIPTION
# Add images to community polls

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #4309 

## Description
Adds images to polls and updated the style of quiz answers.

## Screenshots 
![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/b68e0edf-a0ba-4bca-83f6-0b6d2c6dc9b0)

https://github.com/FreeTubeApp/FreeTube/assets/19561469/58056977-c849-4ff9-883b-688c5a9381ae


## Testing <!-- for code that is not small enough to be easily understandable -->
Tried on:
- https://www.youtube.com/@TechStarr/community
- https://www.youtube.com/@ouya_expert/community

on invidious and local api

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2
- **FreeTube version:**

## Additional context
Should the empty circles be removed to fit youtube's UI?

![image](https://github.com/FreeTubeApp/FreeTube/assets/19561469/539dcc30-476d-4608-bec0-9b779c6df200)

