### PR TITLE
Fix the Invidious DASH manifest generation

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -367,7 +367,7 @@ export async function generateInvidiousDashManifestLocally(formats) {
 
   return await FormatUtils.toDash({
     adaptive_formats: formats
-  }, urlTransformer, undefined, undefined, player)
+  }, false, urlTransformer, undefined, undefined, player)
 }
 
 export function convertInvidiousToLocalFormat(format) {


### PR DESCRIPTION
# Fix the Invidious DASH manifest generation

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4543

## Description
Since the YouTube.js upgrade in https://github.com/FreeTubeApp/FreeTube/pull/4543, the our DASH manifest generation for the Invidious API is broken. Rather ironically I introduced the breaking change on the YouTube.js side, did the YouTube.js upgrade on the FreeTube side and am now the one fixing the issue. Thankfully it's an easy fix.

## Screenshots <!-- If appropriate -->
![error-message](https://github.com/FreeTubeApp/FreeTube/assets/48293849/3b321929-fd79-4eaf-bc4a-eab8abdaffb1)

## Testing <!-- for code that is not small enough to be easily understandable -->
Set the preferred backend to Invidious or turn on proxy through Invidious while the local API is enabled.
You shouldn't get the error in the screenshot anymore.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 30248d6bbc55f3019ae0401ad9846dc4e7bf8734