### PR TITLE
Keep the video options button visible when the dropdown is open

### DIFF
--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -370,7 +370,9 @@ $watched-transition-duration: 0.5s;
     }
 
     &:hover .optionsButton,
-    &:has(:focus-visible) .optionsButton {
+    &:has(:focus-visible) .optionsButton,
+    // Keep visible when the drop down is open
+    :deep(.optionsButton:has(> .iconDropdown:focus-within)) {
       opacity: 1;
     }
 


### PR DESCRIPTION
# Keep the video options button visible when the dropdown is open

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
This pull request fixes the options (three dots button) button fading away/disappearing while the dropdown is open when you move the mouse away. In my opinion we shouldn't be fading away elements when the user has explicitly interacted with them, especially in the case of the dropdown where the user wants to do something with the drop down, so it disappearing in front of their eyes while they are making the decision is a bad UX.

## Testing <!-- for code that is not small enough to be easily understandable -->
Click on the options button (three dots button) on a video in a video list (e.g. subscriptions and search results) so that the drop down opens, then move your mouse away from that video and make sure that the button and the drop down stay visible for as long as the drop down is open.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 4ce19a2185190d6a4dc407b6a702baaeb7cdd415