### PR TITLE
Display Subtitles/CC and 4k tag - #917

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -101,6 +101,8 @@ export default defineComponent({
       watchProgress: 0,
       published: undefined,
       isLive: false,
+      is4k: false,
+      hasCaptions: false,
       isUpcoming: false,
       isPremium: false,
       hideViews: false,
@@ -648,6 +650,8 @@ export default defineComponent({
       this.description = this.data.description
       this.isLive = this.data.liveNow || this.data.lengthSeconds === 'undefined'
       this.isUpcoming = this.data.isUpcoming || this.data.premiere
+      this.is4k = this.data.is4k
+      this.hasCaptions = this.data.hasCaptions
       this.isPremium = this.data.premium || false
       this.viewCount = this.data.viewCount
 

--- a/src/renderer/components/ft-list-video/ft-list-video.scss
+++ b/src/renderer/components/ft-list-video/ft-list-video.scss
@@ -8,3 +8,17 @@
   // Makes img element sized correctly before image loading starts
   aspect-ratio: 16/9 auto;
 }
+
+.videoTagLine {
+  margin-block-start: 3px;
+}
+
+.videoTag {
+  padding: 3px;
+  background-color: rgb(255 255 255 / 10%);
+  font-size: 10px;
+  border-radius: 2px;
+  display: inline-block;
+  font-weight: 500;
+  white-space-collapse: collapse;
+}

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -145,6 +145,28 @@
           class="viewCount"
         > • {{ $tc('Global.Counts.Watching Count', viewCount, {count: parsedViewCount}) }}</span>
       </div>
+      <div
+        v-if="is4k || hasCaptions"
+        class="videoTagLine"
+      >
+        <div
+          v-if="is4k"
+          class="videoTag"
+          :aria-label="$t('Search Listing.Label.4K')"
+          role="img"
+        >
+          {{ $tc('Search Listing.Label.4K') }}
+        </div>
+        <div
+          v-if="hasCaptions"
+          class="videoTag"
+          :aria-label="$t('Search Listing.Label.Closed Captions')"
+          role="img"
+          :style="{marginLeft: is4k ? '4px' : '0px' }"
+        >
+          {{ $tc('Search Listing.Label.Subtitles') }}
+        </div>
+      </div>
       <ft-icon-button
         class="optionsButton"
         :icon="['fas', 'ellipsis-v']"

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -796,6 +796,8 @@ export function parseLocalListVideo(item) {
       lengthSeconds: isNaN(movie.duration.seconds) ? '' : movie.duration.seconds,
       liveNow: false,
       isUpcoming: false,
+      is4k: movie.is_4k,
+      hasCaptions: movie.has_captions
     }
   } else {
     /** @type {import('youtubei.js').YTNodes.Video} */
@@ -826,7 +828,9 @@ export function parseLocalListVideo(item) {
       lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
       liveNow: video.is_live,
       isUpcoming: video.is_upcoming || video.is_premiere,
-      premiereDate: video.upcoming
+      premiereDate: video.upcoming,
+      is4k: video.is_4k,
+      hasCaptions: video.has_captions
     }
   }
 }

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -61,6 +61,12 @@ Search / Go to URL: Search / Go to URL
 Search Bar:
   Clear Input: Clear Input
 Search character limit: Search query is over the {searchCharacterLimit} character limit
+Search Listing:
+  Label:
+    4K: 4K
+    Subtitles: Subtitles
+    # Aria labels
+    Closed Captions: Closed Captions
   # In Filter Button
 Search Filters:
   Search Filters: Search Filters


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #917

## Description
Implementation of the "4K" and "Subtitles" labels on video search results. See screenshots. 
Note: I've only seen this on the search screen so they haven't been implemented anywhere else.


## Screenshots <!-- If appropriate -->
![4k-and-subtitles](https://github.com/FreeTubeApp/FreeTube/assets/144292954/272fcff9-fc13-4024-a6e8-efd83e3eb95e)
![No-labels](https://github.com/FreeTubeApp/FreeTube/assets/144292954/6b389840-aa8c-43d0-95f4-2ad2fb722360)
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
See screenshots for testing
1. Search of 4k and subtitles. Results show 4K and subtitles together
2. Search results including just 4K or subtitles separately
3. Search results including no 4K and subtitle labels
4. Rudimentary check of subscriptions, trending, most popular, history screens. Labels don't appear there. I don't see them on the Youtube website either.

## Desktop
<!-- Please complete the following information-->
- Windows
- 10
- v0.20.0 Beta

## Additional context
The implementation is flexible enough to support the addition of more labels such as "Live". I'll leave that for another ticket. Live shouldn't be that difficult, however someone will probably need to implement the icon. The alternative is a red label saying "Live" perhaps with a big text dot in front of it.
