### PR TITLE
Cleanup SponsorBlock video id hashing

### DIFF
--- a/src/renderer/helpers/sponsorblock.js
+++ b/src/renderer/helpers/sponsorblock.js
@@ -1,17 +1,17 @@
 import store from '../store/index'
+
 async function getVideoHash(videoId) {
   const videoIdBuffer = new TextEncoder().encode(videoId)
 
   const hashBuffer = await crypto.subtle.digest('SHA-256', videoIdBuffer)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  const hashArray = new Uint8Array(hashBuffer)
 
-  return hashArray
-    .map(byte => byte.toString(16).padStart(2, '0'))
-    .slice(0, 4)
-    .join('')
+  return hashArray[0].toString(16).padStart(2, '0') +
+    hashArray[1].toString(16).padStart(2, '0')
 }
+
 export async function sponsorBlockSkipSegments(videoId, categories) {
-  const videoIdHashPrefix = (await getVideoHash(videoId)).substring(0, 4)
+  const videoIdHashPrefix = await getVideoHash(videoId)
   const requestUrl = `${store.getters.getSponsorBlockUrl}/api/skipSegments/${videoIdHashPrefix}?categories=${JSON.stringify(categories)}`
 
   try {
@@ -20,6 +20,11 @@ export async function sponsorBlockSkipSegments(videoId, categories) {
     // 404 means that there are no segments registered for the video
     if (response.status === 404) {
       return []
+    }
+
+    // Sometimes the sponsor block server goes down or returns other errors
+    if (!response.ok) {
+      throw new Error(await response.text())
     }
 
     const json = await response.json()
@@ -33,7 +38,7 @@ export async function sponsorBlockSkipSegments(videoId, categories) {
 }
 
 export async function deArrowData(videoId) {
-  const videoIdHashPrefix = (await getVideoHash(videoId)).substring(0, 4)
+  const videoIdHashPrefix = await getVideoHash(videoId)
   const requestUrl = `${store.getters.getSponsorBlockUrl}/api/branding/${videoIdHashPrefix}`
 
   try {


### PR DESCRIPTION
Cleanup SponsorBlock video id hashing

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Refactor

## Description
Currently the code to create the video ID hash prefix to send to SponsorBlock is rather inefficient, this pull request aims to simplify it, making it more efficient.

Currently it creates an array from the unsigned 8-bit integer array, calls map on it to create a new array with the bytes coverted to hex strings, creates a new array with the first 4 and then joins them to a string, after that it creates a new string with the first 4 characters (this step could have been avoided if only the first two bytes had been chosen in an earlier step, instead of 4).

The new code selects the first two bytes in the unsigned 8-bit integer array and converts those to hex strings and then concatenates them together. This saves a bunch of temporary arrays and strings and also simplifies the code.

## Testing <!-- for code that is not small enough to be easily understandable -->
The testing for this pull request is just regression testing.

Turn on SponsorBlock and open a video with SponsorBlock segments, they should still show up in the seek bar and be skipped if you have that configued.

Turn on DeArrow and make sure titles are still being replaced.