### PR TITLE
Bump Node.js from 18.x to 20.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
         runtime:
           - linux-x64
           - linux-armv7l


### PR DESCRIPTION
# Bump Node.js from 18.x to 20.x

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
Nothing

## Description
Only update Node.js in action from 18 to 20

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
Tested in fork repository with Actions

## Desktop
- **OS: all**
- **OS Version: all**
 