### PR TITLE
Fix hide/show channel in ft-list-video

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -292,7 +292,7 @@ export default defineComponent({
 
       if (this.channelId !== null) {
         const hiddenChannels = JSON.parse(this.$store.getters.getChannelsHidden)
-        const channelShouldBeHidden = hiddenChannels.some(c => c === this.channelId)
+        const channelShouldBeHidden = hiddenChannels.some(c => c.name === this.channelId)
 
         options.push(
           {
@@ -751,7 +751,7 @@ export default defineComponent({
 
     hideChannel: function(channelName, channelId) {
       const hiddenChannels = JSON.parse(this.$store.getters.getChannelsHidden)
-      hiddenChannels.push(channelId)
+      hiddenChannels.push({ name: channelId, preferredName: channelName })
       this.updateChannelsHidden(JSON.stringify(hiddenChannels))
 
       showToast(this.$t('Channel Hidden', { channel: channelName }))
@@ -759,7 +759,7 @@ export default defineComponent({
 
     unhideChannel: function(channelName, channelId) {
       const hiddenChannels = JSON.parse(this.$store.getters.getChannelsHidden)
-      this.updateChannelsHidden(JSON.stringify(hiddenChannels.filter(c => c !== channelId)))
+      this.updateChannelsHidden(JSON.stringify(hiddenChannels.filter(c => c.name !== channelId)))
 
       showToast(this.$t('Channel Unhidden', { channel: channelName }))
     },


### PR DESCRIPTION
# Fix hide/show channel in ft-list-video

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
* closes #5113

## Description
The `ft-list-video` component was never updated to the new (well not very new anymore) structure of the hidden channels. This pull request corrects that so that it now works as expected.

## Testing <!-- for code that is not small enough to be easily understandable -->
(Adapted from the bug reproduction steps in the linked issue)

1. Hover over a video thumbnail
2. Click on the kebab menu
3. Click on `Hide Channel`
4. Go to Distraction Free Settings -> Hide Videos From Channels to verify the channel is listed
5. Repeat step 1 and 2
6. Check that it says `Hide Channel`

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0