### PR TITLE
Support opening video timestamps in a new window

### DIFF
--- a/src/renderer/components/ft-timestamp-catcher/ft-timestamp-catcher.js
+++ b/src/renderer/components/ft-timestamp-catcher/ft-timestamp-catcher.js
@@ -9,18 +9,29 @@ export default defineComponent({
     }
   },
   methods: {
-    catchTimestampClick: function(event) {
-      const match = event.detail.match(/(\d+):(\d+):?(\d+)?/)
-      if (match[3] !== undefined) { // HH:MM:SS
-        const seconds = 3600 * Number(match[1]) + 60 * Number(match[2]) + Number(match[3])
-        this.$emit('timestamp-event', seconds)
-      } else { // MM:SS
-        const seconds = 60 * Number(match[1]) + Number(match[2])
-        this.$emit('timestamp-event', seconds)
-      }
+    catchTimestampClick: function (event) {
+      this.$emit('timestamp-event', event.detail)
     },
     detectTimestamps: function (input) {
-      return input.replaceAll(/(\d+(:\d+)+)/g, '<a href="#" onclick="this.dispatchEvent(new CustomEvent(\'timestamp-clicked\',{bubbles:true, detail:\'$1\'}))">$1</a>')
+      const videoId = this.$route.params.id
+
+      return input.replaceAll(/(?:(\d+):)?(\d+):(\d+)/g, (timestamp, hours, minutes, seconds) => {
+        let time = 60 * Number(minutes) + Number(seconds)
+
+        if (hours) {
+          time += 3600 * Number(hours)
+        }
+
+        const url = this.$router.resolve({
+          path: `/watch/${videoId}`,
+          query: {
+            timestamp: time
+          }
+        }).href
+
+        // Adding the URL lets the user open the video in a new window at this timestamp
+        return `<a href="${url}" onclick="event.preventDefault();this.dispatchEvent(new CustomEvent('timestamp-clicked',{bubbles:true,detail:${time}}))">${timestamp}</a>`
+      })
     }
   }
 })


### PR DESCRIPTION
# Support opening video timestamps in a new window

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Related issue
closes #4018

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

## Screenshots <!-- If appropriate -->
![context-menu-for-timestamp-link](https://github.com/FreeTubeApp/FreeTube/assets/48293849/fb595f5e-768a-4257-8aac-234c5f1297af)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Find a video with timestamps in the description e.g. https://youtu.be/Rb0k9vUCEno
2. Clicking on the timestamps normally should still seek the currently open video (regression test)
3. Middle clicking (e.g. on the scroll wheel) and using the context menu on a timestamp, should open the current video in a new window at that timestamp.
4. You can also test that copying the YouTube and Invidious links works as expected

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1