### PR TITLE
Store portable apps settings in same directory as the EXE

### DIFF
--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -7,6 +7,13 @@ if (process.env.IS_ELECTRON_MAIN) {
   const { join } = require('path')
   // this code only runs in the electron main process, so hopefully using sync fs code here should be fine 😬
   const { statSync, realpathSync } = require('fs')
+  const path = require('path')
+
+  if (process.platform === 'win32' && process.env.PORTABLE_EXECUTABLE_DIR != null) {
+    app.setPath('appData', process.env.PORTABLE_EXECUTABLE_DIR, `${app.name}AppData`)
+    app.setPath('userData', path.join(app.getPath('appData'), `${app.name}AppData`))
+  }
+
   const userDataPath = app.getPath('userData') // This is based on the user's OS
   dbPath = (dbName) => {
     let path = join(userDataPath, `${dbName}.db`)


### PR DESCRIPTION
# Store portable apps settings in same directory as the EXE

## Pull Request Type
- [x] Bugfix

## Related issue
Thanks @rddim for the initial PR https://github.com/FreeTubeApp/FreeTube/pull/868

## Description
This PR should fix the issue with the portable exe storing the data in AppData (thus not making it very portable)

## Testing 
- Build the App on windows
- run the exe file (not setup.exe)
- notice local directory is made
- change settings notice that settings.db file is updated

Build should be available here: https://github.com/ChunkyProgrammer/FreeTube/actions/runs/8283749172/job/22667673906

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.19.1 (nightly)

## Additional context
I coded this on Linux but did some testing on Windows
