### PR TITLE
Distinguish destructive action fixes

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -28,6 +28,8 @@
         />
         <ft-button
           :label="$t('Close')"
+          :text-color="null"
+          :background-color="null"
           @click="showReleaseNotes = !showReleaseNotes"
         />
       </ft-flex-box>

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -109,8 +109,8 @@ export default defineComponent({
       newTitle: '',
       newDescription: '',
       deletePlaylistPromptValues: [
-        'yes',
-        'no'
+        'delete',
+        'cancel'
       ],
     }
   },
@@ -157,8 +157,8 @@ export default defineComponent({
 
     deletePlaylistPromptNames: function () {
       return [
-        this.$t('Yes'),
-        this.$t('No')
+        this.$t('Yes, Delete'),
+        this.$t('Cancel')
       ]
     },
 
@@ -326,56 +326,56 @@ export default defineComponent({
     },
 
     handleRemoveVideosOnWatchPromptAnswer: function (option) {
-      if (option === 'yes') {
-        const videosToWatch = this.selectedUserPlaylist.videos.filter((video) => {
-          return this.historyCacheById[video.videoId] == null
-        })
-
-        const removedVideosCount = this.selectedUserPlaylist.videos.length - videosToWatch.length
-
-        if (removedVideosCount === 0) {
-          showToast(this.$t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'))
-          this.showRemoveVideosOnWatchPrompt = false
-          return
-        }
-
-        const playlist = {
-          playlistName: this.title,
-          protected: this.selectedUserPlaylist.protected,
-          description: this.description,
-          videos: videosToWatch,
-          _id: this.id
-        }
-        try {
-          this.updatePlaylist(playlist)
-          showToast(this.$tc('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', removedVideosCount, {
-            videoCount: removedVideosCount,
-          }))
-        } catch (e) {
-          showToast(this.$t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
-          console.error(e)
-        }
-      }
       this.showRemoveVideosOnWatchPrompt = false
+      if (option !== 'delete') { return }
+
+      const videosToWatch = this.selectedUserPlaylist.videos.filter((video) => {
+        return this.historyCacheById[video.videoId] == null
+      })
+
+      const removedVideosCount = this.selectedUserPlaylist.videos.length - videosToWatch.length
+
+      if (removedVideosCount === 0) {
+        showToast(this.$t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'))
+        this.showRemoveVideosOnWatchPrompt = false
+        return
+      }
+
+      const playlist = {
+        playlistName: this.title,
+        protected: this.selectedUserPlaylist.protected,
+        description: this.description,
+        videos: videosToWatch,
+        _id: this.id
+      }
+      try {
+        this.updatePlaylist(playlist)
+        showToast(this.$tc('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', removedVideosCount, {
+          videoCount: removedVideosCount,
+        }))
+      } catch (e) {
+        showToast(this.$t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+        console.error(e)
+      }
     },
 
     handleDeletePlaylistPromptAnswer: function (option) {
-      if (option === 'yes') {
-        if (this.selectedUserPlaylist.protected) {
-          showToast(this.$t('User Playlists.SinglePlaylistView.Toast["This playlist is protected and cannot be removed."]'))
-        } else {
-          this.removePlaylist(this.id)
-          this.$router.push(
-            {
-              path: '/userPlaylists'
-            }
-          )
-          showToast(this.$t('User Playlists.SinglePlaylistView.Toast["Playlist {playlistName} has been deleted."]', {
-            playlistName: this.title,
-          }))
-        }
-      }
       this.showDeletePlaylistPrompt = false
+      if (option !== 'delete') { return }
+
+      if (this.selectedUserPlaylist.protected) {
+        showToast(this.$t('User Playlists.SinglePlaylistView.Toast["This playlist is protected and cannot be removed."]'))
+      } else {
+        this.removePlaylist(this.id)
+        this.$router.push(
+          {
+            path: '/userPlaylists'
+          }
+        )
+        showToast(this.$t('User Playlists.SinglePlaylistView.Toast["Playlist {playlistName} has been deleted."]', {
+          playlistName: this.title,
+        }))
+      }
     },
 
     enableQuickBookmarkForThisPlaylist() {

--- a/src/renderer/components/privacy-settings/privacy-settings.js
+++ b/src/renderer/components/privacy-settings/privacy-settings.js
@@ -57,10 +57,10 @@ export default defineComponent({
     handleSearchCache: function (option) {
       this.showSearchCachePrompt = false
 
-      if (option === 'delete') {
-        this.clearSessionSearchHistory()
-        showToast(this.$t('Settings.Privacy Settings.Search cache has been cleared'))
-      }
+      if (option !== 'delete') { return }
+
+      this.clearSessionSearchHistory()
+      showToast(this.$t('Settings.Privacy Settings.Search cache has been cleared'))
     },
 
     handleRememberHistory: function (value) {
@@ -74,10 +74,10 @@ export default defineComponent({
     handleRemoveHistory: function (option) {
       this.showRemoveHistoryPrompt = false
 
-      if (option === 'delete') {
-        this.removeAllHistory()
-        showToast(this.$t('Settings.Privacy Settings.Watch history has been cleared'))
-      }
+      if (option !== 'delete') { return }
+
+      this.removeAllHistory()
+      showToast(this.$t('Settings.Privacy Settings.Watch history has been cleared'))
     },
 
     handleRemoveSubscriptions: function (option) {
@@ -107,7 +107,8 @@ export default defineComponent({
 
     handleRemovePlaylists: function (option) {
       this.showRemovePlaylistsPrompt = false
-      if (option !== 'yes') { return }
+
+      if (option !== 'delete') { return }
 
       this.removeAllPlaylists()
       this.updateQuickBookmarkTargetPlaylistId('favorites')


### PR DESCRIPTION
# Distinguish destructive action fixes

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4374#issuecomment-2090485126

## Description
- Fixes playlist deletion not working due to checking for 'yes' rather than new value
- Updates label to `Yes, Delete` for user playlist delete icon actions
- Fixes changelog banner to use gray button for cancel

## Screenshots
![Screenshot_20240502_082527](https://github.com/FreeTubeApp/FreeTube/assets/84899178/068f6868-7e82-4e9d-a6fe-f67bb53fd937)
![Screenshot_20240502_082251](https://github.com/FreeTubeApp/FreeTube/assets/84899178/4efb442a-1522-4af8-abb2-e031719e4ebc)


## Testing <!-- for code that is not small enough to be easily understandable -->
- Test playlist deletion works
- See playlist delete icons (Remove Watched Videos, Delete Playlist) have updated 'Yes' content and work
- See changelog banner uses gray button for cancel (or go off screenshot)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW