### PR TITLE
Clean up unused "search" ref in the Channel and Search components

### DIFF
--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    ref="search"
-  >
+  <div>
     <ft-loader
       v-if="isLoading && !errorMessage"
       :fullscreen="true"

--- a/src/renderer/views/Search/Search.vue
+++ b/src/renderer/views/Search/Search.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    ref="search"
-  >
+  <div>
     <ft-loader
       v-if="isLoading"
       :fullscreen="true"


### PR DESCRIPTION
# Clean up unused "search" ref in the Channel and Search components

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Other - Cleanup

## Description
These two refs aren't referenced anywhere so there is no point keeping them around. I presume that the Channel component was created by copying the Search one, I don't have another good explanation as for why it would have an identical unused ref.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0