### PR TITLE
Add yarn run pack:web to linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,3 +27,5 @@ jobs:
     - run: yarn run lint
     # let's verify that webpack is able to package the project
     - run: yarn run pack
+    # verify that webpack is able to package the project using the web config
+    - run: yarn run pack:web


### PR DESCRIPTION
# Add `pack:web` to linter workflow so it's easier to prevent errors when merging PRs

## Pull Request Type
- [x] Other - Workflow update

## Description
Makes sure that web build dont break even though we don't officially support them

## Related
https://github.com/FreeTubeApp/FreeTube/pull/4927

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.20.0

