### PR TITLE
Use `addVideo` instead of `addVideos` for quick bookmark button

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -786,14 +786,12 @@ export default defineComponent({
         title: this.title,
         author: this.channelName,
         authorId: this.channelId,
-        description: this.description,
-        viewCount: this.viewCount,
         lengthSeconds: this.data.lengthSeconds,
       }
 
-      this.addVideos({
+      this.addVideo({
         _id: this.quickBookmarkPlaylist._id,
-        videos: [videoData],
+        videoData,
       })
       // Update playlist's `lastUpdatedAt`
       this.updatePlaylist({ _id: this.quickBookmarkPlaylist._id })
@@ -831,7 +829,7 @@ export default defineComponent({
       'removeFromHistory',
       'updateChannelsHidden',
       'showAddToPlaylistPromptForManyVideos',
-      'addVideos',
+      'addVideo',
       'updatePlaylist',
       'removeVideo',
     ])

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -360,14 +360,12 @@ export default defineComponent({
         title: this.title,
         author: this.channelName,
         authorId: this.channelId,
-        description: this.description,
-        viewCount: this.viewCount,
         lengthSeconds: this.lengthSeconds,
       }
 
-      this.addVideos({
+      this.addVideo({
         _id: this.quickBookmarkPlaylist._id,
-        videos: [videoData],
+        videoData,
       })
       // Update playlist's `lastUpdatedAt`
       this.updatePlaylist({ _id: this.quickBookmarkPlaylist._id })
@@ -396,7 +394,7 @@ export default defineComponent({
       'openInExternalPlayer',
       'downloadMedia',
       'showAddToPlaylistPromptForManyVideos',
-      'addVideos',
+      'addVideo',
       'updatePlaylist',
       'removeVideo',
     ])


### PR DESCRIPTION
# Use `addVideo` instead of `addVideos` for quick bookmark button

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Performance improvement

## Description
As we already have a dedicated process for adding just one video to the playlist, we might as well use it for the quick bookmark button, as that always just adds one video. Another advantage is that the `addVideo` store action, doesn't need to clone the video object, because we know it's not used anywhere else as we just created it.

I'm not expecting this improvement to be drastic enough to be noticeable without measuring tools, but it's still worth it as we are doing less work and using less memory.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that adding a video to the quick bookmark playlist through the dedicated button on a video thumbnail and on the watch page, still works.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** f7cadd138cd93f67e074bb6d0d402442bf6ce45a