### PR TITLE
Fix overflow issue with share playlist icon drop-down

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.scss
+++ b/src/renderer/components/playlist-info/playlist-info.scss
@@ -1,3 +1,5 @@
+
+
 .playListThumbnail {
   inline-size: 100%;
 }
@@ -71,4 +73,11 @@
   grid-auto-flow: column;
   column-gap: 8px;
   justify-content: flex-end;
+}
+
+@media only screen and (max-width: 1250px) {
+  :deep(.sharePlaylistIcon .iconDropdown) {
+    inset-inline-start: auto;
+    inset-inline-end: auto;
+  }
 }

--- a/src/renderer/components/playlist-info/playlist-info.scss
+++ b/src/renderer/components/playlist-info/playlist-info.scss
@@ -1,5 +1,3 @@
-
-
 .playListThumbnail {
   inline-size: 100%;
 }

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -166,6 +166,7 @@
         <ft-share-button
           v-if="sharePlaylistButtonVisible"
           :id="id"
+          class="sharePlaylistIcon"
           :dropdown-position-y="description ? 'top' : 'bottom'"
           share-target-type="Playlist"
         />

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -7,7 +7,6 @@
   box-sizing: border-box;
   block-size: calc(100vh - 132px);
   margin-inline-end: 1em;
-  overflow-y: auto;
   padding: 10px;
   position: sticky;
   inset-block-start: 96px;


### PR DESCRIPTION
# Fix overflow issue with share playlist icon drop-down

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4660#issuecomment-1938632278

## Description
The share playlist drop-down currently overflows in a way which visually obscures its content. This PR addresses this by removing the `overflow-y: auto;` on `playlistInfo` as well as adding a media query which positions the drop down to the center when the width is `<=1250px`.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

|before|after|
|--|--|
|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/aebf5991-2672-4a39-a8d1-e79f9944dea2)|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/d6ba7074-f358-4c6a-bc0b-1fc26c761b7d)|

![motion](https://github.com/FreeTubeApp/FreeTube/assets/106682128/03b64ebd-2469-48ab-868f-ad8eb622106b)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open a playlist
2. Click the `share playlist` icon
3. Reduce the width of the window to anywhere between `1200px` and `900px`
4. Ensure the dropdown is fully visible and not being cut off

## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 28cc5ef76d45ad497da86b3563f411e51dffa14d
