### PR TITLE
Workaround community post slider dependency incorrectly calculating its size

### DIFF
--- a/src/renderer/components/ft-community-post/ft-community-post.scss
+++ b/src/renderer/components/ft-community-post/ft-community-post.scss
@@ -144,5 +144,5 @@
 }
 
 .sliderContainer {
-  display: block;
+  display: grid;
 }

--- a/src/renderer/components/ft-community-post/ft-community-post.vue
+++ b/src/renderer/components/ft-community-post/ft-community-post.vue
@@ -56,27 +56,25 @@
       class="postText"
       v-html="postText"
     />
-    <div class="sliderContainer">
-      <swiper-container
-        v-if="type === 'multiImage' && postContent.content.length > 0"
-        ref="swiperContainer"
-        init="false"
-        class="slider"
+    <swiper-container
+      v-if="type === 'multiImage' && postContent.content.length > 0"
+      ref="swiperContainer"
+      init="false"
+      class="sliderContainer"
+    >
+      <swiper-slide
+        v-for="(img, index) in postContent.content"
+        :key="index"
+        lazy="true"
       >
-        <swiper-slide
-          v-for="(img, index) in postContent.content"
-          :key="index"
-          lazy="true"
+        <img
+          :src="getBestQualityImage(img)"
+          class="communityImage"
+          alt=""
+          loading="lazy"
         >
-          <img
-            :src="getBestQualityImage(img)"
-            class="communityImage"
-            alt=""
-            loading="lazy"
-          >
-        </swiper-slide>
-      </swiper-container>
-    </div>
+      </swiper-slide>
+    </swiper-container>
     <div
       v-if="type === 'image' && postContent.content.length > 0"
     >


### PR DESCRIPTION
# Workaround community post slider dependency incorrectly calculating its size

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4486

## Description
The dependency that we use for the image sliders in community posts, has a bug that makes its JavaScript severly miscalculate what size it should be, 33 million pixels wide to be exact. The workaround was taken from [this](https://github.com/nolimits4web/swiper/issues/7256) issue on the swiper repository. Considering the maintainers response on that issue, it seems rather unlikely that the bug will ever get fixed (if that is really how flex and grid worked, how come every other item in the flex and grid layouts work just fine?), so I've decided to implement the proposed workaround.

## Testing <!-- for code that is not small enough to be easily understandable -->
Load the community tab on the subscriptions page, if you can see the posts instead of a blank page, the issue is solved.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1