### PR TITLE
Fix handling of video data without `published`

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -738,7 +738,7 @@ export function parseLocalListVideo(item) {
 
     let publishedText
 
-    if (!video.published?.isEmpty()) {
+    if (video.published != null && !video.published.isEmpty()) {
       publishedText = video.published.text
     }
 
@@ -834,7 +834,7 @@ function parseListItem(item) {
 export function parseLocalWatchNextVideo(video) {
   let publishedText
 
-  if (!video.published?.isEmpty()) {
+  if (video.published != null && !video.published.isEmpty()) {
     publishedText = video.published.text
   }
 


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Issue caused by https://github.com/FreeTubeApp/FreeTube/pull/4752

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When playing some videos the data has no `published` property and FT throws error 
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/182c7727-f5f9-45a7-a633-7ac698405b6c)

This is due to 
```
t.published?.isEmpty() = (t.published not null/undefined AND isEmpty())
Reversing that would be (t.published IS null/undefined) or NOT isEmpty()
```


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Try to reproduce the error on a release build (won't happen for me in `yarn dev`) (open dev tool for easier error spotting)
  - example video 1: https://youtu.be/L8I_J2VjsqQ?list=PLWjnM4fZ4U8wLxrFXjL-95ME0QJwdz8m8
- Get a release build or create one (e.g. my custom build including this PR https://github.com/PikachuEXE/FreeTube/actions/runs/8352271057)
- Ensure no more error

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
