### PR TITLE
Update single playlst view for user playlist to have pagination

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -226,7 +226,7 @@ export default defineComponent({
   },
   methods: {
     toggleCopyVideosPrompt: function (force = false) {
-      if (this.moreVideoDataAvailable && !force) {
+      if (this.moreVideoDataAvailable && !this.isUserPlaylist && !force) {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast["Some videos in the playlist are not loaded yet. Click here to copy anyway."]'), 5000, () => {
           this.toggleCopyVideosPrompt(true)
         })

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -159,8 +159,6 @@ export default defineComponent({
       this.getPlaylistInfoDebounce()
     },
     userPlaylistVisibleVideoLimit (val) {
-      sessionStorage.setItem(`Playlist/userPlaylistVisibleVideoLimit/${this.playlistId}`, val)
-
       if (this.selectedUserPlaylistVideos.length < this.userPlaylistVisibleVideoLimit) {
         this.playlistItems = this.selectedUserPlaylistVideos
       } else {
@@ -169,11 +167,6 @@ export default defineComponent({
     },
   },
   mounted: function () {
-    const limit = sessionStorage.getItem(`Playlist/userPlaylistVisibleVideoLimit/${this.playlistId}`)
-    if (limit !== null) {
-      this.userPlaylistVisibleVideoLimit = limit
-    }
-
     this.getPlaylistInfoDebounce = debounce(this.getPlaylistInfo, 100)
     this.getPlaylistInfoDebounce()
   },

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -109,6 +109,13 @@ export default defineComponent({
 
       return this.continuationData !== null
     },
+    playlistInfoVideos() {
+      if (this.selectedUserPlaylist) {
+        return this.selectedUserPlaylist.videos
+      }
+
+      return this.playlistItems
+    },
 
     isUserPlaylistRequested: function () {
       return this.$route.query.playlistType === 'user'

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -360,7 +360,7 @@ export default defineComponent({
     },
 
     moveVideoUp: function (videoId, playlistItemId) {
-      const playlistItems = [].concat(this.playlistItems)
+      const playlistItems = [].concat(this.selectedUserPlaylistVideos)
       const videoIndex = playlistItems.findIndex((video) => {
         return video.videoId === videoId && video.playlistItemId === playlistItemId
       })
@@ -392,7 +392,7 @@ export default defineComponent({
     },
 
     moveVideoDown: function (videoId, playlistItemId) {
-      const playlistItems = [].concat(this.playlistItems)
+      const playlistItems = [].concat(this.selectedUserPlaylistVideos)
       const videoIndex = playlistItems.findIndex((video) => {
         return video.videoId === videoId && video.playlistItemId === playlistItemId
       })

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -391,7 +391,6 @@ export default defineComponent({
       }
       try {
         this.updatePlaylist(playlist)
-        this.playlistItems = playlistItems
       } catch (e) {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
         console.error(e)
@@ -423,7 +422,6 @@ export default defineComponent({
       }
       try {
         this.updatePlaylist(playlist)
-        this.playlistItems = playlistItems
       } catch (e) {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
         console.error(e)

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -152,7 +152,7 @@ export default defineComponent({
       this.getPlaylistInfoDebounce()
     },
     userPlaylistVisibleVideoLimit (val) {
-      sessionStorage.setItem('Playlist/userPlaylistVisibleVideoLimit', val)
+      sessionStorage.setItem(`Playlist/userPlaylistVisibleVideoLimit/${this.playlistId}`, val)
 
       if (this.selectedUserPlaylistVideos.length < this.userPlaylistVisibleVideoLimit) {
         this.playlistItems = this.selectedUserPlaylistVideos
@@ -162,7 +162,7 @@ export default defineComponent({
     },
   },
   mounted: function () {
-    const limit = sessionStorage.getItem('Playlist/userPlaylistVisibleVideoLimit')
+    const limit = sessionStorage.getItem(`Playlist/userPlaylistVisibleVideoLimit/${this.playlistId}`)
     if (limit !== null) {
       this.userPlaylistVisibleVideoLimit = limit
     }

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -18,7 +18,7 @@
       :last-updated="lastUpdated"
       :description="playlistDescription"
       :video-count="videoCount"
-      :videos="playlistItems"
+      :videos="playlistInfoVideos"
       :view-count="viewCount"
       :info-source="infoSource"
       :more-video-data-available="moreVideoDataAvailable"


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Maybe this makes https://github.com/FreeTubeApp/FreeTube/issues/4578 better

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Add pagination to single playlist view for user playlists

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/8d67346b-7c47-4b65-b2d9-2983308f14d1)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Add some playlists with 100+ videos (e.g. copy some playlists from https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw, sort by Last Video Added)
- Ensure single playlist view got videos paginated
- Ensure pagination limit NOT remembered
- Ensure user playlist can be copied without warning even not all videos loaded
- Ensure this issue is fixed: `When moving a video in a playlist up or down, the animation for the videos swapping plays twice`
- What else

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
