### PR TITLE
Add confirmation popup before unsubscribing

### DIFF
--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
@@ -105,6 +105,10 @@ export default defineComponent({
       const currentProfile = deepCopy(profile)
 
       if (this.isProfileSubscribed(profile)) {
+        // confirmation pop-up
+        if (!confirm('Are you sure you want to unsubscribe?')) {
+          return
+        }
         currentProfile.subscriptions = currentProfile.subscriptions.filter((channel) => {
           return channel.id !== this.channelId
         })


### PR DESCRIPTION
# Added a popup to ask for confirmation before unsubscribing

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
solves #4109 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
It asks for a confirmation while unsubscribing channel, to avoid accidental unsubscription. 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![Screenshot from 2024-04-08 01-18-53](https://github.com/FreeTubeApp/FreeTube/assets/148802868/a3d166d5-dd2e-4c0f-bce5-e7524be28573)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
I tested it by first subscribing various channels, and everytime I unsubscribed a channel, it would ask me for a confirmation that if I really want to unsubscribe. 

## Desktop
<!-- Please complete the following information-->
- **OS:**Ubuntu
- **OS Version:**22.04
- **FreeTube version:**0.20.0

