### PR TITLE
Set refresh widget z-index to below dropdown search bar

### DIFF
--- a/src/renderer/components/ft-refresh-widget/ft-refresh-widget.css
+++ b/src/renderer/components/ft-refresh-widget/ft-refresh-widget.css
@@ -13,7 +13,7 @@
   align-items: center;
   gap: 5px;
   justify-content: flex-end;
-  z-index: 4;
+  z-index: 3;
 }
 
 .floatingRefreshSection:has(.lastRefreshTimestamp + .refreshButton) {

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -21,6 +21,10 @@
   inline-size: 100%;
   z-index: 4;
 
+  &:has(+ .sideNav + .routerView .floatingRefreshSection) {
+    box-shadow: none;
+  }
+
   @media only screen and (width >= 961px) {
     display: grid;
     grid-template-columns: 1fr 440px 1fr;


### PR DESCRIPTION
# Set refresh widget z-index to below dropdown search bar

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other


## Description
The topNav is currently lower than the z-index of the ft-refresh-widget. This causes the search to be below the refresh widget when it drops down. This PR addresses this by setting the widget's z-index to `3`. It also hides the box shadow on the topNav when there is a refresh widget present in the routerView. I added that because it was previously hidden by the ft-refresh-widget.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/7f3cab92-fa3a-4025-8c1e-40ccd39fd329)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/7de8f0ef-151a-4316-861e-126fa0b7303e)|



## Testing <!-- for code that is not small enough to be easily understandable -->
1. Ensure the window is narrow `<=680px`
3. Check that the search is visible when expanded
3. Check that the refresh widget is still above watch video progress

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2 (OS Build 19045.4291)
- **FreeTube version:** b69ecd12a56b231bc8277df33e0909a3886a65e4
