### PR TITLE
Fix channel sort values not reflecting their actual value

### DIFF
--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -232,7 +232,7 @@
         <ft-select
           v-if="showVideoSortBy"
           v-show="currentTab === 'videos' && latestVideos.length > 0"
-          :value="videoLiveShortSelectValues[0]"
+          :value="videoSortBy"
           :select-names="videoLiveShortSelectNames"
           :select-values="videoLiveShortSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"
@@ -242,7 +242,7 @@
         <ft-select
           v-if="!hideChannelShorts && showShortSortBy"
           v-show="currentTab === 'shorts' && latestShorts.length > 0"
-          :value="videoLiveShortSelectValues[0]"
+          :value="shortSortBy"
           :select-names="videoLiveShortSelectNames"
           :select-values="videoLiveShortSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"
@@ -252,7 +252,7 @@
         <ft-select
           v-if="!hideLiveStreams && showLiveSortBy"
           v-show="currentTab === 'live' && latestLive.length > 0"
-          :value="videoLiveShortSelectValues[0]"
+          :value="liveSortBy"
           :select-names="videoLiveShortSelectNames"
           :select-values="videoLiveShortSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"
@@ -262,7 +262,7 @@
         <ft-select
           v-if="!hideChannelPlaylists && showPlaylistSortBy"
           v-show="currentTab === 'playlists' && latestPlaylists.length > 0"
-          :value="playlistSelectValues[0]"
+          :value="playlistSortBy"
           :select-names="playlistSelectNames"
           :select-values="playlistSelectValues"
           :placeholder="$t('Search Filters.Sort By.Sort By')"


### PR DESCRIPTION
# Fix channel sort values not reflecting their actual value

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #5160 

## Screenshots <!-- If appropriate -->
![Screenshot_20240523_171744](https://github.com/FreeTubeApp/FreeTube/assets/84899178/d62516d7-1e4b-4c0e-b174-e3e8b9fc06aa)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test video, playlist, short, and live visible sort selection changes when you change the sort selection

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
