### PR TITLE
Only bundle the Swiper modules that we use

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -7,6 +7,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const ProcessLocalesPlugin = require('./ProcessLocalesPlugin')
 const WatchExternalFilesPlugin = require('webpack-watch-external-files-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 const isDevMode = process.env.NODE_ENV === 'development'
 
@@ -131,6 +132,18 @@ const config = {
       filename: isDevMode ? '[name].css' : '[name].[contenthash].css',
       chunkFilename: isDevMode ? '[id].css' : '[id].[contenthash].css',
     }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.join(__dirname, '../node_modules/swiper/modules/{a11y,navigation,pagination}-element.css').replaceAll('\\', '/'),
+          to: 'swiper.css',
+          context: path.join(__dirname, '../node_modules/swiper/modules'),
+          transformAll: (assets) => {
+            return Buffer.concat(assets.map(asset => asset.data))
+          }
+        }
+      ]
+    })
   ],
   resolve: {
     alias: {

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -140,6 +140,18 @@ const config = {
     new MiniCssExtractPlugin({
       filename: isDevMode ? '[name].css' : '[name].[contenthash].css',
       chunkFilename: isDevMode ? '[id].css' : '[id].[contenthash].css',
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: path.join(__dirname, '../node_modules/swiper/modules/{a11y,navigation,pagination}-element.css').replaceAll('\\', '/'),
+          to: 'swiper.css',
+          context: path.join(__dirname, '../node_modules/swiper/modules'),
+          transformAll: (assets) => {
+            return Buffer.concat(assets.map(asset => asset.data))
+          }
+        }
+      ]
     })
   ],
   resolve: {

--- a/src/renderer/components/ft-community-post/ft-community-post.js
+++ b/src/renderer/components/ft-community-post/ft-community-post.js
@@ -5,7 +5,9 @@ import FtCommunityPoll from '../ft-community-poll/ft-community-poll.vue'
 
 import autolinker from 'autolinker'
 
-import { deepCopy, toLocalePublicationString } from '../../helpers/utils'
+import { A11y, Navigation, Pagination } from 'swiper/modules'
+
+import { createWebURL, deepCopy, toLocalePublicationString } from '../../helpers/utils'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 
 export default defineComponent({
@@ -46,6 +48,34 @@ export default defineComponent({
   },
   created: function () {
     this.parseCommunityData()
+  },
+  mounted: function () {
+    if (this.type === 'multiImage' && this.postContent.content.length > 0) {
+      const swiperContainer = this.$refs.swiperContainer
+
+      /** @type {import('swiper/element').SwiperContainer} */
+      const swiperOptions = {
+        modules: [A11y, Navigation, Pagination],
+
+        injectStylesUrls: [
+          // This file is created with the copy webpack plugin in the web and renderer webpack configs.
+          // If you add more modules, please remember to add their CSS files to the list in webpack config files.
+          createWebURL('/swiper.css')
+        ],
+
+        a11y: true,
+        navigation: true,
+        pagination: {
+          enabled: true,
+          clickable: true
+        },
+        slidesPerView: 1
+      }
+
+      Object.assign(swiperContainer, swiperOptions)
+
+      swiperContainer.initialize()
+    }
   },
   methods: {
     parseCommunityData: function () {

--- a/src/renderer/components/ft-community-post/ft-community-post.vue
+++ b/src/renderer/components/ft-community-post/ft-community-post.vue
@@ -59,11 +59,8 @@
     <div class="sliderContainer">
       <swiper-container
         v-if="type === 'multiImage' && postContent.content.length > 0"
-        slides-per-view="1"
-        navigation="true"
-        pagination-clickable="true"
-        pagination="true"
-        a11y="true"
+        ref="swiperContainer"
+        init="false"
         class="slider"
       >
         <swiper-slide

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -6,7 +6,7 @@ import store from './store/index'
 import i18n from './i18n/index'
 import { library } from '@fortawesome/fontawesome-svg-core'
 
-import { register as registerSwiper } from 'swiper/element/bundle'
+import { register as registerSwiper } from 'swiper/element'
 
 // Please keep the list of constants sorted by name
 // to avoid code conflict and duplicate entries


### PR DESCRIPTION
# Only bundle the Swiper modules that we use

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Build optimisation

## Description
Currently we bundle the entirety of `swiper`. As `swiper` has a lot of features, that means we end up bundeling a lot of code that we don't need. This pull request switches to only bundling the `swiper` modules that we actually use. Previously the CSS was previously in the JavaScript bundle and Swiper injected it at runtime, now we have only the styles we need.

| File | Before | After |
| --- | --- | --- |
| `renderer.js` | `2.01 MB` (`2115948 bytes`) | `1.94 MB` (`2041041 bytes`) |
| `web.js` | `1.66 MB` (`1744320 bytes`) | `1.59 MB` (`1669158 bytes`) |
| `swiper.css` | - | `6.33 KB` (`6486 bytes`) |

Web Components have their own scope, known as a shadow DOM, so any CSS that you want inside the Web Component has to be inside that shadow DOM. Swiper supports injecting the CSS either by giving it links to CSS files or by giving it raw CSS. As we only want to inject the styles that Swiper needs, into the component, I decided to split it out into a separate CSS file. That created it's own challenges though, as we need to reference it from JavaScript it has to have a predictable name so the pattern of `[name].[contenthash].css` (`renderer.abcdefg.css`) that we use for the main CSS files wasn't going to work, because we don't know the hash in the JavaScript file. Originally I tried doing it with webpack's split chunks feature, but that resulted in the unpredictable name mentioned previously. In the end I decided to use the CopyWebpackPlugin with it's `transformAll` option to combine the 3 CSS files into one, the generated file still gets optimised, as the optimisations are done after copying.

## Testing <!-- for code that is not small enough to be easily understandable -->
Test that community posts with multiple images still work the same as before this pull request.

Example channel `https://www.youtube.com/@MrBeast/community`

You can only test on the channel page at moment, as the subscriptions page currently has a layout bug on the community tab, which also exists without this pull request.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1