### PR TITLE
Fix user playlist reverse button behavior

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -166,13 +166,6 @@ export default defineComponent({
       // Re-fetch from local store when current user playlist updated
       this.parseUserPlaylist(this.selectedUserPlaylist, { allowPlayingVideoRemoval: true })
     },
-    playlistItemId (newId, _oldId) {
-      // Playing online video
-      if (newId == null) { return }
-
-      // Re-fetch from local store when different item played
-      this.parseUserPlaylist(this.selectedUserPlaylist, { allowPlayingVideoRemoval: true })
-    },
     videoId: function (newId, oldId) {
       // Check if next video is from the shuffled list or if the user clicked a different video
       if (this.shuffleEnabled) {
@@ -284,7 +277,7 @@ export default defineComponent({
       this.reversePlaylist = !this.reversePlaylist
       // Create a new array to avoid changing array in data store state
       // it could be user playlist or cache playlist
-      this.playlistItems = [].concat(this.playlistItems).reverse()
+      this.playlistItems = this.playlistItems.toReversed()
       setTimeout(() => {
         this.isLoading = false
       }, 1)
@@ -486,6 +479,10 @@ export default defineComponent({
         if (latestPlaylistContainsCurrentVideo) {
           this.playlistItems = playlist.videos
         }
+      }
+
+      if (this.reversePlaylist) {
+        this.playlistItems = this.playlistItems.toReversed()
       }
 
       this.isLoading = false


### PR DESCRIPTION
# Fix user playlist reverse button behavior

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
None

## Description

Co-author: @absidue (identified where issue was occurring)

User playlists that are reversed revert to their normal ordering after the next video is loaded. This PR fixes that by making our `parseUserPlaylist` function maintain a reversed order. It also removes a `watch` property that @absidue identified as not relevant.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Reverse a playlist and then navigate to another video in the playlist. See that the playlist is still reversed

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW

## Additional context
CC: @PikachuEXE if we're missing a purpose for this `watch` property. Its removal isn't strictly required for this fix.

Note: we're doing `x = x.toReversed()` instead `x.reverse()` to avoid a warning for mutating Vuex data.
