### PR TITLE
Disable merge conflict detection on draft PRs

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,12 +1,10 @@
 name: "Conflicts"
 on:
-  # So that PRs touching the same files as the push are updated
-  push:
   # So that the `dirtyLabel` is removed if conflicts are resolve
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
-    types: [synchronize, ready_for_review]
+    types: [edited, synchronize, ready_for_review]
 
 jobs:
   main:

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -6,7 +6,7 @@ on:
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
-    types: [synchronize]
+    types: [synchronize, ready_for_review]
 
 jobs:
   main:

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: check if prs are dirty
         uses: eps1lon/actions-label-merge-conflict@releases/2.x


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Keep getting notification about having merge conflicts and resolved on **draft** PRs is unnecessary IMO

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
