### PR TITLE
Fix consecutive sponsor segments not being skipped.

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -146,7 +146,7 @@ export default defineComponent({
       showStatsModal: false,
       statsModalEventName: 'updateStats',
       usingTouch: false,
-      manuallySeeked: false,
+      isManuallySeeking: false,
       dataSetup: {
         fluid: true,
         nativeTextTracks: false,
@@ -747,21 +747,21 @@ export default defineComponent({
 
           this.player.ready(() => {
             this.player.on('timeupdate', () => {
-              if (this.manuallySeeked === true) {
-                return // prevent race condition with ignoreSponsorBlock
+              if (this.isManuallySeeking === true) {
+                return
               }
               this.skipSponsorBlocks(skipSegments)
             })
 
             this.player.controlBar.progressControl.seekBar.on('mousedown', () => {
               // disabling sponsors auto skipping when the user manually seeks
-              this.manuallySeeked = true
+              this.isManuallySeeking = true
             })
 
             const mouseupListener = () => {
-              if (this.manuallySeeked) {
+              if (this.isManuallySeeking) {
                 this.ignoreSponsorBlock(skipSegments)
-                this.manuallySeeked = false
+                this.isManuallySeeking = false
               }
             }
             // needs listener on document for when mousedown has started on seekbar but mouseup off seekbar (dragged)

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -24,7 +24,6 @@ import {
 } from '../../helpers/utils'
 import { getProxyUrl } from '../../helpers/api/invidious'
 import store from '../../store'
-import keycode from 'keycode' // package already exists via video.js
 
 const EXPECTED_PLAY_RELATED_ERROR_MESSAGES = [
   // This is thrown when `play()` called but user already viewing another page
@@ -769,10 +768,9 @@ export default defineComponent({
             document.addEventListener('mouseup', mouseupListener)
 
             // Also handle seeking via keyboard
-            // https://docs.videojs.com/control-bar_progress-control_seek-bar.js#line435
             const keydownListener = (event) => {
-              const keys = ['Left', 'Right', 'pgup', 'pgdn']
-              if (/^\d$/.test(keycode(event)) || keys.some(key => keycode.isEventKey(event, key))) {
+              const keys = ['ArrowLeft', 'ArrowRight', 'PageUp', 'PageDown']
+              if (/^\d$/.test(event.key) || keys.some(key => event.key === key)) {
                 this.ignoreSponsorBlock(skipSegments)
               }
             }

--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -826,12 +826,14 @@ export default defineComponent({
 
     ignoreSponsorBlock(skipSegments) {
       const currentTime = this.player.currentTime()
-      for (let index = 0; index < skipSegments.length; index++) {
-        if (skipSegments[index].segment[0] <= currentTime && currentTime < skipSegments[index].segment[1]) {
+      skipSegments.forEach(segment => {
+        const startTime = segment.segment[0]
+        const endTime = segment.segment[1]
+        if (startTime <= currentTime && currentTime < endTime) {
           // set ignore flag on segment at current time
-          skipSegments[index].ignore = true
+          segment.ignore = true
         }
-      }
+      })
     },
 
     showSkippedSponsorSegmentInformation(category) {

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -120,7 +120,7 @@ User Playlists:
     только те видео, которые вы сохранили или добавили в избранное. После переработки
     этой страницы все видео, которые сейчас находятся здесь, переместятся в подборку
     «Избранное».
-  Search bar placeholder: Поиск в подборке
+  Search bar placeholder: Поиск подборок
   Empty Search Message: В этой подборке нет видео, соответствующих вашему запросу
   This playlist currently has no videos.: Пока в этой подборке нет видео.
   Add to Playlist: Добавить в подборку
@@ -162,6 +162,7 @@ User Playlists:
       This video cannot be moved up.: Это видео нельзя передвинуть вверх.
       This video cannot be moved down.: Это видео нельзя передвинуть вниз.
       Video has been removed: Видео было удалено
+    Search for Videos: Поиск видео
   AddVideoPrompt:
     N playlists selected: '{playlistCount} выбрано'
     Search in Playlists: Поиск подборок
@@ -193,6 +194,8 @@ User Playlists:
   You have no playlists. Click on the create new playlist button to create a new one.: У
     тебя нет подборок. Нажми на кнопку создания новой подборки, чтобы создать новую.
   Create New Playlist: Создать новую подборку
+  Add to Favorites: Добавить в {playlistName}
+  Remove from Favorites: Убрать из {playlistName}
 History:
   # On History Page
   History: 'История'
@@ -506,8 +509,8 @@ Settings:
     Hide Upcoming Premieres: Скрыть предстоящие премьеры
     Hide Channels Placeholder: Идентификатор канала
     Hide Channels: Скрыть видео с каналов
-    Display Titles Without Excessive Capitalisation: Отображать заголовки без чрезмерного
-      использования заглавных букв
+    Display Titles Without Excessive Capitalisation: Отображать заголовки без сплошных
+      заглавных букв и знаков препинания
     Hide Featured Channels: Скрыть избранные каналы
     Hide Channel Playlists: Скрыть подборки канала
     Hide Channel Community: Скрыть сообщество канала


### PR DESCRIPTION
# Fix consecutive sponsor segments not being skipped

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #3534

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Changed the implementation of sponsors auto skip. It instead relies on the `mousedown` event on the player's seekbar to detect manual seeking via user input, meaning sponsor segments can now be safely skipped consecutively. I also added a listener for the keyboard hotkeys used for seeking, to prevent auto skipping when moving into a sponsored segment that way. These event listeners are disposed of alongside the Player dispose event as I didn't want them left in the global scope (`document`).

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
I performed testing on a video with sponsored segments. I tested seeking on the player via clicking, clicking and dragging, and keyboard hotkeys. Currently there are no ramifications I have found. 

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10 Pro
- **OS Version:** 22H2
- **FreeTube version:** 0.20.0

## Additional context
<!-- Add any other context about the pull request here. -->
The `keycode` package used to pick up the keyboard hotkeys already exists within the FreeTube project via `video.js`, I didn't add it myself for the purpose of this bugfix.