### PR TITLE
Move observe-visibility directive registration to main.js

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -1,6 +1,5 @@
-import Vue, { defineComponent } from 'vue'
+import { defineComponent } from 'vue'
 import { mapActions, mapMutations } from 'vuex'
-import { ObserveVisibility } from 'vue-observe-visibility'
 import FtFlexBox from './components/ft-flex-box/ft-flex-box.vue'
 import TopNav from './components/top-nav/top-nav.vue'
 import SideNav from './components/side-nav/side-nav.vue'
@@ -19,8 +18,6 @@ import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 import { translateWindowTitle } from './helpers/strings'
 
 let ipcRenderer = null
-
-Vue.directive('observe-visibility', ObserveVisibility)
 
 export default defineComponent({
   name: 'App',

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -8,6 +8,8 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 
 import { register as registerSwiper } from 'swiper/element'
 
+import { ObserveVisibility } from 'vue-observe-visibility'
+
 // Please keep the list of constants sorted by name
 // to avoid code conflict and duplicate entries
 import {
@@ -193,6 +195,7 @@ library.add(
 registerSwiper()
 
 Vue.component('FontAwesomeIcon', FontAwesomeIcon)
+Vue.directive('observe-visibility', ObserveVisibility)
 
 /* eslint-disable-next-line no-new */
 new Vue({


### PR DESCRIPTION
# Move observe-visibility directive registration to main.js

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Cleanup

## Description
As we do most of the Vue initialisation inside the `renderer/main.js` file, it makes sense to move the registration of the `v-observe-visibility` directive into that file too.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0