### PR TITLE
Format links and show title in the in-app changelog

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -230,7 +230,17 @@ export default defineComponent({
           .then((json) => {
             const tagName = json[0].tag_name
             const versionNumber = tagName.replace('v', '').replace('-beta', '')
-            this.updateChangelog = marked.parse(json[0].body)
+
+            let changelog = json[0].body
+              // Link usernames to their GitHub profiles
+              .replaceAll(/@(\S+)\b/g, '[@$1](https://github.com/$1)')
+              // Shorten pull request links to #1234
+              .replaceAll(/https:\/\/github\.com\/FreeTubeApp\/FreeTube\/pull\/(\d+)/g, '[#$1]($&)')
+
+            // Add the title
+            changelog = `# ${json[0].name}\n${changelog}`
+
+            this.updateChangelog = marked.parse(changelog)
             this.changeLogTitle = json[0].name
 
             this.updateBannerMessage = this.$t('Version {versionNumber} is now available!  Click for more details', { versionNumber })


### PR DESCRIPTION
# Format links and show title in the in-app changelog

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Description
This pull request improves the in-app changelog in 3 ways:
1. The user names/mentions are now linked to the user's GitHub profile
2. The pull request links visually shorted from a full link to the `#1234` that is used on GitHub itself
3. Adds the release title to the top of the changelog, as that wasn't being displayed

## Screenshots <!-- If appropriate -->
Before:
![before-one](https://github.com/FreeTubeApp/FreeTube/assets/48293849/5671fe1c-7cd6-426d-a1a4-b10efc0f8b62)

![before-two](https://github.com/FreeTubeApp/FreeTube/assets/48293849/9bd01859-e917-466c-9017-d84e63400039)

After:

![after-one](https://github.com/FreeTubeApp/FreeTube/assets/48293849/80fbbc34-7de7-41fc-a647-e8d1fb6adee0)

![after-two](https://github.com/FreeTubeApp/FreeTube/assets/48293849/cc587a9d-4d53-41de-a4c4-4e84f4f37c2a)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Change the version in the `package.json` file to `0.19.2`
2. Turn on `Check for Updates` in the general settings and restart FreeTube, if you don't have it on already.
3. Click on the new release available banner

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0