### PR TITLE
Fix getters in the store accessing the wrong state

### DIFF
--- a/src/renderer/store/modules/history.js
+++ b/src/renderer/store/modules/history.js
@@ -10,11 +10,11 @@ const state = {
 }
 
 const getters = {
-  getHistoryCacheSorted: () => {
+  getHistoryCacheSorted(state) {
     return state.historyCacheSorted
   },
 
-  getHistoryCacheById: () => {
+  getHistoryCacheById(state) {
     return state.historyCacheById
   }
 }

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -38,8 +38,8 @@ const state = {
 }
 
 const getters = {
-  getPlaylistsReady: () => state.playlistsReady,
-  getAllPlaylists: () => state.playlists,
+  getPlaylistsReady: (state) => state.playlistsReady,
+  getAllPlaylists: (state) => state.playlists,
   getPlaylist: (state) => (playlistId) => {
     return state.playlists.find(playlist => playlist._id === playlistId)
   },

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -15,7 +15,7 @@ const state = {
 }
 
 const getters = {
-  getProfileList: () => {
+  getProfileList: (state) => {
     return state.profileList
   },
 

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -60,19 +60,19 @@ const state = {
 }
 
 const getters = {
-  getIsSideNavOpen () {
+  getIsSideNavOpen(state) {
     return state.isSideNavOpen
   },
 
-  getOutlinesHidden() {
+  getOutlinesHidden(state) {
     return state.outlinesHidden
   },
 
-  getCurrentVolume () {
+  getCurrentVolume(state) {
     return state.currentVolume
   },
 
-  getSessionSearchHistory () {
+  getSessionSearchHistory(state) {
     return state.sessionSearchHistory
   },
 
@@ -80,87 +80,87 @@ const getters = {
     return state.deArrowCache
   },
 
-  getPopularCache () {
+  getPopularCache(state) {
     return state.popularCache
   },
 
-  getTrendingCache () {
+  getTrendingCache(state) {
     return state.trendingCache
   },
 
-  getCachedPlaylist() {
+  getCachedPlaylist(state) {
     return state.cachedPlaylist
   },
 
-  getSearchSettings () {
+  getSearchSettings(state) {
     return state.searchSettings
   },
 
-  getSearchFilterValueChanged () {
+  getSearchFilterValueChanged(state) {
     return state.searchFilterValueChanged
   },
 
-  getShowAddToPlaylistPrompt () {
+  getShowAddToPlaylistPrompt(state) {
     return state.showAddToPlaylistPrompt
   },
 
-  getShowCreatePlaylistPrompt () {
+  getShowCreatePlaylistPrompt(state) {
     return state.showCreatePlaylistPrompt
   },
 
-  getShowSearchFilters () {
+  getShowSearchFilters(state) {
     return state.showSearchFilters
   },
 
-  getToBeAddedToPlaylistVideoList () {
+  getToBeAddedToPlaylistVideoList(state) {
     return state.toBeAddedToPlaylistVideoList
   },
 
-  getNewPlaylistDefaultProperties () {
+  getNewPlaylistDefaultProperties(state) {
     return state.newPlaylistDefaultProperties
   },
 
-  getNewPlaylistVideoObject () {
+  getNewPlaylistVideoObject(state) {
     return state.newPlaylistVideoObject
   },
 
-  getShowProgressBar () {
+  getShowProgressBar(state) {
     return state.showProgressBar
   },
 
-  getProgressBarPercentage () {
+  getProgressBarPercentage(state) {
     return state.progressBarPercentage
   },
 
-  getRegionNames () {
+  getRegionNames(state) {
     return state.regionNames
   },
 
-  getRegionValues () {
+  getRegionValues(state) {
     return state.regionValues
   },
 
-  getRecentBlogPosts () {
+  getRecentBlogPosts(state) {
     return state.recentBlogPosts
   },
 
-  getExternalPlayerNames () {
+  getExternalPlayerNames(state) {
     return state.externalPlayerNames
   },
 
-  getExternalPlayerValues () {
+  getExternalPlayerValues(state) {
     return state.externalPlayerValues
   },
 
-  getExternalPlayerCmdArguments () {
+  getExternalPlayerCmdArguments (state) {
     return state.externalPlayerCmdArguments
   },
 
-  getLastTrendingRefreshTimestamp() {
+  getLastTrendingRefreshTimestamp(state) {
     return state.lastTrendingRefreshTimestamp
   },
 
-  getLastPopularRefreshTimestamp() {
+  getLastPopularRefreshTimestamp(state) {
     return state.lastPopularRefreshTimestamp
   },
 


### PR DESCRIPTION
# Fix getters in the store accessing the wrong state

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Getters inside a vuex store receive the state as their first argument and are supposed to only use that to access the state. Due to the way we have structured our store modules we are also able to access the state variable directly, which is what we do in some places. While our non-compliance doesn't seem to be causing any noticable issues with Vue 2, it breaks reactivity with Vue 3, breaking things such as expanding the side bar (the value in the store changes, but because the getter doesn't notice that it has changed, it doesn't notify the side bar component, so it doesn't expand or collapse).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 9dcdcefe27557b484b59ce7f6cd1afe7bf78f888