### PR TITLE
Fix block channel channel ID validation

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -5,7 +5,7 @@ import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtInputTags from '../../components/ft-input-tags/ft-input-tags.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import { showToast } from '../../helpers/utils'
-import { checkYoutubeId, findChannelTagInfo } from '../../helpers/channels'
+import { checkYoutubeChannelId, findChannelTagInfo } from '../../helpers/channels'
 
 export default defineComponent({
   name: 'PlayerSettings',
@@ -152,7 +152,7 @@ export default defineComponent({
       showToast(this.$t('Settings.Distraction Free Settings.Hide Channels Already Exists'))
     },
     validateChannelId: function (text) {
-      return checkYoutubeId(text)
+      return checkYoutubeChannelId(text)
     },
     findChannelTagInfo: async function (text) {
       return await findChannelTagInfo(text, this.backendOptions)
@@ -167,7 +167,7 @@ export default defineComponent({
         if (tag.invalid) continue
 
         // process if no preferred name and is possibly a YouTube ID
-        if (tag.preferredName === '' && checkYoutubeId(tag.name)) {
+        if (tag.preferredName === '' && checkYoutubeChannelId(tag.name)) {
           this.channelHiderDisabled = true
 
           const { preferredName, icon, iconHref, invalidId } = await this.findChannelTagInfo(tag.name)

--- a/src/renderer/helpers/channels.js
+++ b/src/renderer/helpers/channels.js
@@ -43,7 +43,7 @@ async function findChannelById(id, backendOptions) {
 * @returns {Promise<{icon: string, iconHref: string, preferredName: string} | { invalidId: boolean }>}
 */
 export async function findChannelTagInfo(id, backendOptions) {
-  if (!/UC\S{22}/.test(id)) return { invalidId: true }
+  if (!checkYoutubeChannelId(id)) return { invalidId: true }
   try {
     const channel = await findChannelById(id, backendOptions)
     if (!process.env.IS_ELECTRON || backendOptions.preference === 'invidious') {
@@ -71,6 +71,6 @@ export async function findChannelTagInfo(id, backendOptions) {
  * @param {string} id
  * @returns {boolean}
  */
-export function checkYoutubeId(id) {
-  return /UC\S{22}/.test(id)
+export function checkYoutubeChannelId(id) {
+  return /^UC[\w-]{22}$/.test(id)
 }


### PR DESCRIPTION
# Fix block channel channel ID validation

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Noticed while testing #4347

## Description
This fixes the regex used to validate the channel IDs passed into the block channel box in the distraction free settings. The regex was missing the start (`^`) and end (`$`) anchors, which means that this invalid string `bla-UCUQo7nzH1sXVpzL92VesANw-bla` would be seen as a valid channel ID, resulting in requests getting sent to YouTube and Invidious which then understandably errored. This pull request adds those missing anchors so that the regex test only returns true if the whole string matches, instead of just a substring, I also changed it from `\S`, which is any non-whitespace character, to `[\w-]` (`A-Za-z0-9_-`), previously strings like this would be counted as valid `UC@@@@@@@@@@@@@@@@@@@@@@` too.

## Testing <!-- for code that is not small enough to be easily understandable -->
`bla-UCUQo7nzH1sXVpzL92VesANw-bla`
`UC@@@@@@@@@@@@@@@@@@@@@@`

It should now show "Channel ID provided was invalid", instead of sending a request to YouTube and Invidious, erorring with "Error retrieving user with the ID provided. Please check again if the ID is correct."

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1 (nightly as the original pull request was merged after the 0.19.1 release)