### PR TITLE
Fix hardcoded FreeTube string on the watch page

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -11,6 +11,7 @@ import WatchVideoLiveChat from '../../components/watch-video-live-chat/watch-vid
 import WatchVideoPlaylist from '../../components/watch-video-playlist/watch-video-playlist.vue'
 import WatchVideoRecommendations from '../../components/watch-video-recommendations/watch-video-recommendations.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
+import packageDetails from '../../../../package.json'
 import { pathExists } from '../../helpers/filesystem'
 import {
   buildVTTFileLocally,
@@ -1774,7 +1775,7 @@ export default defineComponent({
     },
 
     updateTitle: function () {
-      document.title = `${this.videoTitle} - FreeTube`
+      document.title = `${this.videoTitle} - ${packageDetails.productName}`
     },
 
     isHiddenVideo: function (forbiddenTitles, channelsHidden, video) {


### PR DESCRIPTION
# Fix hardcoded FreeTube string on the watch page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
This aligns the window title setting on the watch page with how we do it on the channel and hashtag pages, as well is in the App.js file. Instead of using the hardcoded `FreeTube` string we use the `productName` field in the package.json file, that way if we ever want to rename FreeTube, the name in the window titles and the binary name will match up (electron-builder uses the `productName` field too).

## Testing <!-- for code that is not small enough to be easily understandable -->
Open a video and make sure the window title still says FreeTube.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 23c561804253439862b6bee1258f2e8e5f2f1f42
