### PR TITLE
Add support for sorting the shorts tab by oldest on the local API

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -105,14 +105,10 @@ export default defineComponent({
       errorMessage: '',
       showSearchBar: true,
       showShareMenu: true,
-      videoLiveSelectValues: [
+      videoLiveShortSelectValues: [
         'newest',
         'popular',
         'oldest'
-      ],
-      shortSelectValues: [
-        'newest',
-        'popular'
       ],
       playlistSelectValues: [
         'newest',
@@ -184,18 +180,11 @@ export default defineComponent({
       return profileList[0].subscriptions.some((channel) => channel.id === this.id)
     },
 
-    videoLiveSelectNames: function () {
+    videoLiveShortSelectNames: function () {
       return [
         this.$t('Channel.Videos.Sort Types.Newest'),
         this.$t('Channel.Videos.Sort Types.Most Popular'),
         this.$t('Channel.Videos.Sort Types.Oldest')
-      ]
-    },
-
-    shortSelectNames: function () {
-      return [
-        this.$t('Channel.Videos.Sort Types.Newest'),
-        this.$t('Channel.Videos.Sort Types.Most Popular')
       ]
     },
 
@@ -769,7 +758,7 @@ export default defineComponent({
         this.showVideoSortBy = videosTab.filters.length > 1
 
         if (this.showVideoSortBy && this.videoSortBy !== 'newest') {
-          const index = this.videoLiveSelectValues.indexOf(this.videoSortBy)
+          const index = this.videoLiveShortSelectValues.indexOf(this.videoSortBy)
           videosTab = await videosTab.applyFilter(videosTab.filters[index])
         }
 
@@ -837,7 +826,7 @@ export default defineComponent({
         this.showShortSortBy = shortsTab.filters.length > 1
 
         if (this.showShortSortBy && this.shortSortBy !== 'newest') {
-          const index = this.shortSelectValues.indexOf(this.shortSortBy)
+          const index = this.videoLiveShortSelectValues.indexOf(this.shortSortBy)
           shortsTab = await shortsTab.applyFilter(shortsTab.filters[index])
         }
 
@@ -905,7 +894,7 @@ export default defineComponent({
         this.showLiveSortBy = liveTab.filters.length > 1
 
         if (this.showLiveSortBy && this.liveSortBy !== 'newest') {
-          const index = this.videoLiveSelectValues.indexOf(this.liveSortBy)
+          const index = this.videoLiveShortSelectValues.indexOf(this.liveSortBy)
           liveTab = await liveTab.applyFilter(liveTab.filters[index])
         }
 

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -233,27 +233,27 @@
         <ft-select
           v-if="showVideoSortBy"
           v-show="currentTab === 'videos' && latestVideos.length > 0"
-          :value="videoLiveSelectValues[0]"
-          :select-names="videoLiveSelectNames"
-          :select-values="videoLiveSelectValues"
+          :value="videoLiveShortSelectValues[0]"
+          :select-names="videoLiveShortSelectNames"
+          :select-values="videoLiveShortSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"
           @change="videoSortBy = $event"
         />
         <ft-select
           v-if="!hideChannelShorts && showShortSortBy"
           v-show="currentTab === 'shorts' && latestShorts.length > 0"
-          :value="shortSelectValues[0]"
-          :select-names="shortSelectNames"
-          :select-values="shortSelectValues"
+          :value="videoLiveShortSelectValues[0]"
+          :select-names="videoLiveShortSelectNames"
+          :select-values="videoLiveShortSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"
           @change="shortSortBy = $event"
         />
         <ft-select
           v-if="!hideLiveStreams && showLiveSortBy"
           v-show="currentTab === 'live' && latestLive.length > 0"
-          :value="videoLiveSelectValues[0]"
-          :select-names="videoLiveSelectNames"
-          :select-values="videoLiveSelectValues"
+          :value="videoLiveShortSelectValues[0]"
+          :select-names="videoLiveShortSelectNames"
+          :select-values="videoLiveShortSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"
           @change="liveSortBy = $event"
         />


### PR DESCRIPTION
# Add support for sorting the shorts tab by oldest on the local API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Description
YouTube finally added support for sorting the shorts tab by oldest, which they never added back, unlike the videos and live tabs.
This pull request adds support for that, on the local API only of course, as it might take Invidious a while to catch up (they don't support sorting the live or shorts tabs at all yet).

## Testing <!-- for code that is not small enough to be easily understandable -->
Visit a channel with shorts on the local API such as https://www.youtube.com/@GibiASMR/shorts and test that sorting by oldest works and that I didn't break the other sorting options.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d7b7a40fa3eadd9350d36c6d254d2332274c6481