### PR TITLE
Set max height for storyboards depending on window width

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -697,7 +697,12 @@ export default defineComponent({
           }
 
           if (result.storyboards?.type === 'PlayerStoryboardSpec') {
-            this.createLocalStoryboardUrls(result.storyboards.boards.at(-1))
+            let source = result.storyboards.boards
+            const thumbnailsUnder90 = source.filter((board) => board.thumbnail_height <= 90)
+            if (thumbnailsUnder90.length > 0) {
+              source = thumbnailsUnder90
+            }
+            this.createLocalStoryboardUrls(source.at(-1))
           }
         }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -287,13 +287,8 @@ export default defineComponent({
     getStoryboardsResizeCallback(boards) {
       return () => {
         let source = boards
-        let maxHeight = Infinity
         if (window.innerWidth < 500) {
-          maxHeight = 90
-        }
-        const thumbnailsUnder90 = source.filter((board) => board.thumbnail_height <= maxHeight)
-        if (thumbnailsUnder90.length > 0) {
-          source = thumbnailsUnder90
+          source = source.filter((board) => board.thumbnail_height <= 90)
         }
         this.createLocalStoryboardUrls(source.at(-1))
         if (this.$refs?.videoPlayer?.player !== undefined) {


### PR DESCRIPTION
# Set max height for storyboards depending on window width

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [X] Other (visual issue)

## Description
The current implementation picks the largest storyboard possible. However, the size of these storyboards can end up being a bit unwieldy especially on small displays. This PR addresses this by setting the storyboards to a max height of 90px when the screen is narrow `<=500px`.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/046c3182-eaac-46f9-a902-63705c9b54e0)|![image](https://github.com/FreeTubeApp/FreeTube/assets/106682128/316d30a6-065c-4308-a89f-834b0afe6c91)|


## Testing <!-- for code that is not small enough to be easily understandable -->
**testing that the storyboard is a different size on smaller displays**
1. Ensure `Local API` is your backend preference
2. Open a video with large storyboards (ex: https://youtu.be/qcH2wgRLiV8)
3. Reduce the window width to below `500px`
4. Ensure the storyboard used is smaller than before
 
**testing that the resize listener is being removed properly**
1. Repeat steps 1 and 2 above
2. Open the inspect element to the `Sources` tab
3. Expand the "global listeners" to see all resize events bound to the window
4. Navigate away from the video (to another video or to another view)
5. Refresh the global listeners in the sources tab
6. See that there are no active resize listeners linked to `Watch.js`

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2 (OS Build 19045.4170)
- **FreeTube version:** af2913592ee0e989dba8f5909ff7909f9bc42516

## Additional context
I had considered simply setting the max-height to 90px without a resize listener (since that is already used as the max height for invidious storyboards). That might be a valid option. I'm not a big fan of storing the callback in the `data`. I would love a way to easily bind an anonymous function to the window `resize` that I can clean up later if anyone can think of one. I would simply define it as a method, but it requires data from the `result` object which is only in scope within the `getVideoInformationLocal` function. That is why I used a method which returns a callback instead of a method as a callback.
