### PR TITLE
Always have quick bookmark set

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-brands-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
+    "@fortawesome/free-regular-svg-icons": "^6.5.2",
     "@fortawesome/vue-fontawesome": "^2.0.10",
     "@seald-io/nedb": "^4.0.4",
     "@silvermine/videojs-quality-selector": "^1.3.1",

--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -21,19 +21,21 @@
     background-color: var(--card-bg-color);
     color: var(--primary-text-color);
 
-    &:hover,
-    &:focus-visible {
-      background-color: var(--side-nav-hover-color);
-      color: var(--side-nav-hover-text-color);
-    }
+    &:not(.disabled) {
+      &:hover,
+      &:focus-visible {
+        background-color: var(--side-nav-hover-color);
+        color: var(--side-nav-hover-text-color);
+      }
 
-    &:active {
-      background-color: var(--side-nav-active-color);
-      color: var(--side-nav-active-text-color);
+      &:active {
+        background-color: var(--side-nav-active-color);
+        color: var(--side-nav-active-text-color);
+      }
     }
   }
 
-  &.base-no-default {
+  &.base-no-default:not(.disabled) {
     &:hover,
     &:focus-visible {
       background-color: var(--side-nav-hover-color);
@@ -50,27 +52,32 @@
     background-color: var(--primary-color);
     color: var(--text-with-main-color);
 
-    &:hover,
-    &:focus-visible {
-      background-color: var(--primary-color-hover);
-    }
+    &:not(.disabled) {
+      &:hover,
+      &:focus-visible {
+        background-color: var(--primary-color-hover);
+      }
 
-    &:active {
-      background-color: var(--primary-color-active);
+      &:active {
+        background-color: var(--primary-color-active);
+      }
     }
   }
+
 
   &.secondary {
     background-color: var(--accent-color);
     color: var(--text-with-accent-color);
 
-    &:hover,
-    &:focus-visible {
-      background-color: var(--accent-color-hover);
-    }
+    &:not(.disabled) {
+      &:hover,
+      &:focus-visible {
+        background-color: var(--accent-color-hover);
+      }
 
-    &:active {
-      background-color: var(--accent-color-active);
+      &:active {
+        background-color: var(--accent-color-active);
+      }
     }
   }
 
@@ -78,13 +85,15 @@
     background-color: var(--destructive-color);
     color: var(--destructive-text-color);
 
-    &:hover,
-    &:focus-visible {
-      background-color: var(--destructive-hover-color);
-    }
+    &:not(.disabled) {
+      &:hover,
+      &:focus-visible {
+        background-color: var(--destructive-hover-color);
+      }
 
-    &:active {
-      background-color: var(--destructive-active-color);
+      &:active {
+        background-color: var(--destructive-active-color);
+      }
     }
   }
 
@@ -95,7 +104,8 @@
 
 .disabled {
   opacity: 0.5;
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: default;
   user-select: none;
 }
 

--- a/src/renderer/components/ft-icon-button/ft-icon-button.vue
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.vue
@@ -16,6 +16,7 @@
       }"
       tabindex="0"
       role="button"
+      :aria-disabled="disabled"
       :aria-expanded="dropdownShown"
       @click="handleIconClick"
       @mousedown="handleIconMouseDown"

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -230,9 +230,6 @@ export default defineComponent({
     quickBookmarkPlaylist() {
       return this.$store.getters.getPlaylist(this.quickBookmarkPlaylistId)
     },
-    quickBookmarkEnabled() {
-      return this.quickBookmarkPlaylist != null
-    },
     markedAsQuickBookmarkTarget() {
       // Only user playlists can be target
       if (this.selectedUserPlaylist == null) { return false }
@@ -366,7 +363,7 @@ export default defineComponent({
       if (this.selectedUserPlaylist.protected) {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast["This playlist is protected and cannot be removed."]'))
       } else {
-        this.removePlaylist(this.id)
+        this.removePlaylist(this.id, true)
         this.$router.push(
           {
             path: '/userPlaylists'

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -402,10 +402,6 @@ export default defineComponent({
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast.This playlist is now used for quick bookmark'))
       }
     },
-    disableQuickBookmark() {
-      this.updateQuickBookmarkTargetPlaylistId(null)
-      showToast(this.$t('User Playlists.SinglePlaylistView.Toast.Quick bookmark disabled'))
-    },
 
     updateQuery(query) {
       this.query = query

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -122,7 +122,14 @@
           theme="secondary"
           @click="exitEditMode"
         />
-
+        <ft-icon-button
+          v-if="!editMode && isUserPlaylist"
+          :title="markedAsQuickBookmarkTarget ? $t('User Playlists.Quick Bookmark Enabled') : $t('User Playlists.Enable Quick Bookmark With This Playlist')"
+          :icon="markedAsQuickBookmarkTarget ? ['fas', 'bookmark'] : ['far', 'bookmark']"
+          :disabled="markedAsQuickBookmarkTarget"
+          theme="secondary"
+          @click="enableQuickBookmarkForThisPlaylist"
+        />
         <ft-icon-button
           v-if="!editMode && isUserPlaylist"
           :title="$t('User Playlists.Edit Playlist Info')"
@@ -136,20 +143,6 @@
           :icon="['fas', 'copy']"
           theme="secondary"
           @click="toggleCopyVideosPrompt"
-        />
-        <ft-icon-button
-          v-if="!editMode && isUserPlaylist && !markedAsQuickBookmarkTarget"
-          :title="$t('User Playlists.Enable Quick Bookmark With This Playlist')"
-          :icon="['fas', 'link']"
-          theme="secondary"
-          @click="enableQuickBookmarkForThisPlaylist"
-        />
-        <ft-icon-button
-          v-if="!editMode && isUserPlaylist && markedAsQuickBookmarkTarget"
-          :title="$t('User Playlists.Disable Quick Bookmark')"
-          :icon="['fas', 'link-slash']"
-          theme="secondary"
-          @click="disableQuickBookmark"
         />
         <ft-icon-button
           v-if="!editMode && isUserPlaylist && videoCount > 0"

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -89,6 +89,9 @@ import {
   faUsers,
 } from '@fortawesome/free-solid-svg-icons'
 import {
+  faBookmark as farBookmark
+} from '@fortawesome/free-regular-svg-icons'
+import {
   faBitcoin,
   faGithub,
   faMastodon,
@@ -182,6 +185,9 @@ library.add(
   faTimesCircle,
   faTrash,
   faUsers,
+
+  // solid icons
+  farBookmark,
 
   // brand icons
   faGithub,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -208,6 +208,7 @@ User Playlists:
       There were no videos to remove.: There were no videos to remove.
       This playlist is protected and cannot be removed.: This playlist is protected and cannot be removed.
       Playlist {playlistName} has been deleted.: Playlist {playlistName} has been deleted.
+      Playlist {playlistName} is the new quick bookmark playlist.: Playlist {playlistName} is the new quick bookmark playlist.
 
       This playlist does not exist: This playlist does not exist
   AddVideoPrompt:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -168,7 +168,7 @@ User Playlists:
   Copy Playlist: Copy Playlist
   Remove Watched Videos: Remove Watched Videos
   Enable Quick Bookmark With This Playlist: Enable Quick Bookmark With This Playlist
-  Disable Quick Bookmark: Disable Quick Bookmark
+  Quick Bookmark Enabled: Quick Bookmark Enabled
   Are you sure you want to remove all watched videos from this playlist? This cannot be undone: Are you sure you want to remove all watched videos from this playlist? This cannot be undone.
   Delete Playlist: Delete Playlist
   Are you sure you want to delete this playlist? This cannot be undone: Are you sure you want to delete this playlist? This cannot be undone.
@@ -197,7 +197,6 @@ User Playlists:
       There was a problem with removing this video: There was a problem with removing this video
 
       This playlist is now used for quick bookmark: This playlist is now used for quick bookmark
-      Quick bookmark disabled: Quick bookmark disabled
       This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo: This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo
       Reverted to use {oldPlaylistName} for quick bookmark: Reverted to use {oldPlaylistName} for quick bookmark
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,6 +1272,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "6.5.2"
 
+"@fortawesome/free-regular-svg-icons@^6.5.2":
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.2.tgz#e8e04b4368d49920abdf1bacc63c67c870635222"
+  integrity sha512-iabw/f5f8Uy2nTRtJ13XZTS1O5+t+anvlamJ3zJGLEVE2pKsAWhPv2lq01uQlfgCX7VaveT3EVs515cCN9jRbw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.5.2"
+
 "@fortawesome/free-solid-svg-icons@^6.5.2":
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz#9b40b077b27400a5e9fcbf2d15b986c7be69e9ca"
@@ -7875,16 +7882,7 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7970,14 +7968,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8974,16 +8965,7 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# Always have quick bookmark set

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
closes #5051 

## Description
- Changes "Add/Remove" quick bookmark icon to "regular/solid" bookmark icon instead of link/link-slash. See https://github.com/FreeTubeApp/FreeTube/commit/e8972540076c221ae19326d6b020091def7d7556 for discussion.
- Updates `ft-icon-button` `disabled` styling to show title on hover, and use `aria-disabled` (these is a needed usability improvement to better communicate what the disabled icon actually means, as our only disabled `ft-icon-button` case is the disabled `ft-refresh-widget` icon)
- Makes an enabled Quick Bookmark icon disabled to prevent unselection (see original story for rationale), with position in all cases moved to the be the leftmost icon now (to ensure non-disabled icons are grouped)
- Makes quick bookmark default to the 1st playlist in DB when no playlist is detected during startup / playlist add / playlist removal

## Screenshots <!-- If appropriate -->
![Screenshot_20240503_125848](https://github.com/FreeTubeApp/FreeTube/assets/84899178/cf259965-f439-4213-a95c-314bf8972f8b)
![Screenshot_20240503_134255](https://github.com/FreeTubeApp/FreeTube/assets/84899178/187d83be-bda7-4b48-8e24-dedeceebabe3)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Have 1 user playlist -> delete playlist -> see no quick bookmark button on a given video in subscriptions (REG) -> add playlist -> see quick bookmark on playlist -> (REG, optional) see it persists on Ctrl+R
- Have >0 user playlists with no quick bookmark set (e.g., by removing it before switching to this PR, or deleting the `quickBookmarkTargetPlaylistId` entry in `settings.db`) -> run FreeTube -> see one of the existing playlists is set as the new quick bookmark playlist -> (REG, optional) see it persists on Ctrl+R
- (REG) Have 2 user playlists -> switch quick bookmark target to the other one -> see preference reflected and retained on Ctrl+R
- Have 0 user playlists -> Import user playlists in Data Settings -> see one is selected as new quick bookmark target

## Desktop
<!-- Please complete the following information-->
- **OS:** TW
- **OS Version:** OpenSUSE


## Future work
- Choosing new programmatic quick bookmark target to be the top of the sorting preference, not just the first one in the array

