### PR TITLE
Fix window title displaying null while loading a video or channel

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -78,14 +78,13 @@ export default defineComponent({
       return this.$store.getters.getShowCreatePlaylistPrompt
     },
     windowTitle: function () {
-      const routeName = this.$route.name
-      if (routeName !== 'channel' && routeName !== 'watch' && routeName !== 'hashtag') {
-        let title =
-        this.$route.meta.path === '/home'
-          ? packageDetails.productName
-          : `${translateWindowTitle(this.$route.meta.title, this.$i18n)} - ${packageDetails.productName}`
+      const routePath = this.$route.path
+      if (!routePath.startsWith('/channel/') && !routePath.startsWith('/watch/') && !routePath.startsWith('/hashtag/')) {
+        let title = translateWindowTitle(this.$route.meta.title, this.$i18n)
         if (!title) {
           title = packageDetails.productName
+        } else {
+          title = `${title} - ${packageDetails.productName}`
         }
         return title
       } else {


### PR DESCRIPTION
# Fix title bar displaying null while loading a video or channel

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
The checks to stop the window title from changing when a video or channel is opened weren't working correctly, which meant that it would temporily show `null - FreeTube` while the video or channel was loading, before it was corrected to include the channel name or video title.

## Screenshots <!-- If appropriate -->
![title-bar-with-null](https://github.com/FreeTubeApp/FreeTube/assets/48293849/71c18b4f-2b8f-4079-87b2-4ffe6384c159)

## Testing <!-- for code that is not small enough to be easily understandable -->
Click on a video and check that the window title doesn't change until the video has loaded, instead of temporarily showing `null - FreeTube` while the video is loading.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 86fb75bc08bb92145ec5c192db5e40a9ac1f1dfc