### PR TITLE
Fix video timestamps

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -666,7 +666,7 @@ export default defineComponent({
           this.uploadedTime = new Date(this.data.published).toLocaleDateString([this.currentLocale, 'en'])
         } else {
           // Use 30 days per month, just like calculatePublishedDate
-          this.uploadedTime = getRelativeTimeFromDate(new Date(this.data.published).toDateString(), false)
+          this.uploadedTime = getRelativeTimeFromDate(new Date(this.data.published), false)
         }
       }
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -729,9 +729,7 @@ export function getRelativeTimeFromDate(date, hideSeconds = false, useThirtyDayM
   const now = new Date().getTime()
   // Convert from ms to second
   // For easier code interpretation the value is made to be positive
-  // `comparisonDate` is sometimes a string
-  const comparisonDate = Date.parse(date)
-  let timeDiffFromNow = ((now - comparisonDate) / 1000)
+  let timeDiffFromNow = ((now - date) / 1000)
   let timeUnit = 'second'
 
   if (timeDiffFromNow < 60 && hideSeconds) {
@@ -753,11 +751,17 @@ export function getRelativeTimeFromDate(date, hideSeconds = false, useThirtyDayM
     timeUnit = 'day'
   }
 
+  const timeDiffFromNowDays = timeDiffFromNow
+  if (timeUnit === 'day' && timeDiffFromNow >= 7) {
+    timeDiffFromNow /= 7
+    timeUnit = 'week'
+  }
+
   /* Different months might have a different number of days.
     In some contexts, to ensure the display is fine, we use 31.
     In other contexts, like when working with calculatePublishedDate, we use 30. */
   const daysInMonth = useThirtyDayMonths ? 30 : 31
-  if (timeUnit === 'day' && timeDiffFromNow >= daysInMonth) {
+  if (timeUnit === 'week' && timeDiffFromNowDays >= daysInMonth) {
     timeDiffFromNow /= daysInMonth
     timeUnit = 'month'
   }


### PR DESCRIPTION
# Fix video timestamps

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
None

## Description
I'm a bucket full of mistakes today! Was missing "week" classification in the new `getRelativeTimeFromDate` util function, and was unnecessarily converting to a dateString. As a result, all dates are broken. Now they're not. Fun times!

## Testing
- Search for videos from the last hour

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW