### PR TITLE
Change tooltip popup color to match theme

### DIFF
--- a/src/renderer/components/ft-tooltip/ft-tooltip.css
+++ b/src/renderer/components/ft-tooltip/ft-tooltip.css
@@ -32,9 +32,9 @@
 }
 
 .text {
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: color-mix(in srgb, var(--primary-text-color) 80%, transparent);
   border-radius: 20px;
-  color: #fff;
+  color: var(--card-bg-color);
   font-size: 1rem;
   line-height: 120%;
   margin: 0;


### PR DESCRIPTION
# Change tooltip popup color to match theme

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation

## Related issue
closes #1806 

## Description
Does what it says on the tin.

## Video <!-- If appropriate -->

(Tested by forcing hover state on tooltip)
https://github.com/FreeTubeApp/FreeTube/assets/84899178/1d96a89a-8fa5-4db8-a115-9387866fa90a


## Testing <!-- for code that is not small enough to be easily understandable -->
Do what I did in the video - go through the different themes and see the colors of a tooltip change.

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1
