### PR TITLE
Lazy load thumbnails for hidden channels

### DIFF
--- a/src/renderer/components/ft-input-tags/ft-input-tags.css
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.css
@@ -40,7 +40,6 @@
 
 .tag-icon {
   border-radius: 50%;
-  block-size: 24px;
   vertical-align: middle;
 }
 

--- a/src/renderer/components/ft-input-tags/ft-input-tags.vue
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.vue
@@ -37,6 +37,9 @@
                 :src="tag.icon"
                 alt=""
                 class="tag-icon"
+                height="24"
+                width="24"
+                loading="lazy"
               >
             </router-link>
             <span>{{ (tag.preferredName) ? tag.preferredName : tag.name }}</span>


### PR DESCRIPTION
# Lazy load thumbnails for hidden channels

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Currently the thumbnails for hidden channels are loaded as soon as the settings are opened, this pull request defers the thumbnail loading until the distraction free settings are actually opened.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0