### PR TITLE
Update subscription cache when visiting a channel

### DIFF
--- a/src/renderer/store/modules/subscriptions.js
+++ b/src/renderer/store/modules/subscriptions.js
@@ -54,6 +54,10 @@ const actions = {
     commit('updateShortsCacheByChannel', payload)
   },
 
+  updateSubscriptionShortsCacheWithChannelPageShorts: ({ commit }, payload) => {
+    commit('updateShortsCacheWithChannelPageShorts', payload)
+  },
+
   updateSubscriptionLiveCacheByChannel: ({ commit }, payload) => {
     commit('updateLiveCacheByChannel', payload)
   },
@@ -85,6 +89,31 @@ const mutations = {
     const newObject = existingObject != null ? existingObject : deepCopy(defaultCacheEntryValueForForOneChannel)
     if (videos != null) { newObject.videos = videos }
     state.shortsCache[channelId] = newObject
+  },
+  updateShortsCacheWithChannelPageShorts(state, { channelId, videos }) {
+    const cachedObject = state.shortsCache[channelId]
+
+    if (cachedObject && cachedObject.videos.length > 0) {
+      cachedObject.videos.forEach(cachedVideo => {
+        const channelVideo = videos.find(short => cachedVideo.videoId === short.videoId)
+
+        if (channelVideo) {
+          // authorId probably never changes, so we don't need to update that
+
+          cachedVideo.title = channelVideo.title
+          cachedVideo.author = channelVideo.author
+
+          // as the channel shorts page only has compact view counts for numbers above 1000 e.g. 12k
+          // and the RSS feeds include an exact value, we only want to overwrite it when the number is larger than the cached value
+          // 12345 vs 12000 => 12345
+          // 12345 vs 15000 => 15000
+
+          if (channelVideo.viewCount > cachedVideo.viewCount) {
+            cachedVideo.viewCount = channelVideo.viewCount
+          }
+        }
+      })
+    }
   },
   clearShortsCache(state) {
     state.shortsCache = {}

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -33,6 +33,10 @@ import {
   parseLocalListVideo,
   parseLocalSubscriberCount
 } from '../../helpers/api/local'
+import {
+  addPublishedDatesInvidious,
+  addPublishedDatesLocal
+} from '../../helpers/subscriptions'
 
 export default defineComponent({
   name: 'Channel',
@@ -169,6 +173,13 @@ export default defineComponent({
 
     isSubscribed: function () {
       return this.subscriptionInfo !== null
+    },
+
+    isSubscribedInAnyProfile: function () {
+      const profileList = this.$store.getters.getProfileList
+
+      // check the all channels profile
+      return profileList[0].subscriptions.some((channel) => channel.id === this.id)
     },
 
     videoLiveSelectNames: function () {
@@ -767,6 +778,17 @@ export default defineComponent({
         this.latestVideos = parseLocalChannelVideos(videosTab.videos, this.id, this.channelName)
         this.videoContinuationData = videosTab.has_continuation ? videosTab : null
         this.isElementListLoading = false
+
+        if (this.isSubscribedInAnyProfile && this.latestVideos.length > 0 && this.videoSortBy === 'newest') {
+          addPublishedDatesLocal(this.latestVideos)
+          this.updateSubscriptionVideosCacheByChannel({
+            channelId: this.id,
+            // create a copy so that we only cache the first page
+            // if we use the same array, the store will get angry at us for modifying it outside of the store,
+            // when the user clicks load more
+            videos: [...this.latestVideos]
+          })
+        }
       } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -825,6 +847,16 @@ export default defineComponent({
         this.latestShorts = parseLocalChannelShorts(shortsTab.videos, this.id, this.channelName)
         this.shortContinuationData = shortsTab.has_continuation ? shortsTab : null
         this.isElementListLoading = false
+
+        if (this.isSubscribedInAnyProfile && this.latestShorts.length > 0 && this.shortSortBy === 'newest') {
+          // As the shorts tab API response doesn't include the published dates,
+          // we can't just write the results to the subscriptions cache like we do with videos and live (can't sort chronologically without the date).
+          // However we can still update the metadata in the cache such as the view count and title that might have changed since it was cached
+          this.updateSubscriptionShortsCacheWithChannelPageShorts({
+            channelId: this.id,
+            videos: this.latestShorts
+          })
+        }
       } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -883,6 +915,17 @@ export default defineComponent({
         this.latestLive = parseLocalChannelVideos(liveTab.videos, this.id, this.channelName)
         this.liveContinuationData = liveTab.has_continuation ? liveTab : null
         this.isElementListLoading = false
+
+        if (this.isSubscribedInAnyProfile && this.latestLive.length > 0 && this.liveSortBy === 'newest') {
+          addPublishedDatesLocal(this.latestLive)
+          this.updateSubscriptionLiveCacheByChannel({
+            channelId: this.id,
+            // create a copy so that we only cache the first page
+            // if we use the same array, the store will get angry at us for modifying it outside of the store,
+            // when the user clicks load more
+            videos: [...this.latestLive]
+          })
+        }
       } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -1052,6 +1095,16 @@ export default defineComponent({
         }
         this.videoContinuationData = response.continuation || null
         this.isElementListLoading = false
+
+        if (this.isSubscribedInAnyProfile && !more && this.latestVideos.length > 0 && this.videoSortBy === 'newest') {
+          addPublishedDatesInvidious(this.latestVideos)
+          this.updateSubscriptionVideosCacheByChannel({
+            channelId: this.id,
+            // create a copy so that we only cache the first page
+            // if we use the same array, it will also contain all the next pages
+            videos: [...this.latestVideos]
+          })
+        }
       }).catch((err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -1101,6 +1154,17 @@ export default defineComponent({
         }
         this.shortContinuationData = response.continuation || null
         this.isElementListLoading = false
+
+        if (this.isSubscribedInAnyProfile && !more && this.latestShorts.length > 0 && this.shortSortBy === 'newest') {
+          // As the shorts tab API response doesn't include the published dates,
+          // we can't just write the results to the subscriptions cache like we do with videos and live (can't sort chronologically without the date).
+          // However we can still update the metadata in the cache e.g. adding the duration, as that isn't included in the RSS feeds
+          // and updating the view count and title that might have changed since it was cached
+          this.updateSubscriptionShortsCacheWithChannelPageShorts({
+            channelId: this.id,
+            videos: this.latestShorts
+          })
+        }
       }).catch((err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -1142,6 +1206,17 @@ export default defineComponent({
         }
         this.liveContinuationData = response.continuation || null
         this.isElementListLoading = false
+
+        if (this.isSubscribedInAnyProfile && !more && this.latestLive.length > 0 && this.liveSortBy === 'newest') {
+          addPublishedDatesInvidious(this.latestLive)
+          this.updateSubscriptionLiveCacheByChannel({
+            channelId: this.id,
+            // create a copy so that we only cache the first page
+            // if we use the same array, the store will get angry at us for modifying it outside of the store,
+            // when the user clicks load more
+            videos: [...this.latestLive]
+          })
+        }
       }).catch((err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -1559,6 +1634,19 @@ export default defineComponent({
 
         this.latestCommunityPosts = parseLocalCommunityPosts(posts)
         this.communityContinuationData = communityTab.has_continuation ? communityTab : null
+
+        if (this.latestCommunityPosts.length > 0) {
+          this.latestCommunityPosts.forEach(post => {
+            post.authorId = this.id
+          })
+          this.updateSubscriptionPostsCacheByChannel({
+            channelId: this.id,
+            // create a copy so that we only cache the first page
+            // if we use the same array, the store will get angry at us for modifying it outside of the store,
+            // when the user clicks load more
+            posts: [...this.latestCommunityPosts]
+          })
+        }
       } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -1610,6 +1698,19 @@ export default defineComponent({
           this.latestCommunityPosts = posts
         }
         this.communityContinuationData = continuation
+
+        if (this.isSubscribedInAnyProfile && !more && this.latestCommunityPosts.length > 0) {
+          this.latestCommunityPosts.forEach(post => {
+            post.authorId = this.id
+          })
+          this.updateSubscriptionPostsCacheByChannel({
+            channelId: this.id,
+            // create a copy so that we only cache the first page
+            // if we use the same array, the store will get angry at us for modifying it outside of the store,
+            // when the user clicks load more
+            posts: [...this.latestCommunityPosts]
+          })
+        }
       }).catch(async (err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -1849,7 +1950,11 @@ export default defineComponent({
 
     ...mapActions([
       'showOutlines',
-      'updateSubscriptionDetails'
+      'updateSubscriptionDetails',
+      'updateSubscriptionVideosCacheByChannel',
+      'updateSubscriptionLiveCacheByChannel',
+      'updateSubscriptionShortsCacheWithChannelPageShorts',
+      'updateSubscriptionPostsCacheByChannel'
     ])
   }
 })


### PR DESCRIPTION
# Update subscription cache when visiting a channel

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Feature Implementation

## Description
Currently when you visit a channel, we fetch the latest information from YouTube and display it to the user, we also update the channel name and thumbnail in the subscriptions database. What we don't do yet is update the subscriptions cache with the videos, shorts, live and community post content that we got.

This pull request changes the channel page, so that it updates the subscription cache with the information on the channel page. For the videos, live and community tabs, we just overwrite the current cache for that channel, as what we just received is the last known state (same as what a refresh on the subscriptions page would do). For the shorts tab we unfortunately cannot do that, as the shorts channel tab doesn't have published dates (we need them for sorting on the subscriptions page), on the subscriptions page we always use RSS for the shorts tab, instead this pull request will just update the title, channel name and view count of the existing items in the cache.

You might be wondering what the point of this is, as we don't syncronise the subscription cache across windows (each window has it's own one https://github.com/FreeTubeApp/FreeTube/issues/4152) and don't persist it on disk, so they disappear between app launches. This is basically a "free" subscription refresh for the visited channel as we already have the information without making any additional API requests. It will mostly benefit users that use the same window for a long time, but will help if we do implement synchronisation across windows in the future or disk persistence, as it would also allow us to reduce API requests (e.g. this channel was refreshed less than 1 minute ago, no need to fetch it again).

## Testing <!-- for code that is not small enough to be easily understandable -->
As waiting for any of your subscribed channels to upload a new video would be a slow and unpredictable test case, here are two that allow you to skip the waiting.

**Please note that all steps for a given test case have to be performed in the same window, as we don't synchronise the subscription cache between windows yet**

### Test case 1
This test case will require you to have DeArrow disabled and either not have any watch history or for you to pick a channel that has videos that you haven't watched.

1. Enable `Fetch feeds from RSS` in the `Subscription Settings` section
2. Refresh your subscriptions
3. Visit one of the channels that you are subscribed to
4. Go back to the subscriptions page
5. Notice that video durations have shown up for the videos on that channel (if you have DeArrow enabled or have watched any of those videos, FreeTube would be showing the duration from there instead of nothing, so you wouldn't notice the difference).

### Test case 2
1. Disabled `Fetch feed automatically` in the `Subscription Settings` section
2. Create a new profile
3. Subscribe to a channel that yet from the search results or watch page (don't visit the channel page yet).
4. Visit the subscriptions page and notice that it is empty
5. Visit the channel
6. Go back to the subscriptions page and notice that the videos, live and community tabs should now be populated (shorts won't be as the shorts channel tab doesn't have published dates, so we can only update the metadata in the existing cache, as we need the published dates for sorting)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1