### PR TITLE
Intuitive input bindings

### DIFF
--- a/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.js
+++ b/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.js
@@ -10,6 +10,7 @@ import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtToggleSwitch from '../../components/ft-toggle-switch/ft-toggle-switch.vue'
 import {
   showToast,
+  ctrlFHandler
 } from '../../helpers/utils'
 
 const SORT_BY_VALUES = {
@@ -44,6 +45,8 @@ export default defineComponent({
       lastShownAt: Date.now(),
       lastActiveElement: null,
       sortBy: SORT_BY_VALUES.LatestUpdatedFirst,
+      keyboardShortcutHandler: (e) => ctrlFHandler(e, this.$refs.searchBar),
+
     }
   },
   computed: {
@@ -198,12 +201,13 @@ export default defineComponent({
   },
   mounted: function () {
     this.lastActiveElement = document.activeElement
-
     this.updateQueryDebounce = debounce(this.updateQuery, 500)
     // User might want to search first if they have many playlists
     this.$refs.searchBar.focus()
+    document.addEventListener('keydown', this.keyboardShortcutHandler)
   },
   beforeDestroy() {
+    document.removeEventListener('keydown', this.keyboardShortcutHandler)
     this.lastActiveElement?.focus()
   },
   methods: {

--- a/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
+++ b/src/renderer/components/ft-profile-edit/ft-profile-edit.vue
@@ -46,6 +46,7 @@
               :value="translatedProfileName"
               :show-action-button="false"
               @input="e => profileName = e"
+              @keydown.enter.native="saveProfile"
             />
           </div>
           <div>

--- a/src/renderer/components/password-settings/password-settings.vue
+++ b/src/renderer/components/password-settings/password-settings.vue
@@ -22,6 +22,7 @@
         input-type="password"
         :value="password"
         @input="e => password = e"
+        @keydown.enter.native="handleSetPassword"
       />
       <ft-button
         class="centerButton"

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -7,6 +7,7 @@ import FtInput from '../ft-input/ft-input.vue'
 import FtPrompt from '../ft-prompt/ft-prompt.vue'
 import FtButton from '../ft-button/ft-button.vue'
 import {
+  ctrlFHandler,
   formatNumber,
   showToast,
 } from '../../helpers/utils'
@@ -106,6 +107,7 @@ export default defineComponent({
       showRemoveVideosOnWatchPrompt: false,
       newTitle: '',
       newDescription: '',
+      keyboardShortcutHandler: (e) => ctrlFHandler(e, this.$refs.searchInput),
       deletePlaylistPromptValues: [
         'yes',
         'no'
@@ -408,19 +410,6 @@ export default defineComponent({
     updateQuery(query) {
       this.query = query
       this.$emit('search-video-query-change', query)
-    },
-
-    keyboardShortcutHandler(event) {
-      switch (event.key) {
-        case 'F':
-        case 'f':
-          if (this.searchVideoModeAllowed && ((process.platform !== 'darwin' && event.ctrlKey) || (process.platform === 'darwin' && event.metaKey))) {
-            nextTick(() => {
-              // Some elements only present after rendering update
-              this.$refs.searchInput.focus()
-            })
-          }
-      }
     },
 
     ...mapActions([

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -39,6 +39,7 @@
         :show-label="false"
         :value="newTitle"
         @input="(input) => (newTitle = input)"
+        @keydown.enter.native="savePlaylistInfo"
       />
       <h2
         v-else
@@ -66,6 +67,7 @@
       :show-label="false"
       :value="newDescription"
       @input="(input) => newDescription = input"
+      @keydown.enter.native="savePlaylistInfo"
     />
     <p
       v-else

--- a/src/renderer/components/proxy-settings/proxy-settings.vue
+++ b/src/renderer/components/proxy-settings/proxy-settings.vue
@@ -29,6 +29,7 @@
           :show-label="true"
           :value="proxyHostname"
           @input="handleUpdateProxyHostname"
+          @keydown.enter.native="testProxy"
         />
         <ft-input
           :placeholder="$t('Settings.Proxy Settings.Proxy Port Number')"
@@ -36,6 +37,7 @@
           :show-label="true"
           :value="proxyPort"
           @input="handleUpdateProxyPort"
+          @keydown.enter.native="testProxy"
         />
       </ft-flex-box>
       <p

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -4,6 +4,7 @@ import { IpcChannels } from '../../constants'
 import FtToastEvents from '../components/ft-toast/ft-toast-events'
 import i18n from '../i18n/index'
 import router from '../router/index'
+import { nextTick } from 'vue'
 
 // allowed characters in channel handle: A-Z, a-z, 0-9, -, _, .
 // https://support.google.com/youtube/answer/11585688#change_handle
@@ -766,5 +767,15 @@ export async function fetchWithTimeout(timeoutMs, input, init) {
     } else {
       throw err
     }
+  }
+}
+
+export function ctrlFHandler(event, inputElement) {
+  switch (event.key) {
+    case 'F':
+    case 'f':
+      if (((process.platform !== 'darwin' && event.ctrlKey) || (process.platform === 'darwin' && event.metaKey))) {
+        nextTick(() => inputElement?.focus())
+      }
   }
 }

--- a/src/renderer/views/History/History.js
+++ b/src/renderer/views/History/History.js
@@ -7,6 +7,7 @@ import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtButton from '../../components/ft-button/ft-button.vue'
 import FtInput from '../../components/ft-input/ft-input.vue'
 import FtAutoLoadNextPageWrapper from '../../components/ft-auto-load-next-page-wrapper/ft-auto-load-next-page-wrapper.vue'
+import { ctrlFHandler } from '../../helpers/utils'
 
 export default defineComponent({
   name: 'History',
@@ -27,6 +28,7 @@ export default defineComponent({
       showLoadMoreButton: false,
       query: '',
       activeData: [],
+      keyboardShortcutHandler: (e) => ctrlFHandler(e, this.$refs.searchBar),
     }
   },
   computed: {
@@ -53,6 +55,7 @@ export default defineComponent({
     }
   },
   mounted: function () {
+    document.addEventListener('keydown', this.keyboardShortcutHandler)
     const limit = sessionStorage.getItem('historyLimit')
 
     if (limit !== null) {
@@ -68,6 +71,9 @@ export default defineComponent({
     }
 
     this.filterHistoryDebounce = debounce(this.filterHistory, 500)
+  },
+  beforeDestroy: function () {
+    document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
     increaseLimit: function () {

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -6,6 +6,7 @@ import FtInput from '../../components/ft-input/ft-input.vue'
 import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe-button.vue'
 import { invidiousGetChannelInfo, youtubeImageUrlToInvidious, invidiousImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getLocalChannel } from '../../helpers/api/local'
+import { ctrlFHandler } from '../../helpers/utils'
 
 export default defineComponent({
   name: 'SubscribedChannels',
@@ -26,7 +27,8 @@ export default defineComponent({
       },
       thumbnailSize: 176,
       ytBaseURL: 'https://yt3.ggpht.com',
-      errorCount: 0
+      errorCount: 0,
+      keyboardShortcutHandler: (e) => ctrlFHandler(e, this.$refs.searchBarChannels),
     }
   },
   computed: {
@@ -78,7 +80,11 @@ export default defineComponent({
     }
   },
   mounted: function () {
+    document.addEventListener('keydown', this.keyboardShortcutHandler)
     this.getSubscription()
+  },
+  beforeDestroy: function () {
+    document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
     getSubscription: function () {

--- a/src/renderer/views/UserPlaylists/UserPlaylists.js
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.js
@@ -12,6 +12,7 @@ import FtInput from '../../components/ft-input/ft-input.vue'
 import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 import FtToggleSwitch from '../../components/ft-toggle-switch/ft-toggle-switch.vue'
 import FtAutoLoadNextPageWrapper from '../../components/ft-auto-load-next-page-wrapper/ft-auto-load-next-page-wrapper.vue'
+import { ctrlFHandler } from '../../helpers/utils'
 
 const SORT_BY_VALUES = {
   NameAscending: 'name_ascending',
@@ -52,6 +53,7 @@ export default defineComponent({
       doSearchPlaylistsWithMatchingVideos: false,
       activeData: [],
       sortBy: SORT_BY_VALUES.LatestPlayedFirst,
+      keyboardShortcutHandler: (e) => ctrlFHandler(e, this.$refs.searchBar),
     }
   },
   computed: {
@@ -183,6 +185,7 @@ export default defineComponent({
     },
   },
   mounted: function () {
+    document.addEventListener('keydown', this.keyboardShortcutHandler)
     const limit = sessionStorage.getItem('favoritesLimit')
     if (limit !== null) {
       this.dataLimit = limit
@@ -198,6 +201,9 @@ export default defineComponent({
     this.showLoadMoreButton = this.activeData.length < this.allPlaylists.length
 
     this.filterPlaylistDebounce = debounce(this.filterPlaylist, 500)
+  },
+  beforeDestroy: function () {
+    document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
     increaseLimit: function () {


### PR DESCRIPTION
# Intuitive input bindings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
None

## Description
- Because we don't use forms in most of FreeTube, `ft-input`s that should have an `onsubmit` action fire on <kbd>Enter</kbd> are not actually doing anything on that command, thus leading to some frustrating behavior. This configures <kbd>Enter</kbd> on any `ft-input`s with a corresponding submission action to trigger that action.
- We have many prominent search bars, and <kbd>Ctrl</kbd>+<kbd>F</kbd> is a universal standard for initiating a "find". This adds an event listener to focus these search bars on their applicable routes when <kbd>Ctrl</kbd>+<kbd>F</kbd> is pressed.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test <kbd>Ctrl</kbd>+<kbd>F</kbd> focuses search bars on all routes with a prominent one (History, UserPlaylists, SubscribedChannels, User Playlist, Add to User Playlist Prompt).
- Test 'Enter' properly submits all forms (Profile Edit, User Playlist Edit, Test Proxy, Set Password).

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW

## Additional context
Q: Should this be added to our list of keyboard shortcuts?
A: IMO, these are pretty universal/expected behaviors that users will discover by just trying more often than not. I can maybe budge on the <kbd>Ctrl</kbd>+<kbd>F</kbd> one since that's a bit more specific, and existing users may have tried it before & mentally discounted it.