### PR TITLE
Fix local API erroring when the view count is missing on the channel shorts tab

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -539,7 +539,7 @@ export function parseLocalChannelShorts(shorts, channelId, channelName) {
       title: short.title.text,
       author: channelName,
       authorId: channelId,
-      viewCount: parseLocalSubscriberCount(short.views.text),
+      viewCount: short.views.isEmpty() ? null : parseLocalSubscriberCount(short.views.text),
       lengthSeconds: ''
     }
   })


### PR DESCRIPTION
# Fix local API erroring when the view count is missing on the channel shorts tab

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the local API assumes that all shorts on the shorts channel tab have a view count, it turns out that sometimes it is missing such as with one short on the `@YouTubeMusic` channel.

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit  `@YouTubeMusic` channel (`https://youtube.com/@YouTubeMusic`) with the local API, it shouldn't error with this pull request.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.1