### PR TITLE
Properly localize playlist view and video counts

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -6,6 +6,7 @@ import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtPrompt from '../ft-prompt/ft-prompt.vue'
 import {
+  formatNumber,
   showToast,
 } from '../../helpers/utils'
 
@@ -143,6 +144,14 @@ export default defineComponent({
 
     firstVideoIdExists() {
       return this.firstVideoId !== ''
+    },
+
+    parsedViewCount() {
+      return formatNumber(this.viewCount)
+    },
+
+    parsedVideoCount() {
+      return formatNumber(this.videoCount)
     },
 
     thumbnail: function () {

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -47,9 +47,9 @@
         {{ title }}
       </h2>
       <p>
-        {{ videoCount }} {{ $t("Playlist.Videos") }}
+        {{ $tc('Global.Counts.Video Count', videoCount, {count: parsedVideoCount}) }}
         <span v-if="!hideViews && !isUserPlaylist">
-          - {{ viewCount }} {{ $t("Playlist.Views") }}
+          - {{ $tc('Global.Counts.View Count', viewCount, {count: parsedViewCount}) }}
         </span>
         <span>- </span>
         <span v-if="infoSource !== 'local'">


### PR DESCRIPTION
# Properly localize playlist view and video counts

## Pull Request Type
- [x] Bugfix - localization

## Related issue
Missing from https://github.com/FreeTubeApp/FreeTube/pull/4011

## Description
Properly localize the playlist counts using the `Global counts` we have in the locale files.

## Screenshots <!-- If appropriate -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/685eb9ee-b235-4bcd-9259-a1b6fe52caf1)

## Testing 
- go to a playlist
- notice video count and view count is properly formatted

## Desktop

- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1