### PR TITLE
Fix minor playlist "Play Previous Video" bug

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -305,7 +305,7 @@ export default defineComponent({
         if (videoIndex === 0) {
           this.$router.push(
             {
-              path: `/watch/${this.playlistItems[this.randomizedPlaylistItems.length - 1].id ?? this.playlistItems[this.randomizedPlaylistItems.length - 1].videoId}`,
+              path: `/watch/${this.playlistItems[this.playlistItems.length - 1].id ?? this.playlistItems[this.playlistItems.length - 1].videoId}`,
               query: playlistInfo
             }
           )


### PR DESCRIPTION
# Fix minor playlist "Play Previous Video" bug

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #2728 

## Description
Issue is that it was using an object that is not initialized if shuffle was not enabled, causing an error when trying to hit "Play Previous Video" on the first video of a playlist if Shuffle was not pressed.

```
vue.runtime.esm.js:3049 TypeError: Cannot read properties of undefined (reading 'id')
    at VueComponent.playPreviousVideo (watch-video-playlist.js:308:1)
    at invokeWithErrorHandling (vue.runtime.esm.js:3017:1)
    at SVGSVGElement.invoker (vue.runtime.esm.js:1815:1)
    at original_1._wrapper (vue.runtime.esm.js:7480:1)
```

## Testing <!-- for code that is not small enough to be easily understandable -->
- Go to first video in playlist, ensure "Shuffle" was not pressed, then press "Play Previous Video", ensure you are brought to last video in the playlist

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1