### PR TITLE
Auto select all text when search bar is focused

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -253,6 +253,10 @@ export default defineComponent({
         return
       }
 
+      if (event.getModifierState('Control') && event.key === 'u') {
+        this.handleClearTextClick()
+      }
+
       if (this.visibleDataList.length === 0) { return }
 
       this.searchState.showOptions = true
@@ -316,6 +320,7 @@ export default defineComponent({
 
     focus() {
       this.$refs.input.focus()
+      this.select()
     },
 
     select() {

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -253,8 +253,14 @@ export default defineComponent({
         return
       }
 
-      if (event.getModifierState('Control') && event.key === 'u') {
+      // Press Ctrl+u (Windows/Linux) or Cmd/Meta+u (MacOS) inside the search box to clear the text
+      const isCapslockOff = !event.getModifierState('Capslock')
+      const isCtrlOrCmdPressed = (process.platform !== 'darwin' && event.ctrlKey) ||
+        (process.platform === 'darwin' && event.metaKey)
+
+      if (isCapslockOff && isCtrlOrCmdPressed && event.key === 'u') {
         this.handleClearTextClick()
+        return
       }
 
       if (this.visibleDataList.length === 0) { return }
@@ -320,7 +326,6 @@ export default defineComponent({
 
     focus() {
       this.$refs.input.focus()
-      this.select()
     },
 
     select() {


### PR DESCRIPTION
# Auto select all text when search bar is focused and implement Ctrl+U keyboard shortcut.

## Pull Request Type
- [x] Feature Implementation

## Related issue
Closes #4746 and somewhat related to #4247

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This is my attempt at implementing the auto select feature. When focusing the search bar via Ctrl+L, it will auto select all text for easy deletion. The Ctrl+U is a convenience shortcut that will clear all the text inside the search bar which is pretty standard on all HTML input textbox as well as on YouTube itself.

## Desktop
- **OS:** Linux
- **OS Version:** 6.6.20 LTS
- **FreeTube version:** 0.19.2