### PR TITLE
Improve touch controls for dash quality selector

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1817,7 +1817,20 @@ export default defineComponent({
 
           // For default auto, it may select a resolution before generating the quality buttons
           button.querySelector('#vjs-current-quality').innerText = defaultIsAuto ? autoQualityLabel : currentQualityLabel
-
+          button.addEventListener('touchstart', (e) => {
+            // make it easier to toggle the vjs-menu on touch (hover css is inconsistent w/ touch)
+            if (!e.target.classList.contains('quality-item') && !e.target.classList.contains('vjs-menu-item-text')) {
+              const vjsMenu = button.querySelector('.vjs-menu')
+              let vjsMenuClass = vjsMenu.getAttribute('class')
+              if (vjsMenuClass.indexOf(' vjs-lock-showing') === -1) {
+                vjsMenuClass += ' vjs-lock-showing'
+              } else {
+                vjsMenuClass = vjsMenuClass.replace(' vjs-lock-showing', '')
+              }
+              vjsMenu.setAttribute('class', vjsMenuClass)
+            }
+            this.handleClick(e)
+          })
           return button.children[0]
         }
       }

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -1818,6 +1818,7 @@ export default defineComponent({
           // For default auto, it may select a resolution before generating the quality buttons
           button.querySelector('#vjs-current-quality').innerText = defaultIsAuto ? autoQualityLabel : currentQualityLabel
           button.addEventListener('touchstart', (e) => {
+            button.focus()
             // make it easier to toggle the vjs-menu on touch (hover css is inconsistent w/ touch)
             if (!e.target.classList.contains('quality-item') && !e.target.classList.contains('vjs-menu-item-text')) {
               const vjsMenu = button.querySelector('.vjs-menu')
@@ -1830,6 +1831,12 @@ export default defineComponent({
               vjsMenu.setAttribute('class', vjsMenuClass)
             }
             this.handleClick(e)
+          })
+          button.addEventListener('focusout', () => {
+            const vjsMenu = button.querySelector('.vjs-menu')
+            // remove class which shows the selector
+            const vjsMenuClass = vjsMenu.getAttribute('class').replace(' vjs-lock-showing', '')
+            vjsMenu.setAttribute('class', vjsMenuClass)
           })
           return button.children[0]
         }


### PR DESCRIPTION
# Improve touch controls for dash quality selector

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
MarmadileManteater/FreeTubeCordova#239

## Description
The dash quality selector does not respond well to touch input unlike the legacy and audio quality selectors. The `handleClick` event is being called, but the way that is being called on touch input causes `e.target` to reflect a different element than the one actually tapped on. This causes the quality selector to seem like it is ignoring user input when, it is just treating most taps as if they were on the current quality label (which causes the click handler to return immediately). 

This PR addresses this by adding a `touchstart` event to the button element which simply calls `handleClick` with the appropriate target. Due to the fact that the quality selector is typically hidden and shown by a `hover` psuedo class, code was also added to the touchstart event to handle flipping the `vjs-lock-showing` class.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/41fbe885-3f88-4649-bf85-385d8393a568)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/2a37db42-0844-4110-a79f-ec79e9b22091)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Ensure `dash` is the preferred format
2. Open a video
3. Ensure the dash quality selector hasn't changed at all on mouse input
4. Ensure the dash quality selector behaves the same way with touch input as mouse input

## Desktop
<!-- Please complete the following information-->
 - OS: Windows 10
 - OS Version: Pro Version 21H2 Installed on ‎4/‎3/‎2022 OS build 19044.1889 Experience Windows Feature Experience Pack 120.2212.4180.0
- **FreeTube version:** 672803d30c3fcac392da50e152203b582d192500


## Additional context
To be clear, it is possible to make the dash quality selector "work" (kind of) as is, but it requires "hovering" the button by hold tapping before making a quick shorter tap. Simply tapping once doesn't do anything most of the time.