### PR TITLE
Workaround YouTube returning empty pages on the channel live tab

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -902,7 +902,16 @@ export default defineComponent({
           return
         }
 
-        this.latestLive = parseLocalChannelVideos(liveTab.videos, this.id, this.channelName)
+        // work around YouTube bug where it will return a bunch of responses with only continuations in them
+        // e.g. https://www.youtube.com/@TWLIVES/streams
+
+        let videos = liveTab.videos
+        while (videos.length === 0 && liveTab.has_continuation) {
+          liveTab = await liveTab.getContinuation()
+          videos = liveTab.videos
+        }
+
+        this.latestLive = parseLocalChannelVideos(videos, this.id, this.channelName)
         this.liveContinuationData = liveTab.has_continuation ? liveTab : null
         this.isElementListLoading = false
 


### PR DESCRIPTION
# Workaround YouTube returning empty pages on the channel live tab

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4827 

## Description
This seems to be the same bug that YouTube has on the community tab for some channels (which is still not resolved more than a year later) see #3318. This pull request adds the same workaround to the live channel tab. I'm not a fan of this for the subscriptions page but I'm not sure what the alternative is other than just not displaying items from the live tab for some channels.

## Testing <!-- for code that is not small enough to be easily understandable -->
I haven't seen this happening on any other channel than the one in the bug report, so here it is.
https://www.youtube.com/channel/UCgTt-_uFA3BsO1RntEVEMEw

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0