### PR TITLE
Hide ft-icon-button and ft-profile-selector dropdowns when the escape key is pressed

### DIFF
--- a/src/renderer/components/ft-card/ft-card.vue
+++ b/src/renderer/components/ft-card/ft-card.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="ft-card"
-    @focusout="$emit('focusout')"
   >
     <slot />
   </div>

--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -116,6 +116,11 @@ export default defineComponent({
       }
     },
 
+    handleDropdownEscape: function () {
+      this.$refs.iconButton.focus()
+      // handleDropdownFocusOut will hide the dropdown for us
+    },
+
     handleDropdownClick: function ({ url, index }) {
       if (this.returnIndex) {
         this.$emit('click', index)

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -66,6 +66,7 @@
           top: dropdownPositionY === 'top'
         }"
         @focusout="handleDropdownFocusOut"
+        @keydown.esc.stop="handleDropdownEscape"
       >
         <slot>
           <ul

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.js
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.js
@@ -73,6 +73,11 @@ export default defineComponent({
       }
     },
 
+    handleProfileListEscape: function () {
+      this.$refs.iconButton.focus()
+      // handleProfileListFocusOut will hide the dropdown for us
+    },
+
     setActiveProfile: function (profile) {
       if (this.activeProfile._id !== profile._id) {
         const targetProfile = this.profileList.find((x) => {

--- a/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
+++ b/src/renderer/components/ft-profile-selector/ft-profile-selector.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div
+      ref="iconButton"
       class="colorOption"
       :title="$t('Profile.Toggle Profile List')"
       :style="{ background: activeProfile.bgColor, color: activeProfile.textColor }"
@@ -25,7 +26,8 @@
       ref="profileList"
       class="profileList"
       tabindex="-1"
-      @focusout="handleProfileListFocusOut"
+      @focusout.native="handleProfileListFocusOut"
+      @keydown.native.esc.stop="handleProfileListEscape"
     >
       <h3
         id="profileListTitle"


### PR DESCRIPTION
# Hide ft-icon-button and ft-profile-selector dropdowns when the escape key is pressed

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Description
This pull request adds support for closing `ft-icon-button` and `ft-profile-selector` dropdowns with the escape key.

You may notice that i used the `.native` modifier for the event handlers attached to the `ft-card` in the `ft-profile-selector` component. When using an event handler on a component, Vue 2 defaults to attaching the event handler to the component, that means it only gets called if the component calls `this.$emit()`. By adding the `.native` modifier I am telling Vue 2 that I would like it to attach it to the root element inside the component instead, so in this case a `<div>`.

Vue 3 is different, it removes the `.native` modifier, instead it checks the components `emits` array (`defineEmits()` in the composition API and the `emits: []` property in the options API), if it finds the event in there it attaches the handler to the component so it is only triggered by `emit()` (composition API) or `this.$emit()` (options API), if it doesn't find the event in that list, it attaches it to the component's root element.

https://v2.vuejs.org/v2/guide/components-custom-events#Binding-Native-Events-to-Components

https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open various `ft-icon-button` dropdowns e.g. the three dots button on videos, the share menu and check that when you press the <kbd>Esc</kbd> key, the dropdown closes and the focus moves back to the icon button.
2. Open the profile selector in the top right of the app and check that when you press the <kbd>Esc</kbd> key, the dropdown closes and the focus moves back to the icon button.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 161400470e50d953bd464503f744fc116cae36ce