### PR TITLE
Undo context menu widget layering workaround now that the issue is fixed

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -174,10 +174,6 @@ function runApp() {
     app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecodeLinuxGL')
   }
 
-  // Work around for context menus in the devtools being displayed behind the window
-  // https://github.com/electron/electron/issues/38790
-  app.commandLine.appendSwitch('disable-features', 'WidgetLayering')
-
   // command line switches need to be added before the app ready event first
   // that means we can't use the normal settings system as that is asynchronous,
   // doing it synchronously ensures that we add it before the event fires


### PR DESCRIPTION
# Undo context menu widget layering workaround now that the issue is fixed

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Cleanup

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4264

## Description
This pull request removes the workaround introduced in https://github.com/FreeTubeApp/FreeTube/pull/4264, as the issue seems to have been fixed with Electron 29.

While the issue on the Electron repository is still open, someone did leave a comment that the problem was no longer occuring on the `Electron v29.0.0-nightly.20231129 build` and I can no longer reproduce the original issue on Electron 29.1.1 (the version that is used on the FreeTube development branch at the time of writing).

## Testing <!-- for code that is not small enough to be easily understandable -->
Right click in the dev tools on Windows (Linux users mentioned on the original pull request that they weren't able to reproduce the issue) and make sure the context menus show up.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 88222b784bad78ed48f38e4990c6c1d47d6ad75f