### PR TITLE
Fix color of Sponsor Block category icons

### DIFF
--- a/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.vue
+++ b/src/renderer/components/ft-sponsor-block-category/ft-sponsor-block-category.vue
@@ -14,7 +14,8 @@
       :select-names="colorNames"
       :select-values="colorValues"
       :icon="['fas', 'palette']"
-      :icon-color="sponsorBlockValues.color"
+      :class="'sec' + sponsorBlockValues.color"
+      icon-color="var(--accent-color)"
       @change="updateColor"
     />
     <ft-select


### PR DESCRIPTION
# Fix Sponsor Block category setting icon colors

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5006#issuecomment-2119357446

## Description
> Ah, I see, it's passing in the color name and not the actual value. It's a cute accident that it's actually working with the built-in CSS color names.

Sorry, keyboard having issues, making it hard to type this.

## Screenshots <!-- If appropriate -->
![Screenshot_20240519_194827](https://github.com/FreeTubeApp/FreeTube/assets/84899178/a6c72ca1-8216-4511-8c87-0c71ec44b1cc)

## Testing <!-- for code that is not small enough to be easily understandable -->
Change up SponsorBlock colors and see that the icons change appropriately

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW