### PR TITLE
Stop setting node modules path now that we bundle the modules

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -126,10 +126,7 @@ const config = {
     new HtmlWebpackPlugin({
       excludeChunks: ['processTaskWorker'],
       filename: 'index.html',
-      template: path.resolve(__dirname, '../src/index.ejs'),
-      nodeModules: isDevMode
-        ? path.resolve(__dirname, '../node_modules')
-        : false,
+      template: path.resolve(__dirname, '../src/index.ejs')
     }),
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -136,8 +136,7 @@ const config = {
     new HtmlWebpackPlugin({
       excludeChunks: ['processTaskWorker'],
       filename: 'index.html',
-      template: path.resolve(__dirname, '../src/index.ejs'),
-      nodeModules: false,
+      template: path.resolve(__dirname, '../src/index.ejs')
     }),
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -9,13 +9,6 @@
     <link rel="manifest" href="static/manifest.json" />
     <% } %>
     <title></title>
-    <% if (htmlWebpackPlugin.options.nodeModules) { %>
-    <script>
-      require('module').globalPaths.push(
-        `<%= htmlWebpackPlugin.options.nodeModules.replace(/\\/g, '\\\\') %>`
-      )
-    </script>
-    <% } %>
   </head>
 
   <body>


### PR DESCRIPTION
# Stop setting node modules path now that we bundle the modules

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Code cleanup

## Description
For a long time now (since we switched to YouTube.js), we have been bundling the modules that we import, instead of importing them at runtime. As the only runtime imports in the `renderer` process are `fs/promises`, `path`, `zlib`, `util` and `electron`, which are all built into Electron, we no longer need to be adding the `node_modules` folder the the list of locations to import modules from.

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn run dev` if you get no import issues (you shouldn't) everything is good.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 8fa8e1fd99bf45adff5364f56ede2b6831e0f53e