### PR TITLE
Show latest from channel

### DIFF
--- a/src/renderer/components/subscription-settings/subscription-settings.js
+++ b/src/renderer/components/subscription-settings/subscription-settings.js
@@ -13,6 +13,9 @@ export default defineComponent({
     hideWatchedSubs: function () {
       return this.$store.getters.getHideWatchedSubs
     },
+    onlyShowLatestFromChannel: function () {
+      return this.$store.getters.getOnlyShowLatestFromChannel
+    },
     useRssFeeds: function () {
       return this.$store.getters.getUseRssFeeds
     },
@@ -24,7 +27,8 @@ export default defineComponent({
     ...mapActions([
       'updateHideWatchedSubs',
       'updateUseRssFeeds',
-      'updateFetchSubscriptionsAutomatically'
+      'updateFetchSubscriptionsAutomatically',
+      'updateOnlyShowLatestFromChannel'
     ])
   }
 })

--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -26,6 +26,12 @@
           :compact="true"
           @change="updateHideWatchedSubs"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.Subscription Settings.Only Show Latest Video from Channel')"
+          :default-value="onlyShowLatestFromChannel"
+          :compact="true"
+          @change="updateOnlyShowLatestFromChannel"
+        />
       </div>
     </div>
   </ft-settings-section>

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -8,10 +8,19 @@ import { calculatePublishedDate } from './utils'
 export function updateVideoListAfterProcessing(videos) {
   let videoList = videos
 
-  // Filtering and sorting based in preference
-  videoList.sort((a, b) => {
-    return b.publishedDate - a.publishedDate
-  })
+  if (store.getters.getOnlyShowLatestFromChannel) {
+    const authors = new Set()
+    videoList = videoList.filter((video) => {
+      if (!video.authorId) {
+        return true
+      } else if (!authors.has(video.authorId)) {
+        authors.add(video.authorId)
+        return true
+      }
+
+      return false
+    })
+  }
 
   if (store.getters.getHideLiveStreams) {
     videoList = videoList.filter(item => {
@@ -44,6 +53,10 @@ export function updateVideoListAfterProcessing(videos) {
       return !Object.hasOwn(historyCacheById, video.videoId)
     })
   }
+
+  videoList.sort((a, b) => {
+    return b.publishedDate - a.publishedDate
+  })
 
   return videoList
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -229,6 +229,7 @@ const state = {
   landingPage: 'subscriptions',
   listType: 'grid',
   maxVideoPlaybackRate: 3,
+  onlyShowLatestFromChannel: false,
   playNextVideo: false,
   proxyHostname: '127.0.0.1',
   proxyPort: '9050',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -337,6 +337,7 @@ Settings:
     Fetch Feeds from RSS: Fetch Feeds from RSS
     Manage Subscriptions: Manage Subscriptions
     Fetch Automatically: Fetch Feed Automatically
+    Only Show Latest Video from Channel: Only Show Latest Video from Channel
   Distraction Free Settings:
     Distraction Free Settings: Distraction Free Settings
     Sections:


### PR DESCRIPTION
# Show latest from channel

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
closes #546

## Description
Shows only the latest video from each subscribed channel in Subscriptions. Latest of each video tab that you're on, to be specific (Videos, Shorts, & Live, but not Community).

## Screenshots <!-- If appropriate -->
![Screenshot_20231118_165810](https://github.com/FreeTubeApp/FreeTube/assets/84899178/f019234a-b246-425a-adcb-fc6f11d077a0)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test feature enabled with RSS feed enabled
- Test feature enabled without RSS feed disabled
- Test feature disabled

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1

## Additional context
I wonder if it would be a neat feature later on to have these subscription settings show up on the subscription page. Not sure how to feel about it, but share your thoughts on that with your review if you have any.