### PR TITLE
Fix user playlist z-index issue

### DIFF
--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -49,6 +49,7 @@
       inline-size: 85%;
       background-color: var(--card-bg-color);
       box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
+      z-index: 3;
 
       .playlistInfo {
         padding-block: 10px;


### PR DESCRIPTION
# Fix user playlist z-index issue

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/4949#issuecomment-2132389173

## Description
[weeps silently at another z-index issue]

## Testing <!-- for code that is not small enough to be easily understandable -->
- Test that video progress bar does not poke in front of the user playlist grid view top section

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
