### PR TITLE
Remove existence checks and fallbacks for files that always exist

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { readFileSync } = require('fs')
+const { readFileSync, readdirSync } = require('fs')
 const webpack = require('webpack')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
@@ -117,7 +117,8 @@ const config = {
     new webpack.DefinePlugin({
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
-      'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames)
+      'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames),
+      'process.env.GEOLOCATION_NAMES': JSON.stringify(readdirSync(path.join(__dirname, '..', 'static', 'geolocations')).map(filename => filename.replace('.json', '')))
     }),
     new HtmlWebpackPlugin({
       excludeChunks: ['processTaskWorker'],

--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -1,5 +1,4 @@
 import fs from 'fs/promises'
-import { pathExists } from '../../helpers/filesystem'
 import { createWebURL, fetchWithTimeout } from '../../helpers/utils'
 
 const state = {
@@ -47,7 +46,7 @@ const actions = {
       /* eslint-disable-next-line n/no-path-concat */
       const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
       const filePath = `${fileLocation}${fileName}`
-      if (!process.env.IS_ELECTRON || await pathExists(filePath)) {
+      if (!process.env.IS_ELECTRON) {
         console.warn('reading static file for invidious instances')
         const fileData = process.env.IS_ELECTRON ? await fs.readFile(filePath, 'utf8') : await (await fetch(createWebURL(filePath))).text()
         instances = JSON.parse(fileData).filter(e => {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -358,14 +358,10 @@ const actions = {
   },
 
   async getRegionData ({ commit }, { locale }) {
-    let localePathExists
+    const localePathExists = process.env.GEOLOCATION_NAMES.includes(locale)
     // Exclude __dirname from path if not in electron
     const fileLocation = `${process.env.IS_ELECTRON ? process.env.NODE_ENV === 'development' ? '.' : __dirname : ''}/static/geolocations/`
-    if (process.env.IS_ELECTRON) {
-      localePathExists = await pathExists(`${fileLocation}${locale}.json`)
-    } else {
-      localePathExists = process.env.GEOLOCATION_NAMES.includes(locale)
-    }
+
     const pathName = `${fileLocation}${localePathExists ? locale : 'en-US'}.json`
     const countries = process.env.IS_ELECTRON ? JSON.parse(await fs.readFile(pathName)) : await (await fetch(createWebURL(pathName))).json()
 
@@ -599,15 +595,10 @@ const actions = {
 
   async getExternalPlayerCmdArgumentsData ({ commit }, payload) {
     const fileName = 'external-player-map.json'
-    let fileData
     /* eslint-disable-next-line n/no-path-concat */
     const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
 
-    if (await pathExists(`${fileLocation}${fileName}`)) {
-      fileData = await fs.readFile(`${fileLocation}${fileName}`)
-    } else {
-      fileData = '[{"name":"None","value":"","cmdArguments":null}]'
-    }
+    const fileData = await fs.readFile(`${fileLocation}${fileName}`)
 
     const externalPlayerMap = JSON.parse(fileData).map((entry) => {
       return { name: entry.name, nameTranslationKey: entry.nameTranslationKey, value: entry.value, cmdArguments: entry.cmdArguments }


### PR DESCRIPTION
# Remove existence checks and fallbacks for files that always exist

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Performance Improvement

## Description
Currently we check if the invidious fallback instances file, the external player data file and the geolocation files exist on the filesystem before loading them, however as they are in the source code repository and bundled with FreeTube, they will always exist unless someone goes out of the way to remove them from the FreeTube bundle or accidentally deletes them during development. So I think it's fine to remove the checks and fallbacks, because if they are actually missing, you'll actually get an error message, so that you know about the problem, instead of the silent fallback that we currently have.

For the geolocation files we do actually need to check if one exists in the display language, so that we can fallback to the `en-US` one if it doesn't, to keep that working I decided to copy the behaviour of the web build, which embeds a list of known files at build time, allowing use to just check the array instead of doing the runtime file system check every time.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Change the display language and check that the list of regions for trending still gets updated
2. Check that opening an external player still works

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1