### PR TITLE
Mark destructive buttons as red

### DIFF
--- a/src/renderer/components/experimental-settings/experimental-settings.js
+++ b/src/renderer/components/experimental-settings/experimental-settings.js
@@ -42,7 +42,7 @@ export default defineComponent({
     handleReplaceHttpCache: async function (value) {
       this.showRestartPrompt = false
 
-      if (value === null || value === 'no') {
+      if (value === null || value === 'cancel') {
         this.replaceHttpCache = !this.replaceHttpCache
         return
       }

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -19,8 +19,8 @@
     <ft-prompt
       v-if="showRestartPrompt"
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
-      :option-names="[$t('Yes'), $t('No')]"
-      :option-values="['yes', 'no']"
+      :option-names="[$t('Yes, Restart'), $t('Cancel')]"
+      :option-values="['restart', 'cancel']"
       :is-first-option-destructive="true"
       @click="handleReplaceHttpCache"
     />

--- a/src/renderer/components/experimental-settings/experimental-settings.vue
+++ b/src/renderer/components/experimental-settings/experimental-settings.vue
@@ -21,6 +21,7 @@
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
       :option-names="[$t('Yes'), $t('No')]"
       :option-values="['yes', 'no']"
+      :is-first-option-destructive="true"
       @click="handleReplaceHttpCache"
     />
   </ft-settings-section>

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -76,6 +76,20 @@
     }
   }
 
+  &.destructive {
+    background-color: var(--destructive-color);
+    color: var(--destructive-text-color);
+
+    &:hover,
+    &:focus-visible {
+      background-color: var(--destructive-hover-color);
+    }
+
+    &:active {
+      background-color: var(--destructive-active-color);
+    }
+  }
+
   &.favorite, &.favorite:hover, &.favorite:focus-visible {
     color: var(--favorite-icon-color);
   }

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
@@ -108,7 +108,7 @@ export default defineComponent({
     },
 
     handleDeletePromptClick: function (value) {
-      if (value !== 'no' && value !== null) {
+      if (value !== 'cancel' && value !== null) {
         if (this.isMainProfile) {
           const channelsToRemove = this.subscriptions.filter((channel) => {
             return channel.selected

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
@@ -34,8 +34,8 @@ export default defineComponent({
       subscriptions: [],
       selectedLength: 0,
       deletePromptValues: [
-        'yes',
-        'no'
+        'delete',
+        'cancel'
       ]
     }
   },
@@ -61,8 +61,8 @@ export default defineComponent({
     },
     deletePromptNames: function () {
       return [
-        this.$t('Yes'),
-        this.$t('No')
+        this.$t('Yes, Delete'),
+        this.$t('Cancel')
       ]
     },
     locale: function () {

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.vue
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.vue
@@ -30,8 +30,8 @@
         />
         <ft-button
           :label="$t('Profile.Delete Selected')"
-          text-color="var(--text-with-main-color)"
-          background-color="var(--primary-color)"
+          text-color="var(--destructive-text-color)"
+          background-color="var(--destructive-color)"
           @click="displayDeletePrompt"
         />
       </ft-flex-box>
@@ -41,6 +41,7 @@
       :label="deletePromptMessage"
       :option-names="deletePromptNames"
       :option-values="deletePromptValues"
+      :is-first-option-destructive="true"
       @click="handleDeletePromptClick"
     />
   </div>

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.js
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.js
@@ -36,8 +36,8 @@ export default defineComponent({
       profileBgColor: '',
       profileTextColor: '',
       deletePromptValues: [
-        'yes',
-        'no'
+        'delete',
+        'cancel'
       ]
     }
   },
@@ -62,8 +62,8 @@ export default defineComponent({
     },
     deletePromptNames: function () {
       return [
-        this.$t('Yes'),
-        this.$t('No')
+        this.$t('Yes, Delete'),
+        this.$t('Cancel')
       ]
     }
   },
@@ -84,7 +84,7 @@ export default defineComponent({
     },
 
     handleDeletePrompt: function (response) {
-      if (response === 'yes') {
+      if (response === 'delete') {
         this.deleteProfile()
       } else {
         this.showDeletePrompt = false

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -84,8 +84,8 @@
           <ft-button
             v-if="!isMainProfile"
             :label="$t('Profile.Delete Profile')"
-            text-color="var(--text-with-main-color)"
-            background-color="var(--primary-color)"
+            text-color="var(--destructive-text-color)"
+            background-color="var(--destructive-color)"
             @click="openDeletePrompt"
           />
         </template>
@@ -96,6 +96,7 @@
       :label="deletePromptLabel"
       :option-names="deletePromptNames"
       :option-values="deletePromptValues"
+      :is-first-option-destructive="true"
       @click="handleDeletePrompt"
     />
   </div>

--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -36,7 +36,11 @@ export default defineComponent({
     autosize: {
       type: Boolean,
       default: false
-    }
+    },
+    isFirstOptionDestructive: {
+      type: Boolean,
+      default: false
+    },
   },
   data: function () {
     return {

--- a/src/renderer/components/ft-prompt/ft-prompt.vue
+++ b/src/renderer/components/ft-prompt/ft-prompt.vue
@@ -32,6 +32,8 @@
             :id="'prompt-' + sanitizedLabel + '-' + index"
             :key="index"
             :label="option"
+            :text-color="index === 0 && isFirstOptionDestructive ? 'var(--destructive-text-color)' : null"
+            :background-color="index === 0 && isFirstOptionDestructive ? 'var(--destructive-color)' : null"
             @click="$emit('click', optionValues[index])"
           />
           <ft-button

--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -23,8 +23,8 @@ export default defineComponent({
       showRemoveHistoryPrompt: false,
       showRemoveSubscriptionsPrompt: false,
       promptValues: [
-        'yes',
-        'no'
+        'delete',
+        'cancel'
       ]
     }
   },
@@ -50,8 +50,8 @@ export default defineComponent({
     },
     promptNames: function () {
       return [
-        this.$t('Yes'),
-        this.$t('No')
+        this.$t('Yes, Delete'),
+        this.$t('Cancel')
       ]
     }
   },
@@ -59,7 +59,7 @@ export default defineComponent({
     handleSearchCache: function (option) {
       this.showSearchCachePrompt = false
 
-      if (option === 'yes') {
+      if (option === 'delete') {
         this.clearSessionSearchHistory()
         showToast(this.$t('Settings.Privacy Settings.Search cache has been cleared'))
       }
@@ -83,7 +83,7 @@ export default defineComponent({
     handleRemoveHistory: function (option) {
       this.showRemoveHistoryPrompt = false
 
-      if (option === 'yes') {
+      if (option === 'delete') {
         this.removeAllHistory()
         showToast(this.$t('Settings.Privacy Settings.Watch history has been cleared'))
       }
@@ -94,7 +94,7 @@ export default defineComponent({
 
       this.updateActiveProfile(MAIN_PROFILE_ID)
 
-      if (option !== 'yes') { return }
+      if (option !== 'delete') { return }
 
       this.profileList.forEach((profile) => {
         if (profile._id === MAIN_PROFILE_ID) {

--- a/src/renderer/components/privacy-settings/privacy-settings.vue
+++ b/src/renderer/components/privacy-settings/privacy-settings.vue
@@ -43,20 +43,20 @@
     <ft-flex-box>
       <ft-button
         :label="$t('Settings.Privacy Settings.Clear Search Cache')"
-        text-color="var(--text-with-main-color)"
-        background-color="var(--primary-color)"
+        text-color="var(--destructive-text-color)"
+        background-color="var(--destructive-color)"
         @click="showSearchCachePrompt = true"
       />
       <ft-button
         :label="$t('Settings.Privacy Settings.Remove Watch History')"
-        text-color="var(--text-with-main-color)"
-        background-color="var(--primary-color)"
+        text-color="var(--destructive-text-color)"
+        background-color="var(--destructive-color)"
         @click="showRemoveHistoryPrompt = true"
       />
       <ft-button
         :label="$t('Settings.Privacy Settings.Remove All Subscriptions / Profiles')"
-        text-color="var(--text-with-main-color)"
-        background-color="var(--primary-color)"
+        text-color="var(--destructive-text-color)"
+        background-color="var(--destructive-color)"
         @click="showRemoveSubscriptionsPrompt = true"
       />
     </ft-flex-box>
@@ -65,6 +65,7 @@
       :label="$t('Settings.Privacy Settings.Are you sure you want to clear out your search cache?')"
       :option-names="promptNames"
       :option-values="promptValues"
+      :is-first-option-destructive="true"
       @click="handleSearchCache"
     />
     <ft-prompt
@@ -72,6 +73,7 @@
       :label="$t('Settings.Privacy Settings.Are you sure you want to remove your entire watch history?')"
       :option-names="promptNames"
       :option-values="promptValues"
+      :is-first-option-destructive="true"
       @click="handleRemoveHistory"
     />
     <ft-prompt
@@ -79,6 +81,7 @@
       :label="removeSubscriptionsPromptMessage"
       :option-names="promptNames"
       :option-values="promptValues"
+      :is-first-option-destructive="true"
       @click="handleRemoveSubscriptions"
     />
   </ft-settings-section>

--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -26,8 +26,8 @@ export default defineComponent({
       disableSmoothScrollingToggleValue: false,
       showRestartPrompt: false,
       restartPromptValues: [
-        'yes',
-        'no'
+        'restart',
+        'cancel'
       ],
       baseThemeValues: [
         'system',
@@ -88,8 +88,8 @@ export default defineComponent({
 
     restartPromptNames: function () {
       return [
-        this.$t('Yes'),
-        this.$t('No')
+        this.$t('Yes, Restart'),
+        this.$t('Cancel')
       ]
     },
 
@@ -146,7 +146,7 @@ export default defineComponent({
     handleSmoothScrolling: function (value) {
       this.showRestartPrompt = false
 
-      if (value === null || value === 'no') {
+      if (value === null || value === 'cancel') {
         this.disableSmoothScrollingToggleValue = !this.disableSmoothScrollingToggleValue
         return
       }

--- a/src/renderer/components/theme-settings/theme-settings.vue
+++ b/src/renderer/components/theme-settings/theme-settings.vue
@@ -81,6 +81,7 @@
       :label="restartPromptMessage"
       :option-names="restartPromptNames"
       :option-values="restartPromptValues"
+      :is-first-option-destructive="true"
       @click="handleSmoothScrolling"
     />
   </ft-settings-section>

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -7,6 +7,10 @@
 .pastelPink,
 .hotPink {
   --primary-input-color: rgba(0, 0, 0, 0.50);
+  --destructive-color: #7F0000;
+  --destructive-text-color: #FFFFFF;
+  --destructive-hover-color: #FF2F2F;
+  --destructive-active-color: #AD6060;
 }
 
 .system[data-system-theme*='light'], .light,

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -7,10 +7,10 @@
 .pastelPink,
 .hotPink {
   --primary-input-color: rgba(0, 0, 0, 0.50);
-  --destructive-color: #7F0000;
+  --destructive-color: #f44336;
   --destructive-text-color: #FFFFFF;
-  --destructive-hover-color: #FF2F2F;
-  --destructive-active-color: #AD6060;
+  --destructive-hover-color: #e53935;
+  --destructive-active-color: #c62828;
 }
 
 .system[data-system-theme*='light'], .light,
@@ -239,6 +239,13 @@ it can be safely elided. This looks quite pleasant on this theme. */
 
 .hotPink a:hover {
   text-decoration: underline;
+}
+
+.mainRed, .secRed {
+  --destructive-color: #7F0000 !important;
+  --destructive-text-color: #FFFFFF !important;
+  --destructive-hover-color: #FF2F2F !important;
+  --destructive-active-color: #AD6060 !important;
 }
 
 .mainRed,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -939,3 +939,6 @@ Hashtag:
 Yes: Yes
 No: No
 Ok: Ok
+Yes, Delete: Yes, Delete
+Yes, Restart: Yes, Restart
+Cancel: Cancel


### PR DESCRIPTION
# Mark destructive buttons as red

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #1815 

## Description
- Marks destructive `ft-button`s, `ft-icon-button`s, and `ft-prompt` buttons with appropriate red styling ([source](https://uxmovement.com/buttons/how-to-design-destructive-actions-that-prevent-data-loss/))
- Changes `ft-prompt` confirmations to be more explicit ([source](https://uxpsychology.substack.com/p/how-to-design-better-destructive))

## Screenshots <!-- If appropriate -->
![Screenshot_20231122_235713](https://github.com/FreeTubeApp/FreeTube/assets/84899178/7f1a4012-56bb-44f2-8178-f0789cf5778d)
![Screenshot_20231122_235651](https://github.com/FreeTubeApp/FreeTube/assets/84899178/779394b7-3eee-49e5-812b-b2e6e6eb8c92)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Change secondary theme color to red and confirm noticeable difference between the reds
- Confirm all destructive buttons are marked as red
- Confirm all destructive `ft-prompt` buttons are marked in red & with more explicit text, and test their functionality

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1