### PR TITLE
Fix extracting the subscriber count from channel PageHeader nodes

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -513,7 +513,13 @@ export function parseLocalChannelHeader(channel) {
       }
 
       if (header.content.metadata) {
-        subscriberText = header.content.metadata.metadata_rows[0].metadata_parts[1].text.text
+        // YouTube has already changed the indexes for where the information is stored once,
+        // so we should search for it instead of using hardcoded indexes, just to be safe for the future
+
+        subscriberText = header.content.metadata.metadata_rows
+          .flatMap(row => row.metadata_parts ? row.metadata_parts : [])
+          .find(part => part.text.text?.includes('subscriber'))
+          ?.text.text
       }
 
       break


### PR DESCRIPTION
# Fix extracting the subscriber count from channel PageHeader nodes

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
This pull request fixes the error that randomly appears when refreshing subscriptions (it's part of the PageHeader node on user channels A/B test, which we added support for in #4543)
> Cannot read properties of `undefined` (reading `'text'`)

The issue was caused by YouTube changing the position of the subscriber count in the arrays, which causes an error because it no longer exists where the code was looking for it. To avoid that happening again, I decided to search for the subscriber count instead of hardcoding the array indexes. Unfortunately that means that we have another part of the local API extractor that depends on a language specific string in YouTube's response.

## Testing <!-- for code that is not small enough to be easily understandable -->
Refresh your subscriptions with the local API without RSS, you shouldn't see any error messages appear anymore.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.19.2 and nightlies