### PR TITLE
Add discussion info when opening an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,11 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Start a discussion
+    url:  https://github.com/FreeTubeApp/FreeTube/discussions/categories/general
+    about: Feel free to start a discussion
+  - name: Ask a question
+    url:  https://github.com/FreeTubeApp/FreeTube/discussions/categories/q-a
+    about: Ask and answer questions
+  - name: Join our Matrix Community
+    url: https://matrix.to/#/+freetube:matrix.org
+    about: Feel free to join our Matrix community


### PR DESCRIPTION
# Add discussion info when opening an issue

## Pull Request Type
- [x] Documentation

## Description
Includes links to our discussion board and matrix room when opening an issue

## Screenshots
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/c0b41543-1fad-4dff-866b-979acff7c429)

## Testing 
- go to this repo: https://github.com/ChunkyProgrammer/test-repo2/issues/new/choose
- look at new options (Start a discussion, Ask a question, Join matrix)
- verify than new options work

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1
