### PR TITLE
Bump version number to v0.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freetube",
   "productName": "FreeTube",
   "description": "A private YouTube client",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "license": "AGPL-3.0-or-later",
   "main": "./dist/main.js",
   "private": true,


### PR DESCRIPTION
# Bump version number to v0.19.2

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
IRC chat

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Users in the General Chat were confused about how our versioning system works vs nightly builds.
Seems that nightly builds after 0.19.2 release do have FreeTube-0.19.1-nightly in the name of the file. It also shows up as 0.19.1 in the about tab and you will get to see the install 0.19.2 banner

The build file is looking at the versioning for all branches to determine the name of the file. Bc the package.json contains 0.19.1 for the dev branch it will create nightly builds with the name 0.19.1 in it

dev branch -> 0.19.1, https://github.com/FreeTubeApp/FreeTube/blob/development/package.json
master branch -> 0.19.2 https://github.com/FreeTubeApp/FreeTube/blob/master/package.json

Thats why only nightly build users are encountering this


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Ensure about tab says v0.19.2
2. Ensure no banner is shown to install v0.19.2
