### PR TITLE
Remove formatting markers from DeArrow titles

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -492,7 +492,8 @@ export default defineComponent({
       const data = await deArrowData(this.id)
       const cacheData = { videoId, title: null, videoDuration: null, thumbnail: null, thumbnailTimestamp: null }
       if (Array.isArray(data?.titles) && data.titles.length > 0 && (data.titles[0].locked || data.titles[0].votes >= 0)) {
-        cacheData.title = data.titles[0].title
+        // remove dearrow formatting markers https://github.com/ajayyy/DeArrow/blob/0da266485be902fe54259214c3cd7c942f2357c5/src/titles/titleFormatter.ts#L460
+        cacheData.title = data.titles[0].title.replaceAll(/(^|\s)>(\S)/g, '$1$2').trim()
       }
       if (Array.isArray(data?.thumbnails) && data.thumbnails.length > 0 && (data.thumbnails[0].locked || data.thumbnails[0].votes >= 0)) {
         cacheData.thumbnailTimestamp = data.thumbnails.at(0).timestamp


### PR DESCRIPTION
# Remove formatting markers from DeArrow titles

## Pull Request Type
- [x] Bugfix

## Related issue
closes #4524

## Description
DeArrow titles can contain some markers for the web extension to handle user settings like TitleCase, Capitalizing words, Sentence casing and LowerCasing. This PR removes those markers as that's not something that we use.

## Testing 
- Enable DeArrow
- search "Building TALLY HO's rig - a complex process!"
- See DeArrowed title without formatting characters
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/d2613263-d736-47cf-96c2-28b496bd38cd)

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1