### PR TITLE
IV: check for 404 and 500 for subscriptions

### DIFF
--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -305,7 +305,7 @@ export default defineComponent({
       try {
         const response = await fetch(feedUrl)
 
-        if (response.status === 500) {
+        if (response.status === 500 || response.status === 404) {
           return []
         }
 

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -199,7 +199,7 @@ export default defineComponent({
       try {
         const response = await fetch(feedUrl)
 
-        if (response.status === 500) {
+        if (response.status === 500 || response.status === 404) {
           return []
         }
 

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -302,7 +302,7 @@ export default defineComponent({
       try {
         const response = await fetch(feedUrl)
 
-        if (response.status === 500) {
+        if (response.status === 500 || response.status === 404) {
           this.errorChannels.push(channel)
           return []
         }


### PR DESCRIPTION
# IV: check for 404 and 500 for subscriptions

## Pull Request Type
- [x] Bugfix

## Description
This is a small PR that we can merge before https://github.com/FreeTubeApp/FreeTube/pull/4407
so that we are able to detect 404 errors properly from Invidious
https://github.com/iv-org/invidious/pull/4298

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.2

