### PR TITLE
Playlist performance improvements

### DIFF
--- a/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.css
+++ b/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.css
@@ -1,0 +1,17 @@
+/*
+  Set a height to invisible/unloaded elements, so that lazy loading actually works.
+  If we don't set a height, they all get a height of 0px (because they have no content),
+  so they all bunch up together and end up loading all of them in one go.
+ */
+.placeholder {
+  block-size: 40px;
+}
+
+.videoIndex {
+  color: var(--tertiary-text-color);
+  text-align: center;
+}
+
+.videoIndexIcon {
+  font-size: 14px;
+}

--- a/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.js
+++ b/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.js
@@ -1,0 +1,124 @@
+import { defineComponent } from 'vue'
+import FtListVideo from '../ft-list-video/ft-list-video.vue'
+
+export default defineComponent({
+  name: 'FtListVideoNumbered',
+  components: {
+    'ft-list-video': FtListVideo
+  },
+  props: {
+    data: {
+      type: Object,
+      required: true
+    },
+    playlistId: {
+      type: String,
+      default: null
+    },
+    playlistType: {
+      type: String,
+      default: null
+    },
+    playlistIndex: {
+      type: Number,
+      default: null
+    },
+    playlistReverse: {
+      type: Boolean,
+      default: false
+    },
+    playlistShuffle: {
+      type: Boolean,
+      default: false
+    },
+    playlistLoop: {
+      type: Boolean,
+      default: false
+    },
+    playlistItemId: {
+      type: String,
+      default: null,
+    },
+    appearance: {
+      type: String,
+      required: true
+    },
+    initialVisibleState: {
+      type: Boolean,
+      default: false,
+    },
+    alwaysShowAddToPlaylistButton: {
+      type: Boolean,
+      default: false,
+    },
+    quickBookmarkButtonEnabled: {
+      type: Boolean,
+      default: true,
+    },
+    canMoveVideoUp: {
+      type: Boolean,
+      default: false,
+    },
+    canMoveVideoDown: {
+      type: Boolean,
+      default: false,
+    },
+    canRemoveFromPlaylist: {
+      type: Boolean,
+      default: false,
+    },
+    videoIndex: {
+      type: Number,
+      default: -1
+    },
+    isCurrentVideo: {
+      type: Boolean,
+      default: false
+    },
+    useChannelsHiddenPreference: {
+      type: Boolean,
+      default: false,
+    }
+  },
+  data: function () {
+    return {
+      visible: false,
+      show: true
+    }
+  },
+  computed: {
+    channelsHidden() {
+      // Some component users like channel view will have this disabled
+      if (!this.useChannelsHiddenPreference) { return [] }
+
+      return JSON.parse(this.$store.getters.getChannelsHidden).map((ch) => {
+        // Legacy support
+        if (typeof ch === 'string') {
+          return { name: ch, preferredName: '', icon: '' }
+        }
+        return ch
+      })
+    },
+
+    // As we only use this component in Playlist and watch-video-playlist,
+    // where title filtering is never desired, we don't have any title filtering logic here,
+    // like we do in ft-list-video-lazy
+
+    shouldBeVisible() {
+      return !(this.channelsHidden.some(ch => ch.name === this.data.authorId) ||
+        this.channelsHidden.some(ch => ch.name === this.data.author))
+    }
+  },
+  created() {
+    this.visible = this.initialVisibleState
+  },
+  methods: {
+    onVisibilityChanged: function (visible) {
+      if (visible && this.shouldBeVisible) {
+        this.visible = visible
+      } else if (visible) {
+        this.show = false
+      }
+    }
+  }
+})

