### PR TITLE
Fix handling of video published date in video lists

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -137,13 +137,9 @@
           {{ $tc('Global.Counts.View Count', viewCount, {count: parsedViewCount}) }}
         </span>
         <span
-          v-if="uploadedTime !== '' && !isLive && !inHistory"
+          v-if="uploadedTime !== '' && !isLive"
           class="uploadedTime"
         > • {{ uploadedTime }}</span>
-        <span
-          v-if="inHistory"
-          class="uploadedTime"
-        > • {{ publishedText }}</span>
         <span
           v-if="isLive && !hideViews"
           class="viewCount"

--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -2,10 +2,10 @@ import { defineComponent } from 'vue'
 import { mapActions, mapMutations } from 'vuex'
 import SubscriptionsTabUI from '../subscriptions-tab-ui/subscriptions-tab-ui.vue'
 
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { setPublishedTimestampsInvidious, copyToClipboard, showToast } from '../../helpers/utils'
 import { invidiousAPICall } from '../../helpers/api/invidious'
 import { getLocalChannelLiveStreams } from '../../helpers/api/local'
-import { addPublishedDatesInvidious, addPublishedDatesLocal, parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
+import { parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
 
 export default defineComponent({
   name: 'SubscriptionsLive',
@@ -198,8 +198,6 @@ export default defineComponent({
           }
         }
 
-        addPublishedDatesLocal(result.videos)
-
         return result
       } catch (err) {
         console.error(err)
@@ -294,7 +292,7 @@ export default defineComponent({
         invidiousAPICall(subscriptionsPayload).then((result) => {
           const videos = result.videos.filter(e => e.type === 'video')
 
-          addPublishedDatesInvidious(videos)
+          setPublishedTimestampsInvidious(videos)
 
           let name
 

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -2,10 +2,10 @@ import { defineComponent } from 'vue'
 import { mapActions, mapMutations } from 'vuex'
 import SubscriptionsTabUI from '../subscriptions-tab-ui/subscriptions-tab-ui.vue'
 
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { setPublishedTimestampsInvidious, copyToClipboard, showToast } from '../../helpers/utils'
 import { invidiousAPICall } from '../../helpers/api/invidious'
 import { getLocalChannelVideos } from '../../helpers/api/local'
-import { addPublishedDatesInvidious, addPublishedDatesLocal, parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
+import { parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
 
 export default defineComponent({
   name: 'SubscriptionsVideos',
@@ -198,8 +198,6 @@ export default defineComponent({
           }
         }
 
-        addPublishedDatesLocal(result.videos)
-
         return result
       } catch (err) {
         console.error(err)
@@ -291,7 +289,7 @@ export default defineComponent({
         }
 
         invidiousAPICall(subscriptionsPayload).then((result) => {
-          addPublishedDatesInvidious(result.videos)
+          setPublishedTimestampsInvidious(result.videos)
 
           let name
 

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -3,7 +3,7 @@ import { mapMutations } from 'vuex'
 import FtLoader from '../ft-loader/ft-loader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtListVideoNumbered from '../ft-list-video-numbered/ft-list-video-numbered.vue'
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 import {
   getLocalPlaylist,
   parseLocalPlaylistVideo,
@@ -451,6 +451,8 @@ export default defineComponent({
         this.playlistTitle = result.title
         this.channelName = result.author
         this.channelId = result.authorId
+
+        setPublishedTimestampsInvidious(result.videos)
         this.playlistItems = this.playlistItems.concat(result.videos)
 
         this.isLoading = false

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -5,6 +5,7 @@ import { join } from 'path'
 import { PlayerCache } from './PlayerCache'
 import {
   CHANNEL_HANDLE_REGEX,
+  calculatePublishedDate,
   escapeHTML,
   extractNumberFromString,
   getUserDataPath,
@@ -681,8 +682,7 @@ export function parseLocalPlaylistVideo(video) {
       }
     }
 
-    let publishedText = null
-
+    let publishedText
     // normal videos have 3 text runs with the last one containing the published date
     // live videos have 2 text runs with the number of people watching
     // upcoming either videos don't have any info text or the number of people waiting,
@@ -691,13 +691,20 @@ export function parseLocalPlaylistVideo(video) {
       publishedText = video_.video_info.runs[2].text
     }
 
+    const published = calculatePublishedDate(
+      publishedText,
+      video_.is_live,
+      video_.is_upcoming,
+      video_.upcoming
+    )
+
     return {
       videoId: video_.id,
       title: video_.title.text,
       author: video_.author.name,
       authorId: video_.author.id,
       viewCount,
-      publishedText,
+      published,
       lengthSeconds: isNaN(video_.duration.seconds) ? '' : video_.duration.seconds,
       liveNow: video_.is_live,
       isUpcoming: video_.is_upcoming,
@@ -728,6 +735,20 @@ export function parseLocalListVideo(item) {
   } else {
     /** @type {import('youtubei.js').YTNodes.Video} */
     const video = item
+
+    let publishedText
+
+    if (!video.published?.isEmpty()) {
+      publishedText = video.published.text
+    }
+
+    const published = calculatePublishedDate(
+      publishedText,
+      video.is_live,
+      video.is_upcoming || video.is_premiere,
+      video.upcoming
+    )
+
     return {
       type: 'video',
       videoId: video.id,
@@ -736,7 +757,7 @@ export function parseLocalListVideo(item) {
       authorId: video.author.id,
       description: video.description,
       viewCount: video.view_count == null ? null : extractNumberFromString(video.view_count.text),
-      publishedText: (video.published == null || video.published.isEmpty()) ? null : video.published.text,
+      published,
       lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
       liveNow: video.is_live,
       isUpcoming: video.is_upcoming || video.is_premiere,
@@ -811,6 +832,14 @@ function parseListItem(item) {
  * @param {import('youtubei.js').YTNodes.CompactVideo} video
  */
 export function parseLocalWatchNextVideo(video) {
+  let publishedText
+
+  if (!video.published?.isEmpty()) {
+    publishedText = video.published.text
+  }
+
+  const published = calculatePublishedDate(publishedText, video.is_live, video.is_premiere)
+
   return {
     type: 'video',
     videoId: video.id,
@@ -818,7 +847,7 @@ export function parseLocalWatchNextVideo(video) {
     author: video.author.name,
     authorId: video.author.id,
     viewCount: video.view_count == null ? null : extractNumberFromString(video.view_count.text),
-    publishedText: (video.published == null || video.published.isEmpty()) ? null : video.published.text,
+    published,
     lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
     liveNow: video.is_live,
     isUpcoming: video.is_premiere

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -1,5 +1,4 @@
 import store from '../store/index'
-import { calculatePublishedDate } from './utils'
 
 /**
  * Filtering and sort based on user preferences
@@ -57,7 +56,7 @@ export function updateVideoListAfterProcessing(videos) {
   }
 
   videoList.sort((a, b) => {
-    return b.publishedDate - a.publishedDate
+    return b.published - a.published
   })
 
   return videoList
@@ -106,57 +105,10 @@ async function parseRSSEntry(entry, channelId, channelName) {
     // querySelector doesn't support xml namespaces so we have to use getElementsByTagName here
     videoId: entry.getElementsByTagName('yt:videoId')[0].textContent,
     title: entry.querySelector('title').textContent,
-    publishedDate: published,
-    publishedText: published.toLocaleString(),
+    published: published.getTime(),
     viewCount: entry.getElementsByTagName('media:statistics')[0]?.getAttribute('views') || null,
     type: 'video',
     lengthSeconds: '0:00',
     isRSS: true
   }
-}
-
-/**
- * @param {{
- *  liveNow: boolean,
- *  isUpcoming: boolean,
- *  premiereDate: Date,
- *  publishedText: string,
- *  publishedDate: number
- * }[]} videos publishedDate is added by this function,
- * but adding it to the type definition stops vscode warning that the property doesn't exist
- */
-export function addPublishedDatesLocal(videos) {
-  videos.forEach(video => {
-    if (video.liveNow) {
-      video.publishedDate = new Date().getTime()
-    } else if (video.isUpcoming) {
-      video.publishedDate = video.premiereDate
-    } else {
-      video.publishedDate = calculatePublishedDate(video.publishedText)
-    }
-    return video
-  })
-}
-
-/**
- * @param {{
- *  liveNow: boolean,
- *  isUpcoming: boolean,
- *  premiereTimestamp: number,
- *  published: number,
- *  publishedDate: number
- * }[]} videos publishedDate is added by this function,
- * but adding it to the type definition stops vscode warning that the property doesn't exist
- */
-export function addPublishedDatesInvidious(videos) {
-  videos.forEach(video => {
-    if (video.liveNow) {
-      video.publishedDate = new Date().getTime()
-    } else if (video.isUpcoming) {
-      video.publishedDate = new Date(video.premiereTimestamp * 1000)
-    } else {
-      video.publishedDate = new Date(video.published * 1000)
-    }
-    return video
-  })
 }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -12,7 +12,13 @@ import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe
 import ChannelAbout from '../../components/channel-about/channel-about.vue'
 
 import autolinker from 'autolinker'
-import { copyToClipboard, extractNumberFromString, formatNumber, showToast } from '../../helpers/utils'
+import {
+  setPublishedTimestampsInvidious,
+  copyToClipboard,
+  extractNumberFromString,
+  formatNumber,
+  showToast
+} from '../../helpers/utils'
 import { isNullOrEmpty } from '../../helpers/strings'
 import packageDetails from '../../../../package.json'
 import {
@@ -33,10 +39,6 @@ import {
   parseLocalListVideo,
   parseLocalSubscriberCount
 } from '../../helpers/api/local'
-import {
-  addPublishedDatesInvidious,
-  addPublishedDatesLocal
-} from '../../helpers/subscriptions'
 
 export default defineComponent({
   name: 'Channel',
@@ -780,7 +782,6 @@ export default defineComponent({
         this.isElementListLoading = false
 
         if (this.isSubscribedInAnyProfile && this.latestVideos.length > 0 && this.videoSortBy === 'newest') {
-          addPublishedDatesLocal(this.latestVideos)
           this.updateSubscriptionVideosCacheByChannel({
             channelId: this.id,
             // create a copy so that we only cache the first page
@@ -917,7 +918,6 @@ export default defineComponent({
         this.isElementListLoading = false
 
         if (this.isSubscribedInAnyProfile && this.latestLive.length > 0 && this.liveSortBy === 'newest') {
-          addPublishedDatesLocal(this.latestLive)
           this.updateSubscriptionLiveCacheByChannel({
             channelId: this.id,
             // create a copy so that we only cache the first page
@@ -992,7 +992,6 @@ export default defineComponent({
             thumbnailUrl: youtubeImageUrlToInvidious(thumbnailUrl, this.currentInvidiousInstance)
           }
         })
-        this.latestVideos = response.latestVideos
 
         if (response.authorBanners instanceof Array && response.authorBanners.length > 0) {
           this.bannerUrl = youtubeImageUrlToInvidious(response.authorBanners[0].url, this.currentInvidiousInstance)
@@ -1088,6 +1087,8 @@ export default defineComponent({
       }
 
       invidiousAPICall(payload).then((response) => {
+        setPublishedTimestampsInvidious(response.videos)
+
         if (more) {
           this.latestVideos = this.latestVideos.concat(response.videos)
         } else {
@@ -1097,7 +1098,6 @@ export default defineComponent({
         this.isElementListLoading = false
 
         if (this.isSubscribedInAnyProfile && !more && this.latestVideos.length > 0 && this.videoSortBy === 'newest') {
-          addPublishedDatesInvidious(this.latestVideos)
           this.updateSubscriptionVideosCacheByChannel({
             channelId: this.id,
             // create a copy so that we only cache the first page
@@ -1143,7 +1143,7 @@ export default defineComponent({
         // https://github.com/iv-org/invidious/issues/3801
         response.videos.forEach(video => {
           video.isUpcoming = false
-          delete video.publishedText
+          delete video.published
           delete video.premiereTimestamp
         })
 
@@ -1199,6 +1199,8 @@ export default defineComponent({
       }
 
       invidiousAPICall(payload).then((response) => {
+        setPublishedTimestampsInvidious(response.videos)
+
         if (more) {
           this.latestLive.push(...response.videos)
         } else {
@@ -1208,7 +1210,6 @@ export default defineComponent({
         this.isElementListLoading = false
 
         if (this.isSubscribedInAnyProfile && !more && this.latestLive.length > 0 && this.liveSortBy === 'newest') {
-          addPublishedDatesInvidious(this.latestLive)
           this.updateSubscriptionLiveCacheByChannel({
             channelId: this.id,
             // create a copy so that we only cache the first page

--- a/src/renderer/views/Hashtag/Hashtag.js
+++ b/src/renderer/views/Hashtag/Hashtag.js
@@ -5,7 +5,7 @@ import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import packageDetails from '../../../../package.json'
 import { getHashtagLocal, parseLocalListVideo } from '../../helpers/api/local'
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 import { isNullOrEmpty } from '../../helpers/strings'
 import { getHashtagInvidious } from '../../helpers/api/invidious'
 
@@ -73,6 +73,7 @@ export default defineComponent({
     getInvidiousHashtag: async function(hashtag, page) {
       try {
         const videos = await getHashtagInvidious(hashtag, page)
+        setPublishedTimestampsInvidious(videos)
         this.hashtag = '#' + hashtag
         this.isLoading = false
         this.apiUsed = 'invidious'

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -12,7 +12,7 @@ import {
   getLocalPlaylistContinuation,
   parseLocalPlaylistVideo,
 } from '../../helpers/api/local'
-import { extractNumberFromString, showToast } from '../../helpers/utils'
+import { extractNumberFromString, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 
 export default defineComponent({
@@ -283,6 +283,8 @@ export default defineComponent({
 
         const dateString = new Date(result.updated * 1000)
         this.lastUpdated = dateString.toLocaleDateString(this.currentLocale, { year: 'numeric', month: 'short', day: 'numeric' })
+
+        setPublishedTimestampsInvidious(result.videos)
 
         this.playlistItems = result.videos
 

--- a/src/renderer/views/Popular/Popular.js
+++ b/src/renderer/views/Popular/Popular.js
@@ -5,7 +5,7 @@ import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 
 import { invidiousAPICall } from '../../helpers/api/invidious'
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 
 export default defineComponent({
   name: 'Popular',
@@ -60,11 +60,15 @@ export default defineComponent({
         return
       }
 
-      this.shownResults = result.filter((item) => {
+      const items = result.filter((item) => {
         return item.type === 'video' || item.type === 'shortVideo' || item.type === 'channel' || item.type === 'playlist'
       })
+      setPublishedTimestampsInvidious(items.filter(item => item.type === 'video'))
+
+      this.shownResults = items
+
       this.isLoading = false
-      this.$store.commit('setPopularCache', this.shownResults)
+      this.$store.commit('setPopularCache', items)
     },
 
     /**

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -2,7 +2,12 @@ import { defineComponent } from 'vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
-import { copyToClipboard, searchFiltersMatch, showToast } from '../../helpers/utils'
+import {
+  copyToClipboard,
+  searchFiltersMatch,
+  setPublishedTimestampsInvidious,
+  showToast
+} from '../../helpers/utils'
 import { getLocalSearchContinuation, getLocalSearchResults } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
 
@@ -213,6 +218,8 @@ export default defineComponent({
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist' || item.type === 'hashtag'
         })
+
+        setPublishedTimestampsInvidious(returnData.filter(item => item.type === 'video'))
 
         if (this.searchPage !== 1) {
           this.shownResults = this.shownResults.concat(returnData)

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -6,7 +6,7 @@ import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 import { getLocalTrending } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
 
@@ -145,6 +145,8 @@ export default defineComponent({
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
         })
+
+        setPublishedTimestampsInvidious(returnData.filter(item => item.type === 'video'))
 
         this.shownResults = returnData
         this.isLoading = false


### PR DESCRIPTION
# Fix handling of video published date in video lists

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation

## Related issue
Fixes https://github.com/FreeTubeApp/FreeTube/discussions/4541 (not sure if GitHub automatically closes discussions with pull requests but I'm listing it here anyway)
Fixes #2579
Implements #3736

## Description
This started as an investigation into #4541 (FreeTube showing published dates in German, despite the display language being set to English) and in the process of fixing that, I ended up solving #2579 and implementing #3736.

The issue with the translated published strings was because we were using the `publishedText` property in Invidious' API response, which it turns out is a translatable string on the Invidious side, so when an instance like `invidious.nerdvpn.de` decides to randomly return German translations for no apparent reason, FreeTube bugs out and shows that to the user. The solution to that is using the `published` property instead, which contains Invidious' parsing of the `publishedText` into a unix timestamp in milliseconds.

As I was switching to the `published` field for Invidious anyway, I decided I might as well do it for the local API too, that means parsing the relative date strings during the local API parsing, so that `ft-list-video` only has to deal with unix timestamps. Converting it back to a relative timestamp is then done in `ft-list-video` based on the current date and time. One major benefit of doing that, is that when we save videos in the subscription cache, they are no longer saved with `10 minutes ago`, instead they have the unix timestamp, so instead of only being able to show `10 minutes` ago when it is restored from the cache 3 hours later, it will now show `3 hours ago`.
Please note that as these timestamps are calculated based on relative timestamps, they might not match up with YouTube's, as they have access to the absolute timestamp in their databases. However showing a potentially slightly off relative timestamp is a lot better than still showing `10 minutes ago` 3 hours after the video was published.

The mark as watched invalid date issue was caused by us saving the text `"10 minutes ago"` in the watch history, but as we save the unix timestamp on the watch page, the code that read the date from the history was expecting a unix timestamp, which `"10 mins ago"` most certainly is not. The solution to that was quite easy now that the rest of the `ft-list-video` component was already using unix timestamps.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Test various video lists (e.g. subscriptions, search, trending) with both the local and Invidious API and make sure that published dates show up correctly.
2. Mark a video as watched from the subscription page (3 dots menu -> Mark as Watched) with the local or Invidious API without RSS and check the history tab to confirm that it shows an actual date and time instead of `Invalid date`
3. Refresh your subscriptions without RSS, wait a while and then come back later, switch to a different page (the timestamps don't update live while you are on the same page, as that would be quite expensive to do every second) and then back to the subscriptions page and it should show updated timestamps without you refreshing the subscriptions.

**This pull request doesn't change how published dates are handled for community posts, but I will switch that to the `published` field in a follow up pull request, so we get the same updated timestamps when we restore it from the cache.**

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** latest nightly