### PR TITLE
Parse compact numbers without using floating point numbers to avoid accuracy issues

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1088,32 +1088,40 @@ export function filterLocalFormats(formats, allowAv1 = false) {
 }
 
 /**
- * Really not a fan of this :(, YouTube returns the subscribers as "15.1M subscribers"
- * so we have to parse it somehow
  * @param {string} text
  */
 export function parseLocalSubscriberCount(text) {
-  const match = text
-    .replace(',', '.')
-    .toUpperCase()
-    .match(/([\d.]+)\s*([KM]?)/)
+  const match = text.match(/(\d+)(?:[,.](\d+))?\s?([BKMbkm])\b/)
 
-  let subscribers
   if (match) {
-    subscribers = parseFloat(match[1])
+    let multiplier = 0
 
-    if (match[2] === 'K') {
-      subscribers *= 1000
-    } else if (match[2] === 'M') {
-      subscribers *= 1000_000
+    switch (match[3]) {
+      case 'K':
+      case 'k':
+        multiplier = 3
+        break
+      case 'M':
+      case 'm':
+        multiplier = 6
+        break
+      case 'B':
+      case 'b':
+        multiplier = 9
+        break
     }
 
-    subscribers = Math.trunc(subscribers)
-  } else {
-    subscribers = extractNumberFromString(text)
-  }
+    let parsedDecimals
+    if (typeof match[2] === 'undefined') {
+      parsedDecimals = '0'.repeat(multiplier)
+    } else {
+      parsedDecimals = match[2].padEnd(multiplier, '0')
+    }
 
-  return subscribers
+    return parseInt(match[1] + parsedDecimals)
+  } else {
+    return extractNumberFromString(text)
+  }
 }
 
 /**


### PR DESCRIPTION
# Parse compact numbers without using floating point numbers to avoid accuracy issues

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4808

## Description
As computers are designed to store whole number, JavaScript like many programming languages doesn't store floating point numbers as their literal value, instead they use floating-point arithmetic. Unfortunately as floating-point arithmetic is an approximation of the real value and not the actual value, it can occasionally be inaccurate, such as with `parseFloat('4.02') * 10` which results in `40.199999999999996`.
The wikipedia page on floating-point arithmetic is a good read if you want to know more about it: https://en.wikipedia.org/wiki/Floating-point_arithmetic

To avoid the inaccuracy issues mentioned above, this pull request changes the compact number parsing logic from using floating point numbers, to operating on the strings and then calling `parseInt`. There might be a better way of doing this, but this is the implementation I came up with as a shower thought, it works and is quite readable, so I think it's okay.

At some point we should probably rename the function, as it is now used in many more places than just parsing subscriber counts (maybe `parseLocalCompactNumber` ?).

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit `https://www.youtube.com/@CasuallyExplained` (the channel mentioned in the issue) and check that FreeTube shows the subscriber count as `4,020,000` instead of `4,019,999`.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 255ba91aef9f017a3710f9a0c9ef87fc382c5b4b