### PR TITLE
Prevent layout shifts when thumbnails load in the chapter selector

### DIFF
--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.css
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.css
@@ -54,7 +54,6 @@
 .chapterThumbnail {
   grid-area: thumbnail;
   inline-size: 130px;
-  block-size: auto;
   margin: 3px;
 }
 

--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.vue
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.vue
@@ -46,13 +46,15 @@
         @keydown.space.stop.prevent="changeChapter(index)"
         @keydown.enter.stop.prevent="changeChapter(index)"
       >
+        <!-- Setting the aspect ratio avoids layout shifts when the images load -->
         <img
           v-if="!compact"
           alt=""
           aria-hidden="true"
           class="chapterThumbnail"
           loading="lazy"
-          :src="chapter.thumbnail"
+          :src="chapter.thumbnail.url"
+          :style="{ aspectRatio: chapter.thumbnail.width / chapter.thumbnail.height }"
         >
         <div class="chapterTimestamp">
           {{ chapter.timestamp }}

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -450,7 +450,7 @@ export default defineComponent({
                 timestamp: formatDurationAsTimestamp(start),
                 startSeconds: start,
                 endSeconds: 0,
-                thumbnail: chapter.thumbnail[0].url
+                thumbnail: chapter.thumbnail[0]
               })
             }
           } else {


### PR DESCRIPTION
# Prevent layout shifts when thumbnails load in the chapter selector

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
When you expand the chapters selector for the first time on a video, the thumbnails are fetched from the network, unfortunately as that happens asynchronously, it means that as they load in they cause layout shifts. Those unexpected layout shifts are an unpleasant experience for the user, as they might have already started reading some text, that then changed position on the page, without them doing anything (e.g. no scrolling). We already set a width for the thumbnails in the CSS to avoid them taking up too much of the page, but we don't hardcode a height, to avoid potentially squashing together the image.

As YouTube's API helpfully tells us the height and width, this lets us calculate the desired aspect ratio and pass set that with CSS in the Vue template. Using the aspect ratio, instead of just setting the height, lets us change the width in the CSS file in the future without having to make changes to the Vue file.

## Screenshots <!-- If appropriate -->
_Don't know how to do a screen recording and the issue isn't that hard to notice._

## Testing <!-- for code that is not small enough to be easily understandable -->
Needs to be tested on the local API, as Invidious doesn't support chapters yet, so we have to extract them from the description ourselves and don't have thumbnails.

With this pull request when you open the chapters selector for the first time, the items should just stay where they are when the images load in, instead of moving up and down.

You probably want to pick different videos for the before and after testing, as the issue is a lot less noticeable when the images come from the cache instead of over the network.

Some videos on the `@YouTube` channel that have chapters:
- https://youtu.be/Rb0k9vUCEno
- https://youtu.be/bF424rbJYV0
- https://youtu.be/8hBHQPrVVak
- https://youtu.be/sw6UGkFBIEs

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 7dca54789e5279f63d3119eda2a42ac93729bea6