### PR TITLE
Fix vscode suggesting broken imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,4 +30,5 @@
     "yml",
     "yaml"
   ],
+  "javascript.preferences.importModuleSpecifier": "relative"
 }


### PR DESCRIPTION
# Fix vscode suggesting broken imports

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Other - Developer Experience

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4965

## Description
This pull request fixes Visual Studio Code suggesting imports that start with `src/renderer` instead of imports relative to the current file. Those "absolute" imports cause webpack to fail because it expects the imports to either be relative or dependencies.

The cause of this issue was the addition of the `baseUrl` configuration in the `jsconfig.json` file that I added in https://github.com/FreeTubeApp/FreeTube/pull/4965, so that the data store auto-completion would still work and now Visual Studio Code thinks it's okay to suggest imports relative to that `baseUrl`.

Thankfully the fix is easy, just override the default import suggestion setting to always use relative paths in FreeTube.

## Screenshots <!-- If appropriate -->

![broken-suggestion](https://github.com/FreeTubeApp/FreeTube/assets/48293849/6b93e1f6-dc13-42af-a044-7afc8d9bb4ee)

## Testing <!-- for code that is not small enough to be easily understandable -->
If you want to test this, you'll have to restart vscode after switching to this branch, as the typescript extension (vscode's javascript support is handled by the typescript extension, that's why we can get type hints, despite not using typescript yet) only reads that file at start up.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0