### PR TITLE
Fix logic for setting the locale when using `System Default`

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -720,7 +720,8 @@ function runApp() {
   })
 
   ipcMain.handle(IpcChannels.GET_SYSTEM_LOCALE, () => {
-    return app.getLocale()
+    // we should switch to getPreferredSystemLanguages at some point and iterate through until we find a supported locale
+    return app.getSystemLocale()
   })
 
   ipcMain.handle(IpcChannels.GET_USER_DATA_PATH, () => {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -316,18 +316,20 @@ const stateWithSideEffects = {
       let targetLocale = value
       if (value === 'system') {
         const systemLocaleName = (await getSystemLocale()).replace('-', '_') // ex: en_US
-        const systemLocaleLang = systemLocaleName.split('_')[0] // ex: en
-        const targetLocaleOptions = allLocales.filter((locale) => { // filter out other languages
+        const systemLocaleSplit = systemLocaleName.split('_') // ex: en
+        const targetLocaleOptions = allLocales.filter((locale) => {
+          // filter out other languages
           const localeLang = locale.replace('-', '_').split('_')[0]
-          return localeLang.includes(systemLocaleLang)
+          return localeLang.includes(systemLocaleSplit[0])
         }).sort((a, b) => {
           const aLocaleName = a.replace('-', '_')
           const bLocaleName = b.replace('-', '_')
           const aLocale = aLocaleName.split('_') // ex: [en, US]
           const bLocale = bLocaleName.split('_')
-          if (aLocale.includes(systemLocaleName)) { // country & language match, prefer a
+
+          if (aLocaleName === systemLocaleName) { // country & language match, prefer a
             return -1
-          } else if (bLocale.includes(systemLocaleName)) { // country & language match, prefer b
+          } else if (bLocaleName === systemLocaleName) { // country & language match, prefer b
             return 1
           } else if (aLocale.length === 1) { // no country code for a, prefer a
             return -1
@@ -337,12 +339,11 @@ const stateWithSideEffects = {
             return aLocaleName.localeCompare(bLocaleName)
           }
         })
+
         if (targetLocaleOptions.length > 0) {
           targetLocale = targetLocaleOptions[0]
-        }
-
-        // Go back to default value if locale is unavailable
-        if (!targetLocale) {
+        } else {
+          // Go back to default value if locale is unavailable
           targetLocale = defaultLocale
           // Translating this string isn't necessary
           // because the user will always see it in the default locale

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -1,5 +1,5 @@
 # Put the name of your locale in the same language
-Locale Name: Português
+Locale Name: Português (PT)
 FreeTube: FreeTube
 # Currently on Subscriptions, Playlists, and History
 'This part of the app is not ready yet. Come back later when progress has been made.': >-


### PR DESCRIPTION
# Fix logic for setting the locale when using `System Default`

## Pull Request Type
- [x] Bugfix

## Related issue
closes #3360

## Description
The comparison being done was incorrect and didn't check the country code.

## Testing 
### Test 1 - en-US as system locale
- set system locale to `en-US`
- Log out and log back in to your computer if necessary (you may need to log out for the change to take effect)
- Run FreeTube
- Set locale to System Default
- (notice that text remains `System Default`)

### Test 2 - en-UK as system locale
- set FreeTube locale to `en-US`
- set system locale to `en-UK`
- Log out and log back in to your computer if necessary (you may need to log out for the change to take effect)
- Run FreeTube
- Set locale to System Default
- (notice that text becomes `System default`)

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1

## Additional context
Bug was introduced in https://github.com/FreeTubeApp/FreeTube/pull/2271/
