### PR TITLE
Ask the main process, instead of the file system whether the replace HTTP cache setting is enabled

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -23,7 +23,10 @@ const IpcChannels = {
   SYNC_SETTINGS: 'sync-settings',
   SYNC_HISTORY: 'sync-history',
   SYNC_PROFILES: 'sync-profiles',
-  SYNC_PLAYLISTS: 'sync-playlists'
+  SYNC_PLAYLISTS: 'sync-playlists',
+
+  GET_REPLACE_HTTP_CACHE: 'get-replace-http-cache',
+  TOGGLE_REPLACE_HTTP_CACHE: 'toggle-replace-http-cache'
 }
 
 const DBActions = {

--- a/src/renderer/components/experimental-settings/experimental-settings.js
+++ b/src/renderer/components/experimental-settings/experimental-settings.js
@@ -1,11 +1,9 @@
-import fs from 'fs/promises'
 import { defineComponent } from 'vue'
 import FtSettingsSection from '../ft-settings-section/ft-settings-section.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtPrompt from '../ft-prompt/ft-prompt.vue'
-import { pathExists } from '../../helpers/filesystem'
-import { getUserDataPath } from '../../helpers/utils'
+import { IpcChannels } from '../../../constants'
 
 export default defineComponent({
   name: 'ExperimentalSettings',
@@ -19,19 +17,16 @@ export default defineComponent({
     return {
       replaceHttpCacheLoading: true,
       replaceHttpCache: false,
-      replaceHttpCachePath: '',
       showRestartPrompt: false
     }
   },
-  mounted: function () {
-    getUserDataPath().then((userData) => {
-      this.replaceHttpCachePath = `${userData}/experiment-replace-http-cache`
+  mounted: async function () {
+    if (process.env.IS_ELECTRON) {
+      const { ipcRenderer } = require('electron')
+      this.replaceHttpCache = await ipcRenderer.invoke(IpcChannels.GET_REPLACE_HTTP_CACHE)
+    }
 
-      pathExists(this.replaceHttpCachePath).then((exists) => {
-        this.replaceHttpCache = exists
-        this.replaceHttpCacheLoading = false
-      })
-    })
+    this.replaceHttpCacheLoading = false
   },
   methods: {
     handleRestartPrompt: function (value) {
@@ -39,7 +34,7 @@ export default defineComponent({
       this.showRestartPrompt = true
     },
 
-    handleReplaceHttpCache: async function (value) {
+    handleReplaceHttpCache: function (value) {
       this.showRestartPrompt = false
 
       if (value === null || value === 'no') {
@@ -47,16 +42,10 @@ export default defineComponent({
         return
       }
 
-      if (this.replaceHttpCache) {
-        // create an empty file
-        const handle = await fs.open(this.replaceHttpCachePath, 'w')
-        await handle.close()
-      } else {
-        await fs.rm(this.replaceHttpCachePath)
+      if (process.env.IS_ELECTRON) {
+        const { ipcRenderer } = require('electron')
+        ipcRenderer.send(IpcChannels.TOGGLE_REPLACE_HTTP_CACHE)
       }
-
-      const { ipcRenderer } = require('electron')
-      ipcRenderer.send('relaunchRequest')
     }
   }
 })


### PR DESCRIPTION
# Ask the main process, instead of the file system whether the replace HTTP cache setting is enabled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Refactor

## Description
Currently every time you visit the settings page, we check if the experimental replace HTTP cache setting is enabled, by checking if the `experiment-replace-http-cache` file exists. As we already check if that file exists in the main process when FreeTube starts, I decided that instead of checking the file system, we can just send an IPC call the the main process, that saves unnecessary file system operations. While I was at it I moved the code that creates and deletes the file to the main process as well, that way it's all in one place and we have less Electron specific code sitting on the renderer side.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open the experimental settings section
2. Check that the switch is the same as it was before this pull request (if it was on before, it should still be on)
3. Toggle the switch
4. Click the yes button in the restart prompt
5. Open the experimental settings section again
6. Check that the switch is correctly showing the on/off value (it should be the opposite of what it was in step 2)

You can reset the setting back to what it was before testing if you want.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0