### PR TITLE
Hide playlists in channel search results if "hide channel playlist" preference selected.

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1801,7 +1801,7 @@ export default defineComponent({
         const results = contents
           .filter(node => node.type === 'ItemSection')
           .flatMap(itemSection => itemSection.contents)
-          .filter(item => item.type === 'Video' || item.type === 'Playlist')
+          .filter(item => item.type === 'Video' || (!this.hideChannelPlaylists && item.type === 'Playlist'))
           .map(item => {
             if (item.type === 'Video') {
               return parseLocalListVideo(item)


### PR DESCRIPTION

4453
# Title

Hide playlists in channel search results if "hide channel playlist" preference selected.

## Pull Request Type

- [x ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #4453 

## Description

This PR hides playlists in channel search results if the "hide channel playlists" preference is selected.

## Screenshots 

Before:
![playlist](https://github.com/FreeTubeApp/FreeTube/assets/698207/5eae2013-90b0-4d2e-b014-2851248c6e0c)

After:
![image](https://github.com/FreeTubeApp/FreeTube/assets/698207/9847d59e-c333-4651-ac36-61f05e80e021)

## Testing 

I tested it by searching for "playlist" in the channel page, and observing playlist search results when the "hide channel preference" was not selected.  I think selected this preference and performed the same search.  No playlist results were displayed.

## Desktop
- **OS:** PopOS
- **OS Version:** 22.04
- **FreeTube version:** 0.19.1

## Additional context
This project is great! It makes a big difference to my son.