### PR TITLE
Play next/prev video after removing current video from the playlist

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -160,12 +160,12 @@ export default defineComponent({
     },
     selectedUserPlaylistVideoCount () {
       // Re-fetch from local store when current user playlist updated
-      this.parseUserPlaylist(this.selectedUserPlaylist, { allowPlayingVideoRemoval: true })
+      this.parseUserPlaylist(this.selectedUserPlaylist)
       this.shufflePlaylistItems()
     },
     selectedUserPlaylistLastUpdatedAt () {
       // Re-fetch from local store when current user playlist updated
-      this.parseUserPlaylist(this.selectedUserPlaylist, { allowPlayingVideoRemoval: true })
+      this.parseUserPlaylist(this.selectedUserPlaylist)
     },
     videoId: function (newId, oldId) {
       // Check if next video is from the shuffled list or if the user clicked a different video
@@ -466,22 +466,12 @@ export default defineComponent({
       })
     },
 
-    parseUserPlaylist: function (playlist, { allowPlayingVideoRemoval = true } = {}) {
+    parseUserPlaylist: function (playlist) {
       this.playlistTitle = playlist.playlistName
       this.channelName = ''
       this.channelId = ''
 
-      if (this.playlistItems.length === 0 || allowPlayingVideoRemoval) {
-        this.playlistItems = playlist.videos
-      } else {
-        // `this.currentVideo` relies on `playlistItems`
-        const latestPlaylistContainsCurrentVideo = playlist.videos.some(v => v.playlistItemId === this.playlistItemId)
-        // Only update list of videos if latest video list still contains currently playing video
-        if (latestPlaylistContainsCurrentVideo) {
-          this.playlistItems = playlist.videos
-        }
-      }
-
+      this.playlistItems = playlist.videos
       if (this.reversePlaylist) {
         this.playlistItems = this.playlistItems.toReversed()
       }


### PR DESCRIPTION
# Play next/prev video after removing current video from the playlist

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
closes #4918

## Description
When you delete the video that is shown as being currently watched in `watch-video-playlist`, the video index will now visually appear to be the video prior to that one. if you delete that one, it carries on the video prior, and so forth. When the video autoplays or you click `Play Next Video` in this state, it plays the video that is shown as the one after the current video. When you click `Play Previous Video` in this state, it plays the video that is shown as the "current" video. These are all existing behaviors of YT.

Note that if you were to navigate back to the previous route for a deleted playlist entry through the `Back` button, the current video index will be set to zero, as this feature is reset when you navigate to a new route. This pre-existing behavior is fine, and making this more "durable" is not worth the effort. Believe me, I've tried.

## Screenshots <!-- If appropriate -->
![Screenshot_20240522_150833](https://github.com/FreeTubeApp/FreeTube/assets/84899178/f2fa7106-f5df-42cc-b737-c8c275920ca7)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Test that removing the current video in the playlist will have the play icon in `watch-video-playlist` update to the prior video
  A. Test `Play Previous Video`  plays the video with the same index as the video with the play icon
  B. Test `Play Next Video` and autoplay plays the video with index one higher than the video with the play icon
2. Test that removing the current video in the playlist will have the play icon in `watch-video-playlist` update to the prior video, then delete that one. See that the play icon then goes the video prior to that.
  A. (Optional) Repeat validations 1A and 1B in this state.
4. (Optional) Test 1 with Shuffle and/or Reverse enabled

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW

## Additional context
<!-- Add any other context about the pull request here. -->
