### PR TITLE
Fix search bar handling of Invidious channel URLs

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -580,7 +580,9 @@ const actions = {
           urlType: 'channel',
           channelId,
           subPath,
-          url: url.toString()
+          // The original URL could be from Invidious.
+          // We need to make sure it starts with youtube.com, so that YouTube's resolve endpoint can recognise it
+          url: `https://www.youtube.com${url.pathname}`
         }
       }
 


### PR DESCRIPTION
# Fix search bar handling of Invidious channel URLs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
To figure out what the channel ID for a given username, we need to pass the channel URL to YouTube's resolve endpoint. Currently we pass the original/user provided URL, which works fine if it is a YouTube one, but Invidious and Piped URLs are understandably not recognised by YouTube, so result in FreeTube incorrectly saying that the channel doesn't exist.

This pull request ensures that the URL that FreeTube always passes a youtube.com URL to YouTube, so that the URL resolution works correctly.

## Testing <!-- for code that is not small enough to be easily understandable -->
Paste `https://redirect.invidious.io/@YouTube` into the search bar and press enter.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1