### PR TITLE
Block channel by channel URL (with ID)

### DIFF
--- a/src/renderer/components/ft-input-tags/ft-input-tags.js
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.js
@@ -46,8 +46,8 @@ export default defineComponent({
   },
   methods: {
     updateTags: async function (text, _e) {
-      // text entered add tag and update tag list
-      const name = text.trim()
+      // get text without spaces after last '/' in url, if any
+      const name = text.split('/').pop().trim()
 
       if (!this.validateTagName(name)) {
         this.$emit('invalid-name')


### PR DESCRIPTION
# Block channel by channel URL (with ID)

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Related issue
#4346 (first part)

## Description
Silently enables blocking channels by channel link with ID (i.e., input text like `*/:id`). Silent because if we said you can put in channel IDs without implementing support for the other types of channel links, there will be inevitable confusion and uproar.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Input normal channel IDs and validate that it is working as usual
- Input channel link with ID (e.g., `https://www.youtube.com/channel/UCadtap8RYMNy8w4K9lXhzpQ`, `https://invidious.perennialte.ch/channel/UCc9EIXDG6nul3XXf79GhZDw`) and validate that it is working

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1