### PR TITLE
Add more options to playback rate menu

### DIFF
--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -121,7 +121,7 @@
         :default-value="defaultPlayback"
         :min-value="0.25"
         :max-value="8"
-        :step="0.25"
+        :step="videoPlaybackRateInterval"
         value-extension="x"
         @change="updateDefaultPlayback"
       />


### PR DESCRIPTION
# Add more options to playback rate menu

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #4564 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This pull request makes the playback rate menu smoother by providing users with more playback options at intervals of 0.05 from 0.25 to 3

## Desktop
<!-- Please complete the following information-->
- **OS:** Ubuntu
- **OS Version:** 22.04
- **FreeTube version:** 0.20.0
