### PR TITLE
Move ft-list-channel specific css to ft-list-channel.scss

### DIFF
--- a/src/renderer/components/ft-list-channel/ft-list-channel.scss
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.scss
@@ -1,5 +1,44 @@
 @use '../../scss-partials/_ft-list-item';
 
+.ft-list-channel {
+  &.grid {
+    align-items: center;
+    text-align: center;
+
+    .infoAndSubscribe {
+      flex-flow: column wrap;
+      align-items: center;
+
+      .info {
+        margin-block-end: 12px;
+
+        .infoLine {
+          text-align: center;
+        }
+      }
+    }
+  }
+
+  &.list {
+    .infoAndSubscribe {
+      flex-flow: row wrap;
+      justify-content: center;
+
+      .channelSubscribeButton {
+        margin-block: auto;
+        margin-inline: 7px;
+      }
+    }
+  }
+}
+
+.infoAndSubscribe {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  inline-size: 100%;
+}
+
 .handle {
   color: inherit;
   text-decoration: none;

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -386,45 +386,6 @@ $watched-transition-duration: 0.5s;
   }
 }
 
-.ft-list-channel {
-  .infoAndSubscribe {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: center;
-    inline-size: 100%;
-  }
-
-  &.grid {
-    align-items: center;
-    text-align: center;
-
-    .infoAndSubscribe {
-      flex-flow: column wrap;
-      align-items: center;
-
-      .info {
-        margin-block-end: 12px;
-
-        .infoLine {
-          text-align: center;
-        }
-      }
-    }
-  }
-
-  &.list {
-    .infoAndSubscribe {
-      flex-flow: row wrap;
-      justify-content: center;
-
-      .channelSubscribeButton {
-        margin-block: auto;
-        margin-inline: 7px;
-      }
-    }
-  }
-}
-
 .videoWatched,
 .live,
 .upcoming {


### PR DESCRIPTION
# Move ft-list-channel specific css to ft-list-channel.scss

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Cleanup

## Description
This pull request move CSS that is only used by the `ft-list-channel` component into the `ft-list-channel.scss` file from the `_ft-list-item.scss` file. Not only does this make it easier to find when someone looks for it in the future, it also reduces the CSS output (`renderer.[hash].css`) by `2777` bytes.

Why does the output shrink just by copying it from one file to another?

SCSS' `@use` directive copies the referenced CSS into the file that has the `@use` directive, that means it is copied into 5 files/components `ft-list-video`, `ft-list-channel`, `ft-list-playlist`, `ft-list-hashtag` and `ft-community-post`. That copying is good, because it means we have consistent styling across our list components and Vue can correctly scope the CSS to the component. In this case however, it's CSS that is only used in one of those five components, so it doesn't make sense to copy it into the other four.

## Testing <!-- for code that is not small enough to be easily understandable -->
Search for a channel (e.g. MrBeast) and check that it appears correct in the search results.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0