### PR TITLE
Add `pack` to linter workflow so it's easier to prevent errors when merging PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,3 +25,5 @@ jobs:
         cache: "yarn"
     - run: yarn run ci
     - run: yarn run lint
+    # let's verify that webpack is able to package the project
+    - run: yarn run pack


### PR DESCRIPTION
# Add `pack` to linter workflow so it's easier to prevent errors when merging PRs

## Pull Request Type
- [x] Other - Workflow update

## Description
Prevents PRs that have build errors from getting through + no need to review them until the issues are fixed

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.20.0

