### PR TITLE
Fix fallback to Invidious for the podcasts channel tab

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1444,7 +1444,7 @@ export default defineComponent({
         })
         if (this.backendPreference === 'local' && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
-          this.getChannelPodcastsInvidious()
+          this.channelInvidiousPodcasts()
         } else {
           this.isLoading = false
         }


### PR DESCRIPTION
# Fix fallback to Invidious for the podcasts channel tab

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
So turns out the function is actually called `channelInvidiousPodcasts`.

https://github.com/FreeTubeApp/FreeTube/blob/9e05ac7fc0c19814d086b249f38c6dbae8b7d02c/src/renderer/views/Channel/Channel.js#L1473

## Testing <!-- for code that is not small enough to be easily understandable -->


## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 9e05ac7fc0c19814d086b249f38c6dbae8b7d02c