### PR TITLE
Local API: Fix extracting the published date and view count in playlists

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -697,14 +697,16 @@ export function parseLocalPlaylistVideo(video) {
     // the accessiblity label contains the full view count
     // the video info only contains the short view count
     if (video_.accessibility_label) {
-      const match = video_.accessibility_label.match(/([\d,.]+|no) views?$/i)
+      // the `.*\s+` at the start of the regex, ensures we match the last occurence
+      // just in case the video title also contains that pattern
+      const match = video_.accessibility_label.match(/.*\s+([\d,.]+|no)\s+views?/)
 
       if (match) {
         const count = match[1]
 
         // as it's rare that a video has no views,
         // checking the length allows us to avoid running toLowerCase unless we have to
-        if (count.length === 2 && count.toLowerCase() === 'no') {
+        if (count.length === 2 && count === 'no') {
           viewCount = 0
         } else {
           const views = extractNumberFromString(count)
@@ -718,11 +720,19 @@ export function parseLocalPlaylistVideo(video) {
 
     let publishedText
     // normal videos have 3 text runs with the last one containing the published date
+    // OR no runs and just text with the published date (if the view count is missing)
     // live videos have 2 text runs with the number of people watching
     // upcoming either videos don't have any info text or the number of people waiting,
     // but we have the premiere date for those, so we don't need the published date
-    if (video_.video_info.runs && video_.video_info.runs.length === 3) {
-      publishedText = video_.video_info.runs[2].text
+
+    if (!video_.is_upcoming && !video_.is_live) {
+      const hasRuns = !!video_.video_info.runs
+
+      if (hasRuns && video_.video_info.runs.length === 3) {
+        publishedText = video_.video_info.runs[2].text
+      } else if (!hasRuns && video_.video_info.text) {
+        publishedText = video_.video_info.text
+      }
     }
 
     const published = calculatePublishedDate(


### PR DESCRIPTION
# Local API: Fix extracting the published date and view count in playlists

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
When a video has it's view count hidden inside a playlist, we don't extract the published date, this pull request fixes that. While fixing that I also noticed that the extraction of the view count for videos that do have one, is broken too, due to YouTube changing the accessibility text. The view count used to be at the end of the accessibility text, now it has the following structure: `{title} by {uploader} {view count} views {relative published date} {written out duration e.g. "22 minutes"}` and if the view count is missing `{title} by {uploader} {relative published date} {written out duration e.g. "22 minutes"}`.

The Invidious API doesn't return the view count or the published date, presumably because extracting them is a bit ugly.

## Testing <!-- for code that is not small enough to be easily understandable -->
View the following playlists with the local API.
Some vidoes are missing their view counts: https://youtube.com/playlist?list=PLBsP89CPrMeO7uztAu6YxSB10cRMpjgiY
Live: https://youtube.com/playlist?list=PL6NdkXsPL07Il2hEQGcLI4dg_LTg7xA2L

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0