### PR TITLE
Fix electron-context-menu import

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -14,6 +14,8 @@ import asyncFs from 'fs/promises'
 import { promisify } from 'util'
 import { brotliDecompress } from 'zlib'
 
+import contextMenu from 'electron-context-menu'
+
 import packageDetails from '../../package.json'
 
 const brotliDecompressAsync = promisify(brotliDecompress)
@@ -43,7 +45,7 @@ function runApp() {
     }])
   }
 
-  require('electron-context-menu')({
+  contextMenu({
     showSearchWithGoogle: false,
     showSaveImageAs: true,
     showCopyImageAddress: true,


### PR DESCRIPTION
# Fix electron-context-menu import

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Upcoming dependabot PR that updates the `electron-context-menu` dependency.

## Description
The next version of the `electron-context-menu` dependency switches it from CommonJS to ES Modules. This pull request fixes the import of that dependency to use the ES Modules import syntax so that webpack can handle it as an ES Module after the update, which means it can properly optimise it and not add the then unecessary CommonJS wrapper to simulate the import at runtime.

This won't make any difference to the bundle size right now, as the dependency version that we use still uses CommonJS.

Ideally this change would be done in the same dependabot pull request that upgrades the dependency, but as the dependabot pull requests are usually approved and merged a long time before I even realise that they were created, I decided I would do this in advance.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0