### PR TITLE
Skip jobs instead of just steps in the auto merge and duplicate label workflows

### DIFF
--- a/.github/workflows/autoLabelDuplicate.yml
+++ b/.github/workflows/autoLabelDuplicate.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   test:
+    if: github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER'
     runs-on: ubuntu-latest
     steps:
       - name: Check Comment Author
-        if: github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' 
         uses: Amwam/issue-comment-action@v1.3.1
         with:
           keywords: '["duplicate of #", "duplicate of https://github.com/FreeTubeApp/FreeTube/issues/", "duplicate of https://github.com/FreeTubeApp/FreeTube/pulls/"]'

--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -5,11 +5,11 @@ on:
 
 jobs:
   build:
+    if: ${{ !github.event.pull_request.draft && (contains(github.event.pull_request.base.ref, 'development') || contains(github.event.pull_request.base.ref, 'RC')) }}
     runs-on: ubuntu-latest
 
     steps:
     - name: Auto Merge PR
-      if: ${{ !github.event.pull_request.draft && (contains(github.event.pull_request.base.ref, 'development') || contains(github.event.pull_request.base.ref, 'RC')) }}
       run: |
         echo ${{ secrets.PUSH_TOKEN }} >> auth.txt
         gh auth login --with-token < auth.txt


### PR DESCRIPTION
# Skip jobs instead of just steps in the auto merge and duplicate label workflows

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently when the auto merge or duplicate labelling workflow can be skipped, they will start a runner to run the job, skip the step/do nothing and then stop the runner, that is because the check for whether they need to run or not, is on the step level. If we instead move the check up to the job level, that allows GitHub to skip the entire job, which means it doesn't need to start a runner to do nothing anymore.

Example of one of those empty job runs: https://github.com/FreeTubeApp/FreeTube/actions/runs/8424972810