### PR TITLE
Use playlist name for playlist page title

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -82,7 +82,7 @@ export default defineComponent({
     },
     windowTitle: function () {
       const routePath = this.$route.path
-      if (!routePath.startsWith('/channel/') && !routePath.startsWith('/watch/') && !routePath.startsWith('/hashtag/')) {
+      if (!routePath.startsWith('/channel/') && !routePath.startsWith('/watch/') && !routePath.startsWith('/hashtag/') && !routePath.startsWith('/playlist/')) {
         let title = translateWindowTitle(this.$route.meta.title, this.$i18n)
         if (!title) {
           title = packageDetails.productName

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -21,6 +21,7 @@ import {
   showToast,
 } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
+import packageDetails from '../../../../package.json'
 
 const SORT_BY_VALUES = {
   DateAddedNewest: 'date_added_descending',
@@ -323,7 +324,7 @@ export default defineComponent({
           channelName = subtitle.substring(0, index).trim()
         }
 
-        this.playlistTitle = result.info.title
+        this.setPlaylistTitle(result.info.title)
         this.playlistDescription = result.info.description ?? ''
         this.firstVideoId = result.items[0].id
         this.playlistThumbnail = result.info.thumbnails[0].url
@@ -366,7 +367,7 @@ export default defineComponent({
 
     getPlaylistInvidious: function () {
       invidiousGetPlaylistInfo(this.playlistId).then((result) => {
-        this.playlistTitle = result.title
+        this.setPlaylistTitle(result.title)
         this.playlistDescription = result.description
         this.firstVideoId = result.videos[0].videoId
         this.viewCount = result.viewCount
@@ -403,7 +404,7 @@ export default defineComponent({
     },
 
     parseUserPlaylist: function (playlist) {
-      this.playlistTitle = playlist.playlistName
+      this.setPlaylistTitle(playlist.playlistName)
       this.playlistDescription = playlist.description ?? ''
 
       if (playlist.videos.length > 0) {
@@ -560,6 +561,11 @@ export default defineComponent({
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'))
         console.error(e)
       }
+    },
+
+    setPlaylistTitle: function (value) {
+      this.playlistTitle = value
+      document.title = `${value} - ${packageDetails.productName}`
     },
 
     getIconForSortPreference: (s) => getIconForSortPreference(s),


### PR DESCRIPTION
# Use playlist name for playlist page title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4949#issuecomment-2123750685

## Description
Sets document title to playlist title. This is consistent with how we do it for other routes with custom named content, YT, and user expectations.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test document title is updated to the playlist title for a given user playlist or remote playlist (either backend)

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
