### PR TITLE
Directly switch from PIP to full screen mode using shortcut

### DIFF
--- a/src/renderer/components/ft-video-player/ft-video-player.js
+++ b/src/renderer/components/ft-video-player/ft-video-player.js
@@ -2179,6 +2179,9 @@ export default defineComponent({
           case 'f':
             // Toggle Fullscreen Playback
             event.preventDefault()
+            if (this.player.isInPictureInPicture()) {
+              this.player.exitPictureInPicture()
+            }
             this.toggleFullscreen()
             break
           case 'M':


### PR DESCRIPTION
# Directly switch from PIP to full screen mode using shortcut

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #3232

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Can switch directly to full screen mode from PIP mode using shortcut f / F.

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
First pressed i to switch to PIP mode and then f to switch to Full Screen mode directly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Ubuntu
- **OS Version:** 22.04
- **FreeTube version:** 0.2.0

