### PR TITLE
Filter settings sections at build time instead of run time

### DIFF
--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -23,19 +23,24 @@ export default defineComponent({
     'general-settings': GeneralSettings,
     'theme-settings': ThemeSettings,
     'player-settings': PlayerSettings,
-    'external-player-settings': ExternalPlayerSettings,
     'subscription-settings': SubscriptionSettings,
     'privacy-settings': PrivacySettings,
     'data-settings': DataSettings,
     'distraction-settings': DistractionSettings,
-    'proxy-settings': ProxySettings,
     'sponsor-block-settings': SponsorBlockSettings,
-    'download-settings': DownloadSettings,
     'parental-control-settings': ParentControlSettings,
-    'experimental-settings': ExperimentalSettings,
     'password-settings': PasswordSettings,
     'password-dialog': PasswordDialog,
-    'ft-toggle-switch': FtToggleSwitch
+    'ft-toggle-switch': FtToggleSwitch,
+
+    ...(process.env.IS_ELECTRON
+      ? {
+          'proxy-settings': ProxySettings,
+          'download-settings': DownloadSettings,
+          'external-player-settings': ExternalPlayerSettings,
+          'experimental-settings': ExperimentalSettings
+        }
+      : {})
   },
   data: function () {
     return {
@@ -53,11 +58,14 @@ export default defineComponent({
           type: 'player-settings',
           title: this.$t('Settings.Player Settings.Player Settings')
         },
-        {
-          type: 'external-player-settings',
-          title: this.$t('Settings.External Player Settings.External Player Settings'),
-          usingElectron: true
-        },
+        ...(process.env.IS_ELECTRON
+          ? [
+              {
+                type: 'external-player-settings',
+                title: this.$t('Settings.External Player Settings.External Player Settings')
+              }
+            ]
+          : []),
         {
           type: 'subscription-settings',
           title: this.$t('Settings.Subscription Settings.Subscription Settings')
@@ -74,16 +82,18 @@ export default defineComponent({
           type: 'data-settings',
           title: this.$t('Settings.Data Settings.Data Settings')
         },
-        {
-          type: 'proxy-settings',
-          title: this.$t('Settings.Proxy Settings.Proxy Settings'),
-          usingElectron: true
-        },
-        {
-          type: 'download-settings',
-          title: this.$t('Settings.Download Settings.Download Settings'),
-          usingElectron: true
-        },
+        ...(process.env.IS_ELECTRON
+          ? [
+              {
+                type: 'proxy-settings',
+                title: this.$t('Settings.Proxy Settings.Proxy Settings')
+              },
+              {
+                type: 'download-settings',
+                title: this.$t('Settings.Download Settings.Download Settings')
+              }
+            ]
+          : []),
         {
           type: 'parental-control-settings',
           title: this.$t('Settings.Parental Control Settings.Parental Control Settings')
@@ -92,11 +102,14 @@ export default defineComponent({
           type: 'sponsor-block-settings',
           title: this.$t('Settings.SponsorBlock Settings.SponsorBlock Settings'),
         },
-        {
-          type: 'experimental-settings',
-          title: this.$t('Settings.Experimental Settings.Experimental Settings'),
-          usingElectron: true
-        },
+        ...(process.env.IS_ELECTRON
+          ? [
+              {
+                type: 'experimental-settings',
+                title: this.$t('Settings.Experimental Settings.Experimental Settings')
+              },
+            ]
+          : []),
         {
           type: 'password-settings',
           title: this.$t('Settings.Password Settings.Password Settings')
@@ -122,20 +135,13 @@ export default defineComponent({
     },
 
     settingsSectionComponents: function () {
-      let settingsSections
-      if (!process.env.IS_ELECTRON) {
-        settingsSections = this.settingsComponentsData.filter((settingsComponent) => !settingsComponent.usingElectron)
-      } else {
-        settingsSections = this.settingsComponentsData
-      }
-
       if (this.settingsSectionSortEnabled) {
-        return settingsSections.toSorted((a, b) =>
+        return this.settingsComponentsData.toSorted((a, b) =>
           a.title.toLowerCase().localeCompare(b.title.toLowerCase(), this.locale)
         )
       }
 
-      return settingsSections
+      return this.settingsComponentsData
     },
   },
   created: function () {


### PR DESCRIPTION
# Filter settings sections at build time instead of run time

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Other - Performance improvement

## Related issue
Follow up to #5010

## Description
Filtering settings sections at build time instead of run time, means we have a bit less work to do at runtime and also shaves off 52 bytes from the renderer.js file and 556 bytes from the web.js file.

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn run dev`: Check that the Electron specific settings still show up (download, proxy, external player, experimental)
`yarn run dev:web` Check that the Electron specific settings are not displayed.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 3ab5c3d7c944039d7f3078a6fe8318730031f311