### PR TITLE
Use blob URLs for storyboards instead of writing them to the file system

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build-release": "node _scripts/build.js",
     "build-release:arm64": "node _scripts/build.js arm64",
     "build-release:arm32": "node _scripts/build.js arm32",
-    "clean": "rimraf build/ static/dashFiles/ dist/ static/storyboards/",
+    "clean": "rimraf build/ dist/",
     "debug": "run-s rebuild:electron debug-runner",
     "debug-runner": "node _scripts/dev-runner.js --remote-debug",
     "dev": "run-s rebuild:electron dev-runner",

--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -39,9 +39,6 @@ export default defineComponent({
     saveVideoHistoryWithLastViewedPlaylist: function () {
       return this.$store.getters.getSaveVideoHistoryWithLastViewedPlaylist
     },
-    removeVideoMetaFiles: function () {
-      return this.$store.getters.getRemoveVideoMetaFiles
-    },
 
     profileList: function () {
       return this.$store.getters.getProfileList
@@ -72,13 +69,6 @@ export default defineComponent({
       }
 
       this.updateRememberHistory(value)
-    },
-
-    handleVideoMetaFiles: function (value) {
-      if (!value) {
-        this.updateRemoveVideoMetaFiles(false)
-      }
-      this.updateRemoveVideoMetaFiles(value)
     },
 
     handleRemoveHistory: function (option) {
@@ -126,7 +116,6 @@ export default defineComponent({
 
     ...mapActions([
       'updateRememberHistory',
-      'updateRemoveVideoMetaFiles',
       'removeAllHistory',
       'updateSaveWatchedProgress',
       'updateSaveVideoHistoryWithLastViewedPlaylist',

--- a/src/renderer/components/privacy-settings/privacy-settings.vue
+++ b/src/renderer/components/privacy-settings/privacy-settings.vue
@@ -29,15 +29,6 @@
           @change="updateSaveVideoHistoryWithLastViewedPlaylist"
         />
       </div>
-      <div class="switchColumn">
-        <ft-toggle-switch
-          :label="$t('Settings.Privacy Settings.Automatically Remove Video Meta Files')"
-          :compact="true"
-          :default-value="removeVideoMetaFiles"
-          :tooltip="$t('Tooltips.Privacy Settings.Remove Video Meta Files')"
-          @change="handleVideoMetaFiles"
-        />
-      </div>
     </div>
     <br>
     <ft-flex-box>

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -240,7 +240,6 @@ const state = {
   proxyVideos: !process.env.IS_ELECTRON,
   region: 'US',
   rememberHistory: true,
-  removeVideoMetaFiles: true,
   saveWatchedProgress: true,
   saveVideoHistoryWithLastViewedPlaylist: true,
   showFamilyFriendlyOnly: false,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1,6 +1,5 @@
 import { defineComponent } from 'vue'
 import { mapActions } from 'vuex'
-import fs from 'fs/promises'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtVideoPlayer from '../../components/ft-video-player/ft-video-player.vue'
 import WatchVideoInfo from '../../components/watch-video-info/watch-video-info.vue'
@@ -12,14 +11,12 @@ import WatchVideoPlaylist from '../../components/watch-video-playlist/watch-vide
 import WatchVideoRecommendations from '../../components/watch-video-recommendations/watch-video-recommendations.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
 import packageDetails from '../../../../package.json'
-import { pathExists } from '../../helpers/filesystem'
 import {
   buildVTTFileLocally,
   copyToClipboard,
   formatDurationAsTimestamp,
   formatNumber,
   getFormatsFromHLSManifest,
-  getUserDataPath,
   showToast
 } from '../../helpers/utils'
 import {
@@ -140,9 +137,6 @@ export default defineComponent({
     },
     rememberHistory: function () {
       return this.$store.getters.getRememberHistory
-    },
-    removeVideoMetaFiles: function () {
-      return this.$store.getters.getRemoveVideoMetaFiles
     },
     saveWatchedProgress: function () {
       return this.$store.getters.getSaveWatchedProgress
@@ -703,7 +697,7 @@ export default defineComponent({
           }
 
           if (result.storyboards?.type === 'PlayerStoryboardSpec') {
-            await this.createLocalStoryboardUrls(result.storyboards.boards.at(-1))
+            this.createLocalStoryboardUrls(result.storyboards.boards.at(-1))
           }
         }
 
@@ -1400,9 +1394,7 @@ export default defineComponent({
       this.playNextCountDownIntervalId = setInterval(showCountDownMessage, 1000)
     },
 
-    handleRouteChange: async function (videoId) {
-      // if the user navigates to another video, the ipc call for the userdata path
-      // takes long enough for the video id to have already changed to the new one
+    handleRouteChange: function (videoId) {
       // receiving it as an arg instead of accessing it ourselves means we always have the right one
 
       clearTimeout(this.playNextTimeout)
@@ -1433,21 +1425,9 @@ export default defineComponent({
         }
       }
 
-      if (process.env.IS_ELECTRON && this.removeVideoMetaFiles) {
-        if (process.env.NODE_ENV === 'development') {
-          const vttFileLocation = `static/storyboards/${videoId}.vtt`
-          // only delete the file it actually exists
-          if (await pathExists(vttFileLocation)) {
-            await fs.rm(vttFileLocation)
-          }
-        } else {
-          const userData = await getUserDataPath()
-          const vttFileLocation = `${userData}/storyboards/${videoId}.vtt`
-
-          if (await pathExists(vttFileLocation)) {
-            await fs.rm(vttFileLocation)
-          }
-        }
+      if (this.videoStoryboardSrc.startsWith('blob:')) {
+        URL.revokeObjectURL(this.videoStoryboardSrc)
+        this.videoStoryboardSrc = ''
       }
     },
 
@@ -1612,36 +1592,14 @@ export default defineComponent({
         })
     },
 
-    createLocalStoryboardUrls: async function (storyboardInfo) {
+    createLocalStoryboardUrls: function (storyboardInfo) {
       const results = buildVTTFileLocally(storyboardInfo, this.videoLengthSeconds)
-      const userData = await getUserDataPath()
-      let fileLocation
-      let uriSchema
 
-      // Dev mode doesn't have access to the file:// schema, so we access
-      // storyboards differently when run in dev
-      if (process.env.NODE_ENV === 'development') {
-        fileLocation = `static/storyboards/${this.videoId}.vtt`
-        uriSchema = `storyboards/${this.videoId}.vtt`
-        // if the location does not exist, writeFile will not create the directory, so we have to do that manually
-        if (!(await pathExists('static/storyboards/'))) {
-          fs.mkdir('static/storyboards/')
-        } else if (await pathExists(fileLocation)) {
-          await fs.rm(fileLocation)
-        }
+      // after the player migration, switch to using a data URI, as those don't need to be revoked
 
-        await fs.writeFile(fileLocation, results)
-      } else {
-        if (!(await pathExists(`${userData}/storyboards/`))) {
-          await fs.mkdir(`${userData}/storyboards/`)
-        }
-        fileLocation = `${userData}/storyboards/${this.videoId}.vtt`
-        uriSchema = `file://${fileLocation}`
+      const blob = new Blob([results], { type: 'text/vtt;charset=UTF-8' })
 
-        await fs.writeFile(fileLocation, results)
-      }
-
-      this.videoStoryboardSrc = uriSchema
+      this.videoStoryboardSrc = URL.createObjectURL(blob)
     },
 
     tryAddingTranslatedLocaleCaption: function (captionTracks, locale, baseUrl) {

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -399,7 +399,6 @@ Settings:
       أنت متأكد أنك تريد إزالة جميع الاشتراكات والملفات الشخصية؟ لا يمكن التراجع عن
       هذا.
     Remove All Subscriptions / Profiles: إزالة جميع الاشتراكات \ الملفات الشخصية
-    Automatically Remove Video Meta Files: إزالة ملفات تعريف الفيديو تلقائيًا
     Save Watched Videos With Last Viewed Playlist: حفظ مقاطع الفيديو التي تمت مشاهدتها
       مع آخر قائمة تشغيل تم عرضها
     All playlists have been removed: تمت إزالة جميع قوائم التشغيل
@@ -1068,9 +1067,6 @@ Tooltips:
     Allow DASH AV1 formats: قد تبدو تنسيقات DASH AV1 أفضل من تنسيقات DASH H.264. تتطلب
       تنسيقات DASH AV1 مزيدا من الطاقة للتشغيل! وهي غير متوفرة في جميع مقاطع الفيديو
       ، وفي هذه الحالات سيستخدم المشغل تنسيقات DASH H.264 بدلا من ذلك.
-  Privacy Settings:
-    Remove Video Meta Files: عندما يمكن، يحذف Freetube تلقائيًا ملفات التعريف التي
-      تم إنشاؤها أثناء تشغيل الفيديو ، عندما تكون صفحة المشاهدة مغلقة.
   Subscription Settings:
     Fetch Feeds from RSS: عند تفعيلها، سوف يستخدم فريتيوب طريقة RSS بدلًا من طريقته
       المعتادة لجلب صفحة اشتراكاتك. طريقة RSS أسرع وتتخطى حجب الآي بي IP، لكنها لا

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -307,7 +307,6 @@ Settings:
     Remember History: ''
     Save Watched Progress: ''
     Save Watched Videos With Last Viewed Playlist: ''
-    Automatically Remove Video Meta Files: ''
     Clear Search Cache: ''
     Are you sure you want to clear out your search cache?: ''
     Search cache has been cleared: ''
@@ -802,8 +801,6 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: ''
     Fetch Automatically: ''
-  Privacy Settings:
-    Remove Video Meta Files: ''
   Experimental Settings:
     Replace HTTP Cache: ''
   SponsorBlock Settings:

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -415,7 +415,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Сигурни
       ли сте, че искате да премахнете всички абонаменти и профили? Това не може да
       бъде възстановено.'
-    Automatically Remove Video Meta Files: Автоматично премахване на видео метафайловете
     Save Watched Videos With Last Viewed Playlist: Запазване на гледани видеа с последно
       гледан плейлист
     Remove All Playlists: Премахване на всички плейлисти
@@ -1099,10 +1098,6 @@ Tooltips:
     External Link Handling: "Избор на поведението по подразбиране, когато щракнете
       върху връзка, която не може да бъде отворена във FreeTube.\nПо подразбиране
       FreeTube ще отвори връзката в браузъра по подразбиране.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Когато страницата за гледане бъде затворена, FreeTube
-      автоматично ще изтрива метафайловете, създадени по време на възпроизвеждане
-      на видеото.
   External Player Settings:
     Custom External Player Arguments: Всички персонализирани аргументи от командния
       ред, разделени с точка и запетая (";"), които искате да бъдат предадени на външния

--- a/static/locales/ca.yaml
+++ b/static/locales/ca.yaml
@@ -266,8 +266,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Esteu
       segur que voleu esborrar totes les subscripcions i perfils?  Aquesta acció no
       es pot desfer.'
-    Automatically Remove Video Meta Files: Suprimeix automàticament les metadades
-      dels vídeos
   Subscription Settings:
     Subscription Settings: 'Configuració de les subscripcions'
     Hide Videos on Watch: 'Oculta els vídeos visualitzats'

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -311,7 +311,6 @@ Settings:
     Remember History: ''
     Save Watched Progress: ''
     Save Watched Videos With Last Viewed Playlist: ''
-    Automatically Remove Video Meta Files: ''
     Clear Search Cache: ''
     Are you sure you want to clear out your search cache?: ''
     Search cache has been cleared: ''
@@ -818,8 +817,6 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: ''
     Fetch Automatically: ''
-  Privacy Settings:
-    Remove Video Meta Files: ''
   Experimental Settings:
     Replace HTTP Cache: ''
   SponsorBlock Settings:

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -411,7 +411,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Odstranit všechny odběry / profily'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Opravdu
       chcete odstranit všechny odběry a profily? Tato akce je nevratná.'
-    Automatically Remove Video Meta Files: Automaticky odstranit meta soubory videa
     Save Watched Videos With Last Viewed Playlist: Uložit zhlédnutá videa s naposledy
       zobrazeným playlistem
     All playlists have been removed: Všechny playlisty byly odstraněny
@@ -1057,9 +1056,6 @@ Tooltips:
 # Toast Messages
     Fetch Automatically: Při povolení tohoto nastavení bude FreeTube automaticky načítat
       vaše odběry při otevření nového okna a při přepínání profilů.
-  Privacy Settings:
-    Remove Video Meta Files: Pokud je povoleno, FreeTube automaticky odstraní meta
-      soubory vytvořené během přehrávání videa, když se stránka sledování zavře.
   External Player Settings:
     Ignore Warnings: Potlačuje varování, kdy současný externí přehrávač nepodporuje
       aktuální akci (např. obrácení seznamů skladeb apod.).

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -314,7 +314,6 @@ Settings:
     Remember History: 'Cadw Hanes'
     Save Watched Progress: ''
     Save Watched Videos With Last Viewed Playlist: ''
-    Automatically Remove Video Meta Files: ''
     Clear Search Cache: ''
     Are you sure you want to clear out your search cache?: ''
     Search cache has been cleared: ''
@@ -820,8 +819,6 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: ''
     Fetch Automatically: ''
-  Privacy Settings:
-    Remove Video Meta Files: ''
   Experimental Settings:
     Replace HTTP Cache: ''
   SponsorBlock Settings:

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -383,7 +383,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Er
       du sikker på, at du vil fjerne alle abonnementer og profiler? Dette kan ikke
       fortrydes.'
-    Automatically Remove Video Meta Files: Fjern Automatisk Video Metafiler
     All playlists have been removed: Alle playlister blev fjernet
     Are you sure you want to remove all your playlists?: Er du sikker på, at du vil
       fjerne alle dine playlister?
@@ -1010,9 +1009,6 @@ Tooltips:
       Advarsel: Invidious-indstillinger har ingen effekt på eksterne afspillere.'
     Ignore Warnings: Undertryk advarsler for når den eksterne afspiller ikke understøtter
       den gældende handling (fx vende playlister om, etc.).
-  Privacy Settings:
-    Remove Video Meta Files: Når det er aktiveret, sletter FreeTube automatisk metafiler
-      oprettet under videoafspilning, når siden lukkes.
   Distraction Free Settings:
     Hide Channels: Indtast et kanal-ID for at skjule alle videoer, playlister og selve
       kanalen fra at blive vist i søgning, trending, mest populære og anbefalet. Det

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -461,7 +461,6 @@ Settings:
       du sicher, dass du alle Abos und Profile löschen möchtest?  Diese Aktion kann
       nicht rückgängig gemacht werden.
     Remove All Subscriptions / Profiles: Alle Abos / Profile entfernen
-    Automatically Remove Video Meta Files: Video-Metadateien automatisch entfernen
     Save Watched Videos With Last Viewed Playlist: Angesehene Videos mit der zuletzt
       angesehenen Wiedergabeliste speichern
     Remove All Playlists: Alle Wiedergabelisten entfernen
@@ -1140,10 +1139,6 @@ Tooltips:
       Die DASH AV1-Formate benötigen mehr Leistung für die Wiedergabe! Sie sind nicht
       bei allen Videos verfügbar. In diesen Fällen verwendet der Abspieler stattdessen
       die DASH H.264-Formate.
-  Privacy Settings:
-    Remove Video Meta Files: Wenn aktiviert, löscht FreeTube automatisch die während
-      der Videowiedergabe erstellten Metadateien, wenn die Abspielseite geschlossen
-      wird.
   External Player Settings:
     Custom External Player Arguments: Alle benutzerdefinierten Befehlszeilenargumente,
       getrennt durch Semikolon (';'), die an den externen Abspieler übergeben werden

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -323,7 +323,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Είστε
       βέβαιοι ότι θέλετε να καταργήσετε όλες τις συνδρομές και τα προφίλ; Αυτό δεν
       μπορεί να αναιρεθεί.'
-    Automatically Remove Video Meta Files: Αυτόματη αφαίρεση μετα-αρχείων βίντεο
     Save Watched Videos With Last Viewed Playlist: Αποθήκευση Βίντεο που Παρακολουθήσατε
       Με τη Λίστα Αναπαραγωγής Τελευταίας Προβολής
   Subscription Settings:
@@ -1019,10 +1018,6 @@ Tooltips:
       σε έναν σύνδεσμο, ο οποίος δεν μπορεί να ανοίξει στο FreeTube.\nΑπό προεπιλογή,
       το FreeTube θα ανοίξει τον σύνδεσμο που έχει πατηθεί στο προεπιλεγμένο πρόγραμμα
       περιήγησης.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Όταν είναι ενεργοποιημένο, το FreeTube διαγράφει αυτόματα
-      τα μετα-αρχεία που δημιουργήθηκαν κατά την αναπαραγωγή βίντεο, όταν η σελίδα
-      παρακολούθησης είναι κλειστή.
   External Player Settings:
     Custom External Player Executable: Από προεπιλογή, το FreeTube θα υποθέσει ότι
       το επιλεγμένο εξωτερικό πρόγραμμα αναπαραγωγής μπορεί να βρεθεί μέσω της μεταβλητής

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -413,7 +413,6 @@ Settings:
     Remember History: Remember History
     Save Watched Progress: Save Watched Progress
     Save Watched Videos With Last Viewed Playlist: Save Watched Videos With Last Viewed Playlist
-    Automatically Remove Video Meta Files: Automatically Remove Video Meta Files
     Clear Search Cache: Clear Search Cache
     Are you sure you want to clear out your search cache?: Are you sure you want to
       clear out your search cache?
@@ -1003,9 +1002,6 @@ Tooltips:
       but doesn't provide certain information like video duration or live status
     Fetch Automatically: When enabled, FreeTube will automatically fetch
       your subscription feed when a new window is opened and when switching profile.
-  Privacy Settings:
-    Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files created during video playback,
-      when the watch page is closed.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -417,7 +417,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Are
       you sure you want to remove all subscriptions and profiles?  This cannot be
       undone.'
-    Automatically Remove Video Meta Files: Automatically Remove Video Meta Files
     Save Watched Videos With Last Viewed Playlist: Save Watched Videos With Last Viewed
       Playlist
     Remove All Playlists: Remove all playlists
@@ -1084,9 +1083,6 @@ Tooltips:
     Custom External Player Arguments: Any custom command line arguments, separated
       by semicolons (';'), you want to be passed to the external player.
     DefaultCustomArgumentsTemplate: '(Default: ‘{defaultCustomArguments}’)'
-  Privacy Settings:
-    Remove Video Meta Files: When enabled, FreeTube automatically deletes meta files
-      created during video playback, when the watch page is closed.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk-based HTTP cache and enables a custom
       in-memory image cache. Will lead to increased RAM usage.

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -290,7 +290,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: ¿Estás
       seguro de que deseas eliminar todos los suscripciones y perfiles? Esto no puede
       ser deshecho.
-    Automatically Remove Video Meta Files: Borrar automáticamente metadatos del video
   Data Settings:
     How do I import my subscriptions?: ¿Cómo puedo importar mis suscripciones?
     Export History: Exportar Historia
@@ -796,9 +795,6 @@ Tooltips:
       presionada la tecla Ctrl (tecla Comando en Mac) y haga clic izquierdo para reestablecer
       la velocidad de reproducción predeterminada (que es de 1x, a menos que la haya
       cambiado en configuración).
-  Privacy Settings:
-    Remove Video Meta Files: Si se habilita, FreeTube borrará automáticamente los
-      metadatos creados al abrir el video, una vez que la ventana se cierre.
   Subscription Settings:
     Fetch Feeds from RSS: Si se habilita, FreeTube usará RSS en lugar del método predeterminado
       para recibir videos de sus suscripciones. RSS es más rápido y previene que bloqueen

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -413,8 +413,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Borrar todas las suscripciones/perfiles'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: '¿Confirma
       que quieres borrar todas las suscripciones y perfiles? Esta operación es irreversible.'
-    Automatically Remove Video Meta Files: Eliminar automáticamente los metadatos
-      de vídeos
     Save Watched Videos With Last Viewed Playlist: Guardar vídeos vistos con la última
       lista de reproducción vista
     All playlists have been removed: Se han eliminado todas las listas de reproducción
@@ -1113,10 +1111,6 @@ Tooltips:
     External Link Handling: "Elija el comportamiento por defecto cuando se hace clic
       en un enlace que no se pueda abrirse en FreeTube. \nPor defecto, FreeTube abrirá
       el enlace en el que se hizo clic en su navegador predeterminado.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Cuando se active, FreeTube eliminará automáticamente
-      meta-archivos creados durante la reproducción del vídeo una vez se cierre la
-      página de visualizado.
   External Player Settings:
     Custom External Player Executable: Por defecto, FreeTube buscará el reproductor
       externo seleccionado mediante la variable de entorno PATH, de no encontrarlo,

--- a/static/locales/es_AR.yaml
+++ b/static/locales/es_AR.yaml
@@ -296,7 +296,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Remover todas las suscripciones / perfiles'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: '¿Realmente
       querés remover todas las suscripciones y perfiles? Esta acción no puede deshacerse.'
-    Automatically Remove Video Meta Files: Borrar automáticamente metadatos del video
     Save Watched Videos With Last Viewed Playlist: Guardar videos vistos con la última
       lista de reproducción vista
   Subscription Settings:

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -409,7 +409,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Kas
       sa oled kindel, et soovid kustutada kõik tellimused/profiilid? Seda tegevust
       ei saa tagasi pöörata.'
-    Automatically Remove Video Meta Files: Kustuta videote metateave automaatselt
     Save Watched Videos With Last Viewed Playlist: Salvesta vaadatud videod viimati
       vaadatud videote esitusloendisse
     All playlists have been removed: Kõik esitusloendid on eemaldatud
@@ -1014,9 +1013,6 @@ Tooltips:
       IP-aadressi blokeerimise, kuid ei sisalda video kestust ja otseesituse olekut
     Fetch Automatically: Kui see valik on kasutusel, siis FreeTube automaatselt laadib
       uue akna avamisel ja profiili vahetamisel sinu tellimuste loendi.
-  Privacy Settings:
-    Remove Video Meta Files: Selle valiku kasutamisel FreeTube automaatselt kustutab
-      peale video esitamist kogu metateabe.
   General Settings:
     Region for Trending: Piirkond, mille alusel kuvame hetkel menukad ehk populaarsust
       koguvad videod.

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -400,7 +400,6 @@ Settings:
     Privacy Settings: 'Pribatutasunari buruzko ezarpenak'
     Remember History: 'Historikoa oroitu'
     Save Watched Progress: 'Ikusitakoaren progresioa gorde'
-    Automatically Remove Video Meta Files: 'Bideo metafitxategiak ezabatu automatikoki'
     Clear Search Cache: 'Bilaketen cachea ezabatu'
     Are you sure you want to clear out your search cache?: 'Ziur al zaude bilaketa-cachea
       garbitu nahi duzula?'
@@ -1019,10 +1018,6 @@ Tooltips:
       bideoaren iraupenaren informaziorik ez du ematen, besteak beste'
     Fetch Automatically: Gaituta dagoenean, FreeTubek automatikoki eskuratuko du zure
       harpidetza-jarioa leiho berri bat irekitzen denean eta profila aldatzean.
-  Privacy Settings:
-    Remove Video Meta Files: 'Gaituta dagoenean, FreeTube-k automatikoki ezabatzen
-      ditu bideoen erreprodukzioan sortutako metafitxategiak, bistaratze orria ixten
-      denean.'
 
 # Toast Messages
   External Player Settings:

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -290,8 +290,6 @@ Settings:
     Privacy Settings: 'تنظیمات امنیتی'
     Remember History: 'حفظ تاریخچه'
     Save Watched Progress: 'ذخیره ویدیو های دیده شده'
-    Automatically Remove Video Meta Files: 'به صورت خودکار متا فایل های ویدیو را حذف
-      کردن'
     Clear Search Cache: 'پاک کردن کش جستجو'
     Are you sure you want to clear out your search cache?: 'آیا مطمئن هستید که میخواهید
       کش جستجویتان را پاک کنید؟'
@@ -702,9 +700,6 @@ Tooltips:
       نمی دهد
     Fetch Automatically: هنگامی که فعال باشد، FreeTube به طور خودکار فید اشتراک شما
       را هنگام باز شدن یک پنجره جدید و هنگام تغییر نمایه دریافت می کند.
-  Privacy Settings:
-    Remove Video Meta Files: هنگامی که FreeTube فعال باشد، به طور خودکار فایل های
-      متا ایجاد شده در حین پخش ویدیو را حذف می کند، زمانی که صفحه تماشا بسته می شود.
   External Player Settings:
     Custom External Player Executable: به طور پیش فرض، FreeTube فرض می کند که پخش
       کننده خارجی انتخاب شده را می توان از طریق متغیر محیطی PATH پیدا کرد. در صورت

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -404,7 +404,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: Haluatko
       cvarmasti poistaa kaikki tilaukset ja profiilit. Tätä toimintoa ei voi perua.
     Remove All Subscriptions / Profiles: Poista kaikki tilaukset / profiilit
-    Automatically Remove Video Meta Files: Poista videoiden metadata automaattisesti
     Save Watched Videos With Last Viewed Playlist: Tallenna katsotut videot viimeksi
       katsotulla soittolistalla
     Remove All Playlists: Poista kaikki soittolistat
@@ -1013,9 +1012,6 @@ Tooltips:
       H.264 formaatit. DASH AV1 formaatit vaativat enemmän tehoa toistamiseen! Ne
       eivät ole käytettävissä kaikissa videoissa ja näissä tapauksissa soitin käyttää
       sen sijaan DASH H.264 formaatteja.
-  Privacy Settings:
-    Remove Video Meta Files: Kun tämä on kytkettynä päälle, FreeTube poistaa automaattisesti
-      meta-tiedostot jotka luotiin videon toiston aikana, katselusivu suljettaessa.
   External Player Settings:
     Custom External Player Arguments: Kaikki ne omavalintaiset komentorivin määreet,
       puolipisteillä eroteltuina (';'), jotka haluat siirtää eteenpäin ulkoiselle

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -471,8 +471,6 @@ Settings:
       sûr(e) de vouloir supprimer tous les abonnements et les profils ? Cette action
       est définitive.
     Remove All Subscriptions / Profiles: Supprimer tous les Abonnements / Profils
-    Automatically Remove Video Meta Files: Supprimer automatiquement les métafichiers
-      vidéo
     Save Watched Videos With Last Viewed Playlist: Sauvegarder les vidéos regardées
       avec la dernière liste de lecture vue
     All playlists have been removed: Toutes les listes de lecture ont été supprimées
@@ -1159,10 +1157,6 @@ Tooltips:
     External Link Handling: "Choisissez le comportement par défaut quand on clique
       sur un lien qui ne peut être ouvert dans FreeTube.\nPar défaut, FreeTube ouvrira
       le lien dans votre navigateur par défaut.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Lorsqu'il est activé, FreeTube supprime automatiquement
-      les MétaFichiers créés pendant la lecture de la vidéo, dès que la page de la
-      vidéo est quittée.
   External Player Settings:
     Custom External Player Arguments: Tous les arguments de ligne de commande personnalisés,
       séparés par des points-virgules (';'), que vous souhaitez transmettre au lecteur

--- a/static/locales/gl.yaml
+++ b/static/locales/gl.yaml
@@ -305,8 +305,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Limpar tódalas subscricións / perfís'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Estás
       seguro de querer limpar tódalas subscricións e perfís? Esta acción é irreversible.'
-    Automatically Remove Video Meta Files: Elimina automaticamente os ficheiros meta
-      de vídeo
     Save Watched Videos With Last Viewed Playlist: Gardalos vídeos vistos coa última
       lista de reprodución vista
   Subscription Settings:
@@ -883,10 +881,6 @@ Tooltips:
 # Toast Messages
     Fetch Automatically: Cando estea activado, FreeTube buscará automaticamente o
       teu feed da subscrición, cando se abra unha nova ventá e cando cambies de perfil.
-  Privacy Settings:
-    Remove Video Meta Files: Cando está activado, FreeTube elimina automaticamente
-      os ficheiros meta creados durante a reprodución de vídeo cando a páxina de visualización
-      está pechada.
   External Player Settings:
     Custom External Player Arguments: Calquera argumento de liña de comandos personalizado,
       separado por puntos e coma (';'), que desexa que se pase ao reprodutor externo.

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -307,7 +307,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'למחק את כל המינויים / פרופילים'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'למחוק
       כל את המינויים והפרופילים? זופעולה בלתי הפיכה.'
-    Automatically Remove Video Meta Files: להסיר אוטומטית קובצי נתוני על של הסרטון
     Save Watched Videos With Last Viewed Playlist: לשמור את הסרטונים שנצפו עם רשימת
       הנגינה לאחרונים שנצפו
   Subscription Settings:
@@ -943,9 +942,6 @@ Tooltips:
       נגיש דרך משתנה הסביבה PATH. במקרה הצורך, ניתן להגדיר כאן נתיב משלך.
     Custom External Player Arguments: הארגומנטים משלך לשורת הפקודה שיועברו לנגן החיצוני,
       מופרדים בפסיקים (‚;’).
-  Privacy Settings:
-    Remove Video Meta Files: כאשר אפשרות זו מופעלת, FreeTube מוחק באופן אוטומטי קובצי
-      על שנוצרים במהלך ניגון סרטון, לאחר סגירת עמוד הצפייה.
   Experimental Settings:
     Replace HTTP Cache: משבית את מטמון ה־HTTP מבוסס הכונן ומפעיל מטמון תמונות מותאם
       אישית בזיכרון. יגדיל את צריכת הזיכרון (RAM).

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -401,8 +401,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: Stvarno
       želiš ukloniti sve pretplate i profile? Ovo je nepovratna radnja.
     Remove All Subscriptions / Profiles: Ukloni sve pretplate/profile
-    Automatically Remove Video Meta Files: Automatski ukloni datoteke metapodataka
-      videa
     Save Watched Videos With Last Viewed Playlist: Spremi gledana videa sa zadnjim
       gledanom zbirkom
     Remove All Playlists: Ukloni sve zbirke
@@ -1095,10 +1093,6 @@ Tooltips:
       ili stanja „uživo”
     Fetch Automatically: Kada je aktivirano, FreeTube će automatski dohvatiti feed
       tvoje pretplate kada se otvori novi prozor i prilikom mijenjanja profila.
-  Privacy Settings:
-    Remove Video Meta Files: Kada je aktivirano, FreeTube automatski uklanja datoteke
-      metapodataka koji su stvoreni tijekom reprodukcije videa, kad se zatvori stranica
-      gledanja.
   External Player Settings:
     External Player: Biranjem vanjskog playera prikazat će se ikona, za otvaranje
       videa (zbirka, ako je podržana) u vanjskom playeru, na minijaturi. Upozorenje,

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -422,7 +422,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Összes feliratkozás és profil eltávolítása'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Biztosan
       törli az összes feliratkozást és profilt? A művelet nem vonható vissza.'
-    Automatically Remove Video Meta Files: Videó-metafájlok automatikus eltávolítása
     Save Watched Videos With Last Viewed Playlist: Megtekintett videók mentése az
       utoljára megtekintett lejátszási listával
     All playlists have been removed: Minden lejátszási lista eltávolításra került
@@ -1109,9 +1108,6 @@ Tooltips:
       H.264 formátumok. A DASH AV1 formátumok több energiát igényelnek a lejátszáshoz!
       Nem minden videónál érhetők el, ilyenkor a lejátszó a DASH H.264 formátumot
       használja helyette.
-  Privacy Settings:
-    Remove Video Meta Files: Ha engedélyezve van, a FreeTube automatikusan törli a
-      videolejátszás során létrehozott metafájlokat, amikor a nézőlapot bezárják.
   External Player Settings:
     Custom External Player Executable: Alapértelmezés szerint a FreeTube feltételezi,
       hogy a kiválasztott külső lejátszó megtalálható a PATH (ÚTVONAL) környezeti

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -280,7 +280,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Apakah
       Anda yakin ingin menghapus semua langganan dan profil? Tindakan ini tidak bisa
       diurungkan.'
-    Automatically Remove Video Meta Files: Secara Otomatis Hapus File Meta Video
   Subscription Settings:
     Subscription Settings: 'Pengaturan Langganan'
     Hide Videos on Watch: 'Sembunyikan Video saat Menonton'
@@ -809,9 +808,6 @@ Tooltips:
     External Link Handling: "Pilih perilaku default ketika tautan, yang tidak dapat
       dibuka di FreeTube, diklik.\nSecara default FreeTube akan membuka tautan yang
       diklik dengan browser default Anda.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Saat diaktifkan, FreeTube secara otomatis menghapus file
-      meta yang dibuat selama pemutaran video, saat halaman tonton ditutup.
   External Player Settings:
     Custom External Player Arguments: Semua argumen perintah khusus, dipisahkan dengan
       titik koma (';'), yang Anda ingin gunakan dengan pemutar eksternal.

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -416,7 +416,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Ertu
       viss um að þú viljir fjarlægja allar áskriftir og notkunarsnið? Ekki er hægt
       að afturkalla þetta.'
-    Automatically Remove Video Meta Files: Sjálfvirkt fjarlægja lýsigögn úr myndskeiðaskrám
     Save Watched Videos With Last Viewed Playlist: Vista myndskeið sem horft var á
       með síðast notaða spilunarlista
     Remove All Playlists: Fjarlægja alla spilunarlista
@@ -1027,9 +1026,6 @@ Tooltips:
 # Toast Messages
     Fetch Automatically: Þegar þetta er virkt, mun FreeTube sækja sjálfkrafa áskriftarstreymin
       þín þegar nýr gluggi er opnaður og þegar skipt er um notkunarsnið.
-  Privacy Settings:
-    Remove Video Meta Files: Þegar þetta er virkt, eyðir FreeTube sjálfkrafa lýsigagnaskrám
-      sem útbúnar eru við afspilun, þegar skoðunarsíðunni er lokað.
   External Player Settings:
     Custom External Player Arguments: Öll sérsniðin skipanaviðföng og rofar, aðskilin
       með semíkommum (';'), sem beina á til utanaðkomandi spilarans.

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -412,8 +412,6 @@ Settings:
       sicuro di volere eliminare tutte le iscrizioni e i profili? L'operazione non
       può essere annullata.
     Remove All Subscriptions / Profiles: Elimina tutte le iscrizioni e i profili
-    Automatically Remove Video Meta Files: Rimuovi automaticamente i metafile dai
-      video
     Save Watched Videos With Last Viewed Playlist: Salva i video guardati con l'ultima
       playlist vista
     All playlists have been removed: Tutte le playlist sono state rimosse
@@ -1135,10 +1133,6 @@ Tooltips:
     Ignore Default Arguments: Non inviare argomenti predefiniti al lettore esterno
       oltre all'URL del video (ad esempio velocità di riproduzione, URL della playlist,
       ecc.). Gli argomenti personalizzati verranno comunque trasmessi.
-  Privacy Settings:
-    Remove Video Meta Files: Se abilitato, quando chiuderai la pagina di riproduzione
-      , FreeTube eliminerà automaticamente i metafile creati durante la visione del
-      video .
   Experimental Settings:
     Replace HTTP Cache: Disabilita la cache HTTP basata su disco Electron e abilita
       una cache di immagini in memoria personalizzata. Comporta un aumento dell'uso

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -110,7 +110,7 @@ Playlists: '再生リスト'
 User Playlists:
   Your Playlists: 'あなたの再生リスト'
   Your saved videos are empty. Click on the save button on the corner of a video to have it listed here: 保存した動画はありません。一覧に表示させるには、ビデオの角にある保存ボタンをクリックします
-  Playlist Message: 
+  Playlist Message:
     このページは、完全に動作する動画リストではありません。保存またはお気に入りと設定した動画のみが表示されます。操作が完了すると、現在ここにあるすべての動画は「お気に入り」の動画リストに移動します。
   Search bar placeholder: 動画リスト内の検索
   Empty Search Message: この再生リストに、検索に一致する動画はありません
@@ -332,7 +332,6 @@ Settings:
     Privacy Settings: 個人情報の設定
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: すべての登録チャンネルとプロファイルを削除しますか？元に戻せません。
     Remove All Subscriptions / Profiles: 登録とプロファイルをすべて削除
-    Automatically Remove Video Meta Files: 動画のメタファイルの自動削除
     Save Watched Videos With Last Viewed Playlist: 「最後に再生した」リストで視聴済み動画を保存
   Data Settings:
     How do I import my subscriptions?: 私の登録情報を取り込むにはどうしたらいいですか？
@@ -469,7 +468,7 @@ Settings:
   Experimental Settings:
     Replace HTTP Cache: HTTP キャッシュの置換
     Experimental Settings: 実験中の設定
-    Warning: 
+    Warning:
       これらの設定は実験的なものであり、有効にするとアプリのクラッシュを引き起こす恐れがあります。バックアップをとっておくことを強くお勧めします。自己責任で使用してください！
   Password Settings:
     Password Settings: パスワード設定
@@ -882,8 +881,6 @@ Tooltips:
     Region for Trending: 急上昇の地域設定では、急上昇動画を表示する国を選択できます。
     External Link Handling: "FreeTube で開けないリンクをクリックしたときのデフォルトの動作を選択します。\nデフォルトでは、FreeTube
       はクリックしたリンクをデフォルトのブラウザで開きます。\n"
-  Privacy Settings:
-    Remove Video Meta Files: 有効にすると、FreeTube は動画再生中に作成したメタファイルを、再生ページを閉じるときに自動的に削除します。
   External Player Settings:
     Custom External Player Arguments: '";"、セミコロンで区切られたカスタム コマンド ライン引数を外部プレーヤーに渡します。'
     Ignore Warnings: 現在の外部プレーヤーが、現在のアクションに未対応の場合（動画リストの反転など）に警告を抑制します。

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -286,7 +286,6 @@ Settings:
     Remove All Subscriptions / Profiles: '모든 구독채널과 프로필 삭제'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: '정말로
       모든 구독채널과 프로필을 삭제하시겠습니까? 삭제하면 복구가되지않습니다.'
-    Automatically Remove Video Meta Files: 비디오 메타 파일 자동 제거
   Subscription Settings:
     Subscription Settings: '구독 설정'
     Hide Videos on Watch: '시청한 동영상 숨기기'
@@ -752,9 +751,6 @@ Tooltips:
     Ignore Warnings: '현재 외부 플레이어가 현재 작업을 지원하지 않는 경우(예: 재생 목록 반전 등) 경고를 표시하지 않습니다.'
     Custom External Player Arguments: 외부 플레이어로 전달되기를 원하는사용자 지정 명령줄 인수는 세미콜론(';')으로
       구분됩니다.
-  Privacy Settings:
-    Remove Video Meta Files: 활성화되면 FreeTube는 보기 페이지가 닫힐 때 비디오 재생 중에 생성된 메타 파일을 자동으로
-      삭제합니다.
   Distraction Free Settings:
     Hide Channels: 채널 이름이나 채널 ID를 입력해 해당 채널의 영상이나 재생목록, 채널 자체가 검색이나 인기 영상에 나타나지 않도록
       합니다. 입력되는 채널 이름은 완전히 일치해야하며, 대소문자를 구별합니다.

--- a/static/locales/lt.yaml
+++ b/static/locales/lt.yaml
@@ -311,8 +311,6 @@ Settings:
     Privacy Settings: 'Privatumo nustatymai'
     Remember History: 'Įsiminti istoriją'
     Save Watched Progress: 'Išsaugoti peržiūros progresą'
-    Automatically Remove Video Meta Files: 'Automatiškai pašalinti vaizdo įrašų meta
-      failus'
     Clear Search Cache: 'Išvalyti paieškos talpyklą'
     Are you sure you want to clear out your search cache?: 'Ar tikrai norite išvalyti
       paieškos talpyklą?'
@@ -832,9 +830,6 @@ Tooltips:
       trukmės ar tiesioginės transliacijos būsenos'
     Fetch Automatically: Kai ši funkcija įjungta, FreeTube automatiškai įkels naują
       turinį iš prenumeratų, kai atidaromas naujas langas ir perjungiamas profilis.
-  Privacy Settings:
-    Remove Video Meta Files: 'Įjungus FreeTube, uždarius žiūrėjimo puslapį, automatiškai
-      ištrinami meta failai, sukurti vaizdo atkūrimo metu.'
 
 # Toast Messages
   Experimental Settings:

--- a/static/locales/lv.yaml
+++ b/static/locales/lv.yaml
@@ -309,7 +309,6 @@ Settings:
     Remember History: 'Atcerēties vēsturi'
     Save Watched Progress: 'Saglabāt skatīto attīstību'
     Save Watched Videos With Last Viewed Playlist: ''
-    Automatically Remove Video Meta Files: 'Automātiski noņemt video metadatus'
     Clear Search Cache: ''
     Are you sure you want to clear out your search cache?: ''
     Search cache has been cleared: ''
@@ -817,8 +816,6 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: ''
     Fetch Automatically: ''
-  Privacy Settings:
-    Remove Video Meta Files: ''
   Experimental Settings:
     Replace HTTP Cache: ''
   SponsorBlock Settings:

--- a/static/locales/nb_NO.yaml
+++ b/static/locales/nb_NO.yaml
@@ -295,7 +295,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: Er
       du sikker på at du vil fjerne alle abonnementer og profiler? Dette kan ikke
       angres.
-    Automatically Remove Video Meta Files: Fjern metadata automatisk fra videoer
     Save Watched Videos With Last Viewed Playlist: Lagre sette videoer med sist sette
       spilleliste
   Subscription Settings:
@@ -888,9 +887,6 @@ Tooltips:
     Allow DASH AV1 formats: DASH AV1-formater kan ha bedre kvalitet enn DASH H.264
       -formater. DASH AV1-formater krever dog mer regnekraft for avspilling. Ikke
       tilgjengelig for alle videoer, og i sådant fall bruker avspilleren DASH H.264-formater.
-  Privacy Settings:
-    Remove Video Meta Files: Hvis denne instillingen er på, vil FreeTube automatisk
-      slette metadata generert under videoavspilling når du lukker avspillingsiden.
   External Player Settings:
     Custom External Player Arguments: Alle egendefinerte kommandolinjeargumenter,
       semikoloninndelt («;») du ønsker å sende til den eksterne avspilleren.

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -409,8 +409,6 @@ Settings:
       u zeker dat u alle abonnementen en profielen wil verwijderen? Dit kan niet ongedaan
       worden gemaakt.
     Remove All Subscriptions / Profiles: Verwijder alle abonnementen / profielen
-    Automatically Remove Video Meta Files: Bestanden met metadata van video's automatisch
-      verwijderen
     Save Watched Videos With Last Viewed Playlist: Houd bekeken video's bij met de
       afspeellijst ‘Laatst bekeken’
     Remove All Playlists: Alle afspeel­lijsten verwijderen
@@ -1108,10 +1106,6 @@ Tooltips:
     External Link Handling: "Kies het standaard gedrag voor wanneer een link dat niet
       kan worden geopend in FreeTube is aangeklikt.\nStandaard zal FreeTube de aangeklikte
       link openen in je standaardbrowser.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Wanneer ingeschakeld zal FreeTube automatisch meta bestanden
-      die worden gecreëerd tijdens het afspelen van video's verwijderen zodra de pagina
-      wordt gesloten.
   External Player Settings:
     Custom External Player Arguments: Aangepaste opdrachtregelargumenten, gescheiden
       door puntkomma's (';'), die je wil doorgeven aan de externe videospeler.

--- a/static/locales/nn.yaml
+++ b/static/locales/nn.yaml
@@ -298,7 +298,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Er
       du sikker på at du vil fjerne alle abonnentar og profil? Dette kan ikkje bli
       ugjort.'
-    Automatically Remove Video Meta Files: Fjern metadata automatisk frå videoar
   Subscription Settings:
     Subscription Settings: 'Abonnementinnstillingar'
     Hide Videos on Watch: 'Skjul sette videoar'
@@ -798,9 +797,6 @@ Tooltips:
 # Toast Messages
     Fetch Automatically: Om dette alternativet er aktivert, vil FreeTube automatisk
       hente abonnementfeeden din når eit nytt vindauge opnast og når du bytter profil.
-  Privacy Settings:
-    Remove Video Meta Files: Viss denne innstillinga er på, vil FreeTube automatisk
-      slette metadata generert under videoavspeling når du lukker avspelingsida.
   External Player Settings:
     DefaultCustomArgumentsTemplate: "(Standard: '{defaultCustomArguments}')"
     Custom External Player Executable: Som standard vil FreeTube anta at den valte

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -454,7 +454,6 @@ Settings:
       jesteś pewny/a, że chcesz usunąć wszystkie subskrypcje i profile? Nie będzie
       można tego cofnąć.
     Remove All Subscriptions / Profiles: Usuń wszystkie subskrypcje / profile
-    Automatically Remove Video Meta Files: Automatycznie usuwaj pliki metadanych filmu
     Save Watched Videos With Last Viewed Playlist: Zapisuj do historii film wraz z
       ostatnią odtwarzaną playlistą, która go zawierała
     All playlists have been removed: Wszystkie playlisty zostały usunięte
@@ -1121,9 +1120,6 @@ Tooltips:
       H.264 DASH. Dekodowanie formatu AV1 DASH wymaga większej mocy obliczeniowej.
       W filmach, dla których ten format nie jest dostępny, zostanie użyty format H.264
       DASH.
-  Privacy Settings:
-    Remove Video Meta Files: Po włączeniu FreeTube automatycznie usunie pliki metadanych
-      utworzone podczas odtwarzania filmu, gdy strona odtwarzacza zostanie zamknięta.
   External Player Settings:
     Ignore Warnings: Nie pokazuj ostrzeżeń o nieobsługiwanych akcjach przez zewnętrzny
       odtwarzacz (n.p. odwracanie playlist, itp.).

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -451,8 +451,6 @@ Settings:
       certeza de que deseja remover todas as inscrições e perfis? Isto não pode ser
       desfeito.
     Remove All Subscriptions / Profiles: Remover todas as inscrições ou perfis
-    Automatically Remove Video Meta Files: Remover automaticamente os metarquivos
-      de vídeo
     Save Watched Videos With Last Viewed Playlist: Salvar vídeos assistidos com a
       última playlist visualizada
     All playlists have been removed: Todas as playlists foram removidas
@@ -1115,10 +1113,6 @@ Tooltips:
     External Link Handling: "Escolha o comportamento padrão quando um link que não
       pode ser aberto no FreeTube for clicado.\nPor padrão, o FreeTube abrirá o link
       clicado em seu navegador padrão.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Quando ativado, o FreeTube exclui automaticamente os
-      metarquivos criados durante a reprodução do vídeo quando a página de exibição
-      é fechada.
   External Player Settings:
     Custom External Player Arguments: Quaisquer argumentos de linha de comando personalizados,
       separados por ponto e vírgula (';'), você deseja que seja passado para o player

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -401,8 +401,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: Tem
       a certeza de que pretende remover todas as suas subscrições e perfis? Esta ação
       não pode ser revertida.
-    Automatically Remove Video Meta Files: Remover automaticamente os meta-ficheiros
-      dos vídeos
     Save Watched Videos With Last Viewed Playlist: Guardar os vídeos vistos com a
       última lista de reprodução vista
     Remove All Playlists: Remover todas as listas de reprodução
@@ -1004,9 +1002,6 @@ Tooltips:
 # Toast Messages
     Fetch Automatically: Se ativa, FreeTube irá obter automaticamente as subscrições
       ao abrir uma nova janela e/ou quando mudar de perfil.
-  Privacy Settings:
-    Remove Video Meta Files: Se ativa, ao fechar uma página, FreeTube apagará automaticamente
-      os meta-ficheiros criados durante a reprodução de um vídeo.
   External Player Settings:
     Custom External Player Arguments: Quaisquer argumentos de linha de comando, separados
       por ponto e vírgula (';'), que quiser passar ao reprodutor externo.

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -411,8 +411,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Tem
       a certeza de que pretende remover todas as suas subscrições e perfis? Esta ação
       não pode ser revertida.'
-    Automatically Remove Video Meta Files: Remover automaticamente os meta-ficheiros
-      dos vídeos
     Save Watched Videos With Last Viewed Playlist: Guardar os vídeos vistos com a
       última lista de reprodução vista
     Remove All Playlists: Remover todas as listas de reprodução
@@ -1073,9 +1071,6 @@ This video is unavailable because of missing formats. This can happen due to cou
   vídeo não está disponível porque faltam formatos. Isto pode acontecer devido à indisponibilidade
   no seu país.
 Tooltips:
-  Privacy Settings:
-    Remove Video Meta Files: Se ativa, ao fechar uma página, FreeTube apagará automaticamente
-      os meta-ficheiros criados durante a reprodução de um vídeo.
   Subscription Settings:
     Fetch Feeds from RSS: Se ativa, FreeTube irá obter as subscrições através de RSS
       em vez do método normal. O formato RSS é mais rápido e não é bloqueado pelo

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -317,7 +317,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Sunteți
       sigur că doriți să eliminați toate abonamentele și profilurile?  Acest lucru
       nu poate fi anulat.'
-    Automatically Remove Video Meta Files: Îndepărtați automat fișierele meta video
     Save Watched Videos With Last Viewed Playlist: Salvați videoclipurile vizionate
       cu ultima listă de redare vizualizată
   Subscription Settings:
@@ -893,9 +892,6 @@ Hashtags have not yet been implemented, try again later: Hashtag-urile nu au fos
 Unknown YouTube url type, cannot be opened in app: Tip url YouTube necunoscut, nu
   poate fi deschis în aplicație
 Tooltips:
-  Privacy Settings:
-    Remove Video Meta Files: Atunci când este activat, FreeTube șterge automat fișierele
-      meta create în timpul redării video, atunci când pagina de vizionare este închisă.
   Subscription Settings:
     Fetch Feeds from RSS: Atunci când este activată, FreeTube va utiliza RSS în locul
       metodei implicite pentru a prelua feed-ul de abonament. RSS este mai rapid și

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -428,7 +428,6 @@ Settings:
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: Выполнить
       удаление всех подписок и учётных записей?  Невозможно отменить.
     Remove All Subscriptions / Profiles: Удалить все подписки/профили
-    Automatically Remove Video Meta Files: Автоудаление метафайлов видео
     Save Watched Videos With Last Viewed Playlist: Сохранить просмотренные видео с
       последней просмотренной подборкой
     Are you sure you want to remove all your playlists?: Ты действительно хочешь удалить
@@ -1085,10 +1084,6 @@ Tooltips:
       H.264. Форматы DASH AV1 требуют большей производительности для воспроизведения!
       Они доступны не для всех видео. Если они будут недоступны, тогда проигрыватель
       будет использовать форматы DASH H.264.
-  Privacy Settings:
-    Remove Video Meta Files: Если эта настройка включена, FreeTube автоматически удаляет
-      метаданные, созданные во время воспроизведения видео, когда страница просмотра
-      закрывается.
   External Player Settings:
     Custom External Player Arguments: Любые пользовательские аргументы командной строки,
       разделенные точкой с запятой (';'), которые вы хотите передать внешнему проигрывателю.

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -329,7 +329,6 @@ Settings:
     Are you sure you want to remove your entire watch history?: Naozaj chcete odstrániť
       celú históriu pozerania?
     Search cache has been cleared: Vyrovnávacia pamäť vyhľadávania bola vymazaná
-    Automatically Remove Video Meta Files: Automaticky Odstrániť Metasúbory Videa
   The app needs to restart for changes to take effect. Restart and apply change?: Aplikácia
     požaduje reštart, aby sa zmeny prejavili. Reštartovať a aplikovať zmeny?
   Proxy Settings:
@@ -701,9 +700,6 @@ Tooltips:
     External Link Handling: "Vyberte predvolené správanie pri kliknutí na odkaz, ktorý
       nemožno otvoriť vo FreeTube.\nV predvolenom nastavení FreeTube otvorí odkaz,
       na ktorý ste klikli, vo vašom predvolenom prehliadači.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Ak je povolené, FreeTube po zatvorení stránky prezerania
-      automaticky odstráni metasúbory vytvorené počas prehrávania videa.
   External Player Settings:
     DefaultCustomArgumentsTemplate: "(Predvolené: '{defaultCustomArguments}')"
     External Player: Po výbere externého prehrávača sa na miniatúre zobrazí ikona

--- a/static/locales/sl.yaml
+++ b/static/locales/sl.yaml
@@ -297,7 +297,6 @@ Settings:
       mogoče razveljaviti.'
     Save Watched Videos With Last Viewed Playlist: Shrani gledane videoposnetke z
       nazadnje ogledanim seznamom predvajanja
-    Automatically Remove Video Meta Files: Samodejno izbriši meta datoteke videoposnetkov
   Subscription Settings:
     Subscription Settings: 'Nastavitve naročnin'
     Hide Videos on Watch: 'Skrij gledane videoposnetke'

--- a/static/locales/sm.yaml
+++ b/static/locales/sm.yaml
@@ -308,7 +308,6 @@ Settings:
     Remember History: ''
     Save Watched Progress: ''
     Save Watched Videos With Last Viewed Playlist: ''
-    Automatically Remove Video Meta Files: ''
     Clear Search Cache: ''
     Are you sure you want to clear out your search cache?: ''
     Search cache has been cleared: ''
@@ -803,8 +802,6 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: ''
     Fetch Automatically: ''
-  Privacy Settings:
-    Remove Video Meta Files: ''
   Experimental Settings:
     Replace HTTP Cache: ''
   SponsorBlock Settings:

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -419,8 +419,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Уклони сва праћења/профиле'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Желите
       ли заиста да уклоните сва праћења и профиле?   Ово се не може поништити.'
-    Automatically Remove Video Meta Files: Аутоматски уклони мета фајлове за видео
-      снимак
     Save Watched Videos With Last Viewed Playlist: Сачувај одгледане видео снимке
       са последње гледане плејлисте
     All playlists have been removed: Све плејлисте су уклоњене
@@ -940,9 +938,6 @@ Tooltips:
       разликује велика и мала слова) да бисте сакрили све видео снимке и плејлисте
       чији их оригинални наслови садрже у целом FreeTube-у, искључујући само историју,
       ваше плејлисте и видео снимке унутар плејлиста.
-  Privacy Settings:
-    Remove Video Meta Files: Када је омогућено, FreeTube аутоматски брише мета фајлове
-      направљене током репродукције видео снимка, када се страница гледања затвори.
   Player Settings:
     Allow DASH AV1 formats: DASH AV1 формати могу изгледати боље од DASH H.264 формата.
       DASH AV1 формати захтевају више снаге за репродукцију! Они нису доступни на

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -331,7 +331,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Ta bort alla prenumerationer och profiler'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Vill
       du verkligen ta bort alla prenumerationer och profiler? Detta kan inte ångras.'
-    Automatically Remove Video Meta Files: Ta automatiskt bort videons metafiler
     Save Watched Videos With Last Viewed Playlist: Spara sedda vidoer till Senast
       tittade spellista
   Subscription Settings:
@@ -978,9 +977,6 @@ Tooltips:
     External Link Handling: "Välj standardförfarande när en länk klickas, som inte
       kan öppnas i FreeTube är. \nStandard är att FreeTube kommer öppna länken i din
       standardwebbläsare.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Om vald, kommer FreeTube automatiskt att kasta metadata
-      filer som skapades under uppspelning, när sidan stängs.
   External Player Settings:
     Custom External Player Arguments: Alla anpassade kommandoradsargument, åtskilda
       av semikolon (';'), ska skickas till den externa spelaren.

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -412,8 +412,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Tüm Abonelikler/Profilleri Temizle'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Tüm
       abonelikler/profilleri temizlemek istediğinizden emin misiniz?  Geri alınamaz.'
-    Automatically Remove Video Meta Files: Video Meta Dosyalarını Otomatik Olarak
-      Kaldır
     Save Watched Videos With Last Viewed Playlist: İzlenen Videoları Son Görüntülenen
       Oynatma Listesiyle Kaydet
     All playlists have been removed: Tüm oynatma listeleri kaldırıldı
@@ -1107,9 +1105,6 @@ Tooltips:
     External Link Handling: "FreeTube'da açılamayan bir bağlantı tıklandığında öntanımlı
       davranışı seçin.\nÖntanımlı olarak FreeTube, tıklanan bağlantıyı öntanımlı tarayıcınızda
       açacaktır.\n"
-  Privacy Settings:
-    Remove Video Meta Files: Etkinleştirildiğinde, izleme sayfası kapatıldığında video
-      oynatma sırasında oluşturulan meta dosyaları otomatik olarak silinir.
   External Player Settings:
     Custom External Player Arguments: Harici oynatıcıya iletmek isteyeceğiniz, noktalı
       virgülle (';') ayrılmış özel komut satırı argümanları.

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -341,7 +341,6 @@ Settings:
     Remove All Subscriptions / Profiles: 'Видалити всі підписки / профілі'
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 'Справді
       хочете вилучити всі підписки та профілі? Цю дію не можна скасувати.'
-    Automatically Remove Video Meta Files: Автоматично вилучати метафайли відео
     Save Watched Videos With Last Viewed Playlist: Зберегти переглянуті відео у список
       відтворення, який ви переглядали останнім часом
   Subscription Settings:
@@ -922,9 +921,6 @@ Tooltips:
 # Toast Messages
     Fetch Automatically: Якщо увімкнено, FreeTube автоматично отримуватиме вашу стрічку
       підписок під час відкриття нового вікна та за перемикання профілю.
-  Privacy Settings:
-    Remove Video Meta Files: Якщо увімкнено, FreeTube автоматично видаляє метафайли,
-      створені під час відтворення відео, коли сторінку перегляду закрито.
   External Player Settings:
     Custom External Player Arguments: Будь-які нетипові аргументи командного рядка
       розділяються (';') крапкою з комою, ви бажаєте, щоб вас було перенаправлено

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -201,9 +201,6 @@ Tooltips:
       کرے گا۔ آپ کی سبسکرپشن فیڈ حاصل کرنے کا طریقہ۔ آر ایس ایس تیز ہے اور آئی پی
       کو بلاک کرنے سے روکتا ہے، لیکن کچھ معلومات فراہم نہیں کرتا ہے جیسے ویڈیو کا
       دورانیہ یا لائیو اسٹیٹس'
-  Privacy Settings:
-    Remove Video Meta Files: 'فعال ہونے پر، FreeTube ویڈیو پلے بیک کے دوران بنائی
-      گئی میٹا فائلوں کو خود بخود حذف کر دیتا ہے، جب دیکھنے کا صفحہ بند ہوتا ہے۔'
 
 # Toast Messages
 This video is unavailable because of missing formats. This can happen due to country unavailability.: 'یہ

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -542,7 +542,6 @@ Settings:
     Save Watched Progress: Lưu quá trình xem
     Remember History: Nhớ lịch sử
     Privacy Settings: Cài đặt quyền riêng tư
-    Automatically Remove Video Meta Files: Tự động xóa các tệp meta video
     Remove All Playlists: Xóa tất cả danh sách phát
     Are you sure you want to remove all your playlists?: Bạn có chắc muốn xóa tất
       cả các danh sách phát không?
@@ -1112,9 +1111,6 @@ Tooltips:
       hoặc trạng thái phát trực tiếp
     Fetch Automatically: Khi được bật, FreeTube sẽ tự động tìm nạp nguồn cấp dữ liệu
       đăng ký của bạn khi cửa sổ mới được mở và khi chuyển đổi hồ sơ.
-  Privacy Settings:
-    Remove Video Meta Files: Khi được bật lên, FreeTube sẽ tự động xóa các tệp meta
-      được tạo trong quá trình phát lại video, khi trang xem bị đóng.
   Distraction Free Settings:
     Hide Channels: Nhập tên kênh hoặc ID kênh để ẩn tất cả video, danh sách phát và
       chính kênh đó khỏi xuất hiện trong tìm kiếm, xu hướng, phổ biến nhất và được

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -403,7 +403,6 @@ Settings:
     Clear Search Cache: 清除搜索缓存
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 您确定您想移除所有订阅和配置文件吗？这无法撤销。
     Remove All Subscriptions / Profiles: 移除所有订阅 / 配置文件
-    Automatically Remove Video Meta Files: 自动删除硬盘元数据文件
     Save Watched Videos With Last Viewed Playlist: 记住上次看过的播放列表中看过的视频 ID
     All playlists have been removed: 已删除所有播放列表
     Remove All Playlists: 删除所有播放列表
@@ -979,8 +978,6 @@ Tooltips:
     DefaultCustomArgumentsTemplate: "(默认: '{defaultCustomArguments}')"
     Custom External Player Arguments: 任何你希望传递给外部播放器的用分号(';')分隔的自定义命令行参数。
     Ignore Default Arguments: 不要向外部播放器发送除视频 URL 外的任何默认变量（如播放速度、播放列表 URL 等）。自定义变量仍将被传递。
-  Privacy Settings:
-    Remove Video Meta Files: 启用后，当观看页面关闭时，FreeTube 会自动删除在视频播放时创建的元文件。
   Experimental Settings:
     Replace HTTP Cache: 禁用 Electron 基于磁盘的 HTTP 缓存，启用自定义内存中图像缓存。会增加内存的使用。
   Distraction Free Settings:

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -405,7 +405,6 @@ Settings:
     Privacy Settings: 隱私設定
     Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: 您確定要移除所有訂閱與設定檔嗎嗎?  注意:這無法復原。
     Remove All Subscriptions / Profiles: 移除所有訂閱／設定檔
-    Automatically Remove Video Meta Files: 自動刪除影片元檔案
     Save Watched Videos With Last Viewed Playlist: 使用上次觀看的播放清單儲存觀看的影片
     Remove All Playlists: 移除所有播放清單
     All playlists have been removed: 所有播放清單已被移除
@@ -983,8 +982,6 @@ Tooltips:
       API 需要 Invidious 伺服器才能連線。
     Region for Trending: 熱門影片區域可以讓您選擇想要顯示哪個國家的熱門影片。
     External Link Handling: "選擇點擊後無法在 FreeTube 中開啟連結時的預設行為。\n預設情況下 FreeTube 將會在您的預設瀏覽器中開啟點擊的連結。\n"
-  Privacy Settings:
-    Remove Video Meta Files: 如果啟用，FreeTube會在關閉觀看頁面時，自動刪除影片播放過程中建立的暫存檔案。
   External Player Settings:
     Custom External Player Arguments: 任何您想要傳遞給外部播放程式的自訂命令列參數，以半形冒號分隔 (';')。
     Ignore Warnings: 當目前的外部播放程式不支援目前動作時（例如反向播放清單等等），消除警告。


### PR DESCRIPTION
# Use blob URLs for storyboards instead of writing them to the file system

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #2768

## Description
I was originally going to switch to data URIs as part of the player migration, as `videojs-vtt-thumbnails` doesn't handle data URIs correctly, however I have since discovered that it does handle blob URLs correctly. Therefore I decided that to extract the changes from the player migration and put them in this separate pull request, so that the player migration is slightly smaller.

`videojs-vtt-thumbnails` has a check to see if a URI is relative or absolute, it does so by checking if the URL contains `//`, if it does, then it counts it as an absolute URL. As data URIs don't have that, it adds the origin to the start of the URL `http://localhost:9080/data:text/vtt,WEBVTT...`, so it fails to load the storyboard. Interestingly because blob URLs use this format `blob:{origin}/{uuid}` it means that in dev the URLs look like this `blob:http://localhost:9080/{uuid}` and in release builds they look like this `blob:file:///{uuid}`, so they pass the absolute URL check and get correctly handled by `videojs-vtt-thumbnails`.

As this pull request stops writing the storyboards to the file system and we stopped writing the DASH manifests to the filesystem in #4423 we can now remove the `Automatically Remove Video Meta Files` setting, as it is unused now.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open a video
2. Hover over the seek bar
3. Check that the thumbnails still show up

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0