### PR TITLE
Make video thumbnails have certain height before image loading starts to avoid layout shifts

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -105,6 +105,7 @@ export default defineComponent({
       hideViews: false,
       addToPlaylistPromptCloseCallback: null,
       debounceGetDeArrowThumbnail: null,
+      thumbnailLoaded: false,
     }
   },
   computed: {
@@ -855,6 +856,10 @@ export default defineComponent({
 
       // TODO: Maybe show playlist name
       showToast(this.$t('Video.Video has been removed from your saved list'))
+    },
+
+    onThumbnailLoad() {
+      this.thumbnailLoaded = true
     },
 
     ...mapActions([

--- a/src/renderer/components/ft-list-video/ft-list-video.scss
+++ b/src/renderer/components/ft-list-video/ft-list-video.scss
@@ -3,3 +3,8 @@
 .thumbnailLink:hover {
   outline: 3px solid var(--side-nav-hover-color);
 }
+
+.thumbnailImage.thumbnailLoading {
+  // Makes img element sized correctly before image loading starts
+  aspect-ratio: 16 / 9;
+}

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -19,8 +19,12 @@
         <img
           :src="thumbnail"
           class="thumbnailImage"
+          :class="{
+            thumbnailLoading: !thumbnailLoaded,
+          }"
           alt=""
           :style="{filter: blurThumbnailsStyle}"
+          @load="onThumbnailLoad"
         >
       </router-link>
       <div


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Similar to https://github.com/FreeTubeApp/FreeTube/pull/4713

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
As title
The constant aspect ratio is only applied before image loading finished (no idea how to detect image loading start) in case the image got different aspect ratio

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Image loading not started yet
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/56659cf2-fbdb-48dd-ae65-cc491b1f3851)

Image loaded started
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/4622f1ce-abb1-44d7-a2e8-7cb19366bf90)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Turn off `Replace HTTP Cache` (so that renderer does the image loading)
- In dev tool change network speed to slow 3G
- Find some random playlist to load (user playlist might be faster)
- Ensure thumbnail element got height before image loading starts

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
