### PR TITLE
Simplify static file loading

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -111,13 +111,14 @@ function startRenderer(callback) {
 
   const server = new WebpackDevServer({
     static: {
-      directory: path.join(process.cwd(), 'static'),
+      directory: path.resolve(__dirname, '..', 'static'),
       watch: {
         ignored: [
           /(dashFiles|storyboards)\/*/,
           '/**/.DS_Store',
         ]
-      }
+      },
+      publicPath: '/static'
     },
     port
   }, compiler)

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -111,8 +111,8 @@ const config = {
     ]
   },
   node: {
-    __dirname: isDevMode,
-    __filename: isDevMode
+    __dirname: false,
+    __filename: false
   },
   plugins: [
     processLocalesPlugin,

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -108,8 +108,8 @@ const config = {
     ]
   },
   node: {
-    __dirname: true,
-    __filename: isDevMode,
+    __dirname: false,
+    __filename: false
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -276,10 +276,7 @@ export default defineComponent({
     },
 
     checkExternalPlayer: async function () {
-      const payload = {
-        externalPlayer: this.externalPlayer
-      }
-      this.getExternalPlayerCmdArgumentsData(payload)
+      this.getExternalPlayerCmdArgumentsData()
     },
 
     handleUpdateBannerClick: function (response) {

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -36,14 +36,14 @@ export async function loadLocale(locale) {
 
   // locales are only compressed in our production Electron builds
   if (process.env.IS_ELECTRON && process.env.NODE_ENV !== 'development') {
-    const { readFile } = require('fs/promises')
     const { promisify } = require('util')
     const { brotliDecompress } = require('zlib')
     const brotliDecompressAsync = promisify(brotliDecompress)
     try {
       // decompress brotli compressed json file and then load it
-      // eslint-disable-next-line n/no-path-concat
-      const compressed = await readFile(`${__dirname}/static/locales/${locale}.json.br`)
+      const url = createWebURL(`/static/locales/${locale}.json.br`)
+      const compressed = await (await fetch(url)).arrayBuffer()
+
       const decompressed = await brotliDecompressAsync(compressed)
       const data = JSON.parse(decompressed.toString())
       i18n.setLocaleMessage(locale, data)

--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -1,4 +1,3 @@
-import fs from 'fs/promises'
 import { createWebURL, fetchWithTimeout } from '../../helpers/utils'
 
 const state = {
@@ -42,14 +41,11 @@ const actions = {
 
     // If the invidious instance fetch isn't returning anything interpretable
     if (instances.length === 0) {
-      // Fallback: read from static file
-      const fileName = 'invidious-instances.json'
-      /* eslint-disable-next-line n/no-path-concat */
-      const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
-      const filePath = `${fileLocation}${fileName}`
       console.warn('reading static file for invidious instances')
-      const fileData = process.env.IS_ELECTRON ? await fs.readFile(filePath, 'utf8') : await (await fetch(createWebURL(filePath))).text()
-      instances = JSON.parse(fileData).filter(e => {
+      const url = createWebURL('/static/invidious-instances.json')
+
+      const fileData = await (await fetch(url)).json()
+      instances = fileData.filter(e => {
         return process.env.SUPPORTS_LOCAL_API || e.cors
       }).map(e => {
         return e.url

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -354,11 +354,10 @@ const actions = {
 
   async getRegionData ({ commit }, { locale }) {
     const localePathExists = process.env.GEOLOCATION_NAMES.includes(locale)
-    // Exclude __dirname from path if not in electron
-    const fileLocation = `${process.env.IS_ELECTRON ? process.env.NODE_ENV === 'development' ? '.' : __dirname : ''}/static/geolocations/`
 
-    const pathName = `${fileLocation}${localePathExists ? locale : 'en-US'}.json`
-    const countries = process.env.IS_ELECTRON ? JSON.parse(await fs.readFile(pathName)) : await (await fetch(createWebURL(pathName))).json()
+    const url = createWebURL(`/static/geolocations/${localePathExists ? locale : 'en-US'}.json`)
+
+    const countries = await (await fetch(url)).json()
 
     const regionNames = countries.map((entry) => { return entry.name })
     const regionValues = countries.map((entry) => { return entry.code })
@@ -590,16 +589,9 @@ const actions = {
     commit('setSessionSearchHistory', [])
   },
 
-  async getExternalPlayerCmdArgumentsData ({ commit }, payload) {
-    const fileName = 'external-player-map.json'
-    /* eslint-disable-next-line n/no-path-concat */
-    const fileLocation = process.env.NODE_ENV === 'development' ? './static/' : `${__dirname}/static/`
-
-    const fileData = await fs.readFile(`${fileLocation}${fileName}`)
-
-    const externalPlayerMap = JSON.parse(fileData).map((entry) => {
-      return { name: entry.name, value: entry.value, cmdArguments: entry.cmdArguments }
-    })
+  async getExternalPlayerCmdArgumentsData ({ commit }) {
+    const url = createWebURL('/static/external-player-map.json')
+    const externalPlayerMap = await (await fetch(url)).json()
     // Sort external players alphabetically & case-insensitive, keep default entry at the top
     const playerNone = externalPlayerMap.shift()
     externalPlayerMap.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))


### PR DESCRIPTION
# Simplify static file loading

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Refactor

## Description
This pull request changes the way static files are loaded, it removes all of the different code paths that were used until now for development vs production and Electron vs non-Electron. Instead it switches to using the fetch API in all scenarios, that means we don't need complicated lines like this anymore:
```js
const fileLocation = `${process.env.IS_ELECTRON ? process.env.NODE_ENV === 'development' ? '.' : __dirname : ''}/static/geolocations/`
```

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Change the language and make sure that the text changes
2. When the language changes, make sure that the region names change in the region for trending setting
3. Check the external player settings and make sure the list of players still gets populated
4. Turn off your wifi or unplug your ethernet cable, launch FreeTube and check that `reading static file for invidious instances` warning shows up in the console and that the invidious instance box still gets populated with a random instance.

As the change to the language loading only affects release builds, here is one you can test it with: https://github.com/absidue/FreeTube/actions/runs/8726633691

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0