### PR TITLE
Fix the web build's manifest.json file getting included in the electron build

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -56,7 +56,7 @@ if (!isDevMode) {
             to: path.join(__dirname, '../dist/static'),
             globOptions: {
               dot: true,
-              ignore: ['**/.*', '**/locales/**', '**/pwabuilder-sw.js', '**/dashFiles/**', '**/storyboards/**'],
+              ignore: ['**/.*', '**/locales/**', '**/pwabuilder-sw.js', '**/manifest.json', '**/dashFiles/**', '**/storyboards/**'],
             },
           },
       ]


### PR DESCRIPTION
# Fix the web build's manifest.json file getting included in the electron build

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
The manifest.json file is used for PWAs to let the browser/operating system know metadata about the PWA and control how the PWA behaves. Docs here: https://developer.mozilla.org/en-US/docs/Web/Manifest

As the Electron build isn't a PWA, we don't need to include that file.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 6d8f45ee7df6b08fd0a233fe3c313b7338b53814