### PR TITLE
Use webpack dev server's open option

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -130,7 +130,7 @@ function startRenderer(callback) {
   })
 }
 
-function startWeb (callback) {
+function startWeb () {
   const compiler = webpack(webConfig)
   const { name } = compiler
 
@@ -140,6 +140,7 @@ function startWeb (callback) {
   })
 
   const server = new WebpackDevServer({
+    open: true,
     static: {
       directory: path.join(process.cwd(), 'dist/web/static'),
       watch: {
@@ -154,15 +155,10 @@ function startWeb (callback) {
 
   server.startCallback(err => {
     if (err) console.error(err)
-
-    callback({ port: server.options.port })
   })
 }
 if (!web) {
   startRenderer(startMain)
 } else {
-  startWeb(async ({ port }) => {
-    const open = (await import('open')).default
-    open(`http://localhost:${port}`)
-  })
+  startWeb()
 }


### PR DESCRIPTION
# Use webpack dev server's open option

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Other - Cleanup

## Description
Was looking through the webpack dev server docs for something else and noticed that it has an option to launch the browser, which means we don't need to do it ourselves, which simplifies the code a bit.

## Testing <!-- for code that is not small enough to be easily understandable -->
Run `yarn dev:web`, your default browser should be launched the same as it was before this change.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0