### PR TITLE
Minor ft-subscribe-button visual bugfix

### DIFF
--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.scss
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.scss
@@ -13,6 +13,7 @@
 .ftSubscribeButton {
   position: relative;
   text-align: start;
+  inline-size: fit-content;
 }
 
 /* Ensures style here overrides style of .btn */


### PR DESCRIPTION
# Fix minor ft-subscribe-button visual bug

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
N/A

## Description
Fixes odd appearance of button on certain videos like this one (with locale set to `English (US)`): https://youtu.be/yOSdWqdyAuk

Does not affect any other instances of the `ft-subscribe-button`.

## Screenshots <!-- If appropriate -->
Before:
(Only one profile)
![Screenshot_20231213_101044](https://github.com/FreeTubeApp/FreeTube/assets/84899178/58109b74-cdf5-4aa0-a77d-cac785f6e49e)

(Multiple profiles)
![Screenshot_20231213_101510](https://github.com/FreeTubeApp/FreeTube/assets/84899178/334e86fa-2de2-4fa6-b353-0c508db81720)

After:
(Only one profile)
![Screenshot_20231213_101721](https://github.com/FreeTubeApp/FreeTube/assets/84899178/f22b4fc6-6f77-4952-97c7-d39d4ed5394e)

(Multiple profiles)
![Screenshot_20231213_101614](https://github.com/FreeTubeApp/FreeTube/assets/84899178/a2f5e1a0-5683-45d9-929d-f7e3d7b828dd)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Test with this video: https://youtu.be/yOSdWqdyAuk
- Regression test in SubscribedChannels tab & on a given channel page

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1
