### PR TITLE
Display more profiles on the profile drop-down list, v2 (fixed for low res, fixed linter) 

### DIFF
--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.css
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.css
@@ -27,7 +27,7 @@
   inset-block-start: 60px;
   inset-inline-end: 10px;
   min-inline-size: 250px;
-  block-size: 400px;
+  block-size: auto;
   padding: 5px;
   background-color: var(--card-bg-color);
   box-shadow: 0 0 4px var(--scrollbar-color-hover);
@@ -35,8 +35,10 @@
 
 .profileWrapper {
   margin-block-start: 60px;
-  block-size: 340px;
+  block-size: auto;
   overflow-y: auto;
+  max-block-size: calc(90vh - 100px);
+  min-block-size: 340px;
 }
 
 .profile {


### PR DESCRIPTION
Fixed: https://github.com/FreeTubeApp/FreeTube/pull/4357

Current profile list has fixed size, so it can display only 5 profiles. If you have more profiles you have to scroll, if you have much more profiles, like 15+ scrolling for what you want to find in that little 5-items box is inconvenient.

This extends profile list size to fit the amount of profiles.

- it scales with window size and resolution. 
- for resolution 800x600 and any lower it's exactly the same as it was before


## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #2871

## Description
it changes 4 lines of .css

## Screenshots <!-- If appropriate -->
before:
![p1](https://github.com/FreeTubeApp/FreeTube/assets/105959781/58ed6434-a667-4e15-a9fe-c931511e0523)
after (at 1920x1080)
![p2](https://github.com/FreeTubeApp/FreeTube/assets/105959781/7191341f-d7e8-4cb4-9d87-03b0f52123b7)
after (at 1920x1080 ,random window size)
![p3](https://github.com/FreeTubeApp/FreeTube/assets/105959781/017dfa71-458a-42cf-a05f-8dc5d98ceed0)
after (at 1280x720)
![p4](https://github.com/FreeTubeApp/FreeTube/assets/105959781/00173fb6-436e-417e-977f-b051dcf89550)


## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**


