### PR TITLE
Download correct resolution for side bar channel thumbnails

### DIFF
--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -35,6 +35,12 @@ export default defineComponent({
     activeSubscriptions: function () {
       const subscriptions = deepCopy(this.activeProfile.subscriptions)
 
+      subscriptions.forEach(channel => {
+        // Change thumbnail size to 35x35, as that's the size we display it
+        // so we don't need to download a bigger image (the default is 176x176)
+        channel.thumbnail = channel.thumbnail?.replace(/=s\d+/, '=s35')
+      })
+
       subscriptions.sort((a, b) => {
         return a.name?.toLowerCase().localeCompare(b.name?.toLowerCase(), this.locale)
       })


### PR DESCRIPTION
# Download correct resolution for side bar channel thumbnails

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
We display the channel thumbnails in the sidebar with a width and height of 35 pixels, but we currently download them with a height and width of 176 pixels. In the example below with the YouTube channel thumbnail it saved 3.5 kb, but with more complex ones it saves about 10 kb per thumbnail.

This does add a bit of overhead for the loop, regex and extra strings that get created but it's negligible compared to the savings in data downloaded.

## Screenshots <!-- If appropriate -->
Before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/09360e0d-ea84-4203-af3e-2661b74f8374)

After:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/73e5d61c-7c1f-43f1-8ab2-6990a6612b23)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0