### PR TITLE
Landing page logic fix

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -183,8 +183,8 @@ export default defineComponent({
       })
 
       this.$router.onReady(() => {
-        if (this.$router.currentRoute.path === '/subscriptions' && this.landingPage !== '/subscriptions') {
-          this.$router.push({ path: this.landingPage })
+        if (this.$router.currentRoute.path === '/' && this.landingPage !== '/subscriptions') {
+          this.$router.replace({ path: this.landingPage })
         }
       })
     })

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -183,7 +183,7 @@ export default defineComponent({
       })
 
       this.$router.onReady(() => {
-        if (this.$router.currentRoute.path !== this.landingPage && this.landingPage !== '/subscriptions') {
+        if (this.$router.currentRoute.path === '/subscriptions' && this.landingPage !== '/subscriptions') {
           this.$router.push({ path: this.landingPage })
         }
       })

--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
@@ -29,6 +29,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    openDropdownOnSubscribe: {
+      type: Boolean,
+      default: true
+    },
     subscriptionCountText: {
       default: '',
       type: String,
@@ -152,7 +156,7 @@ export default defineComponent({
         }
       }
 
-      if (this.isProfileDropdownEnabled && !this.isProfileDropdownOpen) {
+      if (this.isProfileDropdownEnabled && this.openDropdownOnSubscribe && !this.isProfileDropdownOpen) {
         this.toggleProfileDropdown()
       }
     },

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -56,6 +56,7 @@
                 :channel-id="channel.id"
                 :channel-name="channel.name"
                 :channel-thumbnail="channel.thumbnail"
+                :open-dropdown-on-subscribe="false"
               />
             </div>
           </div>


### PR DESCRIPTION
# Landing page logic fix

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4377
closes [chore](https://github.com/FreeTubeApp/FreeTube/projects/10#card-91177785)

## Description
- Checks now for `/` in `router.onReady` instead of the path not being equal to the landing page
- Ensures profile dropdown won't open on SubscribedChannels when hitting "Unsubscribe"

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test that landing page is properly set when first loading the app
- Test that landing page preference is not enforced at any other time 
- Test unsubscribing on "Channels" side nav tab will not open dropdown, but the carat still will

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1
