### PR TITLE
Fix comment sort breakpoint

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -31,7 +31,7 @@
   float: var(--float-right-ltr-rtl-value);
 }
 
-@media only screen and (max-width: 800px) {
+@media only screen and (max-width: 1000px) {
   .commentSort {
     float: none;
     inline-size: fit-content;


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Issue spotted while testing https://github.com/FreeTubeApp/FreeTube/pull/4405

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
With sidebar present the comment sort component in watch page "invades" 1st comment space with certain width

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After
< 1000px
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/6a29d796-9063-4aa3-b8fd-b8687e94a127)

> 1000px
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/ad992d73-dc6c-4fb8-8d4f-b34a0f137043)

Before
> 900px
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/aded3b84-858a-4fff-8c4a-812453bf7f72)



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
