### PR TITLE
Fix playlists database import and export not using the actual database format

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -882,7 +882,10 @@ export default defineComponent({
         showToast(`${message}: ${err}`)
         return
       }
-      const playlists = JSON.parse(data)
+      data = data.split('\n')
+      data.pop()
+
+      const playlists = data.map(playlistJson => JSON.parse(playlistJson))
 
       const requiredKeys = [
         'playlistName',
@@ -1015,7 +1018,11 @@ export default defineComponent({
         ]
       }
 
-      await this.promptAndWriteToFile(options, JSON.stringify(this.allPlaylists), 'All playlists has been successfully exported')
+      const playlistsDb = this.allPlaylists.map(playlist => {
+        return JSON.stringify(playlist)
+      }).join('\n') + '\n'// a trailing line is expected
+
+      await this.promptAndWriteToFile(options, playlistsDb, 'All playlists has been successfully exported')
     },
 
     exportPlaylistsForOlderVersionsSometimes: function () {


### PR DESCRIPTION
# Fix playlists DB import and export not using the actual DB format

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the playlists export generates a JSON array with the playlists and the playlists import expects said JSON array, however that doesn't match the actual playlists database format, so you can't import a real playlists database file. If we exported it as JSON file that would be fine, but we explicitly label it as a database file and expect a database file to be picked during the import.

This pull request changes the import and export to match the real database format (each playlist is a JSON object on it's own line, with a final new line at the end of the file), so that we are consistent across the board.

While yes this is technically a breaking change compared to previous nightly builds, it's not a breaking change compared to the previous (0.19.1) release. It corrects incorrect behaviour and people cannot expect stability across nightly builds, as they are by definition development/bleeding edge builds, which we've never recommended normal users use for every day use.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Create multiple playlists
2. Close FreeTube
3. Backup your playlists database file (https://docs.freetubeapp.io/usage/data-location/, `yarn dev` uses a folder called `Electron` instead)
4. Open FreeTube again and click `Remove All Playlists` in the `Privacy Settings`
5. Import your backed up playlists database
6. Check that your playlists show up correctly in the UI
7. Export your playlists
8. `Remove All Playlists` in the `Privacy Settings` again
9. Import the playlists database that you just exported
10. Check that your playlists show up correctly in the UI

If both the original import (a real database written by nedb) and the secondary one (the database created by the export) were successful (no errors and playlists show up), this pull request works as expected.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 30248d6 (nightlies)