### PR TITLE
Display more profiles on the profile drop-down list

### DIFF
--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -31,12 +31,15 @@
   padding: 5px;
   background-color: var(--card-bg-color);
   box-shadow: 0 0 4px var(--scrollbar-color-hover);
+  height: fit-content;
 }
 
 .profileWrapper {
   margin-block-start: 60px;
   block-size: 340px;
   overflow-y: auto;
+  height: fit-content;
+  max-height: 80vh;
 }
 
 .profile {


### PR DESCRIPTION
# Title
Current profile list has fixed size, so it can display only 5 profiles. If you have more profiles you have to scroll, if you have much more profiles, like 15+ scrolling for what you want to find in that little 5-items box is inconvenient.

This extends profile list size to fit the amount of profiles, but to no more than 80% of window size.  


## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ x] Bugfix
- [ x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes  #2871

## Description
It adds 3 lines of .css

## Screenshots <!-- If appropriate -->
old:
![p1](https://github.com/FreeTubeApp/FreeTube/assets/105959781/74ddf1db-8d41-4d3f-94b6-8e294891b9fa)
new:
![p2](https://github.com/FreeTubeApp/FreeTube/assets/105959781/7ce48167-76cd-471c-b808-fed5982e4c9e)


## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version: 2023**
- **FreeTube version:**


