### PR TITLE
Create empty subscriptions cache objects directly instead of cloning

### DIFF
--- a/src/renderer/store/modules/subscriptions.js
+++ b/src/renderer/store/modules/subscriptions.js
@@ -1,9 +1,3 @@
-import { deepCopy } from '../../helpers/utils'
-
-const defaultCacheEntryValueForForOneChannel = {
-  videos: null,
-}
-
 const state = {
   videoCache: {},
   liveCache: {},
@@ -77,7 +71,7 @@ const actions = {
 const mutations = {
   updateVideoCacheByChannel(state, { channelId, videos }) {
     const existingObject = state.videoCache[channelId]
-    const newObject = existingObject != null ? existingObject : deepCopy(defaultCacheEntryValueForForOneChannel)
+    const newObject = existingObject ?? { videos: null }
     if (videos != null) { newObject.videos = videos }
     state.videoCache[channelId] = newObject
   },
@@ -86,7 +80,7 @@ const mutations = {
   },
   updateShortsCacheByChannel(state, { channelId, videos }) {
     const existingObject = state.shortsCache[channelId]
-    const newObject = existingObject != null ? existingObject : deepCopy(defaultCacheEntryValueForForOneChannel)
+    const newObject = existingObject ?? { videos: null }
     if (videos != null) { newObject.videos = videos }
     state.shortsCache[channelId] = newObject
   },
@@ -120,7 +114,7 @@ const mutations = {
   },
   updateLiveCacheByChannel(state, { channelId, videos }) {
     const existingObject = state.liveCache[channelId]
-    const newObject = existingObject != null ? existingObject : deepCopy(defaultCacheEntryValueForForOneChannel)
+    const newObject = existingObject ?? { videos: null }
     if (videos != null) { newObject.videos = videos }
     state.liveCache[channelId] = newObject
   },
@@ -129,7 +123,7 @@ const mutations = {
   },
   updatePostsCacheByChannel(state, { channelId, posts }) {
     const existingObject = state.postsCache[channelId]
-    const newObject = existingObject != null ? existingObject : deepCopy(defaultCacheEntryValueForForOneChannel)
+    const newObject = existingObject ?? { posts: null }
     if (posts != null) { newObject.posts = posts }
     state.postsCache[channelId] = newObject
   },


### PR DESCRIPTION
# Create empty subscriptions cache objects directly instead of cloning

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Performance improvement

## Description
As the empty subscriptions cache object is so simple, we might as well just create it directly, instead of going through `JSON.stringify` and `JSON.parse`. Especially for the posts cache, the cloning made no sense, as it uses the `posts` property but we were cloning an object with a `videos` property, so each post cache entry contained an unused `videos: null` property.

If the cache objects get more complex in the future, we can always move the creation code into a function that returns the objects, that will still be faster than going through `JSON.stringify` and `JSON.parse`, which also create temporary strings that then need to get garbage collected.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Refresh your subscriptions
2. Leave the subscriptions page
3. Come back to it
4. Your cached subscriptions should show up just like before.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 255ba91aef9f017a3710f9a0c9ef87fc382c5b4b