### PR TITLE
Set a max length of 100 for most inputs

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -23,6 +23,10 @@ export default defineComponent({
       type: String,
       default: null
     },
+    maxlength: {
+      type: Number,
+      default: 100
+    },
     value: {
       type: String,
       default: ''

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -45,6 +45,7 @@
         :value="inputDataDisplayed"
         :list="idDataList"
         class="ft-input"
+        :maxlength="maxlength"
         :type="inputType"
         :placeholder="placeholder"
         :disabled="disabled"

--- a/src/renderer/components/password-dialog/password-dialog.vue
+++ b/src/renderer/components/password-dialog/password-dialog.vue
@@ -8,6 +8,7 @@
       ref="password"
       :placeholder="$t('Settings.Password Dialog.Password')"
       :show-action-button="false"
+      :maxlength="null"
       input-type="password"
       class="passwordInput"
       @input="handlePasswordInput"

--- a/src/renderer/components/password-settings/password-settings.vue
+++ b/src/renderer/components/password-settings/password-settings.vue
@@ -20,6 +20,7 @@
         :show-action-button="false"
         :show-label="true"
         input-type="password"
+        :maxlength="null"
         :value="password"
         @input="e => password = e"
         @keydown.enter.native="handleSetPassword"

--- a/src/renderer/components/playlist-info/playlist-info.vue
+++ b/src/renderer/components/playlist-info/playlist-info.vue
@@ -71,6 +71,7 @@
       :show-action-button="false"
       :show-label="false"
       :value="newDescription"
+      :maxlength="null"
       @input="(input) => newDescription = input"
       @keydown.enter.native="savePlaylistInfo"
     />


### PR DESCRIPTION
Excluded are playlist descriptions, which presumably deserve to have some leeway, and the password input, to prevent the edge case of a user being locked out if they had a longer one set (and also why not for this one).

# Set a max length of 100 for most inputs

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5150#issuecomment-2124043618

## Description
There's just no need for that much information in a custom label, because beyond 100 (and before, in many cases), we're already limiting the visible text. 

Excluded are playlist descriptions, which presumably deserve to have some leeway, and the password input, to prevent the edge case of a user being locked out if they had a longer one set (and also why not for this one)

**Note:** Due to the value of 100 chosen, [this code](https://github.com/FreeTubeApp/FreeTube/pull/4992/files) is currently not in use. We can 1) keep this code here in case that number ever changes, or 2) remove it and just remember to revert a commit. I don't have a preference.

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test that inputs are limited from continued text at 100
- (Optional) Test edge case behavior when a playlist title is already >100 characters and the title is edited. Expected outcome: you can't add new characters, but you can remove them, and save at any length.

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW

## Additional context
The User Playlist desktop list view breaks for long enough titles and descriptions. We probably need code truncating those after x lines. 
