### PR TITLE
Update references of `FreeTubeCordova` to `FreeTubeAndroid`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -92,7 +92,7 @@ body:
         - Portable
         - .rpm
         - .zip
-        - .apk (Android, FreeTubeCordova Unofficial)
+        - .apk (FreeTubeAndroid Unofficial)
         - AUR (Unofficial)
         - Chocolatey (Unofficial)
         - Homebrew (Unofficial)

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -2,7 +2,7 @@
     - '(visual bug)'
 
 'B: Unofficial Download':
-    - '(AUR \(Unofficial\)|Chocolatey \(Unofficial\)|\.apk \(Android, FreeTubeCordova Unofficial\)|Homebrew \(Unofficial\)|PortableApps \(Unofficial\)|WAPT \(Unofficial\)|winget \(Unofficial\)|Scoop \(Unofficial\)|Snapcraft \(Unofficial\)|MPR \(Unofficial\)|Nix \(Unofficial\))'
+    - '(AUR \(Unofficial\)|Chocolatey \(Unofficial\)|\.apk \(FreeTubeAndroid Unofficial\)|Homebrew \(Unofficial\)|PortableApps \(Unofficial\)|WAPT \(Unofficial\)|winget \(Unofficial\)|Scoop \(Unofficial\)|Snapcraft \(Unofficial\)|MPR \(Unofficial\)|Nix \(Unofficial\))'
 
 'B: keyboard control':
     - '(keyboard control not working)'

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The first build with a green check mark is the latest build.
 
 * Chocolatey: [Download](https://chocolatey.org/packages/freetube/)
 
-* FreeTubeCordova (FreeTube port for Android and PWA): [Download](https://github.com/MarmadileManteater/FreeTubeCordova/releases) and [Source Code](https://github.com/MarmadileManteater/FreeTubeCordova)
+* FreeTubeAndroid (FreeTube port for Android and PWA): [Download](https://github.com/MarmadileManteater/FreeTubeAndroid/releases) and [Source Code](https://github.com/MarmadileManteater/FreeTubeAndroid)
 
 * Homebrew Formulae (Mac only): [Download](https://formulae.brew.sh/cask/freetube)
 


### PR DESCRIPTION
# Update references of `FreeTubeCordova` to `FreeTubeAndroid`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [X] Other

## Description
I recently changed the name of FreeTubeCordova to FreeTubeAndroid because Cordova isn't used anymore (as of 0.20.0.115). This PR updates references of the name in the README and the bug report template.
