### PR TITLE
Fix users seeing no comment message when it's due to having error handling new YT comment structure

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -40,6 +40,7 @@ export default defineComponent({
   data: function () {
     return {
       isLoading: false,
+      isError: false,
       showComments: false,
       nextPageToken: null,
       commentData: [],
@@ -111,7 +112,9 @@ export default defineComponent({
     },
 
     canPerformInitialCommentLoading: function () {
-      return this.commentData.length === 0 && !this.isLoading && !this.showComments
+      // When error encountered due to YT returning new comment structure
+      // Until YouTube.js supports it, we can only allow users to retry fetching comments
+      return this.isError || (this.commentData.length === 0 && !this.isLoading && !this.showComments)
     },
 
     canPerformMoreCommentLoading: function () {
@@ -151,6 +154,7 @@ export default defineComponent({
 
     getCommentData: function () {
       this.isLoading = true
+      this.isError = false
       if (!process.env.IS_ELECTRON || this.backendPreference === 'invidious') {
         this.getCommentDataInvidious()
       } else {
@@ -225,6 +229,7 @@ export default defineComponent({
           showToast(this.$t('Falling back to Invidious API'))
           this.getCommentDataInvidious()
         } else {
+          this.isError = true
           this.isLoading = false
         }
       }

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -265,7 +265,7 @@
       </div>
     </div>
     <div
-      v-else-if="showComments && !isLoading"
+      v-else-if="showComments && !isLoading && !isError"
     >
       <h3 class="noCommentMsg">
         {{ $t("Comments.There are no comments available for this video") }}


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This is a workaround (until FT/Youtube.js can handle new YT comment structure)
When an error is encountered, currently only "no comment" message is shown
But with the new comment structure issue (which happens sometimes) users should be allow to retry

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After error encountered
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/99746a97-6d91-4039-ba55-20b5b4932ff8)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Find random video
- Keep switching `Sort By`
- Ensure you can retry fetching comment

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
