### PR TITLE
Add invidious fallback for likes

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -354,22 +354,6 @@ export default defineComponent({
             break
         }
 
-        if (this.hideVideoLikesAndDislikes) {
-          this.videoLikeCount = null
-        } else {
-          try {
-            if (!isNaN(result.basic_info.like_count)) {
-              this.videoLikeCount = result.basic_info.like_count
-            } else {
-              console.warn('Had to fallback to invidious to get video likes')
-              this.getLikesInvidious()
-            }
-          } catch {
-            this.videoLikeCount = 0
-            console.error('Could not load video likes')
-          }
-        }
-
         this.isLive = !!result.basic_info.is_live
         this.isUpcoming = !!result.basic_info.is_upcoming
         this.isLiveContent = !!result.basic_info.is_live_content
@@ -653,6 +637,22 @@ export default defineComponent({
 
         this.isLoading = false
         this.updateTitle()
+
+        if (this.hideVideoLikesAndDislikes) {
+          this.videoLikeCount = null
+        } else {
+          try {
+            if (!isNaN(result.basic_info.like_count)) {
+              this.videoLikeCount = result.basic_info.like_count
+            } else {
+              console.warn('Had to fallback to invidious to get video likes')
+              this.getLikesInvidious()
+            }
+          } catch {
+            this.videoLikeCount = 0
+            console.error('Could not load video likes')
+          }
+        }
       } catch (err) {
         const errorMessage = this.$t('Local API Error (Click to copy)')
         showToast(`${errorMessage}: ${err}`, 10000, () => {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -105,7 +105,6 @@
         :published="videoPublished"
         :subscription-count-text="channelSubscriptionCountText"
         :like-count="videoLikeCount"
-        :dislike-count="videoDislikeCount"
         :view-count="videoViewCount"
         :get-timestamp="getTimestamp"
         :is-live-content="isLiveContent"


### PR DESCRIPTION
# Add invidious fallback for likes

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
youtubei.js is just not returning video likes for me, this however is not treated as an error, so I was just getting likes of 0. Invidious however was giving me video likes. I added a fallback where if the likes are not found I ask Invidious for them. I also moved the fetch likes code to the bottom of the try/catch in case something else above throws, since this would also fetch likes from invidious, so it avoids having to make two fetches. 

I also removed any reference to youtube dislikes form the file since its no longer relevant 


## Desktop
<!-- Please complete the following information-->
- **OS: POP_OS 22.04
- **FreeTube version:** 0.19.1"

## Additional context
Is anyone else having issues with the likes not loading on any videos? Maybe youtube is trying to block likes for people that are not logged in? I've attempted to update youtubei and tried with/without my VPN and its always undefined. If this is just a me issue it might not be worth merging. 
