### PR TITLE
Hide date and views separator on the watch page when views are hidden

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -9,7 +9,10 @@
     </div>
     <div class="videoMetrics">
       <div class="datePublishedAndViewCount">
-        {{ publishedString }} {{ dateString }} • {{ parsedViewCount }}
+        {{ publishedString }} {{ dateString }}
+        <template v-if="!hideVideoViews">
+          • {{ parsedViewCount }}
+        </template>
       </div>
       <div
         v-if="!hideVideoLikesAndDislikes"


### PR DESCRIPTION
# Hide date and views separator on the watch page when views are hidden

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently when the `Hide View Counts` `Distraction Free Setting` is enabled, the separator between the date and the view count is still shown, this pull request corrects that to hide both at the same time.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/f3c2d230-bd46-4b5c-a058-5d796aa81336)

after:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/832bac5b-0904-492f-ba37-5c001ee65b53)

## Testing <!-- for code that is not small enough to be easily understandable -->
Turn on the `Hide Video Views` setting in the `General` subsection of the `Distraction Free Settings` and make sure the separator is hidden when the view count is hidden.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b965dc30bdbb31e0183489323554b59d91232a14