### PR TITLE
Order watched recommended videos last

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -281,6 +281,12 @@ export default defineComponent({
           ?.filter((item) => item.type === 'CompactVideo')
           .map(parseLocalWatchNextVideo) ?? []
 
+        // place watched recommended videos last
+        this.recommendedVideos = [
+          ...this.recommendedVideos.filter((video) => !this.isRecommendedVideoWatched(video.videoId)),
+          ...this.recommendedVideos.filter((video) => this.isRecommendedVideoWatched(video.videoId))
+        ]
+
         if (this.showFamilyFriendlyOnly && !this.isFamilyFriendly) {
           this.isLoading = false
           this.handleVideoEnded()
@@ -700,6 +706,11 @@ export default defineComponent({
           this.videoPublished = result.published * 1000
           this.videoDescriptionHtml = result.descriptionHtml
           this.recommendedVideos = result.recommendedVideos
+          // place watched recommended videos last
+          this.recommendedVideos = [
+            ...this.recommendedVideos.filter((video) => !this.isRecommendedVideoWatched(video.videoId)),
+            ...this.recommendedVideos.filter((video) => this.isRecommendedVideoWatched(video.videoId))
+          ]
           this.adaptiveFormats = await this.getAdaptiveFormatsInvidious(result)
           this.isLive = result.liveNow
           this.isFamilyFriendly = result.isFamilyFriendly
@@ -1065,6 +1076,10 @@ export default defineComponent({
     handleVideoReady: function () {
       this.videoPlayerReady = true
       this.checkIfWatched()
+    },
+
+    isRecommendedVideoWatched: function (videoId) {
+      return !!this.$store.getters.getHistoryCacheById[videoId]
     },
 
     checkIfWatched: function () {


### PR DESCRIPTION
# Order watched recommended videos last

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
closes #397

## Description
Orders watched videos last in the recommended videos list. Only sets ordering once when route is first loaded, not live during any "Mark as Watched" / "Mark as Unwatched" events (because this would be undesirable). This should functionally make infinite autoplay loops impossible.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Enable autoplay and mark videos at the top of the rec list as watched
- Reload route and see that those watched videos are at the bottom of the rec list
- Let video autoplay and see that the video visibly at the top of the rec list is played

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1
