### PR TITLE
Split view count and published date into two lines on small displays

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.scss
+++ b/src/renderer/components/watch-video-info/watch-video-info.scss
@@ -70,31 +70,43 @@
 .videoMetrics {
   font-size: 14px;
   color: var(--tertiary-text-color);
-
   .likeSection {
-  color: var(--tertiary-text-color);
-  display: flex;
-  flex-direction: column;
-  margin-inline-start: auto;
-  margin-block-start: 4px;
-  max-inline-size: 210px;
-  text-align: end;
-
-  @media screen and (max-width: 680px) {
-    margin-inline-start: 0;
-    text-align: start;
-  }
-
-  .likeBar {
-    border-radius: 4px;
-    block-size: 8px;
-    margin-block-end: 4px;
-  }
-
-  .likeCount {
-    margin-inline-end: 0;
+    color: var(--tertiary-text-color);
     display: flex;
-    gap: 3px;
+    flex-direction: column;
+    margin-inline-start: auto;
+    margin-block-start: 4px;
+    max-inline-size: 210px;
+    text-align: end;
+
+    @media screen and (max-width: 680px) {
+      margin-inline-start: 0;
+      text-align: start;
+    }
+
+    .likeBar {
+      border-radius: 4px;
+      block-size: 8px;
+      margin-block-end: 4px;
+    }
+
+    .likeCount {
+      margin-inline-end: 0;
+      display: flex;
+      gap: 3px;
+    }
   }
-}
+  .datePublishedAndViewCount {
+    @media only screen and (max-width: 460px) {
+      display: flex;
+      justify-content: left;
+      flex-direction: column;
+      .seperator {
+        display: none;
+      }
+    }
+  }
+  .videoViews {
+    white-space: nowrap;
+  }
 }

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -10,8 +10,10 @@
     <div class="videoMetrics">
       <div class="datePublishedAndViewCount">
         {{ publishedString }} {{ dateString }}
-        <template v-if="!hideVideoViews">
-          • {{ parsedViewCount }}
+        <template
+          v-if="!hideVideoViews"
+        >
+          <span class="seperator">• </span><span class="videoViews">{{ parsedViewCount }}</span>
         </template>
       </div>
       <div


### PR DESCRIPTION
# Split view count and published date into two lines on small displays

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The view count tends to split in a way that looks awkward on small displays. The number part of the view count ends up on a different line than the text part of the view count, and it makes it a little difficult to read. This PR addresses this by splitting the published date and view count onto different lines on small displays so that the view count is less likely to wrap in this way.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![before-2](https://github.com/FreeTubeApp/FreeTube/assets/106682128/6b3e216a-90c2-4b88-a3a6-7f19bf51b492)|![after-2](https://github.com/FreeTubeApp/FreeTube/assets/106682128/26690c3c-dde4-4122-be61-403d6c8c1878)|



## Testing <!-- for code that is not small enough to be easily understandable -->
1. Make sure you are using the local API (iv seems to return 0 for likes ATM)
2. Find a video with a high view count and a high like count (ex: https://youtu.be/K_CbgLpvH9E)
3. Reduce the screen width to `<= 460px` 
4. Ensure the view count does not split the text part of the line from the number part


## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 65b7ba1f88f2f5595a8284de2ebc90a8563b2da2

## Additional context
<!-- Add any other context about the pull request here. -->
I picked 460px because view counts and like counts can vary. The example video in the screenshots has plenty of space at screen width 460px, but not all videos do. That is why the width was picked.