### PR TITLE
Fix incorrect published dates in the channel search with the Invidious API

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1916,6 +1916,7 @@ export default defineComponent({
       }
 
       invidiousAPICall(payload).then((response) => {
+        setPublishedTimestampsInvidious(response.filter(item => item.type === 'video'))
         if (this.hideChannelPlaylists) {
           this.searchResults = this.searchResults.concat(response.filter(item => item.type !== 'playlist'))
         } else {


### PR DESCRIPTION
# Fix incorrect published dates in the channel search with the Invidious API

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4908 

## Description
Looks like I missed a place when I refactored the published date handling to use the numeric timestamps instead of the relative ones provided by the Invidious API.

## Screenshots <!-- If appropriate -->
See linked issue.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Set the preferred backend to the Invidious API
2. Open a channel
3. Search for something on that channel
4. Make sure the published dates, don't say 55 years ago anymore

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0