--- a/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.vue
+++ b/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.vue
@@ -1,0 +1,53 @@
+<template>
+  <div
+    v-show="show"
+    v-observe-visibility="!initialVisibleState ? {
+      callback: onVisibilityChanged,
+      once: true,
+    } : null"
+    :class="{ placeholder: !visible }"
+  >
+    <template
+      v-if="visible"
+    >
+      <p
+        class="videoIndex"
+      >
+        <font-awesome-icon
+          v-if="isCurrentVideo"
+          class="videoIndexIcon"
+          :icon="['fas', 'play']"
+        />
+        <template
+          v-else
+        >
+          {{ videoIndex + 1 }}
+        </template>
+      </p>
+      <ft-list-video
+        :data="data"
+        :playlist-id="playlistId"
+        :playlist-type="playlistType"
+        :playlist-index="playlistIndex"
+        :playlist-reverse="playlistReverse"
+        :playlist-shuffle="playlistShuffle"
+        :playlist-loop="playlistLoop"
+        :playlist-item-id="playlistItemId"
+        force-list-type="list"
+        :appearance="appearance"
+        :always-show-add-to-playlist-button="alwaysShowAddToPlaylistButton"
+        :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
+        :can-move-video-up="canMoveVideoUp"
+        :can-move-video-down="canMoveVideoDown"
+        :can-remove-from-playlist="canRemoveFromPlaylist"
+        @pause-player="$emit('pause-player')"
+        @move-video-up="$emit('move-video-up')"
+        @move-video-down="$emit('move-video-down')"
+        @remove-from-playlist="$emit('remove-from-playlist')"
+      />
+    </template>
+  </div>
+</template>
+
+<script src="./ft-list-video-numbered.js" />
+<style scoped src="./ft-list-video-numbered.css" />

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -97,7 +97,6 @@ export default defineComponent({
       lengthSeconds: 0,
       duration: '',
       description: '',
-      watched: false,
       watchProgress: 0,
       publishedText: '',
       isLive: false,
@@ -223,7 +222,7 @@ export default defineComponent({
     dropdownOptions: function () {
       const options = [
         {
-          label: this.watched
+          label: this.historyEntryExists
             ? this.$t('Video.Remove From History')
             : this.$t('Video.Mark As Watched'),
           value: 'history'
@@ -343,7 +342,7 @@ export default defineComponent({
     },
 
     addWatchedStyle: function () {
-      return this.watched && !this.inHistory
+      return this.historyEntryExists && !this.inHistory
     },
 
     externalPlayer: function () {
@@ -576,7 +575,7 @@ export default defineComponent({
       }
       this.openInExternalPlayer(payload)
 
-      if (this.saveWatchedProgress && !this.watched) {
+      if (this.saveWatchedProgress && !this.historyEntryExists) {
         this.markAsWatched()
       }
     },
@@ -584,7 +583,7 @@ export default defineComponent({
     handleOptionsClick: function (option) {
       switch (option) {
         case 'history':
-          if (this.watched) {
+          if (this.historyEntryExists) {
             this.removeFromWatched()
           } else {
             this.markAsWatched()
@@ -727,8 +726,6 @@ export default defineComponent({
 
     checkIfWatched: function () {
       if (this.historyEntryExists) {
-        this.watched = true
-
         const historyEntry = this.historyEntry
 
         if (this.saveWatchedProgress) {
@@ -744,7 +741,6 @@ export default defineComponent({
           this.publishedText = ''
         }
       } else {
-        this.watched = false
         this.watchProgress = 0
       }
     },
@@ -766,8 +762,6 @@ export default defineComponent({
       }
       this.updateHistory(videoData)
       showToast(this.$t('Video.Video has been marked as watched'))
-
-      this.watched = true
     },
 
     removeFromWatched: function () {
@@ -775,7 +769,6 @@ export default defineComponent({
 
       showToast(this.$t('Video.Video has been removed from your history'))
 
-      this.watched = false
       this.watchProgress = 0
     },
 

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -104,7 +104,7 @@
         {{ $t("Video.Watched") }}
       </div>
       <div
-        v-if="watched"
+        v-if="historyEntryExists"
         class="watchedProgressBar"
         :style="{inlineSize: progressPercentage + '%'}"
       />

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -126,12 +126,13 @@
         >
           <span>{{ channelName }}</span>
         </router-link>
-        <template v-if="!isLive && !isUpcoming && !isPremium && !hideViews">
-          <span class="viewCount">
-            <template v-if="channelId !== null"> • </template>
-            {{ $tc('Global.Counts.View Count', viewCount, {count: parsedViewCount}) }}
-          </span>
-        </template>
+        <span
+          v-if="!isLive && !isUpcoming && !isPremium && !hideViews"
+          class="viewCount"
+        >
+          <template v-if="channelId !== null"> • </template>
+          {{ $tc('Global.Counts.View Count', viewCount, {count: parsedViewCount}) }}
+        </span>
         <span
           v-if="uploadedTime !== '' && !isLive && !inHistory"
           class="uploadedTime"

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -157,7 +157,7 @@
         @click="handleOptionsClick"
       />
       <p
-        v-if="((listType === 'list' || forceListType === 'list') && forceListType !== 'grid') &&
+        v-if="description && ((listType === 'list' || forceListType === 'list') && forceListType !== 'grid') &&
           appearance === 'result'"
         class="description"
         v-html="description"

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -226,7 +226,7 @@ export default defineComponent({
   },
   methods: {
     toggleCopyVideosPrompt: function (force = false) {
-      if (this.moreVideoDataAvailable && !force) {
+      if (this.moreVideoDataAvailable && !this.isUserPlaylist && !force) {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast["Some videos in the playlist are not loaded yet. Click here to copy anyway."]'), 5000, () => {
           this.toggleCopyVideosPrompt(true)
         })

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -85,19 +85,6 @@
   transition: background 0.2s ease-in;
 }
 
-.videoIndexContainer {
-  text-align: center;
-}
-
-.videoIndex {
-  color: var(--tertiary-text-color);
-}
-
-.videoIndexIcon {
-  font-size: 14px;
-  color: var(--tertiary-text-color);
-}
-
 .videoInfo {
   margin-inline-start: 30px;
   position: relative;

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -2,7 +2,7 @@ import { defineComponent, nextTick } from 'vue'
 import { mapMutations } from 'vuex'
 import FtLoader from '../ft-loader/ft-loader.vue'
 import FtCard from '../ft-card/ft-card.vue'
-import FtListVideoLazy from '../ft-list-video-lazy/ft-list-video-lazy.vue'
+import FtListVideoNumbered from '../ft-list-video-numbered/ft-list-video-numbered.vue'
 import { copyToClipboard, showToast } from '../../helpers/utils'
 import {
   getLocalPlaylist,
@@ -16,7 +16,7 @@ export default defineComponent({
   components: {
     'ft-loader': FtLoader,
     'ft-card': FtCard,
-    'ft-list-video-lazy': FtListVideoLazy,
+    'ft-list-video-numbered': FtListVideoNumbered
   },
   props: {
     playlistId: {
@@ -471,14 +471,13 @@ export default defineComponent({
     parseUserPlaylist: function (playlist, { allowPlayingVideoRemoval = true } = {}) {
       this.playlistTitle = playlist.playlistName
       this.channelName = ''
-      this.channelThumbnail = ''
       this.channelId = ''
 
       if (this.playlistItems.length === 0 || allowPlayingVideoRemoval) {
         this.playlistItems = playlist.videos
       } else {
         // `this.currentVideo` relies on `playlistItems`
-        const latestPlaylistContainsCurrentVideo = playlist.videos.find(v => v.playlistItemId === this.playlistItemId) != null
+        const latestPlaylistContainsCurrentVideo = playlist.videos.some(v => v.playlistItemId === this.playlistItemId)
         // Only update list of videos if latest video list still contains currently playing video
         if (latestPlaylistContainsCurrentVideo) {
           this.playlistItems = playlist.videos
@@ -511,7 +510,7 @@ export default defineComponent({
       const currentVideoItem = (this.$refs.currentVideoItem || [])[0]
       if (container != null && currentVideoItem != null) {
         // Watch view can be ready sooner than this component
-        container.scrollTop = currentVideoItem.offsetTop - container.offsetTop
+        container.scrollTop = currentVideoItem.$el.offsetTop - container.offsetTop
       }
     },
 

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
@@ -116,41 +116,25 @@
         ref="playlistItems"
         class="playlistItems"
       >
-        <div
+        <ft-list-video-numbered
           v-for="(item, index) in playlistItems"
           :key="item.playlistItemId || item.videoId"
           :ref="currentVideoIndexZeroBased === index ? 'currentVideoItem' : null"
           class="playlistItem"
-        >
-          <div class="videoIndexContainer">
-            <font-awesome-icon
-              v-if="currentVideoIndexZeroBased === index"
-              class="videoIndexIcon"
-              :icon="['fas', 'play']"
-            />
-            <p
-              v-else
-              class="videoIndex"
-            >
-              {{ index + 1 }}
-            </p>
-          </div>
-          <ft-list-video-lazy
-            :data="item"
-            :playlist-id="playlistId"
-            :playlist-type="playlistType"
-            :playlist-index="reversePlaylist ? playlistItems.length - index - 1 : index"
-            :playlist-item-id="item.playlistItemId"
-            :playlist-reverse="reversePlaylist"
-            :playlist-shuffle="shuffleEnabled"
-            :playlist-loop="loopEnabled"
-            :hide-forbidden-titles="false"
-            appearance="watchPlaylistItem"
-            force-list-type="list"
-            :initial-visible-state="index < (currentVideoIndexZeroBased + 4) && index > (currentVideoIndexZeroBased - 4)"
-            @pause-player="$emit('pause-player')"
-          />
-        </div>
+          :data="item"
+          :playlist-id="playlistId"
+          :playlist-type="playlistType"
+          :playlist-index="reversePlaylist ? playlistItems.length - index - 1 : index"
+          :playlist-item-id="item.playlistItemId"
+          :playlist-reverse="reversePlaylist"
+          :playlist-shuffle="shuffleEnabled"
+          :playlist-loop="loopEnabled"
+          :video-index="index"
+          :is-current-video="currentVideoIndexZeroBased === index"
+          appearance="watchPlaylistItem"
+          :initial-visible-state="index < (currentVideoIndexZeroBased + 4) && index > (currentVideoIndexZeroBased - 4)"
+          @pause-player="$emit('pause-player')"
+        />
       </div>
     </div>
   </ft-card>

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -63,10 +63,13 @@ const actions = {
     payload.createdAt = Date.now()
     payload.lastUpdatedAt = Date.now()
     // Ensure all videos has required attributes
+
+    const currentTime = new Date().getTime()
+
     if (Array.isArray(payload.videos)) {
       payload.videos.forEach(videoData => {
         if (videoData.timeAdded == null) {
-          videoData.timeAdded = new Date().getTime()
+          videoData.timeAdded = currentTime
         }
         if (videoData.playlistItemId == null) {
           videoData.playlistItemId = generateRandomUniqueId()
@@ -149,11 +152,14 @@ const actions = {
     // Since this action will ensure uniqueness of `playlistItemId` of added video entries
     try {
       const { _id, videos } = payload
+
+      const currentTime = new Date().getTime()
+
       const newVideoObjects = videos.map((video) => {
         // Create a new object to prevent changing existing values outside
         const videoData = Object.assign({}, video)
         if (videoData.timeAdded == null) {
-          videoData.timeAdded = new Date().getTime()
+          videoData.timeAdded = currentTime
         }
         videoData.playlistItemId = generateRandomUniqueId()
         // For backward compatibility
@@ -188,6 +194,9 @@ const actions = {
           dispatch('addPlaylist', playlist)
         })
       } else {
+        const dateNow = Date.now()
+        const currentTime = new Date().getTime()
+
         payload.forEach((playlist) => {
           let anythingUpdated = false
           // Assign generated playlist ID in case DB data corrupted
@@ -205,19 +214,19 @@ const actions = {
           // Assign current time as created time in case DB data corrupted
           if (playlist.createdAt == null) {
             // Time now in unix time, in ms
-            playlist.createdAt = Date.now()
+            playlist.createdAt = dateNow
             anythingUpdated = true
           }
           // Assign current time as last updated time in case DB data corrupted
           if (playlist.lastUpdatedAt == null) {
             // Time now in unix time, in ms
-            playlist.lastUpdatedAt = Date.now()
+            playlist.lastUpdatedAt = dateNow
             anythingUpdated = true
           }
           playlist.videos.forEach((v) => {
             // Ensure all videos has `timeAdded` property
             if (v.timeAdded == null) {
-              v.timeAdded = new Date().getTime()
+              v.timeAdded = currentTime
               anythingUpdated = true
             }
 
@@ -257,8 +266,9 @@ const actions = {
           return playlist.playlistName === 'Watch Later' || playlist._id === 'watchLater'
         })
 
-        const defaultFavoritesPlaylist = state.defaultPlaylists.find((e) => e._id === 'favorites')
         if (favoritesPlaylist != null) {
+          const defaultFavoritesPlaylist = state.defaultPlaylists.find((e) => e._id === 'favorites')
+
           // Update existing matching playlist only if it exists
           if (favoritesPlaylist._id !== defaultFavoritesPlaylist._id || favoritesPlaylist.protected !== defaultFavoritesPlaylist.protected) {
             const oldId = favoritesPlaylist._id
@@ -277,8 +287,9 @@ const actions = {
           }
         }
 
-        const defaultWatchLaterPlaylist = state.defaultPlaylists.find((e) => e._id === 'watchLater')
         if (watchLaterPlaylist != null) {
+          const defaultWatchLaterPlaylist = state.defaultPlaylists.find((e) => e._id === 'watchLater')
+
           // Update existing matching playlist only if it exists
           if (watchLaterPlaylist._id !== defaultWatchLaterPlaylist._id || watchLaterPlaylist.protected !== defaultWatchLaterPlaylist.protected) {
             const oldId = watchLaterPlaylist._id
@@ -394,7 +405,7 @@ const mutations = {
   addVideos(state, payload) {
     const playlist = state.playlists.find(playlist => playlist._id === payload._id)
     if (playlist) {
-      playlist.videos = [].concat(playlist.videos).concat(payload.videos)
+      playlist.videos = [].concat(playlist.videos, payload.videos)
     }
   },
 

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import PlaylistInfo from '../../components/playlist-info/playlist-info.vue'
-import FtListVideoLazy from '../../components/ft-list-video-lazy/ft-list-video-lazy.vue'
+import FtListVideoNumbered from '../../components/ft-list-video-numbered/ft-list-video-numbered.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
 import {
@@ -21,7 +21,7 @@ export default defineComponent({
     'ft-loader': FtLoader,
     'ft-card': FtCard,
     'playlist-info': PlaylistInfo,
-    'ft-list-video-lazy': FtListVideoLazy,
+    'ft-list-video-numbered': FtListVideoNumbered,
     'ft-flex-box': FtFlexBox,
     'ft-button': FtButton
   },

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -26,7 +26,7 @@ export default defineComponent({
     'ft-button': FtButton
   },
   beforeRouteLeave(to, from, next) {
-    if (!this.isLoading && to.path.startsWith('/watch') && to.query.playlistId === this.playlistId) {
+    if (!this.isLoading && !this.isUserPlaylistRequested && to.path.startsWith('/watch') && to.query.playlistId === this.playlistId) {
       this.setCachedPlaylist({
         id: this.playlistId,
         title: this.playlistTitle,

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -62,11 +62,6 @@
   transform: translate(calc(10% * var(--horizontal-directionality-coefficient)));
 }
 
-.videoIndex {
-  color: var(--tertiary-text-color);
-  text-align: center;
-}
-
 .loadNextPageWrapper {
   /* about the same height as the button */
   max-block-size: 7vh;

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -43,35 +43,27 @@
           name="playlistItem"
           tag="span"
         >
-          <div
+          <ft-list-video-numbered
             v-for="(item, index) in visiblePlaylistItems"
             :key="`${item.videoId}-${item.playlistItemId || index}`"
             class="playlistItem"
-          >
-            <p
-              class="videoIndex"
-            >
-              {{ index + 1 }}
-            </p>
-            <ft-list-video-lazy
-              :data="item"
-              :playlist-id="playlistId"
-              :playlist-type="infoSource"
-              :playlist-index="index"
-              :playlist-item-id="item.playlistItemId"
-              appearance="result"
-              force-list-type="list"
-              :always-show-add-to-playlist-button="true"
-              :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
-              :can-move-video-up="index > 0"
-              :can-move-video-down="index < visiblePlaylistItems.length - 1"
-              :can-remove-from-playlist="true"
-              :hide-forbidden-titles="false"
-              @move-video-up="moveVideoUp(item.videoId, item.playlistItemId)"
-              @move-video-down="moveVideoDown(item.videoId, item.playlistItemId)"
-              @remove-from-playlist="removeVideoFromPlaylist(item.videoId, item.playlistItemId)"
-            />
-          </div>
+            :data="item"
+            :playlist-id="playlistId"
+            :playlist-type="infoSource"
+            :playlist-index="index"
+            :playlist-item-id="item.playlistItemId"
+            appearance="result"
+            :always-show-add-to-playlist-button="true"
+            :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
+            :can-move-video-up="index > 0"
+            :can-move-video-down="index < visiblePlaylistItems.length - 1"
+            :can-remove-from-playlist="true"
+            :video-index="index"
+            :initial-visible-state="index < 10"
+            @move-video-up="moveVideoUp(item.videoId, item.playlistItemId)"
+            @move-video-down="moveVideoDown(item.videoId, item.playlistItemId)"
+            @remove-from-playlist="removeVideoFromPlaylist(item.videoId, item.playlistItemId)"
+          />
         </transition-group>
         <ft-flex-box
           v-if="moreVideoDataAvailable && !isLoadingMore"

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -36,7 +36,7 @@
       v-if="!isLoading"
       class="playlistItems"
     >
-      <span
+      <template
         v-if="playlistItems.length > 0"
       >
         <transition-group
@@ -89,7 +89,7 @@
         >
           <ft-loader />
         </div>
-      </span>
+      </template>
       <ft-flex-box
         v-else
       >

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -44,7 +44,7 @@
           tag="span"
         >
           <div
-            v-for="(item, index) in playlistItems"
+            v-for="(item, index) in visiblePlaylistItems"
             :key="`${item.videoId}-${item.playlistItemId || index}`"
             class="playlistItem"
           >
@@ -64,7 +64,7 @@
               :always-show-add-to-playlist-button="true"
               :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
               :can-move-video-up="index > 0"
-              :can-move-video-down="index < playlistItems.length - 1"
+              :can-move-video-down="index < visiblePlaylistItems.length - 1"
               :can-remove-from-playlist="true"
               :hide-forbidden-titles="false"
               @move-video-up="moveVideoUp(item.videoId, item.playlistItemId)"


### PR DESCRIPTION
# Playlist performance improvements

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Performance Improvement

## Related issue
#4578
Mostly solves the issue, however we will need to do some more involved refactoring to fix the watch page entirely.

## Description
This pull request addresses some of the performance problems concerning gigantic user playlists (over 17k items) that were brought up in the linked issue. It doesn't completely solve the issue, especially on the watch page, as we are still rendering at least one `<div>` per playlist item, so that we can figure out when to load the items (there is a reason YouTube only displays a maximum of 200 videos on their watch page), we also don't unload items when they disappear from view again. Fixing the watch page properly will require switching to a virtual scrolling approach, so that we really only have as many HTML elements in the DOM as we really need, which is out of scope of this pull request.

Here is the list of changes that this pull request makes:
1. Add pagination to the playlist page for user playlists, extra pages can be loaded with the load more button.
2. Fixes the load more loading icon being displayed off-screen (it's now used for both local API and user playlists, we don't support pagination for Invidious).
3. Avoids caching users playlists when switching from the playlist page to the watch page, as user playlists are already in the store so it's just extra work. The caching is still in place for remote playlists, as it saves making some network requests on the watch page.
4. Various minor changes to the playlists store, in the worst case (every possible fixable issue is present) these shave about 30 milliseconds off, in the best case (all checks succeed, no repairs to the data necessary) they add a negligible overhead (less than a millisecond), so they seem worth it.
5. Makes the `ft-list-video` element slightly cheaper to render:
    - Only creates the description element when there is actually a description (user playlists don't have one, the code in the store explicitly removes them)
    - Removes an unnecessary template wrapper
    - Replaces the `watched` property with the `historyEntryExists` computed property, as they served the same purpose.
6. Fix the video number not getting lazy loaded, it will now load at the same time as the rest of the video item.

The final result is that the playlist page loads quickly, as it only has to render 100 items initially, however if you press load more enough times, things do slow down, because we don't unload items once they are loaded. The watch page is still slow to load, it did go from 16.24 to 14.88 seconds with the test playlist on my computer, but that is still slow. Doing a performance benchmark shows that the majority of time is spent in Vue's internals, as it struggles with the sheer number of component instances and DOM elements (16200+ of each).

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Backup the playlists in your dev environment (Almost the same directory as usual, replace the last path segment (`FreeTube`) with `Electron` https://docs.freetubeapp.io/usage/data-location/)
2. Download this database that contains a test playlist with 16200 items inside it.
3. Rename it to `playlists.db`
4. Place it in the dev data location
5. Test the playlist page and watch page for that playlist

The playlist was created by copying https://www.youtube.com/playlist?list=PLxYGDfxfyiF85ZwSBchVX7datipeOJhtH multiple times inside itself.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1