### PR TITLE
Fix the local API about tab for channels without a joined date

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -770,7 +770,7 @@ export default defineComponent({
           const videoCount = extractNumberFromString(metadata.video_count)
           this.videoCount = isNaN(videoCount) ? null : videoCount
 
-          this.joined = metadata.joined_date.isEmpty() ? 0 : new Date(metadata.joined_date.text.replace('Joined').trim())
+          this.joined = metadata.joined_date && !metadata.joined_date.isEmpty() ? new Date(metadata.joined_date.text.replace('Joined').trim()) : 0
 
           this.location = metadata.country ?? null
         }


### PR DESCRIPTION
# Fix the local API about tab for channels without a joined date

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the local API errors when it tries to extract the about tab for channels that don't have a joined date, like the official `@YouTube`  channel.

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit the official `@YouTube` channel and check that no local API error shows up (the shorts duration parsing error logs will be fixed in a separate pull request)

https://www.youtube.com/channel/UCBR8-60-B28hp2BmDPdntcQ

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1 (nightlies)