### PR TITLE
Fix startup problems for some Linux platforms for some installs

### DIFF
--- a/_scripts/ebuilder.config.js
+++ b/_scripts/ebuilder.config.js
@@ -47,6 +47,7 @@ const config = {
     category: 'Network',
     icon: '_icons/icon.svg',
     target: ['deb', 'zip', '7z', 'apk', 'rpm', 'AppImage', 'pacman'],
+    executableArgs: ['--ozone-platform-hint=auto']
   },
   // See the following issues for more information
   // https://github.com/jordansissel/fpm/issues/1503


### PR DESCRIPTION
# Fix startup problems for some Linux platforms for some installs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
None; `Segmentation fault (core dumped)` occurring for some Linux users post-Electron 30 

## Description
Co-created with @absidue 
- Fixes downloads for Wayland (not sure if any others) users using  non-`7z`/`portable` Linux builds

## Testing <!-- for code that is not small enough to be easily understandable -->
- [Download a  non-`7z`/`portable` Linux build from here](https://github.com/jasonhenriquez/FreeTube/actions/runs/8930351772) and confirm the app opens & runs correctly

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW

## Additional context
This does not work for `7z` / `portable` downloads, which is going to be a major problem for those users going forward. The commit in this PR can be reverted once https://github.com/electron/electron/pull/35630 is merged.
