### PR TITLE
Update playlist view to auto load next page for local API to workaround UX issue of useless continuation data

### DIFF
--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -199,9 +199,14 @@ export default defineComponent({
 
         this.playlistItems = result.items.map(parseLocalPlaylistVideo)
 
+        let shouldGetNextPage = false
         if (result.has_continuation) {
           this.continuationData = result
+          shouldGetNextPage = this.playlistItems.length < 100
         }
+        // To workaround the effect of useless continuation data
+        // auto load next page again when no. of parsed items < page size
+        if (shouldGetNextPage) { this.getNextPageLocal() }
 
         this.isLoading = false
       }).catch((err) => {
@@ -294,12 +299,17 @@ export default defineComponent({
       this.isLoadingMore = true
 
       getLocalPlaylistContinuation(this.continuationData).then((result) => {
+        let shouldGetNextPage = false
+
         if (result) {
           const parsedVideos = result.items.map(parseLocalPlaylistVideo)
           this.playlistItems = this.playlistItems.concat(parsedVideos)
 
           if (result.has_continuation) {
             this.continuationData = result
+            // To workaround the effect of useless continuation data
+            // auto load next page again when no. of parsed items < page size
+            shouldGetNextPage = parsedVideos.length < 100
           } else {
             this.continuationData = null
           }
@@ -308,6 +318,7 @@ export default defineComponent({
         }
 
         this.isLoadingMore = false
+        if (shouldGetNextPage) { this.getNextPageLocal() }
       })
     },
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
The issue of YT returning useless continuation data fixed in https://github.com/FreeTubeApp/FreeTube/pull/4102
But UX becomes worse especially after we have multiple playlist (copy function which complains about not fully loaded remote playlists) https://github.com/FreeTubeApp/FreeTube/pull/4234

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
For viewing remote playlists with local API
This PR makes FT loads when playlist video count < 100 (no change for playlist with >= 100 videos)
So that for those < 100 remote playlists
1. No more load more button at the bottom of video list
2. No more complaint from FT when copying playlist

Also affects loading next page behaviour 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Video? Lazy
You should test anyway

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- playlist < 100 - Just find a random one
- playlist > 100 - https://www.youtube.com/playlist?list=PL8mG-RkN2uTx1lbFS8z8wRYS3RrHCp8TG
  Press load next page to ensure no more load next page button
- playlist = 100 - can't find one

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
