### PR TITLE
Fix displaying playlists when using the IV API

### DIFF
--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -269,7 +269,7 @@ export default defineComponent({
         const dateString = new Date(result.updated * 1000)
         this.lastUpdated = dateString.toLocaleDateString(this.currentLocale, { year: 'numeric', month: 'short', day: 'numeric' })
 
-        this.allPlaylistItems = result.videos
+        this.playlistItems = result.videos
 
         this.isLoading = false
       }).catch((err) => {


### PR DESCRIPTION
# Fix displaying playlists when using the IV API

## Pull Request Type
- [x] Bugfix

## Related issue
Copied from #4299 https://github.com/FreeTubeApp/FreeTube/pull/4299/files#diff-1d702e6381a99185e240fe47a79563920174af6e327b61d1c171543ebfc44a81R287

## Description
Using the Invidious API doesn't display any playlist videos. This PR fixes displaying YouTube playlist videos when using the Invidious API

## Screenshots <!-- If appropriate -->
Before:
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/983f62e8-944c-4121-879b-94df8f173a3b)

After:
![image](https://github.com/FreeTubeApp/FreeTube/assets/78101139/f4e9ef17-a087-4c15-9a6a-cc0040a269fc)

## Testing 
- use Invidious API as primary
- search "hi" with playlist search filter on
- click on a playlist
- videos load

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1
