### PR TITLE
Add fallback to "es" when strings are missing in "es_AR" and "es-MX"

### DIFF
--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -8,7 +8,16 @@ Vue.use(VueI18n)
 
 const i18n = new VueI18n({
   locale: 'en-US',
-  fallbackLocale: { default: 'en-US' }
+  fallbackLocale: {
+    // https://kazupon.github.io/vue-i18n/guide/fallback.html#explicit-fallback-with-decision-maps
+
+    // es_AR -> es -> en-US
+    es_AR: ['es'],
+    // es-MX -> es -> en-US
+    'es-MX': ['es'],
+    // any -> en-US
+    default: ['en-US'],
+  }
 })
 
 export async function loadLocale(locale) {
@@ -18,6 +27,7 @@ export async function loadLocale(locale) {
   }
   if (!activeLocales.includes(locale)) {
     console.error(`Unable to load unknown locale: "${locale}"`)
+    return
   }
 
   // locales are only compressed in our production Electron builds
@@ -44,7 +54,5 @@ export async function loadLocale(locale) {
     i18n.setLocaleMessage(locale, data)
   }
 }
-
-loadLocale('en-US')
 
 export default i18n

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -353,7 +353,27 @@ const stateWithSideEffects = {
         }
       }
 
-      await loadLocale(targetLocale)
+      const loadPromises = []
+
+      if (targetLocale !== defaultLocale) {
+        // "en-US" is used as a fallback for missing strings in other locales
+        loadPromises.push(
+          loadLocale(defaultLocale)
+        )
+      }
+
+      // "es" is used as a fallback for "es_AR" and "es-MX"
+      if (targetLocale === 'es_AR' || targetLocale === 'es-MX') {
+        loadPromises.push(
+          loadLocale('es')
+        )
+      }
+
+      loadPromises.push(
+        loadLocale(targetLocale)
+      )
+
+      await Promise.allSettled(loadPromises)
 
       i18n.locale = targetLocale
       await dispatch('getRegionData', {


### PR DESCRIPTION
# Add fallback to "es" when strings are missing in "es_AR" and "es-MX"

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Description
As discussed in the Matrix chat, the `español (Argentina)` and `español (MX)` locales are currently 44% and 66% translated respectively, whereas the `español (España)` locale is 100% translated. To improve the user experience for the users of the `español (Argentina)` and `español (MX)` locales, this pull request adds a fallback to `español (España)` for missing strings (it will still fallback to `en-US` if the strings are also missing from `es`).

https://hosted.weblate.org/projects/free-tube/#languages

This means that the fallback strategies look like this now:

| Locale | Fallback strategy |
| --- | --- |
| español (Argentina) | `es_AR -> es -> en-US` |
| español (MX) | `es-MX -> es -> en-US` |
| all other locales | `{locale} -> en-US` |

## Testing <!-- for code that is not small enough to be easily understandable -->
Set the display language to `español (Argentina)` and `español (MX)` and check that the logs in the console say that it is falling back to `es` instead of `en-US`.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0