### PR TITLE
Multiple user playlist export data handling

### DIFF
--- a/src/renderer/components/data-settings/data-settings.vue
+++ b/src/renderer/components/data-settings/data-settings.vue
@@ -38,7 +38,7 @@
     <ft-flex-box>
       <ft-button
         :label="$t('Settings.Data Settings.Import Playlists')"
-        @click="importPlaylists"
+        @click="importPlaylistsIntoFavoritesPlaylist"
       />
       <ft-button
         :label="$t('Settings.Data Settings.Export Playlists')"

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -601,7 +601,7 @@ export default defineComponent({
       }
 
       const payload = {
-        playlistName: 'Favorites',
+        playlistName: this.$store.getters.getFavorites.playlistName,
         videoData: videoData
       }
 
@@ -612,7 +612,7 @@ export default defineComponent({
 
     removeFromPlaylist: function () {
       const payload = {
-        playlistName: 'Favorites',
+        playlistName: this.$store.getters.getFavorites.playlistName,
         videoId: this.id
       }
 

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -322,7 +322,7 @@ export default defineComponent({
       }
 
       const payload = {
-        playlistName: 'Favorites',
+        playlistName: this.$store.getters.getFavorites.playlistName,
         videoData: videoData
       }
 
@@ -333,7 +333,7 @@ export default defineComponent({
 
     removeFromPlaylist: function () {
       const payload = {
-        playlistName: 'Favorites',
+        playlistName: this.$store.getters.getFavorites.playlistName,
         videoId: this.id
       }
 


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
This should be released **before** #4234 merged to allow smooth revert in case user wants to


## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Fixes when reverting from #4234, unable to add or remove videos to/from favorites playlist
  This is caused by code using hardcoded playlist name instead of `this.$store.getters.getFavorites` like `UserPlaylists` view
- Update playlist import code to add videos from **all playlists** into favorites playlist
  It's added as a new function for easier code conflict resolving in #4234

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

### Unable to add or remove videos to/from favorites playlist
- Checkout #4234
- **Rename** every playlist (coz no idea which one is the **first** playlist, the one used by `this.$store.getters.getFavorites`
- Add some videos to every playlist
- Checkout `development`
- Try to add/remove videos in favorites playlist

### Update playlist import
- Checkout #4234
- **Rename** every playlist (coz no idea which one is the **first** playlist, the one used by `this.$store.getters.getFavorites`
- Add some videos to every playlist
- **Export playlist** (before switching branch)
- Checkout `development`
- Remove some/all/no videos from favorites playlist (not sure how you want to test)
- Import exported playlist file

You can optionally use the following exported playlist file to test (update `.txt` to `.db`)
[NEW-freetube-playlists-2023-11-19-trimmed.txt](https://github.com/FreeTubeApp/FreeTube/files/13402819/NEW-freetube-playlists-2023-11-19-trimmed.txt)

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
