### PR TITLE
Replace certain labels with clearer values

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -134,7 +134,7 @@ export default defineComponent({
   methods: {
     handleHideRecommendedVideos: function (value) {
       if (value) {
-        this.updatePlayNextVideo(false)
+        this.updateEnableAutoplay(false)
       }
 
       this.updateHideRecommendedVideos(value)
@@ -196,7 +196,7 @@ export default defineComponent({
       'updateHidePlaylists',
       'updateHideLiveChat',
       'updateHideActiveSubscriptions',
-      'updatePlayNextVideo',
+      'updateEnableAutoplay',
       'updateDefaultTheatreMode',
       'updateHideVideoDescription',
       'updateHideComments',

--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -197,7 +197,7 @@ export default defineComponent({
       'updateHideLiveChat',
       'updateHideActiveSubscriptions',
       'updateEnableAutoplay',
-      'updateDefaultTheatreMode',
+      'updateDefaultTheaterMode',
       'updateHideVideoDescription',
       'updateHideComments',
       'updateHideCommentPhotos',

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -108,11 +108,11 @@ export default defineComponent({
       type: Array,
       default: () => ([])
     },
-    theatrePossible: {
+    theaterPossible: {
       type: Boolean,
       default: false
     },
-    useTheatreMode: {
+    useTheaterMode: {
       type: Boolean,
       default: false
     }
@@ -174,7 +174,7 @@ export default defineComponent({
             'descriptionsButton',
             'subsCapsButton',
             'pictureInPictureToggle',
-            'toggleTheatreModeButton',
+            'toggleTheaterModeButton',
             'fullWindowButton',
             'qualitySelector',
             'fullscreenToggle'
@@ -392,7 +392,7 @@ export default defineComponent({
 
     this.createFullWindowButton()
     this.createLoopButton()
-    this.createToggleTheatreModeButton()
+    this.createToggleTheaterModeButton()
     this.createScreenshotButton()
     this.determineFormatType()
 
@@ -1494,28 +1494,28 @@ export default defineComponent({
       videojs.registerComponent('fullWindowButton', fullWindowButton)
     },
 
-    createToggleTheatreModeButton: function () {
-      if (!this.theatrePossible) {
+    createToggleTheaterModeButton: function () {
+      if (!this.theaterPossible) {
         return
       }
 
-      const theatreModeActive = this.useTheatreMode ? ' vjs-icon-theatre-active' : ''
+      const theaterModeActive = this.useTheaterMode ? ' vjs-icon-theatre-active' : ''
 
-      const toggleTheatreMode = this.toggleTheatreMode
+      const toggleTheaterMode = this.toggleTheaterMode
 
       const VjsButton = videojs.getComponent('Button')
-      class toggleTheatreModeButton extends VjsButton {
+      class toggleTheaterModeButton extends VjsButton {
         handleClick() {
-          toggleTheatreMode()
+          toggleTheaterMode()
         }
 
         createControlTextEl(button) {
           button.classList.add('vjs-button-theatre')
-          button.title = 'Toggle Theatre Mode'
+          button.title = 'Toggle Theater Mode'
 
           const div = document.createElement('div')
-          div.id = 'toggleTheatreModeButton'
-          div.className = `vjs-icon-theatre-inactive${theatreModeActive} vjs-button`
+          div.id = 'toggleTheaterModeButton'
+          div.className = `vjs-icon-theatre-inactive${theaterModeActive} vjs-button`
 
           button.appendChild(div)
 
@@ -1523,20 +1523,20 @@ export default defineComponent({
         }
       }
 
-      videojs.registerComponent('toggleTheatreModeButton', toggleTheatreModeButton)
+      videojs.registerComponent('toggleTheaterModeButton', toggleTheaterModeButton)
     },
 
-    toggleTheatreMode: function () {
+    toggleTheaterMode: function () {
       if (!this.player.isFullscreen_) {
-        const toggleTheatreModeButton = document.getElementById('toggleTheatreModeButton')
-        if (!this.useTheatreMode) {
-          toggleTheatreModeButton.classList.add('vjs-icon-theatre-active')
+        const toggleTheaterModeButton = document.getElementById('toggleTheaterModeButton')
+        if (!this.useTheaterMode) {
+          toggleTheaterModeButton.classList.add('vjs-icon-theatre-active')
         } else {
-          toggleTheatreModeButton.classList.remove('vjs-icon-theatre-active')
+          toggleTheaterModeButton.classList.remove('vjs-icon-theatre-active')
         }
       }
 
-      this.$emit('toggle-theatre-mode')
+      this.$emit('toggle-theater-mode')
     },
 
     createScreenshotButton: function () {
@@ -2231,8 +2231,8 @@ export default defineComponent({
             break
           case 'T':
           case 't':
-            // Toggle Theatre Mode
-            this.toggleTheatreMode()
+            // Toggle Theater Mode
+            this.toggleTheaterMode()
             break
           case 'U':
           case 'u':

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -212,8 +212,8 @@ export default defineComponent({
       }
     },
 
-    autoplayVideos: function () {
-      return this.$store.getters.getAutoplayVideos
+    startVideosAutomatically: function () {
+      return this.$store.getters.getStartVideosAutomatically
     },
 
     videoVolumeMouseScroll: function () {
@@ -321,8 +321,8 @@ export default defineComponent({
       return playbackRates
     },
 
-    enableScreenshot: function () {
-      return this.$store.getters.getEnableScreenshot
+    enableVideoScreenshot: function () {
+      return this.$store.getters.getEnableVideoScreenshot
     },
 
     screenshotFormat: function () {
@@ -350,7 +350,7 @@ export default defineComponent({
       this.player.trigger(this.statsModalEventName)
     },
 
-    enableScreenshot: function () {
+    enableVideoScreenshot: function () {
       this.toggleScreenshotButton()
     }
   },
@@ -589,7 +589,7 @@ export default defineComponent({
           })
         }
 
-        if (this.autoplayVideos) {
+        if (this.startVideosAutomatically) {
           // Calling play() won't happen right away, so a quick timeout will make it function properly.
           setTimeout(() => {
             // `this.player` can be destroyed before this runs
@@ -1570,7 +1570,7 @@ export default defineComponent({
 
     toggleScreenshotButton: function () {
       const button = document.getElementById('screenshotButton').parentNode
-      if (this.enableScreenshot && this.format !== 'audio') {
+      if (this.enableVideoScreenshot && this.format !== 'audio') {
         button.classList.remove('vjs-hidden')
       } else {
         button.classList.add('vjs-hidden')
@@ -1578,7 +1578,7 @@ export default defineComponent({
     },
 
     takeScreenshot: async function () {
-      if (!this.enableScreenshot || this.format === 'audio') {
+      if (!this.enableVideoScreenshot || this.format === 'audio') {
         return
       }
 

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -321,8 +321,8 @@ export default defineComponent({
       return playbackRates
     },
 
-    enableVideoScreenshot: function () {
-      return this.$store.getters.getEnableVideoScreenshot
+    enableScreenshot: function () {
+      return this.$store.getters.getEnableScreenshot
     },
 
     screenshotFormat: function () {
@@ -350,7 +350,7 @@ export default defineComponent({
       this.player.trigger(this.statsModalEventName)
     },
 
-    enableVideoScreenshot: function () {
+    enableScreenshot: function () {
       this.toggleScreenshotButton()
     }
   },
@@ -1570,7 +1570,7 @@ export default defineComponent({
 
     toggleScreenshotButton: function () {
       const button = document.getElementById('screenshotButton').parentNode
-      if (this.enableVideoScreenshot && this.format !== 'audio') {
+      if (this.enableScreenshot && this.format !== 'audio') {
         button.classList.remove('vjs-hidden')
       } else {
         button.classList.add('vjs-hidden')
@@ -1578,7 +1578,7 @@ export default defineComponent({
     },
 
     takeScreenshot: async function () {
-      if (!this.enableVideoScreenshot || this.format === 'audio') {
+      if (!this.enableScreenshot || this.format === 'audio') {
         return
       }
 

--- a/src/renderer/components/parental-control-settings/parental-control-settings.js
+++ b/src/renderer/components/parental-control-settings/parental-control-settings.js
@@ -13,8 +13,8 @@ export default defineComponent({
     hideSearchBar: function () {
       return this.$store.getters.getHideSearchBar
     },
-    hideUnsubscribeButton: function() {
-      return this.$store.getters.getHideUnsubscribeButton
+    hideSubscribeButton: function() {
+      return this.$store.getters.getHideSubscribeButton
     },
     showFamilyFriendlyOnly: function() {
       return this.$store.getters.getShowFamilyFriendlyOnly
@@ -23,7 +23,7 @@ export default defineComponent({
   methods: {
     ...mapActions([
       'updateHideSearchBar',
-      'updateHideUnsubscribeButton',
+      'updateHideSubscribeButton',
       'updateShowFamilyFriendlyOnly'
     ])
   }

--- a/src/renderer/components/parental-control-settings/parental-control-settings.vue
+++ b/src/renderer/components/parental-control-settings/parental-control-settings.vue
@@ -7,8 +7,8 @@
         <ft-toggle-switch
           :label="$t('Settings.Parental Control Settings.Hide Unsubscribe Button')"
           :compact="true"
-          :default-value="hideUnsubscribeButton"
-          @change="updateHideUnsubscribeButton"
+          :default-value="hideSubscribeButton"
+          @change="updateHideSubscribeButton"
         />
         <ft-toggle-switch
           :label="$t('Settings.Parental Control Settings.Show Family Friendly Only')"

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -68,16 +68,16 @@ export default defineComponent({
       return this.$store.getters.getBackendPreference
     },
 
-    autoplayVideos: function () {
-      return this.$store.getters.getAutoplayVideos
+    startVideosAutomatically: function () {
+      return this.$store.getters.getStartVideosAutomatically
     },
 
-    autoplayPlaylists: function () {
-      return this.$store.getters.getAutoplayPlaylists
+    enablePlaylistAutoplay: function () {
+      return this.$store.getters.getEnablePlaylistAutoplay
     },
 
-    playNextVideo: function () {
-      return this.$store.getters.getPlayNextVideo
+    enableAutoplay: function () {
+      return this.$store.getters.getEnableAutoplay
     },
 
     enableSubtitles: function () {
@@ -176,8 +176,8 @@ export default defineComponent({
       ]
     },
 
-    enableScreenshot: function() {
-      return this.$store.getters.getEnableScreenshot
+    enableVideoScreenshot: function() {
+      return this.$store.getters.getEnableVideoScreenshot
     },
 
     screenshotFormat: function() {
@@ -292,9 +292,9 @@ export default defineComponent({
     },
 
     ...mapActions([
-      'updateAutoplayVideos',
-      'updateAutoplayPlaylists',
-      'updatePlayNextVideo',
+      'updateStartVideosAutomatically',
+      'updateEnablePlaylistAutoplay',
+      'updateEnableAutoplay',
       'updateEnableSubtitles',
       'updateForceLocalBackendForLegacy',
       'updateProxyVideos',
@@ -313,7 +313,7 @@ export default defineComponent({
       'updateEnterFullscreenOnDisplayRotate',
       'updateMaxVideoPlaybackRate',
       'updateVideoPlaybackRateInterval',
-      'updateEnableScreenshot',
+      'updateEnableVideoScreenshot',
       'updateScreenshotFormat',
       'updateScreenshotQuality',
       'updateScreenshotAskPath',

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -176,8 +176,8 @@ export default defineComponent({
       ]
     },
 
-    enableVideoScreenshot: function() {
-      return this.$store.getters.getEnableVideoScreenshot
+    enableScreenshot: function() {
+      return this.$store.getters.getEnableScreenshot
     },
 
     screenshotFormat: function() {
@@ -313,7 +313,7 @@ export default defineComponent({
       'updateEnterFullscreenOnDisplayRotate',
       'updateMaxVideoPlaybackRate',
       'updateVideoPlaybackRateInterval',
-      'updateEnableVideoScreenshot',
+      'updateEnableScreenshot',
       'updateScreenshotFormat',
       'updateScreenshotQuality',
       'updateScreenshotAskPath',

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -120,8 +120,8 @@ export default defineComponent({
       return this.$store.getters.getAllowDashAv1Formats
     },
 
-    defaultTheatreMode: function () {
-      return this.$store.getters.getDefaultTheatreMode
+    defaultTheaterMode: function () {
+      return this.$store.getters.getDefaultTheaterMode
     },
 
     hideRecommendedVideos: function () {
@@ -298,7 +298,7 @@ export default defineComponent({
       'updateEnableSubtitles',
       'updateForceLocalBackendForLegacy',
       'updateProxyVideos',
-      'updateDefaultTheatreMode',
+      'updateDefaultTheaterMode',
       'updateDefaultSkipInterval',
       'updateDefaultInterval',
       'updateDefaultVolume',

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -29,8 +29,8 @@
         <ft-toggle-switch
           :label="$t('Settings.Player Settings.Enable Theatre Mode by Default')"
           :compact="true"
-          :default-value="defaultTheatreMode"
-          @change="updateDefaultTheatreMode"
+          :default-value="defaultTheaterMode"
+          @change="updateDefaultTheaterMode"
         />
         <ft-toggle-switch
           :label="$t('Settings.Player Settings.Scroll Volume Over Video Player')"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -175,11 +175,11 @@
     >
       <ft-toggle-switch
         :label="$t('Settings.Player Settings.Screenshot.Enable')"
-        :default-value="enableVideoScreenshot"
-        @change="updateEnableVideoScreenshot"
+        :default-value="enableScreenshot"
+        @change="updateEnableScreenshot"
       />
     </ft-flex-box>
-    <div v-if="usingElectron && enableVideoScreenshot">
+    <div v-if="usingElectron && enableScreenshot">
       <ft-flex-box>
         <ft-select
           :placeholder="$t('Settings.Player Settings.Screenshot.Format Label')"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -59,21 +59,22 @@
         <ft-toggle-switch
           :label="$t('Settings.Player Settings.Autoplay Videos')"
           :compact="true"
-          :default-value="autoplayVideos"
-          @change="updateAutoplayVideos"
-        />
-        <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Autoplay Playlists')"
-          :compact="true"
-          :default-value="autoplayPlaylists"
-          @change="updateAutoplayPlaylists"
+          :default-value="startVideosAutomatically"
+          @change="updateStartVideosAutomatically"
         />
         <ft-toggle-switch
           :label="$t('Settings.Player Settings.Play Next Video')"
           :compact="true"
           :disabled="hideRecommendedVideos"
-          :default-value="playNextVideo"
-          @change="updatePlayNextVideo"
+          :default-value="enableAutoplay"
+          @change="updateEnableAutoplay"
+        />
+        <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Autoplay Playlists')"
+          :compact="true"
+          :disabled="enableAutoplay"
+          :default-value="enablePlaylistAutoplay"
+          @change="updateEnablePlaylistAutoplay"
         />
         <ft-toggle-switch
           :label="$t('Settings.Player Settings.Display Play Button In Video Player')"
@@ -174,11 +175,11 @@
     >
       <ft-toggle-switch
         :label="$t('Settings.Player Settings.Screenshot.Enable')"
-        :default-value="enableScreenshot"
-        @change="updateEnableScreenshot"
+        :default-value="enableVideoScreenshot"
+        @change="updateEnableVideoScreenshot"
       />
     </ft-flex-box>
-    <div v-if="usingElectron && enableScreenshot">
+    <div v-if="usingElectron && enableVideoScreenshot">
       <ft-flex-box>
         <ft-select
           :placeholder="$t('Settings.Player Settings.Screenshot.Format Label')"

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -109,8 +109,8 @@ export default defineComponent({
       return this.$store.getters.getHideSharingActions
     },
 
-    hideUnsubscribeButton: function() {
-      return this.$store.getters.getHideUnsubscribeButton
+    hideSubscribeButton: function() {
+      return this.$store.getters.getHideSubscribeButton
     },
 
     currentLocale: function () {

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -31,7 +31,7 @@
               {{ channelName }}
             </router-link>
             <ft-subscribe-button
-              v-if="!hideUnsubscribeButton"
+              v-if="!hideSubscribeButton"
               :channel-id="channelId"
               :channel-name="channelName"
               :channel-thumbnail="channelThumbnail"

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -157,7 +157,7 @@ export default defineComponent({
 
     if ('mediaSession' in navigator) {
       navigator.mediaSession.setActionHandler('previoustrack', this.playPreviousVideo)
-      navigator.mediaSession.setActionHandler('nexttrack', this.playNextVideo)
+      navigator.mediaSession.setActionHandler('nexttrack', this.enableAutoplay)
     }
   },
   beforeDestroy: function () {
@@ -209,7 +209,7 @@ export default defineComponent({
       }
     },
 
-    playNextVideo: function () {
+    enableAutoplay: function () {
       const playlistInfo = {
         playlistId: this.playlistId
       }

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
@@ -91,9 +91,9 @@
           :title="$t('Video.Play Next Video')"
           role="button"
           tabindex="0"
-          @click="playNextVideo"
-          @keydown.enter.prevent="playNextVideo"
-          @keydown.space.prevent="playNextVideo"
+          @click="enableAutoplay"
+          @keydown.enter.prevent="enableAutoplay"
+          @keydown.space.prevent="enableAutoplay"
         />
         <font-awesome-icon
           class="playlistIcon"

--- a/src/renderer/components/watch-video-recommendations/watch-video-recommendations.js
+++ b/src/renderer/components/watch-video-recommendations/watch-video-recommendations.js
@@ -22,8 +22,8 @@ export default defineComponent({
     }
   },
   computed: {
-    playNextVideo: function () {
-      return this.$store.getters.getPlayNextVideo
+    enableAutoplay: function () {
+      return this.$store.getters.getEnableAutoplay
     },
     hideRecommendedVideos: function () {
       return this.$store.getters.getHideRecommendedVideos
@@ -31,7 +31,7 @@ export default defineComponent({
   },
   methods: {
     ...mapActions([
-      'updatePlayNextVideo'
+      'updateEnableAutoplay'
     ])
   }
 })

--- a/src/renderer/components/watch-video-recommendations/watch-video-recommendations.vue
+++ b/src/renderer/components/watch-video-recommendations/watch-video-recommendations.vue
@@ -12,8 +12,8 @@
         class="autoPlayToggle"
         :label="$t('Video.Autoplay')"
         :compact="true"
-        :default-value="playNextVideo"
-        @change="updatePlayNextVideo"
+        :default-value="enableAutoplay"
+        @change="updateEnableAutoplay"
       />
     </div>
     <ft-list-video-lazy

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -162,8 +162,8 @@ const defaultSideEffectsTriggerId = settingId =>
 /*****/
 
 const state = {
-  enablePlaylistAutoplay: true,
-  startVideosAutomatically: true,
+  autoplayPlaylists: true,
+  autoplayVideos: true,
   backendFallback: process.env.IS_ELECTRON,
   backendPreference: !process.env.IS_ELECTRON ? 'invidious' : 'local',
   barColor: false,
@@ -178,7 +178,7 @@ const state = {
   defaultProfile: MAIN_PROFILE_ID,
   defaultQuality: '720',
   defaultSkipInterval: 5,
-  defaultTheaterMode: false,
+  defaultTheatreMode: false,
   defaultVideoFormat: 'dash',
   disableSmoothScrolling: false,
   displayVideoPlayButton: true,
@@ -218,7 +218,7 @@ const state = {
   hideSubscriptionsLive: false,
   hideSubscriptionsCommunity: false,
   hideTrendingVideos: false,
-  hideSubscribeButton: false,
+  hideUnsubscribeButton: false,
   hideUpcomingPremieres: false,
   hideVideoLikesAndDislikes: false,
   hideVideoViews: false,
@@ -229,7 +229,7 @@ const state = {
   landingPage: 'subscriptions',
   listType: 'grid',
   maxVideoPlaybackRate: 3,
-  enableAutoplay: false,
+  playNextVideo: false,
   proxyHostname: '127.0.0.1',
   proxyPort: '9050',
   proxyProtocol: 'socks5',
@@ -286,7 +286,7 @@ const state = {
   downloadAskPath: true,
   downloadFolderPath: '',
   downloadBehavior: 'download',
-  enableVideoScreenshot: false,
+  enableScreenshot: false,
   screenshotFormat: 'png',
   screenshotQuality: 95,
   screenshotAskPath: false,
@@ -297,6 +297,18 @@ const state = {
   allowDashAv1Formats: false,
   commentAutoLoadEnabled: false,
   useDeArrowTitles: false,
+}
+
+// NOTE: when an old setting's variable name is changed, place the new value here as the key
+// and keep the original key in the state object above. This preserves users' settings selections
+// even after these variable names are altered, and even in older versions of FreeTube.
+const aliasToOriginal = {
+  defaultTheaterMode: 'defaultTheatreMode',
+  enableAutoplay: 'playNextVideo',
+  enablePlaylistAutoplay: 'autoplayPlaylists',
+  enableVideoScreenshot: 'enableScreenshot',
+  hideSubscribeButton: 'hideUnsubscribeButton',
+  startVideosAutomatically: 'autoplayVideos'
 }
 
 const stateWithSideEffects = {
@@ -542,6 +554,24 @@ Object.assign(
 
 // Build default getters, mutations and actions for every setting id
 for (const settingId of Object.keys(state)) {
+  buildSettingsStoreMethods(settingId)
+}
+
+// point alias keys to their original values
+for (const alias of Object.keys(aliasToOriginal)) {
+  const aliasFor = aliasToOriginal[alias]
+  const originalGetter = getters[defaultGetterId(aliasFor)]
+  const originalMutation = mutations[defaultMutationId(aliasFor)]
+  const originalTrigger = actions[defaultSideEffectsTriggerId(aliasFor)]
+  const originalAction = actions[defaultUpdaterId(aliasFor)]
+
+  if (originalGetter) getters[defaultGetterId(alias)] = originalGetter
+  if (originalMutation) mutations[defaultMutationId(alias)] = originalMutation
+  if (originalTrigger) actions[defaultSideEffectsTriggerId(alias)] = originalTrigger
+  if (originalAction) actions[defaultUpdaterId(alias)] = originalAction
+}
+
+function buildSettingsStoreMethods(settingId) {
   const getterId = defaultGetterId(settingId)
   const mutationId = defaultMutationId(settingId)
   const updaterId = defaultUpdaterId(settingId)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -162,8 +162,8 @@ const defaultSideEffectsTriggerId = settingId =>
 /*****/
 
 const state = {
-  autoplayPlaylists: true,
-  autoplayVideos: true,
+  enablePlaylistAutoplay: true,
+  startVideosAutomatically: true,
   backendFallback: process.env.IS_ELECTRON,
   backendPreference: !process.env.IS_ELECTRON ? 'invidious' : 'local',
   barColor: false,
@@ -218,7 +218,7 @@ const state = {
   hideSubscriptionsLive: false,
   hideSubscriptionsCommunity: false,
   hideTrendingVideos: false,
-  hideUnsubscribeButton: false,
+  hideSubscribeButton: false,
   hideUpcomingPremieres: false,
   hideVideoLikesAndDislikes: false,
   hideVideoViews: false,
@@ -229,7 +229,7 @@ const state = {
   landingPage: 'subscriptions',
   listType: 'grid',
   maxVideoPlaybackRate: 3,
-  playNextVideo: false,
+  enableAutoplay: false,
   proxyHostname: '127.0.0.1',
   proxyPort: '9050',
   proxyProtocol: 'socks5',
@@ -286,7 +286,7 @@ const state = {
   downloadAskPath: true,
   downloadFolderPath: '',
   downloadBehavior: 'download',
-  enableScreenshot: false,
+  enableVideoScreenshot: false,
   screenshotFormat: 'png',
   screenshotQuality: 95,
   screenshotAskPath: false,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -178,7 +178,7 @@ const state = {
   defaultProfile: MAIN_PROFILE_ID,
   defaultQuality: '720',
   defaultSkipInterval: 5,
-  defaultTheatreMode: false,
+  defaultTheaterMode: false,
   defaultVideoFormat: 'dash',
   disableSmoothScrolling: false,
   displayVideoPlayButton: true,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -306,7 +306,6 @@ const aliasToOriginal = {
   defaultTheaterMode: 'defaultTheatreMode',
   enableAutoplay: 'playNextVideo',
   enablePlaylistAutoplay: 'autoplayPlaylists',
-  enableVideoScreenshot: 'enableScreenshot',
   hideSubscribeButton: 'hideUnsubscribeButton',
   startVideosAutomatically: 'autoplayVideos'
 }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -147,8 +147,8 @@ export default defineComponent({
       return this.$store.getters.getBackendFallback
     },
 
-    hideUnsubscribeButton: function() {
-      return this.$store.getters.getHideUnsubscribeButton
+    hideSubscribeButton: function() {
+      return this.$store.getters.getHideSubscribeButton
     },
 
     showFamilyFriendlyOnly: function() {

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -66,7 +66,7 @@
             />
 
             <ft-subscribe-button
-              v-if="!hideUnsubscribeButton && (!errorMessage || isSubscribed)"
+              v-if="!hideSubscribeButton && (!errorMessage || isSubscribed)"
               :channel-id="id"
               :channel-name="channelName"
               :channel-thumbnail="thumbnailUrl"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -50,8 +50,8 @@ export default defineComponent({
       }
     },
 
-    hideUnsubscribeButton: function() {
-      return this.$store.getters.getHideUnsubscribeButton
+    hideSubscribeButton: function() {
+      return this.$store.getters.getHideSubscribeButton
     },
 
     locale: function () {

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -49,7 +49,7 @@
               {{ channel.name }}
             </router-link>
             <div
-              v-if="!hideUnsubscribeButton"
+              v-if="!hideSubscribeButton"
               class="unsubscribeContainer"
             >
               <ft-subscribe-button

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -76,7 +76,7 @@ export default defineComponent({
     return {
       isLoading: true,
       firstLoad: true,
-      useTheatreMode: false,
+      useTheaterMode: false,
       videoPlayerReady: false,
       showDashPlayer: true,
       showLegacyPlayer: false,
@@ -162,8 +162,8 @@ export default defineComponent({
     defaultInterval: function () {
       return this.$store.getters.getDefaultInterval
     },
-    defaultTheatreMode: function () {
-      return this.$store.getters.getDefaultTheatreMode
+    defaultTheaterMode: function () {
+      return this.$store.getters.getDefaultTheaterMode
     },
     defaultVideoFormat: function () {
       return this.$store.getters.getDefaultVideoFormat
@@ -201,7 +201,7 @@ export default defineComponent({
     hideVideoLikesAndDislikes: function () {
       return this.$store.getters.getHideVideoLikesAndDislikes
     },
-    theatrePossible: function () {
+    theaterPossible: function () {
       return !this.hideRecommendedVideos || (!this.hideLiveChat && this.isLive) || this.watchingPlaylist
     },
     currentLocale: function () {
@@ -249,7 +249,7 @@ export default defineComponent({
   mounted: function () {
     this.videoId = this.$route.params.id
     this.activeFormat = this.defaultVideoFormat
-    this.useTheatreMode = this.defaultTheatreMode && this.theatrePossible
+    this.useTheaterMode = this.defaultTheaterMode && this.theaterPossible
 
     this.checkIfPlaylist()
     this.checkIfTimestamp()

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -174,11 +174,11 @@ export default defineComponent({
     thumbnailPreference: function () {
       return this.$store.getters.getThumbnailPreference
     },
-    playNextVideo: function () {
-      return this.$store.getters.getPlayNextVideo
+    enableAutoplay: function () {
+      return this.$store.getters.getEnableAutoplay
     },
-    autoplayPlaylists: function () {
-      return this.$store.getters.getAutoplayPlaylists
+    enablePlaylistAutoplay: function () {
+      return this.$store.getters.getEnablePlaylistAutoplay
     },
     hideRecommendedVideos: function () {
       return this.$store.getters.getHideRecommendedVideos
@@ -1234,7 +1234,7 @@ export default defineComponent({
     },
 
     handleVideoEnded: function () {
-      if ((!this.watchingPlaylist || !this.autoplayPlaylists) && !this.playNextVideo) {
+      if ((!this.watchingPlaylist || !this.enablePlaylistAutoplay) && !this.enableAutoplay) {
         return
       }
 
@@ -1245,7 +1245,7 @@ export default defineComponent({
 
       if (this.watchingPlaylist && this.$refs.watchVideoPlaylist.shouldStopDueToPlaylistEnd) {
         // Let `watchVideoPlaylist` handle end of playlist, no countdown needed
-        this.$refs.watchVideoPlaylist.playNextVideo()
+        this.$refs.watchVideoPlaylist.enableAutoplay()
         return
       }
       const nextVideoInterval = this.defaultInterval
@@ -1253,7 +1253,7 @@ export default defineComponent({
         const player = this.$refs.videoPlayer.player
         if (player !== null && player.paused()) {
           if (this.watchingPlaylist) {
-            this.$refs.watchVideoPlaylist.playNextVideo()
+            this.$refs.watchVideoPlaylist.enableAutoplay()
           } else {
             const nextVideoId = this.recommendedVideos[0].videoId
             this.$router.push({

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -2,7 +2,7 @@
   grid-template: 'video video sidebar' 0fr 'info info sidebar' auto 'info info sidebar' 1fr / 1fr 1fr 1fr;
 }
 
-@mixin theatre-mode-template {
+@mixin theater-mode-template {
   grid-template: 'video video video' auto 'info info sidebar' auto 'info info sidebar' auto / 1fr 1fr 1fr;
 }
 
@@ -110,7 +110,7 @@
 
   .watchVideoPlaylist,
   .watchVideoSidebar,
-  .theatrePlaylist {
+  .theaterPlaylist {
     margin-block: 0 16px;
     margin-inline: 8px;
   }
@@ -131,7 +131,7 @@
   }
 
   .watchVideoRecommendations,
-  .theatreRecommendations {
+  .theaterRecommendations {
     margin-block: 0 16px;
     margin-inline: 0;
 
@@ -142,12 +142,12 @@
   }
 
   @media only screen and (max-width: 1350px) {
-    @include theatre-mode-template;
+    @include theater-mode-template;
   }
 
   @media only screen and (min-width: 901px) {
-    &.useTheatreMode {
-      @include theatre-mode-template;
+    &.useTheaterMode {
+      @include theater-mode-template;
     }
   }
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -3,8 +3,8 @@
     class="videoLayout"
     :class="{
       isLoading,
-      useTheatreMode: useTheatreMode && !isLoading,
-      noSidebar: !theatrePossible
+      useTheaterMode: useTheaterMode && !isLoading,
+      noSidebar: !theaterPossible
     }"
   >
     <ft-loader
@@ -31,15 +31,15 @@
           :length-seconds="videoLengthSeconds"
           :chapters="videoChapters"
           :current-chapter-index="videoCurrentChapterIndex"
-          :theatre-possible="theatrePossible"
-          :use-theatre-mode="useTheatreMode"
+          :theater-possible="theaterPossible"
+          :use-theater-mode="useTheaterMode"
           class="videoPlayer"
-          :class="{ theatrePlayer: useTheatreMode }"
+          :class="{ theaterPlayer: useTheaterMode }"
           @ready="handleVideoReady"
           @ended="handleVideoEnded"
           @error="handleVideoError"
           @store-caption-list="captionHybridList = $event"
-          @toggle-theatre-mode="useTheatreMode = !useTheatreMode"
+          @toggle-theater-mode="useTheaterMode = !useTheaterMode"
           v-on="!hideChapters && videoChapters.length > 0 ? { timeupdate: updateCurrentChapter } : {}"
         />
         <div
@@ -120,7 +120,7 @@
         :length-seconds="videoLengthSeconds"
         :video-thumbnail="thumbnail"
         class="watchVideo"
-        :class="{ theatreWatchVideo: useTheatreMode }"
+        :class="{ theaterWatchVideo: useTheaterMode }"
         @change-format="handleFormatChange"
         @pause-player="pausePlayer"
         @set-info-area-sticky="infoAreaSticky = $event"
@@ -131,7 +131,7 @@
         :chapters="videoChapters"
         :current-chapter-index="videoCurrentChapterIndex"
         class="watchVideo"
-        :class="{ theatreWatchVideo: useTheatreMode }"
+        :class="{ theaterWatchVideo: useTheaterMode }"
         @timestamp-event="changeTimestamp"
       />
       <watch-video-description
@@ -139,14 +139,14 @@
         :description="videoDescription"
         :description-html="videoDescriptionHtml"
         class="watchVideo"
-        :class="{ theatreWatchVideo: useTheatreMode }"
+        :class="{ theaterWatchVideo: useTheaterMode }"
         @timestamp-event="changeTimestamp"
       />
       <watch-video-comments
         v-if="!isLoading && !isLive && !hideComments"
         :id="videoId"
         class="watchVideo"
-        :class="{ theatreWatchVideo: useTheatreMode }"
+        :class="{ theaterWatchVideo: useTheaterMode }"
         :channel-thumbnail="channelThumbnail"
         :channel-name="channelName"
         :video-player-ready="videoPlayerReady"
@@ -164,7 +164,7 @@
         :video-id="videoId"
         :channel-id="channelId"
         class="watchVideoSideBar watchVideoPlaylist"
-        :class="{ theatrePlaylist: useTheatreMode }"
+        :class="{ theaterPlaylist: useTheaterMode }"
       />
       <watch-video-playlist
         v-if="watchingPlaylist"
@@ -174,7 +174,7 @@
         :playlist-id="playlistId"
         :video-id="videoId"
         class="watchVideoSideBar watchVideoPlaylist"
-        :class="{ theatrePlaylist: useTheatreMode }"
+        :class="{ theaterPlaylist: useTheaterMode }"
         @pause-player="pausePlayer"
       />
       <watch-video-recommendations
@@ -183,7 +183,7 @@
         :data="recommendedVideos"
         class="watchVideoSideBar watchVideoRecommendations"
         :class="{
-          theatreRecommendations: useTheatreMode,
+          theaterRecommendations: useTheaterMode,
           watchVideoRecommendationsLowerCard: watchingPlaylist || isLive,
           watchVideoRecommendationsNoCard: !watchingPlaylist || !isLive
         }"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -253,18 +253,18 @@ Settings:
   Player Settings:
     Player Settings: Player Settings
     Force Local Backend for Legacy Formats: Force Local Backend for Legacy Formats
-    Play Next Video: Play Next Video
+    Play Next Video: Autoplay (Recommended Channels and Playlists)
     Turn on Subtitles by Default: Turn on Subtitles by Default
-    Autoplay Videos: Autoplay Videos
+    Autoplay Videos: Start Videos Automatically
     Proxy Videos Through Invidious: Proxy Videos Through Invidious
-    Autoplay Playlists: Autoplay Playlists
-    Enable Theatre Mode by Default: Enable Theatre Mode by Default
+    Autoplay Playlists: Autoplay (Playlists Only)
+    Enable Theatre Mode by Default: Enable Theater Mode by Default
     Scroll Volume Over Video Player: Scroll Volume Over Video Player
     Scroll Playback Rate Over Video Player: Scroll Playback Rate Over Video Player
     Skip by Scrolling Over Video Player: Skip by Scrolling Over Video Player
     Display Play Button In Video Player: Display Play Button In Video Player
-    Enter Fullscreen on Display Rotate: Enter Fullscreen on Display Rotate
-    Next Video Interval: Next Video Interval
+    Enter Fullscreen on Display Rotate: Enter Fullscreen On Rotating the Device
+    Next Video Interval: Autoplay Countdown Timer
     Fast-Forward / Rewind Interval: Fast-Forward / Rewind Interval
     Default Volume: Default Volume
     Default Playback Rate: Default Playback Rate
@@ -289,7 +289,7 @@ Settings:
       8k: 8k
     Allow DASH AV1 formats: Allow DASH AV1 formats
     Screenshot:
-      Enable: Enable Screenshot
+      Enable: Enable Video Screenshot
       Format Label: Screenshot Format
       Quality Label: Screenshot Quality
       Ask Path: Ask for Save Folder
@@ -454,7 +454,7 @@ Settings:
     Category Color: Category Color
   Parental Control Settings:
     Parental Control Settings: Parental Control Settings
-    Hide Unsubscribe Button: Hide Unsubscribe Button
+    Hide Unsubscribe Button: Hide Subscribe Button
     Show Family Friendly Only: Show Family Friendly Only
     Hide Search Bar: Hide Search Bar
   Download Settings:


### PR DESCRIPTION
# Replace certain labels with clearer values

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A; although, general reports of confusion with these labels in comments, issues, and the Matrix channel

## Description
`en-US` label changes:
- `Next Video Interval` -> `Autoplay Countdown Timer`
- `Enter Fullscreen on Display Rotate` -> `Enter Fullscreen On Rotating the Device`
- `Enable Screenshot` -> `Enable Video Screenshot`
- `Hide Unsubscribe Button` -> `Hide Subscribe Button`*
- `Play Next Video` -> `Autoplay (Recommended Channels and Playlists)`*
- `Autoplay Playlists` -> `Autoplay (Playlists Only)`*
- `Autoplay Videos` -> `Start Videos Automatically`*
- `Enable Theatre Mode by Default` -> `Enable Theater Mode by Default`*

* variable naming updated as well

Behavioral change:
- The Playlist Autoplay toggle in `Player Settings` is now disabled when General Autoplay is enabled (to more clearly represent that it is a subset of its behavior)

New dev utility:
- Creates the `aliasToOriginal` object in `settings.js` to allow for easy, safe, & reverse-compatible modification of older existing settings variable names

## Testing <!-- for code that is not small enough to be easily understandable -->
- Before running the PR locally, set the values of the variables marked by the asterisk above to ones different from their default. Confirm those selections are still preserved while running this PR.
- While running this PR locally, change the values of the variables marked by the asterisk above to new ones again. Run `development` from your local and confirm that those selections are still preserved.
- In Player Settings, validate that `Autoplay (Playlists Only)` is disabled as a choice when `Autoplay (Recommended Channels and Playlists)` is enabled.
- Confirm no errors appear on the affected routes (Watch and Settings)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1

## Additional context
I kept the original keys of `en-US.yaml` intact to prevent any disruption to non-English language users.
