### PR TITLE
Fix loading invidious instances from static file for electron builds

### DIFF
--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -39,6 +39,7 @@ const actions = {
         console.error(err)
       }
     }
+
     // If the invidious instance fetch isn't returning anything interpretable
     if (instances.length === 0) {
       // Fallback: read from static file
@@ -46,15 +47,13 @@ const actions = {
       /* eslint-disable-next-line n/no-path-concat */
       const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
       const filePath = `${fileLocation}${fileName}`
-      if (!process.env.IS_ELECTRON) {
-        console.warn('reading static file for invidious instances')
-        const fileData = process.env.IS_ELECTRON ? await fs.readFile(filePath, 'utf8') : await (await fetch(createWebURL(filePath))).text()
-        instances = JSON.parse(fileData).filter(e => {
-          return process.env.IS_ELECTRON || e.cors
-        }).map(e => {
-          return e.url
-        })
-      }
+      console.warn('reading static file for invidious instances')
+      const fileData = process.env.IS_ELECTRON ? await fs.readFile(filePath, 'utf8') : await (await fetch(createWebURL(filePath))).text()
+      instances = JSON.parse(fileData).filter(e => {
+        return process.env.IS_ELECTRON || e.cors
+      }).map(e => {
+        return e.url
+      })
     }
     commit('setInvidiousInstancesList', instances)
   },


### PR DESCRIPTION
# Fix loading invidious instances from static file for electron builds

## Pull Request Type
- [x] Bugfix

## Description
Using the fallback file was hidden behind a if (!electron), this PR fixes that issue

## Testing
I updated line 42 to be `instances = []` to test the fix

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1
