### PR TITLE
Update places generating sharable YT video URLs to always return prefix https://youtu.be/

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -188,11 +188,12 @@ export default defineComponent({
     },
 
     youtubeShareUrl: function () {
+      const videoUrl = `https://youtu.be/${this.id}`
       if (this.playlistSharable) {
         // `index` seems can be ignored
-        return `https://youtu.be/${this.id}?list=${this.playlistIdFinal}`
+        return `${videoUrl}&list=${this.playlistIdFinal}`
       }
-      return `https://youtu.be/${this.id}`
+      return videoUrl
     },
 
     youtubeChannelUrl: function () {

--- a/src/renderer/components/ft-share-button/ft-share-button.js
+++ b/src/renderer/components/ft-share-button/ft-share-button.js
@@ -127,11 +127,12 @@ export default defineComponent({
       if (this.isPlaylist) {
         return this.youtubePlaylistUrl
       }
+      const videoUrl = `https://youtu.be/${this.id}`
       if (this.playlistSharable) {
         // `index` seems can be ignored
-        return `https://www.youtube.com/watch?v=${this.id}&list=${this.playlistId}`
+        return `${videoUrl}&list=${this.playlistId}`
       }
-      return `https://youtu.be/${this.id}`
+      return videoUrl
     },
 
     youtubeEmbedURL() {


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Can't really say it's a bug but it's better to return consistent values for sharable video URLs 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Places that can copy sharable video URLs
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/0e2526eb-5bbe-4049-8c81-7e9a9fe92fb1)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/c6bc4140-8096-46e2-98c0-afc30bf3a0d6)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/aa7c7156-ca60-4456-9b58-6e6339664fb2)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Find (A) video with online playlist (B) video without online playlist
Ensure all places that can copy youtube URL will copy same working URLs
For places see screenshots

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
