### PR TITLE
Remove unused isLoading from ft-community-post

### DIFF
--- a/src/renderer/components/ft-community-post/ft-community-post.js
+++ b/src/renderer/components/ft-community-post/ft-community-post.js
@@ -40,7 +40,6 @@ export default defineComponent({
       voteCount: '',
       postContent: '',
       commentCount: '',
-      isLoading: true,
       author: '',
       authorId: '',
     }
@@ -132,7 +131,6 @@ export default defineComponent({
       this.type = (this.data.postContent !== null && this.data.postContent !== undefined) ? this.data.postContent.type : 'text'
       this.author = this.data.author
       this.authorId = this.data.authorId
-      this.isLoading = false
     },
 
     getBestQualityImage(imageArray) {

--- a/src/renderer/components/ft-community-post/ft-community-post.vue
+++ b/src/renderer/components/ft-community-post/ft-community-post.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-if="!isLoading"
     class="ft-list-post ft-list-item outside"
     :appearance="appearance"
     :class="{ list: listType === 'list', grid: listType === 'grid' }"


### PR DESCRIPTION
# Remove unused isLoading from ft-community-post

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Other - Code cleanup

## Description
The original intention of the `isLoading` property seems to have been to hide the component while the data was being parsed. As we've since change to parsing the data and setting `isLoading` to `false`, before the component is rendered, the `isLoading` property is no longer used.

Here is a diagram of how Vue's lifecycle works, we parse the data in the `created` lifecycle hook: https://vuejs.org/guide/essentials/lifecycle.html#lifecycle-diagram

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit the community page on a channel, if it works the same as before, then this pull request didn't break anything.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1