### PR TITLE
Skip superfluous conversion to Date in ft-list-video

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -670,7 +670,7 @@ export default defineComponent({
           this.uploadedTime = new Date(this.data.published).toLocaleDateString([this.currentLocale, 'en'])
         } else {
           // Use 30 days per month, just like calculatePublishedDate
-          this.uploadedTime = getRelativeTimeFromDate(new Date(this.data.published), false)
+          this.uploadedTime = getRelativeTimeFromDate(this.data.published, false)
         }
       }
 


### PR DESCRIPTION
# Skip superfluous conversion to Date in ft-list-video

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Inside `ft-list-video` we create a `Date` object from the `published` timestamp number before passing it to `getRelativeTimeFromDate` but in that function it only gets used in some arithmetic, so gets immediately converted back into a number by JavaScript (the `date` variable):
https://github.com/FreeTubeApp/FreeTube/blob/b9d5778a4d9f5626a25796c5dc46f63dde03e983/src/renderer/helpers/utils.js#L748-L756

We also know that it will always be a number because it's typechecked just a few lines above:
https://github.com/FreeTubeApp/FreeTube/blob/b9d5778a4d9f5626a25796c5dc46f63dde03e983/src/renderer/components/ft-list-video/ft-list-video.js#L666-L674

TL;DR it's a number and we use it as a number, so we don't need the conversion to a `Date` object and back.

## Testing <!-- for code that is not small enough to be easily understandable -->
Open a video list e.g. the subscriptions and check that the relative published dates show up correctly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b9d5778a4d9f5626a25796c5dc46f63dde03e983
