### PR TITLE
Fetch invidious instances from file then use api

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -159,10 +159,16 @@ export default defineComponent({
     this.grabUserSettings().then(async () => {
       this.checkThemeSettings()
 
-      await this.fetchInvidiousInstances()
+      await this.fetchInvidiousInstancesFromFile()
       if (this.defaultInvidiousInstance === '') {
         await this.setRandomCurrentInvidiousInstance()
       }
+
+      this.fetchInvidiousInstances().then(e => {
+        if (this.defaultInvidiousInstance === '') {
+          this.setRandomCurrentInvidiousInstance()
+        }
+      })
 
       this.grabAllProfiles(this.$t('Profile.All Channels')).then(async () => {
         this.grabHistory()
@@ -538,6 +544,7 @@ export default defineComponent({
       'getYoutubeUrlInfo',
       'getExternalPlayerCmdArgumentsData',
       'fetchInvidiousInstances',
+      'fetchInvidiousInstancesFromFile',
       'setRandomCurrentInvidiousInstance',
       'setupListenersToSyncWindows',
       'updateBaseTheme',

--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -16,14 +16,26 @@ const getters = {
 }
 
 const actions = {
+  async fetchInvidiousInstancesFromFile({ commit }) {
+    const url = createWebURL('/static/invidious-instances.json')
+
+    const fileData = await (await fetch(url)).json()
+    const instances = fileData.filter(e => {
+      return process.env.SUPPORTS_LOCAL_API || e.cors
+    }).map(e => {
+      return e.url
+    })
+
+    commit('setInvidiousInstancesList', instances)
+  },
+
+  /// fetch invidious instances from site and overwrite static file.
   async fetchInvidiousInstances({ commit }) {
     const requestUrl = 'https://api.invidious.io/instances.json'
-
-    let instances = []
     try {
       const response = await fetchWithTimeout(15_000, requestUrl)
       const json = await response.json()
-      instances = json.filter((instance) => {
+      const instances = json.filter((instance) => {
         return !(instance[0].includes('.onion') ||
           instance[0].includes('.i2p') ||
           !instance[1].api ||
@@ -31,6 +43,13 @@ const actions = {
       }).map((instance) => {
         return instance[1].uri.replace(/\/$/, '')
       })
+
+      if (instances.length !== 0) {
+        commit('setInvidiousInstancesList', instances)
+        return true
+      } else {
+        console.warn('using static file for invidious instances')
+      }
     } catch (err) {
       if (err.name === 'TimeoutError') {
         console.error('Fetching the Invidious instance list timed out after 15 seconds. Falling back to local copy.')
@@ -38,20 +57,7 @@ const actions = {
         console.error(err)
       }
     }
-
-    // If the invidious instance fetch isn't returning anything interpretable
-    if (instances.length === 0) {
-      console.warn('reading static file for invidious instances')
-      const url = createWebURL('/static/invidious-instances.json')
-
-      const fileData = await (await fetch(url)).json()
-      instances = fileData.filter(e => {
-        return process.env.SUPPORTS_LOCAL_API || e.cors
-      }).map(e => {
-        return e.url
-      })
-    }
-    commit('setInvidiousInstancesList', instances)
+    return false
   },
 
   setRandomCurrentInvidiousInstance({ commit, state }) {

--- a/static/invidious-instances.json
+++ b/static/invidious-instances.json
@@ -24,10 +24,6 @@
     "cors": true
   },
   {
-    "url": "https://invidious.flokinet.to",
-    "cors": true
-  },
-  {
     "url": "https://invidious.privacydev.net",
     "cors": true
   },
@@ -40,11 +36,11 @@
     "cors": true
   },
   {
-    "url": "https://invidious.protokolla.fi",
+    "url": "https://iv.nboeck.de",
     "cors": true
   },
   {
-    "url": "https://iv.nboeck.de",
+    "url": "https://invidious.protokolla.fi",
     "cors": true
   },
   {
@@ -56,11 +52,7 @@
     "cors": true
   },
   {
-    "url": "https://inv.n8pjl.ca",
-    "cors": true
-  },
-  {
-    "url": "https://iv.datura.network",
+    "url": "https://inv.us.projectsegfau.lt",
     "cors": true
   },
   {
@@ -85,6 +77,10 @@
   },
   {
     "url": "https://vid.lilay.dev",
+    "cors": true
+  },
+  {
+    "url": "https://iv.datura.network",
     "cors": true
   },
   {


### PR DESCRIPTION
# Fetch invidious instances from file then use API

## Pull Request Type
- [x] Bugfix

## Description
Instead of waiting for the Invidious API endpoint for FreeTube to start, this PR will default to loading the included file of invidious instances and then update the instance list if it is successful

## Testing 
- add console.logs in the `fetchInvidiousInstancesFromFile` and `fetchInvidiousInstances` actions to ensure that the api is being updated properly

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** 0.20.0 - nightly


