### PR TITLE
Hide subscription refresh button when there are no subscriptions

### DIFF
--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.js
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.js
@@ -108,7 +108,7 @@ export default defineComponent({
         case 'r':
         case 'R':
         case 'F5':
-          if (!this.isLoading) {
+          if (!this.isLoading && this.activeSubscriptionList.length > 0) {
             this.$emit('refresh')
           }
           break

--- a/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.vue
+++ b/src/renderer/components/subscriptions-tab-ui/subscriptions-tab-ui.vue
@@ -56,7 +56,7 @@
       />
     </ft-flex-box>
     <ft-icon-button
-      v-if="!isLoading"
+      v-if="!isLoading && activeSubscriptionList.length > 0"
       :icon="['fas', 'sync']"
       class="floatingTopButton"
       :title="$t('Subscriptions.Refresh Subscriptions')"


### PR DESCRIPTION
# Hide subscription refresh button when there are no subscriptions

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently when you have zero subscriptions in the active profile, FreeTube still shows the refresh button.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/1014e1c3-68c7-4130-95d7-8b91ca3b3ee9)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/ba9bedd0-89b1-4e4f-adf1-b41cd6eb7007)

## Testing <!-- for code that is not small enough to be easily understandable -->
Create a new empty profile and visit the subscription page.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1