### PR TITLE
Update add video ot playlist prompt to show presence count when adding one video

### DIFF
--- a/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.vue
+++ b/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.vue
@@ -38,7 +38,7 @@
         >
           <ft-playlist-selector
             tabindex="0"
-            :data="playlist"
+            :playlist="playlist"
             :index="index"
             :selected="selectedPlaylistIdList.includes(playlist._id)"
             @selected="countSelected(playlist._id)"

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
@@ -8,7 +8,7 @@ export default defineComponent({
     'ft-icon-button': FtIconButton
   },
   props: {
-    data: {
+    playlist: {
       type: Object,
       required: true,
     },
@@ -52,16 +52,16 @@ export default defineComponent({
   },
   methods: {
     parseUserData: function () {
-      this.title = this.data.playlistName
-      if (this.data.videos.length > 0) {
-        const thumbnailURL = `https://i.ytimg.com/vi/${this.data.videos[0].videoId}/mqdefault.jpg`
+      this.title = this.playlist.playlistName
+      if (this.playlist.videos.length > 0) {
+        const thumbnailURL = `https://i.ytimg.com/vi/${this.playlist.videos[0].videoId}/mqdefault.jpg`
         if (this.backendPreference === 'invidious') {
           this.thumbnail = thumbnailURL.replace('https://i.ytimg.com', this.currentInvidiousInstance)
         } else {
           this.thumbnail = thumbnailURL
         }
       }
-      this.videoCount = this.data.videos.length
+      this.videoCount = this.playlist.videos.length
     },
 
     toggleSelection: function () {

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
@@ -30,6 +30,8 @@ export default defineComponent({
       title: '',
       thumbnail: require('../../assets/img/thumbnail_placeholder.svg'),
       videoCount: 0,
+
+      videoPresenceCountInPlaylistTextShouldBeVisible: false,
     }
   },
   computed: {
@@ -39,12 +41,44 @@ export default defineComponent({
     currentInvidiousInstance: function () {
       return this.$store.getters.getCurrentInvidiousInstance
     },
+    toBeAddedToPlaylistVideoList: function () {
+      return this.$store.getters.getToBeAddedToPlaylistVideoList
+    },
 
     titleForDisplay: function () {
       if (typeof this.title !== 'string') { return '' }
       if (this.title.length <= 255) { return this.title }
 
       return `${this.title.substring(0, 255)}...`
+    },
+
+    loneToBeAddedToPlaylistVideo: function () {
+      if (this.toBeAddedToPlaylistVideoList.length !== 1) { return null }
+
+      return this.toBeAddedToPlaylistVideoList[0]
+    },
+    loneVideoPresenceCountInPlaylist() {
+      if (this.loneToBeAddedToPlaylistVideo == null) { return null }
+
+      const v = this.playlist.videos.reduce((accumulator, video) => {
+        return video.videoId === this.loneToBeAddedToPlaylistVideo.videoId
+          ? accumulator + 1
+          : accumulator
+      }, 0)
+      // Don't display zero value
+      return v === 0 ? null : v
+    },
+    loneVideoPresenceCountInPlaylistText() {
+      if (this.loneVideoPresenceCountInPlaylist == null) { return null }
+
+      return this.$tc('User Playlists.AddVideoPrompt.Added {count} Times', this.loneVideoPresenceCountInPlaylist, {
+        count: this.loneVideoPresenceCountInPlaylist,
+      })
+    },
+    videoPresenceCountInPlaylistTextVisible() {
+      if (!this.videoPresenceCountInPlaylistTextShouldBeVisible) { return false }
+
+      return this.loneVideoPresenceCountInPlaylistText != null
     },
   },
   created: function () {
@@ -66,6 +100,12 @@ export default defineComponent({
 
     toggleSelection: function () {
       this.$emit('selected', this.index)
+    },
+
+    onVisibilityChanged(visible) {
+      if (!visible) { return }
+
+      this.videoPresenceCountInPlaylistTextShouldBeVisible = true
     },
 
     ...mapActions([

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.scss
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.scss
@@ -54,6 +54,10 @@
       word-wrap: break-word;
       word-break: break-word;
     }
+
+    .videoPresenceCount {
+      margin-block-start: 4px;
+    }
   }
 
   &.grid {

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.vue
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.vue
@@ -29,12 +29,24 @@
         </div>
       </div>
     </div>
-    <div class="info">
-      <span
+    <div
+      v-observe-visibility="{
+        callback: onVisibilityChanged,
+        once: true,
+      }"
+      class="info"
+    >
+      <div
         class="title"
       >
         {{ titleForDisplay }}
-      </span>
+      </div>
+      <div
+        v-if="videoPresenceCountInPlaylistTextVisible"
+        class="videoPresenceCount"
+      >
+        {{ loneVideoPresenceCountInPlaylistText }}
+      </div>
     </div>
   </div>
 </template>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -201,6 +201,8 @@ User Playlists:
     Search in Playlists: Search in Playlists
     Save: Save
 
+    Added {count} Times: 'Added {count} Time | Added {count} Times'
+
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
       "{videoCount} video(s) added to 1 playlist": "1 video added to 1 playlist | {videoCount} videos added to 1 playlist"


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/PikachuEXE/FreeTube/issues/55

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When adding **one** video, display no. of times the video is added in playlists
If not added nothing extra would be displayed

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/9f329d57-bdcf-4cf9-9a9b-e317a0dd9e1b)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/bdd7a747-808a-4fda-a170-24ffbc94f8f5)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Create Playlist (A) & (B) (if needed)
- Add a video to A once, B twice (or more)
- Try to add the same video again to see what's displayed

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
I got text for adding 2+ videos ready but probably easier reviewing this first
