### PR TITLE
Fix the left arrow key not working on the first button in prompts

### DIFF
--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -77,7 +77,7 @@ export default defineComponent({
     focusItem: function (value) {
       let index = value
       if (index < 0) {
-        index = this.promptButtons.length
+        index = this.promptButtons.length - 1
       } else if (index >= this.promptButtons.length) {
         index = 0
       }


### PR DESCRIPTION
# Fix the left arrow key not working on the first button in prompts

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Pressing the right arrow key while the focus is on the last button in the prompt, move the focus to the first button in the prompt. However if you try to do the equivalent action on the first button with the left arrow key, nothing happens. This pull request makes the focus correctly move to the last button in the prompt.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open the `Data Settings`
2. Click the `Export Subscriptions` button
3. Press the left arrow key
4. The focus should move to the `Close` button

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** dd19ac8c7f3484b563bcc5199af816ab991b670d