### PR TITLE
Local API: List related games in featured channels section

### DIFF
--- a/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
+++ b/src/renderer/components/ft-channel-bubble/ft-channel-bubble.css
@@ -25,6 +25,7 @@
   block-size: 50px;
   border-radius: 100%;
   -webkit-border-radius: 100%;
+  object-fit: cover;
 }
 
 .selected {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -495,6 +495,7 @@ export default defineComponent({
       const expectedId = this.id
 
       try {
+        /** @type {import('youtubei.js').YT.Channel|undefined} */
         let channel
         if (!this.channelInstance) {
           channel = await getLocalChannel(this.id)
@@ -651,19 +652,44 @@ export default defineComponent({
           this.bannerUrl = null
         }
 
-        this.relatedChannels = channel.channels.map(({ author }) => {
-          let thumbnailUrl = author.best_thumbnail.url
+        let relatedChannels = channel.channels.map(({ author }) => ({
+          name: author.name,
+          id: author.id,
+          thumbnailUrl: author.best_thumbnail.url
+        }))
 
-          if (thumbnailUrl.startsWith('//')) {
-            thumbnailUrl = `https:${thumbnailUrl}`
-          }
+        if (channel.memo.has('GameDetails')) {
+          /** @type {import('youtubei.js').YTNodes.GameDetails[]} */
+          const games = channel.memo.get('GameDetails')
 
-          return {
-            name: author.name,
-            id: author.id,
-            thumbnailUrl
-          }
-        })
+          relatedChannels.push(...games.map(game => ({
+            id: game.endpoint.payload.browseId,
+            name: game.title.text,
+            thumbnailUrl: game.box_art[0].url
+          })))
+        }
+
+        if (relatedChannels.length > 0) {
+          /** @type {Set<string>} */
+          const knownChannelIds = new Set()
+
+          relatedChannels = relatedChannels.filter(channel => {
+            if (!knownChannelIds.has(channel.id)) {
+              knownChannelIds.add(channel.id)
+              return true
+            }
+
+            return false
+          })
+
+          relatedChannels.forEach(channel => {
+            if (channel.thumbnailUrl.startsWith('//')) {
+              channel.thumbnailUrl = `https:${channel.thumbnailUrl}`
+            }
+          })
+        }
+
+        this.relatedChannels = relatedChannels
 
         this.channelInstance = channel
 


### PR DESCRIPTION
# local API: List related games in featured channels section

## Pull Request Type

- [x] Feature Implementation

## Description
This pull request extracts the related games listed on the official Gaming channel and the auto-generated game channels and places them in the featured channels section on the channel about tab.

On the Gaming channel they are in the "Top live games" section and on auto-generated game channels (e.g. Minecraft) they are in the "Other games from this developer" section.

## Screenshots <!-- If appropriate -->
YouTube Gaming:
![gaming-channel](https://github.com/FreeTubeApp/FreeTube/assets/48293849/e5dcd9e2-a1d0-4a53-aa82-37dcf2dd8cd3)

Minecraft Channel:
![minecraft-channel](https://github.com/FreeTubeApp/FreeTube/assets/48293849/3d8984a0-385c-4a4f-b5f9-c888d5a83da2)

## Testing <!-- for code that is not small enough to be easily understandable -->
YouTube Gaming channel: https://youtube.com/@gaming
Auto-generated Minecraft channel: https://www.youtube.com/channel/UCQvWX73GQygcwXOTSf_VDVg

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1