### PR TITLE
IV RSS Subscriptions: properly detect `error channels`

### DIFF
--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -315,7 +315,7 @@ export default defineComponent({
           // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
 
           const response2 = await fetch(`${this.currentInvidiousInstance}/feed/channel/${channel.id}`, {
-            method: 'HEAD'
+            method: 'GET'
           })
 
           if (response2.status === 404) {

--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -305,7 +305,23 @@ export default defineComponent({
       try {
         const response = await fetch(feedUrl)
 
+        // remove once IV returns 404 for non-existent playlists
         if (response.status === 500) {
+          return []
+        }
+
+        if (response.status === 404) {
+          // playlists don't exist if the channel was terminated but also if it doesn't have the tab,
+          // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
+
+          const response2 = await fetch(`${this.currentInvidiousInstance}/feed/channel/${channel.id}`, {
+            method: 'HEAD'
+          })
+
+          if (response2.status === 404) {
+            this.errorChannels.push(channel)
+          }
+
           return []
         }
 

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -199,7 +199,23 @@ export default defineComponent({
       try {
         const response = await fetch(feedUrl)
 
+        // remove once IV returns 404 for non-existent playlists
         if (response.status === 500) {
+          return []
+        }
+
+        if (response.status === 404) {
+          // playlists don't exist if the channel was terminated but also if it doesn't have the tab,
+          // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
+
+          const response2 = await fetch(`${this.currentInvidiousInstance}/feed/channel/${channel.id}`, {
+            method: 'HEAD'
+          })
+
+          if (response2.status === 404) {
+            this.errorChannels.push(channel)
+          }
+
           return []
         }
 

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -209,7 +209,7 @@ export default defineComponent({
           // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
 
           const response2 = await fetch(`${this.currentInvidiousInstance}/feed/channel/${channel.id}`, {
-            method: 'HEAD'
+            method: 'GET'
           })
 
           if (response2.status === 404) {

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -312,7 +312,7 @@ export default defineComponent({
           // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
 
           const response2 = await fetch(`${this.currentInvidiousInstance}/feed/channel/${channel.id}`, {
-            method: 'HEAD'
+            method: 'GET'
           })
 
           if (response2.status === 404) {

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -302,8 +302,23 @@ export default defineComponent({
       try {
         const response = await fetch(feedUrl)
 
+        // remove once IV returns 404 for non-existent playlists
         if (response.status === 500) {
-          this.errorChannels.push(channel)
+          return []
+        }
+
+        if (response.status === 404) {
+          // playlists don't exist if the channel was terminated but also if it doesn't have the tab,
+          // so we need to check the channel feed too before deciding it errored, as that only 404s if the channel was terminated
+
+          const response2 = await fetch(`${this.currentInvidiousInstance}/feed/channel/${channel.id}`, {
+            method: 'HEAD'
+          })
+
+          if (response2.status === 404) {
+            this.errorChannels.push(channel)
+          }
+
           return []
         }
 


### PR DESCRIPTION
# IV RSS Subscriptions: properly detect `error channels`

## Pull Request Type
- [x] Feature Implementation

## Description
This PR will properly detect channels that have errors when using RSS through the Invidious API

## Screenshots 
Error channel properly showing up in list:
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/82377c1f-c21e-47d2-a6e1-414b807c1338)

## Testing 
- set api to Invidious
- force rss
- add an invalid subscription to your subscriptions file.
- load subscriptions

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.2
