### PR TITLE
Implement minor settings section visual fixes & height change

### DIFF
--- a/src/renderer/components/ft-settings-section/ft-settings-section.scss
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.scss
@@ -27,9 +27,8 @@
 }
 
 .sectionLine {
-  background-color: var(--primary-color);
   border: 0;
-  block-size: 2px;
+  border-block-start: 2px solid var(--primary-color);
   margin-block-start: -1px;
   inline-size: 100%;
 }
@@ -44,6 +43,7 @@
   -webkit-user-select: none;
   user-select: none;
   margin-inline-start: 2%;
+  margin-block: 0.5em;
 }
 
 :deep(.switchGrid) {

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -1,8 +1,13 @@
 hr {
-  block-size: 2px;
   inline-size: 85%;
   margin-block: 0;
   margin-inline: auto;
   border: 0;
-  background-color: var(--scrollbar-color-hover);
+  border-block-start: 2px solid var(--scrollbar-color-hover);
+}
+
+@media only screen and (max-width: 800px) {
+  hr {
+    inline-size: 100%;
+  }
 }


### PR DESCRIPTION
# Implement minor settings section visual fixes & height change

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
none

## Description
- Resolves Settings Section border width bug (media query in only one place at 750px)
- Remediates Sections Section differing border widths subpixel bug (was worsened by changing zoom levels and especially apparent/annoying at a lower zoom level)
  - Discussion: subpixel issue 
- Sets Settings Section `margin-block` to `0.5em` from previous value of `1em` (looks cleaner and keeps all sections in frame on load at default zoom for most devices)

## Screenshots <!-- If appropriate -->

Border width bug:
| Before | After |
---|---
| ![Screenshot_20231116_221317](https://github.com/FreeTubeApp/FreeTube/assets/84899178/9f2110b2-1492-493e-9eb2-9c7218cdfef8) | ![Screenshot_20231116_221337](https://github.com/FreeTubeApp/FreeTube/assets/84899178/7d927a46-eae1-46cd-ad62-d75372a21c32)  |

Subpixel bug:
| Before | After |
---|---
| ![Screenshot_20231116_221654](https://github.com/FreeTubeApp/FreeTube/assets/84899178/397e0e86-9115-4979-ad04-4d148bca3f5c) | ![Screenshot_20231116_221710](https://github.com/FreeTubeApp/FreeTube/assets/84899178/ae8c0be3-c618-479d-bfb2-03446dec5c5c) |

## Testing <!-- for code that is not small enough to be easily understandable -->
- Place browser viewport width below 750px and confirm settings section border lengths are preserved
- Increase and decrease zoom levels, while ensuring settings section border widths are not noticeably uneven

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1

## Additional context
Technically [this](https://stackoverflow.com/a/58408821) is the "best" solution to the subpixel issue, but `medium` is a bit too thick, and `thin` is a bit too thin, in my opinion. This current solution resolves any noticeable subpixel oddities as per my testing.