### PR TITLE
Update add video to playlist prompt to show presence count when adding 2+ videos

### DIFF
--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
@@ -90,8 +90,9 @@ export default defineComponent({
     multiVideoPresenceCountInPlaylistText() {
       if (this.multiVideoPresenceCountInPlaylist == null) { return null }
 
-      return this.$tc('User Playlists.AddVideoPrompt.{videoCount} Videos Already Added', this.multiVideoPresenceCountInPlaylist, {
+      return this.$tc('User Playlists.AddVideoPrompt.{videoCount}/{totalVideoCount} Videos Already Added', this.multiVideoPresenceCountInPlaylist, {
         videoCount: this.multiVideoPresenceCountInPlaylist,
+        totalVideoCount: this.toBeAddedToPlaylistVideoList.length,
       })
     },
     videoPresenceCountInPlaylistText() {

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
@@ -75,10 +75,32 @@ export default defineComponent({
         count: this.loneVideoPresenceCountInPlaylist,
       })
     },
+    multiVideoPresenceCountInPlaylist() {
+      if (this.toBeAddedToPlaylistVideoList.length < 2) { return null }
+
+      // Count of to be added videos already present in this playlist
+      const v = this.toBeAddedToPlaylistVideoList.reduce((accumulator, toBeAddedToVideo) => {
+        return this.playlist.videos.some((pv) => pv.videoId === toBeAddedToVideo.videoId)
+          ? accumulator + 1
+          : accumulator
+      }, 0)
+      // Don't display zero value
+      return v === 0 ? null : v
+    },
+    multiVideoPresenceCountInPlaylistText() {
+      if (this.multiVideoPresenceCountInPlaylist == null) { return null }
+
+      return this.$tc('User Playlists.AddVideoPrompt.{videoCount} Videos Already Added', this.multiVideoPresenceCountInPlaylist, {
+        videoCount: this.multiVideoPresenceCountInPlaylist,
+      })
+    },
+    videoPresenceCountInPlaylistText() {
+      return this.loneVideoPresenceCountInPlaylistText ?? this.multiVideoPresenceCountInPlaylistText
+    },
     videoPresenceCountInPlaylistTextVisible() {
       if (!this.videoPresenceCountInPlaylistTextShouldBeVisible) { return false }
 
-      return this.loneVideoPresenceCountInPlaylistText != null
+      return this.videoPresenceCountInPlaylistText != null
     },
   },
   created: function () {

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.vue
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.vue
@@ -45,7 +45,7 @@
         v-if="videoPresenceCountInPlaylistTextVisible"
         class="videoPresenceCount"
       >
-        {{ loneVideoPresenceCountInPlaylistText }}
+        {{ videoPresenceCountInPlaylistText }}
       </div>
     </div>
   </div>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -218,7 +218,7 @@ User Playlists:
     Save: Save
 
     Added {count} Times: 'Added {count} Time | Added {count} Times'
-    "{videoCount} Videos Already Added": '{videoCount} Video Already Added | {videoCount} Videos Already Added'
+    "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Video Already Added | {videoCount}/{totalVideoCount} Videos Already Added'
 
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -218,6 +218,7 @@ User Playlists:
     Save: Save
 
     Added {count} Times: 'Added {count} Time | Added {count} Times'
+    "{videoCount} Videos Already Added": '{videoCount} Video Already Added | {videoCount} Videos Already Added'
 
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow up of https://github.com/FreeTubeApp/FreeTube/pull/4561

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When adding **2+** videos, display no. of videos already added in individual playlists
If not already added nothing extra would be displayed

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/7b0cef96-b291-43df-bd85-2339d241d850)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Create Playlist (A) & (B) (if needed)
- Add a video to A & B, 2nd video to A, 3rd video to B
- Try to copy playlist A/B

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
