### PR TITLE
Use auto scrollbar size for all scrollbars except the side nav

### DIFF
--- a/src/renderer/components/side-nav/side-nav.css
+++ b/src/renderer/components/side-nav/side-nav.css
@@ -161,6 +161,13 @@
   margin-block: 0.3em;
 }
 
+@media only screen and (width > 680px) {
+  .sideNav ::-webkit-scrollbar {
+    inline-size: 6px;
+    block-size: 6px;
+  }
+}
+
 @media only screen and (width <= 680px) {
   .inner {
     display: contents; /* sunglasses emoji */

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -1371,8 +1371,8 @@ a:visited {
 }
 
 ::-webkit-scrollbar {
-	inline-size: 6px;
-  block-size: 6px;
+	inline-size: auto;
+  block-size: auto;
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
# Use auto scrollbar size for all scrollbars except the side nav

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
#321, #346, #3057 (sets higher sensible default addressing the usability issues referenced)

## Description
Uses default platform scrollbar size for all scrollbars except the side nav (where it's too much of a headache to address at this time). Hopefully should help most users having issues with the scrollbar being too small. If people's needs still aren't adequately addressed by this come v0.21, we can go forward with adding a new setting as requested in #3057.

## Screenshots <!-- If appropriate -->
![Screenshot_20240525_084404](https://github.com/FreeTubeApp/FreeTube/assets/84899178/c892af15-a9fa-464a-84b6-e99516b0d765)

## Testing <!-- for code that is not small enough to be easily understandable -->
- Open the app and look at the scrollbars

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
