### PR TITLE
Fix refresh widget z-index

### DIFF
--- a/src/renderer/components/ft-refresh-widget/ft-refresh-widget.css
+++ b/src/renderer/components/ft-refresh-widget/ft-refresh-widget.css
@@ -13,6 +13,7 @@
   align-items: center;
   gap: 5px;
   justify-content: flex-end;
+  z-index: 4;
 }
 
 .floatingRefreshSection:has(.lastRefreshTimestamp + .refreshButton) {


### PR DESCRIPTION
# Fix refresh widget z-index

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4380#issuecomment-2063764486

## Description
Sets it to same value as top-nav.

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
