### PR TITLE
Fix visible toast messages flickering when one disappears

### DIFF
--- a/src/renderer/components/ft-toast/ft-toast.js
+++ b/src/renderer/components/ft-toast/ft-toast.js
@@ -1,6 +1,8 @@
 import { defineComponent } from 'vue'
 import FtToastEvents from './ft-toast-events.js'
 
+let id = 0
+
 export default defineComponent({
   name: 'FtToast',
   data: function () {
@@ -15,7 +17,9 @@ export default defineComponent({
     FtToastEvents.removeEventListener('toast-open', this.open)
   },
   methods: {
-    performAction: function (index) {
+    performAction: function (id) {
+      const index = this.toasts.findIndex(toast => id === toast.id)
+
       this.toasts[index].action()
       this.remove(index)
     },
@@ -26,7 +30,13 @@ export default defineComponent({
       toast.isOpen = false
     },
     open: function ({ detail: { message, time, action } }) {
-      const toast = { message: message, action: action || (() => { }), isOpen: false, timeout: null }
+      const toast = {
+        message: message,
+        action: action || (() => { }),
+        isOpen: false,
+        timeout: null,
+        id: id++
+      }
       toast.timeout = setTimeout(this.close, time || 3000, toast)
       setTimeout(() => { toast.isOpen = true })
       if (this.toasts.length > 4) {

--- a/src/renderer/components/ft-toast/ft-toast.vue
+++ b/src/renderer/components/ft-toast/ft-toast.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="toast-holder">
     <div
-      v-for="(toast, index) in toasts"
-      :key="'toast-' + index"
+      v-for="toast in toasts"
+      :key="toast.id"
       class="toast"
       :class="{ closed: !toast.isOpen, open: toast.isOpen }"
       tabindex="0"
       role="status"
-      @click="performAction(index)"
-      @keydown.enter.prevent="performAction(index)"
-      @keydown.space.prevent="performAction(index)"
+      @click="performAction(toast.id)"
+      @keydown.enter.prevent="performAction(toast.id)"
+      @keydown.space.prevent="performAction(toast.id)"
     >
       <p class="message">
         {{ toast.message }}


### PR DESCRIPTION
# Fix visible toast messages flickering when one disappears

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
As we were previously using the array index for the `:key` in the toast's `v-for`, it meant than when a toast disappears, all of the toasts would get re-rendered by Vue, as the items would be at different indexes, causing the CSS animations to trigger again which results in the flickering effect.

This pull request assigns each toast a unique ID, which means that when the toasts array changes, the keys don't change, so Vue knows it only needs to update the toasts that are being added or removed.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
Click the `Set Current Instance as Default` and `Clear Default Instance` buttons in the general settings section to create a bunch of toasts. Watch the toasts as some of them start disappearing, after this pull request they should no longer flicker.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.2
