### PR TITLE
Fix forward button being enabled after clicking on Subscriptions icon on startup

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -183,7 +183,7 @@ export default defineComponent({
       })
 
       this.$router.onReady(() => {
-        if (this.$router.currentRoute.path === '/' && this.landingPage !== '/subscriptions') {
+        if (this.$router.currentRoute.path === '/') {
           this.$router.replace({ path: this.landingPage })
         }
       })


### PR DESCRIPTION
# Fix forward button being enabled after clicking on Subscriptions icon on startup

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #1749 

## Description
There wasn't any real purpose for that second if-condition anyway

## Testing <!-- for code that is not small enough to be easily understandable -->
- With Landing Page set as Subscriptions, after first load of `npm run dev`, click Subscriptions tab & see forward button not enabled.

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1

## Additional context
<!-- Add any other context about the pull request here. -->
