### PR TITLE
Fix app starting in fullscreen if a fullscreen video is closed

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1060,6 +1060,11 @@ function runApp() {
 
   let resourcesCleanUpDone = false
 
+  app.on('before-quit', () => {
+    // Prevent closing the app with open fullscreen videos causing the app to start in fullscreen on next load
+    window?.webContents.executeJavascript('if (document.fullscreenElement?.player) await document.exitFullscreen()')
+  })
+
   app.on('window-all-closed', () => {
     // Clean up resources (datastores' compaction + Electron cache and storage data clearing)
     cleanUpResources().finally(() => {


### PR DESCRIPTION
# Fix app starting in fullscreen if a fullscreen video is closed

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4534

## Description
Co-created with @absidue. Fixes issue of the app starting in fullscreen if a video was closed in fullscreen.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
- Close a video with Ctrl/Cmd + Q while video is in fullscreen, then restart the app to see app not in fullscreen.
- Regression: Ensure #2495 is still working correctly (app remains in fullscreen on creating new windows while in fullscreen).

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE Tumbleweed
- **OS Version:** 2023xxxx
- **FreeTube version:** 0.19.1

## Additional context
IIRC, fullscreen works differently in dev mode versus an actual build. [Here are the builds](https://github.com/jasonhenriquez/FreeTube/actions/runs/7628912439), if that helps.
