### PR TITLE
Hide channel sidebar label under `more` when `Hide Side Bar Labels` setting is enabled

### DIFF
--- a/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
+++ b/src/renderer/components/side-nav-more-options/side-nav-more-options.vue
@@ -44,6 +44,7 @@
           />
         </div>
         <p
+          v-if="!hideLabelsSideBar"
           id="channelLabel"
           class="navLabel"
         >


### PR DESCRIPTION
# Hide channel sidebar label under `more` when `Hide Side Bar Labels` setting is enabled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `channel` sidebar label under `more` does not hide when the `hide sidebar labels` setting is enabled. This PR addresses this by applying the same `v-if` to that channel label as all the other side bar labels.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/d1d82665-9aa4-41d0-b1e1-ed2a2056f297)|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/8128bca8-9a3c-4d29-9743-e319ad51d684)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Enable the `Hide Side Bar Labels` setting
2. Reduce the width of the window to around `<=680px`
3. Ensure that the `Channels` side bar option under `...` doesn't show the label

## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 28cc5ef76d45ad497da86b3563f411e51dffa14d


