### PR TITLE
Change the default download behaviour to the better "Open in web browser" value

### DIFF
--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -289,7 +289,7 @@ const state = {
   videoPlaybackRateInterval: 0.25,
   downloadAskPath: true,
   downloadFolderPath: '',
-  downloadBehavior: 'download',
+  downloadBehavior: 'open',
   enableScreenshot: false,
   screenshotFormat: 'png',
   screenshotQuality: 95,


### PR DESCRIPTION
# Change the default download behaviour to the better "Open in web browser" value

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
As discussed with the other maintainers, this pull request changes the default download behaviour to the objectively better "Open in web browser" option.

When the pull request that added the minimal "Download in app" option was introduced, it was done so with the expectation that it would be expanded upon not long afterwards. As it's now two years later and the in-app downloader hasn't been improved, we should definitely not default to it. While the "Open in web browser" option isn't great either, it is the lesser of two evils, as web browsers generally come with download managers, including being able to view progress, pause and resume downloads.

If users want to use the incomplete in-app downloader, they can still opt into it by changing the setting, we just will no longer use it as a default.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1