### PR TITLE
Move local API player cache internals into the main process

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,8 +4,6 @@ const IpcChannels = {
   DISABLE_PROXY: 'disable-proxy',
   OPEN_EXTERNAL_LINK: 'open-external-link',
   GET_SYSTEM_LOCALE: 'get-system-locale',
-  GET_USER_DATA_PATH: 'get-user-data-path',
-  GET_USER_DATA_PATH_SYNC: 'get-user-data-path-sync',
   GET_PICTURES_PATH: 'get-pictures-path',
   SHOW_OPEN_DIALOG: 'show-open-dialog',
   SHOW_SAVE_DIALOG: 'show-save-dialog',
@@ -26,7 +24,10 @@ const IpcChannels = {
   SYNC_PLAYLISTS: 'sync-playlists',
 
   GET_REPLACE_HTTP_CACHE: 'get-replace-http-cache',
-  TOGGLE_REPLACE_HTTP_CACHE: 'toggle-replace-http-cache'
+  TOGGLE_REPLACE_HTTP_CACHE: 'toggle-replace-http-cache',
+
+  PLAYER_CACHE_GET: 'player-cache-get',
+  PLAYER_CACHE_SET: 'player-cache-set'
 }
 
 const DBActions = {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,6 +1,5 @@
 import { ClientType, Endpoints, Innertube, Misc, UniversalCache, Utils, YT } from 'youtubei.js'
 import Autolinker from 'autolinker'
-import { join } from 'path'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
 import { PlayerCache } from './PlayerCache'
@@ -9,7 +8,6 @@ import {
   calculatePublishedDate,
   escapeHTML,
   extractNumberFromString,
-  getUserDataPath,
   toLocalePublicationString
 } from '../utils'
 
@@ -41,8 +39,7 @@ async function createInnertube({ withPlayer = false, location = undefined, safet
   let cache
   if (withPlayer) {
     if (process.env.IS_ELECTRON) {
-      const userData = await getUserDataPath()
-      cache = new PlayerCache(join(userData, 'player_cache'))
+      cache = new PlayerCache()
     } else {
       cache = new UniversalCache(false)
     }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -611,16 +611,6 @@ export async function getSystemLocale() {
   return locale || 'en-US'
 }
 
-export async function getUserDataPath() {
-  if (process.env.IS_ELECTRON) {
-    const { ipcRenderer } = require('electron')
-    return await ipcRenderer.invoke(IpcChannels.GET_USER_DATA_PATH)
-  } else {
-    // TODO: implement getUserDataPath web compatible callback
-    return null
-  }
-}
-
 export async function getPicturesPath() {
   if (process.env.IS_ELECTRON) {
     const { ipcRenderer } = require('electron')


### PR DESCRIPTION
# Move local API player cache internals into the main process

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Security improvement

## Description
Currently the player cache implementation that we use in Electron, writes to the file system in the renderer process (the stuff that actually runs inside of the window), this pull request moves it to the main process with IPC calls. That allows us to add checks to ensure that the player cache can only be used to read and write files in the `player_cache` directory. It also avoids exposing where the `player_cache` directory is located on the file system.

As an added bonus this pull request shaves off 1591 bytes from the `renderer.js` file but only adds 240 bytes to the `main.js` file.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open the dev data location (same as normal one but in the `Electron` folder instead of the `FreeTube` one)
2. Delete the `player_cache` folder
3. `yarn run dev`
4. Open a video with the local API
5. Check that the `player_cache` folder gets created and an item appears inside of it
6. Open another video
7. Check in the Network tab of the dev tools that only one request was made to `https://www.youtube.com/s/player/{identifier}/player_ias.vflset/en_US/base.js`. If there was only one, that means the second video used the cached player data.

After step 5 you've tested that adding an item to the cache works and after step 7 that reading from the cache works.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0