### PR TITLE
Add support for CommentViews in video comments

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1023,7 +1023,7 @@ export function mapLocalFormat(format) {
 }
 
 /**
- * @param {import('youtubei.js').YTNodes.Comment} comment
+ * @param {import('youtubei.js').YTNodes.Comment|import('youtubei.js').YTNodes.CommentView} comment
  * @param {import('youtubei.js').YTNodes.CommentThread} commentThread
  */
 export function parseLocalComment(comment, commentThread = undefined) {
@@ -1035,26 +1035,48 @@ export function parseLocalComment(comment, commentThread = undefined) {
     replyToken = commentThread
   }
 
-  return {
+  const parsed = {
     dataType: 'local',
     authorLink: comment.author.id,
     author: comment.author.name,
     authorId: comment.author.id,
     authorThumb: comment.author.best_thumbnail.url,
     isPinned: comment.is_pinned,
-    isOwner: comment.author_is_channel_owner,
-    isMember: comment.is_member,
-    memberIconUrl: comment.is_member ? comment.sponsor_comment_badge.custom_badge[0].url : '',
+    isOwner: !!comment.author_is_channel_owner,
+    isMember: !!comment.is_member,
     text: Autolinker.link(parseLocalTextRuns(comment.content.runs, 16, { looseChannelNameDetection: true })),
-    time: toLocalePublicationString({ publishText: comment.published.text.replace('(edited)', '').trim() }),
-    likes: comment.vote_count,
-    isHearted: comment.is_hearted,
-    numReplies: comment.reply_count,
+    isHearted: !!comment.is_hearted,
     hasOwnerReplied,
     replyToken,
     showReplies: false,
-    replies: []
+    replies: [],
+
+    // default values for the properties set below
+    memberIconUrl: '',
+    time: '',
+    likes: 0,
+    numReplies: 0
   }
+
+  if (comment.type === 'Comment') {
+    /** @type {import('youtubei.js').YTNodes.Comment} */
+    const comment_ = comment
+
+    parsed.memberIconUrl = comment_.is_member ? comment_.sponsor_comment_badge.custom_badge[0].url : ''
+    parsed.time = toLocalePublicationString({ publishText: comment_.published.text.replace('(edited)', '').trim() })
+    parsed.likes = comment_.vote_count
+    parsed.numReplies = comment_.reply_count
+  } else {
+    /** @type {import('youtubei.js').YTNodes.CommentView} */
+    const commentView = comment
+
+    parsed.memberIconUrl = commentView.is_member ? commentView.member_badge.url : ''
+    parsed.time = toLocalePublicationString({ publishText: commentView.published_time.replace('(edited)', '').trim() })
+    parsed.likes = commentView.like_count
+    parsed.numReplies = parseLocalSubscriberCount(commentView.reply_count)
+  }
+
+  return parsed
 }
 
 /**


### PR DESCRIPTION
# Add support for CommentViews in video comments

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Related issue
closes #4724

## Description
This pull request adds support for the CommentView nodes that YouTube is currently A/B testing in the video comments.

## Testing <!-- for code that is not small enough to be easily understandable -->
Please test the comments on various videos. Here are two special cases that should be tested:
Formatting (bold, italics, strikethrough): `https://youtu.be/OqiXFXlYFi8`
Member icon, as well as custom and normal emojis: https://youtu.be/v3wm83zoSSY

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 8fa8e1fd99bf45adff5364f56ede2b6831e0f53e

## Additional context
As a bonus of me adding suppor for parsing text formatting in attributed text, you will now also see formatting in video descriptions e.g.: `https://youtu.be/OyVK4M7sgDE`