### PR TITLE
Fix settings section close on interaction bug

### DIFF
--- a/src/renderer/components/ft-settings-section/ft-settings-section.js
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.js
@@ -6,7 +6,7 @@ export default defineComponent({
     title: {
       type: String,
       required: true
-    }
+    },
   },
   computed: {
     allSettingsSectionsExpandedByDefault: function () {

--- a/src/renderer/components/ft-settings-section/ft-settings-section.vue
+++ b/src/renderer/components/ft-settings-section/ft-settings-section.vue
@@ -1,6 +1,6 @@
 <template>
   <details
-    :open="allSettingsSectionsExpandedByDefault ? 'true' : null"
+    :open="allSettingsSectionsExpandedByDefault"
     class="settingsSection"
   >
     <summary class="sectionHeader">


### PR DESCRIPTION
# Fix settings section bug

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4379#issuecomment-1826866487

## Description
This was easier than I was anticipating.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Disable Expand All Settings Sections disabled -> interact with toggles in sections and observe sections are not auto-closing
- And vice versa when setting is enabled
- Ensure Enable/Disable opens/closes all sections appropriately

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1
