### PR TITLE
Bundle datastores as ES modules instead of commonjs

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -151,6 +151,8 @@ const config = {
     alias: {
       vue$: 'vue/dist/vue.runtime.esm.js',
 
+      'DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$': path.resolve(__dirname, '../src/datastores/handlers/electron.js'),
+
       'youtubei.js$': 'youtubei.js/web',
 
       // video.js's mpd-parser uses @xmldom/xmldom so that it can support both node and web browsers

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -160,6 +160,8 @@ const config = {
     alias: {
       vue$: 'vue/dist/vue.runtime.esm.js',
 
+      'DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$': path.resolve(__dirname, '../src/datastores/handlers/web.js'),
+
       // video.js's mpd-parser uses @xmldom/xmldom so that it can support both node and web browsers
       // As FreeTube only runs in electron and web browsers, we can use the native DOMParser class, instead of the "polyfill"
       // https://caniuse.com/mdn-api_domparser

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,6 +3,13 @@
     "target": 2.7
   },
   "compilerOptions": {
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": "./",
+    "paths": {
+      "DB_HANDLERS_ELECTRON_RENDERER_OR_WEB": [
+        "src/datastores/handlers/electron",
+        "src/datastores/handlers/web"
+      ]
+    }
   }
 }

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -1,4 +1,4 @@
-import db from '../index'
+import * as db from '../index'
 
 class Settings {
   static find() {
@@ -192,13 +192,11 @@ function compactAllDatastores() {
   ])
 }
 
-const baseHandlers = {
-  settings: Settings,
-  history: History,
-  profiles: Profiles,
-  playlists: Playlists,
+export {
+  Settings as settings,
+  History as history,
+  Profiles as profiles,
+  Playlists as playlists,
 
   compactAllDatastores,
 }
-
-export default baseHandlers

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -205,11 +205,9 @@ class Playlists {
   }
 }
 
-const handlers = {
-  settings: Settings,
-  history: History,
-  profiles: Profiles,
-  playlists: Playlists
+export {
+  Settings as settings,
+  History as history,
+  Profiles as profiles,
+  Playlists as playlists
 }
-
-export default handlers

--- a/src/datastores/handlers/index.js
+++ b/src/datastores/handlers/index.js
@@ -1,18 +1,6 @@
-let handlers
-if (process.env.IS_ELECTRON) {
-  handlers = require('./electron').default
-} else {
-  handlers = require('./web').default
-}
-
-const DBSettingHandlers = handlers.settings
-const DBHistoryHandlers = handlers.history
-const DBProfileHandlers = handlers.profiles
-const DBPlaylistHandlers = handlers.playlists
-
 export {
-  DBSettingHandlers,
-  DBHistoryHandlers,
-  DBProfileHandlers,
-  DBPlaylistHandlers
-}
+  settings as DBSettingHandlers,
+  history as DBHistoryHandlers,
+  profiles as DBProfileHandlers,
+  playlists as DBPlaylistHandlers
+} from 'DB_HANDLERS_ELECTRON_RENDERER_OR_WEB'

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -1,4 +1,4 @@
-import baseHandlers from './base'
+import * as baseHandlers from './base'
 
 // TODO: Syncing
 // Syncing on the web would involve a different implementation
@@ -118,11 +118,9 @@ class Playlists {
   }
 }
 
-const handlers = {
-  settings: Settings,
-  history: History,
-  profiles: Profiles,
-  playlists: Playlists
+export {
+  Settings as settings,
+  History as history,
+  Profiles as profiles,
+  Playlists as playlists
 }
-
-export default handlers

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -22,10 +22,7 @@ if (process.env.IS_ELECTRON_MAIN) {
   dbPath = (dbName) => `${dbName}.db`
 }
 
-const db = {}
-db.settings = new Datastore({ filename: dbPath('settings'), autoload: true })
-db.profiles = new Datastore({ filename: dbPath('profiles'), autoload: true })
-db.playlists = new Datastore({ filename: dbPath('playlists'), autoload: true })
-db.history = new Datastore({ filename: dbPath('history'), autoload: true })
-
-export default db
+export const settings = new Datastore({ filename: dbPath('settings'), autoload: true })
+export const profiles = new Datastore({ filename: dbPath('profiles'), autoload: true })
+export const playlists = new Datastore({ filename: dbPath('playlists'), autoload: true })
+export const history = new Datastore({ filename: dbPath('history'), autoload: true })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -7,7 +7,7 @@ import path from 'path'
 import cp from 'child_process'
 
 import { IpcChannels, DBActions, SyncEvents } from '../constants'
-import baseHandlers from '../datastores/handlers/base'
+import * as baseHandlers from '../datastores/handlers/base'
 import { extractExpiryTimestamp, ImageCache } from './ImageCache'
 import { existsSync } from 'fs'
 import asyncFs from 'fs/promises'


### PR DESCRIPTION
# Bundle datastores as ES modules instead of commonjs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Bundling improvement

## Description
FreeTube has two different data store implementations, the way that we decide which one to use and bundle is currently done via an if with an Electron check and the importing the datastore with `require()`. That works well, but isn't the most efficient way of doing it, as using `require()` makes webpack treat the datastore as a commonjs module, despite it being written in the ES modules style. Unlike ES modules that use static imports and exports, commonjs allows dynamically assigning the exported values, so webpack has to simulate the import at runtime with a commonjs wrapper.

You may notice that the delta for the `renderer.js` file is much larger than for the other two, that is because the datastore implemenation for the renderer, also imports the constants so that it can use the IPC channels. So the constants had to be treated as a commonjs module too.

To avoid that happening, I've switched to using a `resolve.alias` for the datastore import, that way webpack can treat the datastores as completely normal ES modules and do all the usual optimisations. While I was at it, I also decided to get rid of the unnecessary object wrappers around the datastore classes (`export default {}` vs `export {}`), which means the classes can now be directly referenced.

| File | Before | After | Delta |
| --- | --- | --- | --- |
| `main.js` | `255952` bytes | `255169` bytes | `-783` bytes |
| `renderer.js` | `2159853` bytes | `2158396` bytes | `-1457` bytes |
| `web.js` | `1749596` bytes | `1748738` bytes | `-858` bytes |

## Testing <!-- for code that is not small enough to be easily understandable -->
Start FreeTube and check that your settings, subscriptions, playlists and watch history load.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0