### PR TITLE
Constrain release notes width

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -40,6 +40,7 @@
   overflow-y: scroll;
   block-size: 40vh;
   display: block;
+  padding-inline: 15px;
 }
 
 .fade-enter-active, .fade-leave-active {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -40,7 +40,8 @@
   overflow-y: scroll;
   block-size: 40vh;
   display: block;
-  padding-inline: 15px;
+  padding-inline: 16px;
+  margin-block: 16px;
 }
 
 .fade-enter-active, .fade-leave-active {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -15,6 +15,7 @@
     <ft-prompt
       v-if="showReleaseNotes"
       :label="changeLogTitle"
+      theme="readable-width"
       @click="showReleaseNotes = !showReleaseNotes"
     >
       <span

--- a/src/renderer/components/ft-prompt/ft-prompt.css
+++ b/src/renderer/components/ft-prompt/ft-prompt.css
@@ -47,6 +47,13 @@
   padding-block: 10px;
 }
 
+.promptCard.readable-width {
+  max-inline-size: 40em;
+  margin-inline: auto;
+  inset-inline: 0;
+  padding-inline: 0;
+}
+
 .center {
   text-align: center;
 }


### PR DESCRIPTION
# Add 'readable width' theme for making release notes more easily readable

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5045#issuecomment-2088588505

## Description
Constrains max width of release notes modal to 40em to make it more readable. Also does some very minor padding/margin adjustments (I'm sorry, just hard to justify for a PR by itself) to put the scrollbar fully to the right and keep the button section top/bottom margin equivalent.

## Screenshots <!-- If appropriate -->

| Before | After |
| :--- | :----: |
| ![Screenshot_20240513_154853](https://github.com/FreeTubeApp/FreeTube/assets/84899178/f7ef4e2e-1b85-4250-bc72-05401a8b60f7) | ![Screenshot_20240513_154410](https://github.com/FreeTubeApp/FreeTube/assets/84899178/7373ce45-c094-41aa-b0ce-9348e5bafa6b) |


## Testing <!-- for code that is not small enough to be easily understandable -->
- Set version to 0.19.2 in `package.json`, then click banner

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW