### PR TITLE
Make activating a chapter selector makes window scroll to top like clicking on timestamp links

### DIFF
--- a/src/renderer/components/watch-video-chapters/watch-video-chapters.js
+++ b/src/renderer/components/watch-video-chapters/watch-video-chapters.js
@@ -49,6 +49,7 @@ export default defineComponent({
     changeChapter: function(index) {
       this.currentIndex = index
       this.$emit('timestamp-event', this.chapters[index].startSeconds)
+      window.scrollTo(0, 0)
     },
 
     navigateChapters(direction) {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Idea from https://github.com/FreeTubeApp/FreeTube/pull/4687#pullrequestreview-1900332790

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
As title

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Test yourself I am lazy to take video :)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Find a video with chapter (plenty from [LTT](https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw))
- Click on random chapter and ensure window jumps back to top

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
