### PR TITLE
Add back author search in video playlist searching

### DIFF
--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -142,7 +142,11 @@ export default defineComponent({
       if (this.processedVideoSearchQuery === '') { return this.playlistItems }
 
       return this.playlistItems.filter((v) => {
-        return v.title.toLowerCase().includes(this.processedVideoSearchQuery)
+        if (typeof (v.title) !== 'string' || typeof (v.author) !== 'string') {
+          return false
+        } else {
+          return v.title.toLowerCase().includes(this.processedVideoSearchQuery) || v.author.toLowerCase().includes(this.processedVideoSearchQuery)
+        }
       })
     },
     visiblePlaylistItems: function () {


### PR DESCRIPTION
# Add back author search in video playlist searching

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
N/A (marked as bug in #4857)

## Description
Reuses previous paradigm (the paradigm currently in place in History.js). This was the pre-existing behavior before the Playlist PR. See https://github.com/FreeTubeApp/FreeTube/blob/5c8d49bf51dde8ffd8c8d291dce3e5ff27b0d9fb/src/renderer/views/UserPlaylists/UserPlaylists.js#L98-L103.

## Screenshots <!-- If appropriate -->
![Screenshot_20240410_063611](https://github.com/FreeTubeApp/FreeTube/assets/84899178/6c7240cc-324b-428b-8b25-fe6bc2743346)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Search for video title (variegate casing, should be insensitive)
- Search for author (variegate casing, should be insensitive)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
- **FreeTube version:** Why do we even ask this one for PRs?
