### PR TITLE
Fix comment channel link display w/ local API

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -742,7 +742,7 @@ export function parseLocalTextRuns(runs, emojiSize = 16, options = { looseChanne
           case 'WEB_PAGE_TYPE_CHANNEL': {
             const trimmedText = text.trim()
             // In comments, mention can be `@Channel Name` (not handle, but name)
-            if (CHANNEL_HANDLE_REGEX.test(trimmedText) || (options.looseChannelNameDetection && trimmedText.startsWith('@'))) {
+            if (CHANNEL_HANDLE_REGEX.test(trimmedText) || options.looseChannelNameDetection) {
               // Note that in regex `\s` must be used since the text contain non-default space (the half-width space char when we press spacebar)
               const spacesBefore = (spacesBeforeRegex.exec(text) || [''])[0]
               const spacesAfter = (spacesAfterRegex.exec(text) || [''])[0]


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Same as title
It seems that YT no longer return text with `@` prefix for channel links so we have to drop that check
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/e2e75122-879f-4875-bfc6-50d430a1f680)


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/73ed7369-45b0-4cb9-a0cb-76128147d864)
Before
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/8c68fbdc-9583-4286-8623-d65891dee757)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Find a random video with comment/comment replies with channel link (e.g. https://youtu.be/d-7zjsM5nQA?list=PLzFTGYa_evXjMh3jdjNmXFIgYEBAKcnK8
- Ensure channel link displayed as text not URL

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
