### PR TITLE
Cache quick bookmark playlist to reduce the amount of lookups

### DIFF
--- a/src/renderer/components/ft-list-playlist/ft-list-playlist.js
+++ b/src/renderer/components/ft-list-playlist/ft-list-playlist.js
@@ -44,9 +44,6 @@ export default defineComponent({
     quickBookmarkPlaylistId() {
       return this.$store.getters.getQuickBookmarkTargetPlaylistId
     },
-    quickBookmarkPlaylist() {
-      return this.$store.getters.getPlaylist(this.quickBookmarkPlaylistId)
-    },
     markedAsQuickBookmarkTarget() {
       // Only user playlists can be target
       if (this.playlistId == null) { return false }
@@ -174,7 +171,7 @@ export default defineComponent({
     },
 
     enableQuickBookmarkForThisPlaylist: function () {
-      const currentQuickBookmarkTargetPlaylist = this.quickBookmarkPlaylist
+      const currentQuickBookmarkTargetPlaylist = this.$store.getters.getQuickBookmarkPlaylist
 
       this.updateQuickBookmarkTargetPlaylistId(this.playlistId)
       if (currentQuickBookmarkTargetPlaylist != null) {

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -430,11 +430,8 @@ export default defineComponent({
       return this.playlistIdTypePairFinal?.playlistItemId
     },
 
-    quickBookmarkPlaylistId() {
-      return this.$store.getters.getQuickBookmarkTargetPlaylistId
-    },
     quickBookmarkPlaylist() {
-      return this.$store.getters.getPlaylist(this.quickBookmarkPlaylistId)
+      return this.$store.getters.getQuickBookmarkPlaylist
     },
     isQuickBookmarkEnabled() {
       return this.quickBookmarkPlaylist != null

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -228,11 +228,8 @@ export default defineComponent({
       return !this.hideSharingActions
     },
 
-    quickBookmarkPlaylistId() {
-      return this.$store.getters.getQuickBookmarkTargetPlaylistId
-    },
     quickBookmarkPlaylist() {
-      return this.$store.getters.getPlaylist(this.quickBookmarkPlaylistId)
+      return this.$store.getters.getQuickBookmarkPlaylist
     },
     markedAsQuickBookmarkTarget() {
       // Only user playlists can be target

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -217,11 +217,8 @@ export default defineComponent({
       return this.$store.getters.getDefaultPlayback
     },
 
-    quickBookmarkPlaylistId() {
-      return this.$store.getters.getQuickBookmarkTargetPlaylistId
-    },
     quickBookmarkPlaylist() {
-      return this.$store.getters.getPlaylist(this.quickBookmarkPlaylistId)
+      return this.$store.getters.getQuickBookmarkPlaylist
     },
     isQuickBookmarkEnabled() {
       return this.quickBookmarkPlaylist != null

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -63,6 +63,15 @@ const getters = {
   getPlaylist: (state) => (playlistId) => {
     return state.playlists.find(playlist => playlist._id === playlistId)
   },
+  getQuickBookmarkPlaylist(state, getters) {
+    const playlistId = getters.getQuickBookmarkTargetPlaylistId
+
+    if (!playlistId) {
+      return undefined
+    }
+
+    return state.playlists.find((playlist) => playlist._id === playlistId)
+  }
 }
 
 const actions = {


### PR DESCRIPTION
# Cache quick bookmark playlist to reduce the amount of lookups

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Performance improvement

## Description
The quick bookmark playlist is accessed in many places in the app, most notably inside every `ft-list-video` instance to check if said video is in the quick bookmark playlist. Every place that needs the quick bookmark playlist currently searches for the playlist by itself, not just when it's created but any time that any playlist is updated or the quick bookmark target is updated. This pull request moves that search into a getter inside the playlist store. Getters inside the vuex store cache their result (not if you return a function though) and are lazily evaluated, just like computed properties inside a component. That means that the search only needs to be done once, per triggering change, instead of many times.

I'm not expecting this improvement to be drastic enough to be noticeable without measuring tools, but it's still worth it as we are doing less work.

## Testing <!-- for code that is not small enough to be easily understandable -->
Add videos to and remove videos from the quick bookmark playlist, while checking that the icon still updates accordingly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 6481123d48815e87374ac5467c4419db23d46348