### PR TITLE
Fix `ft-prompt` closing when clicking elements with `role="button"`

### DIFF
--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -97,7 +97,7 @@ export default defineComponent({
       this.$emit('click', null)
     },
     handleHide: function (event) {
-      if (event.target.getAttribute('role') === 'button' || event.target.className === 'prompt') {
+      if (event.target.className === 'prompt') {
         this.hide()
       }
     },


### PR DESCRIPTION
# Fix `ft-prompt` closing when clicking elements with `role="button"`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other


## Description
There does not seem to be any cases of `role="button"` currently within an `ft-prompt` except for within the `ft-input` in the add video to playlist prompt. In that case, the search clear button has `role="button"`, and hiding the whole prompt when it is clicked doesn't seem like intentional behaviour. I find it jarring as it overrides what the button is supposed to do (clear the search bar) with seemingly unintended functionality (close the whole prompt). This PR addresses this by removing the check for elements with `role="button"` within the `handleHide` method of `ft-prompt`.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![before](https://github.com/FreeTubeApp/FreeTube/assets/106682128/e89eb441-adda-4e7b-9f93-ce51ee5719f3)|![after](https://github.com/FreeTubeApp/FreeTube/assets/106682128/dc3c7620-71c0-423e-aabc-dbff703668a2)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open the add video to playlist prompt
2. Click the `X` button within the `ft-input` component
3. Ensure the `ft-prompt` does not close

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2 (OS Build 19045.4291)
- **FreeTube version:** 71b7c60b68a48fb4000c2c279b51d69de6e9526c

## Additional context
On the chance that there is some usage of this check in the app currently which I overlooked, I would reason that it should be adjusted by modifying the click event on UI elements that need this functionality rather than having a case for it within the `ft-prompt` itself.

This change should make it easier to add `ft-icon-button`s to a prompt in the future since they all use `role="button"`.