### PR TITLE
Set icon dropdown position to `left` on `watch-video-info` on narrow displays

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -60,8 +60,8 @@
 
     @media screen and (max-width: 680px) {
       :deep(.iconDropdown) {
-        inset-inline-start: calc(50% - 20px);
-        inset-inline-end: auto;
+        inset-inline-start: auto;
+        inset-inline-end: calc(50% - 20px);
       }
     }
   }


### PR DESCRIPTION
# Set icon dropdown position to `left` in `watch-video-info` on narrow displays

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `ft-icon-button`s in `watch-video-info` recently moved from the left to the right side of the screen on mobile. However, the dropdowns for these buttons are still positioned to the `right` causing them to overflow the screen. This PR addresses this by positioning them to the `left`.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
| before | after |
| -- | -- |
|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/d77ac63e-a862-4170-9aa2-23b2c09d0bac)| ![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/d3810b42-d09f-438d-9687-c4b3a5b4bb94)|
## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open any video
2. Ensure display width is <=680px
3. Ensure the icon drop-downs in the watch video info don't cause the screen to overflow
## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** bf83faa322d1742f5e823023df93da986e6ecbde

