### PR TITLE
Implement hot reloading for the locale files during development

### DIFF
--- a/_scripts/_hotReloadLocalesScript.js
+++ b/_scripts/_hotReloadLocalesScript.js
@@ -1,0 +1,18 @@
+const websocket = new WebSocket('ws://localhost:9080/ws')
+
+websocket.onmessage = (event) => {
+  const message = JSON.parse(event.data)
+
+  if (message.type === 'freetube-locale-update') {
+    const i18n = document.getElementById('app').__vue__.$i18n
+
+    for (const [locale, data] of message.data) {
+      // Only update locale data if it was already loaded
+      if (i18n.availableLocales.includes(locale)) {
+        const localeData = JSON.parse(data)
+
+        i18n.setLocaleMessage(locale, localeData)
+      }
+    }
+  }
+}

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -6,7 +6,6 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const ProcessLocalesPlugin = require('./ProcessLocalesPlugin')
-const WatchExternalFilesPlugin = require('webpack-watch-external-files-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 const isDevMode = process.env.NODE_ENV === 'development'
@@ -163,18 +162,6 @@ const config = {
     extensions: ['.js', '.vue']
   },
   target: 'electron-renderer',
-}
-
-if (isDevMode) {
-  const activeLocales = JSON.parse(readFileSync(path.join(__dirname, '../static/locales/activeLocales.json')))
-
-  config.plugins.push(
-    new WatchExternalFilesPlugin({
-      files: [
-        `./static/locales/{${activeLocales.join(',')}}.yaml`,
-      ],
-    }),
-  )
 }
 
 module.exports = config

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -14,6 +14,7 @@ const { version: swiperVersion } = JSON.parse(readFileSync(path.join(__dirname, 
 
 const processLocalesPlugin = new ProcessLocalesPlugin({
   compress: !isDevMode,
+  hotReload: isDevMode,
   inputDir: path.join(__dirname, '../static/locales'),
   outputDir: 'static/locales',
 })

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -178,6 +178,7 @@ const config = {
 
 const processLocalesPlugin = new ProcessLocalesPlugin({
   compress: false,
+  hotReload: isDevMode,
   inputDir: path.join(__dirname, '../static/locales'),
   outputDir: 'static/locales',
 })

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",
-    "webpack-watch-external-files-plugin": "^3.0.0",
     "yaml-eslint-parser": "^1.2.2"
   }
 }

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -50,23 +50,4 @@ export async function loadLocale(locale) {
   i18n.setLocaleMessage(locale, data)
 }
 
-if (process.env.NODE_ENV === 'development') {
-  const websocket = new WebSocket('ws://localhost:9080/ws')
-
-  websocket.onmessage = (event) => {
-    const message = JSON.parse(event.data)
-
-    if (message.type === 'freetube-locale-update') {
-      for (const [locale, data] of message.data) {
-        // Only update locale data if it was already loaded
-        if (i18n.availableLocales.includes(locale)) {
-          const localeData = JSON.parse(data)
-
-          i18n.setLocaleMessage(locale, localeData)
-        }
-      }
-    }
-  }
-}
-
 export default i18n

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -50,4 +50,23 @@ export async function loadLocale(locale) {
   i18n.setLocaleMessage(locale, data)
 }
 
+if (process.env.NODE_ENV === 'development') {
+  const websocket = new WebSocket('ws://localhost:9080/ws')
+
+  websocket.onmessage = (event) => {
+    const message = JSON.parse(event.data)
+
+    if (message.type === 'freetube-locale-update') {
+      for (const [locale, data] of message.data) {
+        // Only update locale data if it was already loaded
+        if (i18n.availableLocales.includes(locale)) {
+          const localeData = JSON.parse(data)
+
+          i18n.setLocaleMessage(locale, localeData)
+        }
+      }
+    }
+  }
+}
+
 export default i18n

--- a/yarn.lock
+++ b/yarn.lock
@@ -4611,7 +4611,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@10.3.10, glob@^10.3.7:
+glob@^10.3.7:
   version "10.3.10"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.3.10.tgz#0351ebb809fd187fe421ab96af83d3a70715df4b"
   integrity sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==
@@ -6595,14 +6595,6 @@ path-type@^5.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-5.0.0.tgz#14b01ed7aea7ddf9c7c3f46181d4d04f9c785bb8"
   integrity sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==
 
-path@0.12.7:
-  version "0.12.7"
-  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
-  integrity sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==
-  dependencies:
-    process "^0.11.1"
-    util "^0.10.3"
-
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -6990,7 +6982,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process@^0.11.1, process@^0.11.10:
+process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
@@ -8550,13 +8542,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
-
 util@^0.12.4:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
@@ -8868,14 +8853,6 @@ webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
-
-webpack-watch-external-files-plugin@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-watch-external-files-plugin/-/webpack-watch-external-files-plugin-3.0.0.tgz#65d75389b1c9b05e84a2cfad83897ac12f146c7e"
-  integrity sha512-u0geLnZ/uJXh92B+40apyovnexoP+m9I6QktyGlG8rP6CXXYKe3yhG7zY9P2Wbg75sPTP1PYv2rropRlZdxg9A==
-  dependencies:
-    glob "10.3.10"
-    path "0.12.7"
 
 webpack@^5.91.0:
   version "5.91.0"


### PR DESCRIPTION
# Implement hot reloading for the locale files during development

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Other - Development enhancement

## Description
This pull request implements hot reloading for the locale files. I recommend reviewing this pull request by commit, so that it's easier to understand what changes are related to what.

Currently we have it setup to reload the entire app when a locale file is edited, which is not ideal for multiple reasons, a major one being that we have to load all the data from the databases again like we do at startup and all the caches get cleared.

What is hot reloading?
You know when you edit one of the Vue or JavaScript files and it only reloads the parts of the app that changed, that's hot reloading.

Please keep in mind that not all parts of the app react to changes to the locales, the same bits that don't automatically change when you change the language won't change here either, but you can just use the backwards and forwards arrows in the navigation bar, then which still avoids the full reload.

## Testing <!-- for code that is not small enough to be easily understandable -->
The easiest way to test that it works is to edit the `Search / Go to URL: Search / Go to URL` string in the language that you currently have selected, as that is the text that is shown in the search bar at the top of the window that is visible on all pages.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0