### PR TITLE
Refresh widget separator adjustments

### DIFF
--- a/src/renderer/components/ft-refresh-widget/ft-refresh-widget.css
+++ b/src/renderer/components/ft-refresh-widget/ft-refresh-widget.css
@@ -8,7 +8,7 @@
   padding-inline: 10px;
   box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
   background-color: var(--card-bg-color);
-  border-inline-start: 2px solid var(--primary-color);
+  border-inline-start: 2px solid var(--primary-shadow-color);
   display: flex;
   align-items: center;
   gap: 5px;
@@ -33,5 +33,6 @@
 @media only screen and (width <= 680px) {
   .floatingRefreshSection, .floatingRefreshSection.sideNavOpen {
     inline-size: 100%;
+    border-inline-start: none;
   }
 }

--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -21,10 +21,6 @@
   inline-size: 100%;
   z-index: 4;
 
-  &:has(+ .sideNav + .routerView .floatingRefreshSection) {
-    box-shadow: none;
-  }
-
   @media only screen and (width >= 961px) {
     display: grid;
     grid-template-columns: 1fr 440px 1fr;
@@ -36,6 +32,10 @@
 
   @media only screen and (width <= 680px) {
     position: fixed;
+
+    &:has(+ .sideNav + .routerView .floatingRefreshSection) {
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
# Refresh widget separator adjustments

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4980#issuecomment-2071160303

## Description
- Add back refresh-widget box-shadow for desktop view
- Change refresh widget left border color to match box-shadow, & have it disappear on mobile and tablet view

## Screenshots <!-- If appropriate -->
Before:
![Screenshot_20240503_141543](https://github.com/FreeTubeApp/FreeTube/assets/84899178/a190fbb0-c447-4dbd-9b98-dc67756f97f4)
![Screenshot_20240503_141521](https://github.com/FreeTubeApp/FreeTube/assets/84899178/dac0c013-83c1-46cc-99b9-2a8601216686)

After:
![Screenshot_20240503_140626](https://github.com/FreeTubeApp/FreeTube/assets/84899178/f48b4af1-693c-4308-9ce3-7ce279f1bfca)
![Screenshot_20240503_140954](https://github.com/FreeTubeApp/FreeTube/assets/84899178/32bc9d8e-3dd3-4add-9046-6e880de4bed9)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
