### PR TITLE
Access reactive video id once outside of the quick bookmark check

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -442,8 +442,10 @@ export default defineComponent({
     isInQuickBookmarkPlaylist: function () {
       if (!this.isQuickBookmarkEnabled) { return false }
 
+      const id = this.id
+
       return this.quickBookmarkPlaylist.videos.some((video) => {
-        return video.videoId === this.id
+        return video.videoId === id
       })
     },
     quickBookmarkIconText: function () {

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -229,8 +229,10 @@ export default defineComponent({
     isInQuickBookmarkPlaylist: function () {
       if (!this.isQuickBookmarkEnabled) { return false }
 
+      const id = this.id
+
       return this.quickBookmarkPlaylist.videos.some((video) => {
-        return video.videoId === this.id
+        return video.videoId === id
       })
     },
     quickBookmarkIconText: function () {


### PR DESCRIPTION
# Access reactive video id once outside of the quick bookmark check

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Performance improvement

## Description
As the `id` property is reactive (it's inside of `data`), there is a small overhead for each access, during normal use that's not a problem, but in this case where we are accessing it potentially thousands of times (depends on how many items are in the quick bookmark playlist of course) inside a loop, it starts adding up. To avoid that, we can save the video to a temporary variable outside of the loop and access that directly, which avoids the reactivity overhead inside the loop.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 6481123d48815e87374ac5467c4419db23d46348