### PR TITLE
Fix quick bookmark buttons appearing for remote playlists

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -48,7 +48,7 @@
       </h2>
       <p>
         {{ videoCount }} {{ $t("Playlist.Videos") }}
-        <span v-if="!hideViews && infoSource !== 'user'">
+        <span v-if="!hideViews && !isUserPlaylist">
           - {{ viewCount }} {{ $t("Playlist.Views") }}
         </span>
         <span>- </span>
@@ -79,7 +79,7 @@
       class="channelShareWrapper"
     >
       <router-link
-        v-if="infoSource !== 'user' && channelId"
+        v-if="!isUserPlaylist && channelId"
         class="playlistChannel"
         :to="`/channel/${channelId}`"
       >
@@ -122,7 +122,7 @@
         />
 
         <ft-icon-button
-          v-if="!editMode && infoSource === 'user'"
+          v-if="!editMode && isUserPlaylist"
           :title="$t('User Playlists.Edit Playlist Info')"
           :icon="['fas', 'edit']"
           theme="secondary"
@@ -136,21 +136,21 @@
           @click="toggleCopyVideosPrompt"
         />
         <ft-icon-button
-          v-if="!editMode && !markedAsQuickBookmarkTarget"
+          v-if="!editMode && isUserPlaylist && !markedAsQuickBookmarkTarget"
           :title="$t('User Playlists.Enable Quick Bookmark With This Playlist')"
           :icon="['fas', 'link']"
           theme="secondary"
           @click="enableQuickBookmarkForThisPlaylist"
         />
         <ft-icon-button
-          v-if="!editMode && markedAsQuickBookmarkTarget"
+          v-if="!editMode && isUserPlaylist && markedAsQuickBookmarkTarget"
           :title="$t('User Playlists.Disable Quick Bookmark')"
           :icon="['fas', 'link-slash']"
           theme="secondary"
           @click="disableQuickBookmark"
         />
         <ft-icon-button
-          v-if="!editMode && infoSource === 'user' && videoCount > 0"
+          v-if="!editMode && isUserPlaylist && videoCount > 0"
           :title="$t('User Playlists.Remove Watched Videos')"
           :icon="['fas', 'eye-slash']"
           theme="primary"


### PR DESCRIPTION
# Fix quick bookmark buttons appearing for remote playlists

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4518#issuecomment-1904950573

## Description
Removes quick bookmark buttons for remote playlists. Also switches to using the property name `isUserPlaylist` to check whether it is a user playlist consistently throughout the file to improve readability.

## Screenshots <!-- If appropriate -->
![Screenshot_20240122_175259](https://github.com/FreeTubeApp/FreeTube/assets/84899178/870f0599-b045-4e8e-af7d-5808cda1e83e)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Test buttons do not appear for remote playlist
- Test buttons do appear for user playlist

## Desktop
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1
