### PR TITLE
Wrap `Watch` ft-icon buttons below before they go fully vertical

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -64,6 +64,19 @@
         inset-inline-end: calc(50% - 20px);
       }
     }
+
+    @media screen and (max-width: 460px) {
+      flex-wrap: nowrap;
+      :deep(.iconDropdown) {
+        inset-inline-start: auto;
+        inset-inline-end: auto;
+      }
+    }
+  }
+  @media screen and (max-width: 460px) {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-block-start: 10px;
   }
 }
 


### PR DESCRIPTION
# Wrap `Watch` ft-icon buttons below before they go fully vertical

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
When there is a long channel name (ex: ThatGuyFromThatOneChannel) and the width of the window is narrow, the ft icon buttons in the watch video info wrap into a vertical line. This creates a lot of white-space above and below the channel name. This PR addresses this by moving the buttons under the channel info when the window width is narrow `<460px`.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/48adf8fc-38f0-46f7-b333-0e6c0d4b93af)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/af421706-9903-4dda-8f75-016ccfdaac62)|


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open a video with a channel name that is very long and one word (ex: https://youtu.be/7e7jGSzmzIw or https://youtu.be/_5xMT3mQTrg  ) 
2. Reduce the window width to `<=460px`
3. Ensure the ft-icons in the watch-video-info wrap below the channel information

## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 65b7ba1f88f2f5595a8284de2ebc90a8563b2da2

## Additional context
I also considered solving the problem by limiting the width of the channel name and forcing it to break word. It is technically less whitespace, but everything feels a bit crunched together IMHO.

<img src="https://github.com/FreeTubeApp/FreeTube/assets/106682128/e60535ab-4e9c-46b4-a346-79c4db476f53" width="300" />
