### PR TITLE
Use F5 to refresh subscriptions

### DIFF
--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.js
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.js
@@ -107,6 +107,7 @@ export default defineComponent({
       switch (event.key) {
         case 'r':
         case 'R':
+        case 'F5':
           if (!this.isLoading) {
             this.$emit('refresh')
           }

--- a/src/renderer/views/Popular/Popular.js
+++ b/src/renderer/views/Popular/Popular.js
@@ -82,6 +82,7 @@ export default defineComponent({
       switch (event.key) {
         case 'r':
         case 'R':
+        case 'F5':
           if (!this.isLoading) {
             this.fetchPopularInfo()
           }

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -183,6 +183,7 @@ export default defineComponent({
       switch (event.key) {
         case 'r':
         case 'R':
+        case 'F5':
           if (!this.isLoading) {
             this.getTrendingInfo(true)
           }


### PR DESCRIPTION
# Add F5 as a refresh option

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A

## Description
Use F5 to refresh the subscription, trending and popular pages, same shortcut you would use to refresh a browser. window 


## Testing <!-- for code that is not small enough to be easily understandable -->

Pressed F5, it refreshes :)

## Desktop
<!-- Please complete the following information-->
- **OS:** POP_OS
- **OS Version:** 22.04
- **FreeTube version:** 0.19.1

## Additional context

I was wondering if there was a keyboard shortcut to refresh my subscription page, I noticed after trying F5 and checking the source code it was `R`. I imagine I'm not the only one who would try F5, so it would be nice if it worked. 
