### PR TITLE
Move usingElectron from computed into data

### DIFF
--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -26,6 +26,7 @@ export default defineComponent({
   },
   data: function () {
     return {
+      usingElectron: process.env.IS_ELECTRON,
       formatValues: [
         'dash',
         'legacy',
@@ -60,10 +61,6 @@ export default defineComponent({
     }
   },
   computed: {
-    usingElectron: function () {
-      return process.env.IS_ELECTRON
-    },
-
     backendPreference: function () {
       return this.$store.getters.getBackendPreference
     },

--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -20,6 +20,7 @@ export default defineComponent({
   },
   data: function () {
     return {
+      usingElectron: process.env.IS_ELECTRON,
       minUiScale: 50,
       maxUiScale: 300,
       uiScaleStep: 5,
@@ -122,10 +123,6 @@ export default defineComponent({
 
     areColorThemesEnabled: function() {
       return this.baseTheme !== 'hotPink'
-    },
-
-    usingElectron: function () {
-      return process.env.IS_ELECTRON
     }
   },
   mounted: function () {

--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -39,14 +39,11 @@ export default defineComponent({
   },
   data: function () {
     return {
+      usingElectron: process.env.IS_ELECTRON,
       unlocked: false
     }
   },
   computed: {
-    usingElectron: function () {
-      return process.env.IS_ELECTRON
-    },
-
     settingsPassword: function () {
       return this.$store.getters.getSettingsPassword
     },


### PR DESCRIPTION
# Move usingElectron from computed into data

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Code cleanup

## Description
As that value is set at build time and never changes at runtime, we don't need any of the benefits of a computed property (avoiding doing costly operations more often than necessary), so it's better suited in `data`.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the external player settings still show up in the Electron build (`yarn run dev`), check that they are still correctly hidden in the web build (`yarn run dev:web`).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 8fa8e1fd99bf45adff5364f56ede2b6831e0f53e