### PR TITLE
Fix vue-devtools getting bundled into production builds

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -543,7 +543,11 @@ function runApp() {
     await createWindow()
 
     if (process.env.NODE_ENV === 'development') {
-      installDevTools()
+      try {
+        require('vue-devtools').install()
+      } catch (err) {
+        console.error(err)
+      }
     }
 
     if (isDebug) {
@@ -589,16 +593,6 @@ function runApp() {
       return protocol === 'http:' && host === 'localhost:9080' && (pathname === '/' || pathname === '/index.html')
     } else {
       return protocol === 'app:' && host === 'bundle' && pathname === '/index.html'
-    }
-  }
-
-  async function installDevTools() {
-    try {
-      /* eslint-disable */
-      require('vue-devtools').install()
-      /* eslint-enable */
-    } catch (err) {
-      console.error(err)
     }
   }
 


### PR DESCRIPTION
# Fix vue-devtools getting bundled into production builds

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
As the `vue-devtools` dependency is a CommonJS module, webpack wraps it in a CommonJS wrapper so it can simulate the import at runtime (as CommonJS exports can be completely dynamic), which means it won't get eliminated by terser's dead code elimination. To fix that we can make sure that the import itself is inside the build time guard, that way webpack will skip the import.

This shaves 1195 bytes off the `main.js` file.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0