### PR TITLE
local API: Work around YouTube sending empty watch next responses

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -317,6 +317,24 @@ export default defineComponent({
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
 
+        if (result.watch_next_feed) {
+          try {
+            // work-around YouTube occasionally sending a watch next feed that only contains a continuation
+            if (result.watch_next_feed.length === 0 && result.wn_has_continuation) {
+              await result.getWatchNextContinuation()
+            }
+
+            this.recommendedVideos = result.watch_next_feed
+              ?.filter((item) => item.type === 'CompactVideo' || item.type === 'CompactMovie')
+              .map(parseLocalWatchNextVideo) ?? []
+          } catch (error) {
+            console.error('Failed to fetch the watch next feed', error)
+            this.recommendedVideos = []
+          }
+        } else {
+          this.recommendedVideos = []
+        }
+
         const recommendedVideos = result.watch_next_feed
           ?.filter((item) => item.type === 'CompactVideo' || item.type === 'CompactMovie')
           .map(parseLocalWatchNextVideo) ?? []


### PR DESCRIPTION
# local API: Work around YouTube sending empty watch next responses

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4625

## Description
In draft status as this relies on https://github.com/LuanRT/YouTube.js/pull/590.

YouTube has started randomly returning a watch next feed that only contains a continuation, this is similar to the empty response issue that we have on the community page (https://github.com/FreeTubeApp/FreeTube/pull/3318, yes that pull request was 10 months ago, but the issue still exists on YouTube's side today), so the workaround is similar too.

This pull request will fetch the watch next continuation when the response is empty and there is a continuation (we can't do anything about videos that have an empty response and no continuation).

This only addresses the local API, as Invidious will need to add the workaround on their end too.

## Screenshots
![request-log](https://github.com/FreeTubeApp/FreeTube/assets/48293849/bde3a368-52cb-46d8-954f-ada0c23b2dcd)

## Testing <!-- for code that is not small enough to be easily understandable -->
Test various videos and make sure that the watch next feed shows up, as the issue happens randomly you'll just have to try a few.
You'll know that the changes in this pull request came into action, when you see a second `/next` request right after the original `/browse` and `/next`  requests (see screenshot above).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1