### PR TITLE
Fix player full screen causing the app to start in full screen

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -867,6 +867,8 @@ function runApp() {
     }
   }
 
+  const htmlFullscreenWindowIds = new Set()
+
   async function createWindow(
     {
       replaceMainWindow = true,
@@ -1144,7 +1146,18 @@ function runApp() {
       newWindow.once('ready-to-show', showWindow)
     }
 
+    newWindow.on('enter-html-full-screen', () => {
+      htmlFullscreenWindowIds.add(newWindow.id)
+    })
+
+    newWindow.on('leave-html-full-screen', () => {
+      htmlFullscreenWindowIds.delete(newWindow.id)
+    })
+
     newWindow.once('close', async () => {
+      // returns true if the element existed in the set
+      const htmlFullscreen = htmlFullscreenWindowIds.delete(newWindow.id)
+
       if (BrowserWindow.getAllWindows().length !== 1) {
         return
       }
@@ -1152,7 +1165,9 @@ function runApp() {
       const value = {
         ...newWindow.getNormalBounds(),
         maximized: newWindow.isMaximized(),
-        fullScreen: newWindow.isFullScreen()
+
+        // Don't save the full screen state if it was triggered by an HTML API e.g. the video player
+        fullScreen: newWindow.isFullScreen() && !htmlFullscreen
       }
 
       await baseHandlers.settings._updateBounds(value)


### PR DESCRIPTION
# Fix player full screen causing the app to start in full screen

## Pull Request Type

- [x] Bugfix

## Related issue
- closes #4534
- closes #4649
- closes #3220

## Description
This is an alternative to https://github.com/FreeTubeApp/FreeTube/pull/4649 that should hopefully work more consistently (the creator of that pull request is aware that I am making this one).

When the app is closed while in full screen regardless of whether only the player or the entire window was full-screened, we save the full screen state and restore it at start up. For people that full-screened the app that is great, but for people that full-screened the player it's less desirable to have the entire app start in full screen.

## Testing
### Full screen doesn't persist if player is full-screened
1. Open a video
2. Full screen the player, either through the button or the <kbd>F</kbd> hotkey
3. Close the app e.g. <kbd>Ctrl</kbd>+<kbd>Q</kbd> or <kbd>Alt</kbd>+<kbd>F4</kbd>
4. Open the app again and make sure it launches with normal window dimensions

### Full screen persists if you full screen the window (regression test)
1. Full screen the window e.g. <kbd>F11</kbd>
2. Close the app e.g. <kbd>Ctrl</kbd>+<kbd>Q</kbd> or <kbd>Alt</kbd>+<kbd>F4</kbd>
3. Open the app again and make sure it launches in full screen.

## Desktop

- **OS:** Windows
- **OS Version:** 11