### PR TITLE
Fix hide sharing actions also hiding hide/show channel

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -285,26 +285,30 @@ export default defineComponent({
             {
               label: this.$t('Video.Open Channel in Invidious'),
               value: 'openInvidiousChannel'
-            },
-            {
-              type: 'divider'
             }
           )
-
-          const hiddenChannels = JSON.parse(this.$store.getters.getChannelsHidden)
-          const channelShouldBeHidden = hiddenChannels.some(c => c === this.channelId)
-          if (channelShouldBeHidden) {
-            options.push({
-              label: this.$t('Video.Unhide Channel'),
-              value: 'unhideChannel'
-            })
-          } else {
-            options.push({
-              label: this.$t('Video.Hide Channel'),
-              value: 'hideChannel'
-            })
-          }
         }
+      }
+
+      if (this.channelId !== null) {
+        const hiddenChannels = JSON.parse(this.$store.getters.getChannelsHidden)
+        const channelShouldBeHidden = hiddenChannels.some(c => c === this.channelId)
+
+        options.push(
+          {
+            type: 'divider'
+          },
+
+          channelShouldBeHidden
+            ? {
+                label: this.$t('Video.Unhide Channel'),
+                value: 'unhideChannel'
+              }
+            : {
+                label: this.$t('Video.Hide Channel'),
+                value: 'hideChannel'
+              }
+        )
       }
 
       return options


### PR DESCRIPTION
# Fix hide sharing actions also hiding hide/unhide channel

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #5109

## Description
The `Hide Sharing Actions` setting currently also hides the `Hide/Show Channel` option in the 3 dots drop down on videos in lists. This pull request corrects that.

## Screenshots <!-- If appropriate -->
Before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/ec5178b8-cb97-4961-97b7-289dcf0605d5)

After:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/ca7b76f3-6682-4f24-ab4d-3182b115622d)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Turn on the `Hide Sharing Actions` in the distraction free settings
2. Click the 3 dots button on a video in a list
3. The `Hide Channel` or `Show Channel` option should still be visible.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0