### PR TITLE
Implement persistent subscription cache

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,11 +17,13 @@ const IpcChannels = {
   DB_HISTORY: 'db-history',
   DB_PROFILES: 'db-profiles',
   DB_PLAYLISTS: 'db-playlists',
+  DB_SUBSCRIPTIONS: 'db-subscriptions',
 
   SYNC_SETTINGS: 'sync-settings',
   SYNC_HISTORY: 'sync-history',
   SYNC_PROFILES: 'sync-profiles',
   SYNC_PLAYLISTS: 'sync-playlists',
+  SYNC_SUBSCRIPTIONS: 'sync-subscriptions',
 
   GET_REPLACE_HTTP_CACHE: 'get-replace-http-cache',
   TOGGLE_REPLACE_HTTP_CACHE: 'toggle-replace-http-cache',
@@ -52,7 +54,14 @@ const DBActions = {
     DELETE_VIDEO_ID: 'db-action-playlists-delete-video-by-playlist-name',
     DELETE_VIDEO_IDS: 'db-action-playlists-delete-video-ids',
     DELETE_ALL_VIDEOS: 'db-action-playlists-delete-all-videos',
-  }
+  },
+
+  SUBSCRIPTIONS: {
+    UPDATE_VIDEOS_BY_CHANNEL: 'db-action-subscriptions-update-videos-by-channel',
+    UPDATE_LIVE_STREAMS_BY_CHANNEL: 'db-action-subscriptions-update-live-streams-by-channel',
+    UPDATE_SHORTS_BY_CHANNEL: 'db-action-subscriptions-update-shorts-by-channel',
+    UPDATE_COMMUNITY_POSTS_BY_CHANNEL: 'db-action-subscriptions-update-community-posts-by-channel',
+  },
 }
 
 const SyncEvents = {
@@ -71,7 +80,14 @@ const SyncEvents = {
   PLAYLISTS: {
     UPSERT_VIDEO: 'sync-playlists-upsert-video',
     DELETE_VIDEO: 'sync-playlists-delete-video',
-  }
+  },
+
+  SUBSCRIPTIONS: {
+    UPDATE_VIDEOS_BY_CHANNEL: 'sync-subscriptions-update-videos-by-channel',
+    UPDATE_LIVE_STREAMS_BY_CHANNEL: 'sync-subscriptions-update-live-streams-by-channel',
+    UPDATE_SHORTS_BY_CHANNEL: 'sync-subscriptions-update-shorts-by-channel',
+    UPDATE_COMMUNITY_POSTS_BY_CHANNEL: 'sync-subscriptions-update-community-posts-by-channel',
+  },
 }
 
 // Utils

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -183,12 +183,63 @@ class Playlists {
   }
 }
 
+class Subscriptions {
+  static find() {
+    return db.subscriptions.findAsync({})
+  }
+
+  static updateVideosByChannelId({ channelId, entries, timestamp }) {
+    return db.subscriptions.updateAsync(
+      { _id: channelId },
+      { $set: { videos: entries, videosTimestamp: timestamp } },
+      { upsert: true }
+    )
+  }
+
+  static updateLiveStreamsByChannelId({ channelId, entries, timestamp }) {
+    return db.subscriptions.updateAsync(
+      { _id: channelId },
+      { $set: { liveStreams: entries, liveStreamsTimestamp: timestamp } },
+      { upsert: true }
+    )
+  }
+
+  static updateShortsByChannelId({ channelId, entries, timestamp }) {
+    return db.subscriptions.updateAsync(
+      { _id: channelId },
+      { $set: { shorts: entries, shortsTimestamp: timestamp } },
+      { upsert: true }
+    )
+  }
+
+  static updateCommunityPostsByChannelId({ channelId, entries, timestamp }) {
+    return db.subscriptions.updateAsync(
+      { _id: channelId },
+      { $set: { communityPosts: entries, communityPostsTimestamp: timestamp } },
+      { upsert: true }
+    )
+  }
+
+  static deleteMultipleChannels(channelIds) {
+    return db.subscriptions.removeAsync({ _id: { $in: channelIds } }, { multi: true })
+  }
+
+  static deleteAll() {
+    return db.subscriptions.removeAsync({}, { multi: true })
+  }
+
+  static persist() {
+    return db.subscriptions.compactDatafileAsync()
+  }
+}
+
 function compactAllDatastores() {
   return Promise.allSettled([
     Settings.persist(),
     History.persist(),
     Profiles.persist(),
     Playlists.persist(),
+    Subscriptions.persist(),
   ])
 }
 
@@ -197,6 +248,7 @@ export {
   History as history,
   Profiles as profiles,
   Playlists as playlists,
+  Subscriptions as subscriptions,
 
   compactAllDatastores,
 }

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -205,9 +205,73 @@ class Playlists {
   }
 }
 
+class Subscriptions {
+  static find() {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      { action: DBActions.GENERAL.FIND }
+    )
+  }
+
+  static updateVideosByChannelId({ channelId, entries, timestamp }) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      {
+        action: DBActions.SUBSCRIPTIONS.UPDATE_VIDEOS_BY_CHANNEL,
+        data: { channelId, entries, timestamp },
+      }
+    )
+  }
+
+  static updateLiveStreamsByChannelId({ channelId, entries, timestamp }) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      {
+        action: DBActions.SUBSCRIPTIONS.UPDATE_LIVE_STREAMS_BY_CHANNEL,
+        data: { channelId, entries, timestamp },
+      }
+    )
+  }
+
+  static updateShortsByChannelId({ channelId, entries, timestamp }) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      {
+        action: DBActions.SUBSCRIPTIONS.UPDATE_SHORTS_BY_CHANNEL,
+        data: { channelId, entries, timestamp },
+      }
+    )
+  }
+
+  static updateCommunityPostsByChannelId({ channelId, entries, timestamp }) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      {
+        action: DBActions.SUBSCRIPTIONS.UPDATE_COMMUNITY_POSTS_BY_CHANNEL,
+        data: { channelId, entries, timestamp },
+      }
+    )
+  }
+
+  static deleteMultipleChannels(channelIds) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      { action: DBActions.GENERAL.DELETE_MULTIPLE, data: channelIds }
+    )
+  }
+
+  static deleteAll() {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_SUBSCRIPTIONS,
+      { action: DBActions.GENERAL.DELETE_ALL }
+    )
+  }
+}
+
 export {
   Settings as settings,
   History as history,
   Profiles as profiles,
-  Playlists as playlists
+  Playlists as playlists,
+  Subscriptions as subscriptions,
 }

--- a/src/datastores/handlers/index.js
+++ b/src/datastores/handlers/index.js
@@ -2,5 +2,6 @@ export {
   settings as DBSettingHandlers,
   history as DBHistoryHandlers,
   profiles as DBProfileHandlers,
-  playlists as DBPlaylistHandlers
+  playlists as DBPlaylistHandlers,
+  subscriptions as DBSubscriptionsHandlers,
 } from 'DB_HANDLERS_ELECTRON_RENDERER_OR_WEB'

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -118,9 +118,56 @@ class Playlists {
   }
 }
 
+class Subscriptions {
+  static find() {
+    return baseHandlers.subscriptions.find()
+  }
+
+  static updateVideosByChannelId({ channelId, entries, timestamp }) {
+    return baseHandlers.subscriptions.updateVideosByChannelId({
+      channelId,
+      entries,
+      timestamp,
+    })
+  }
+
+  static updateLiveStreamsByChannelId({ channelId, entries, timestamp }) {
+    return baseHandlers.subscriptions.updateLiveStreamsByChannelId({
+      channelId,
+      entries,
+      timestamp,
+    })
+  }
+
+  static updateShortsByChannelId({ channelId, entries, timestamp }) {
+    return baseHandlers.subscriptions.updateShortsByChannelId({
+      channelId,
+      entries,
+      timestamp,
+    })
+  }
+
+  static updateCommunityPostsByChannelId({ channelId, entries, timestamp }) {
+    return baseHandlers.subscriptions.updateCommunityPostsByChannelId({
+      channelId,
+      entries,
+      timestamp,
+    })
+  }
+
+  static deleteMultipleChannels(channelIds) {
+    return baseHandlers.subscriptions.deleteMultipleChannels(channelIds)
+  }
+
+  static deleteAll() {
+    return baseHandlers.subscriptions.deleteAll()
+  }
+}
+
 export {
   Settings as settings,
   History as history,
   Profiles as profiles,
-  Playlists as playlists
+  Playlists as playlists,
+  Subscriptions as subscriptions,
 }

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -26,3 +26,4 @@ export const settings = new Datastore({ filename: dbPath('settings'), autoload: 
 export const profiles = new Datastore({ filename: dbPath('profiles'), autoload: true })
 export const playlists = new Datastore({ filename: dbPath('playlists'), autoload: true })
 export const history = new Datastore({ filename: dbPath('history'), autoload: true })
+export const subscriptions = new Datastore({ filename: dbPath('subscriptions'), autoload: true })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1223,6 +1223,84 @@ function runApp() {
 
   // *********** //
 
+  // *********** //
+  // Profiles
+  ipcMain.handle(IpcChannels.DB_SUBSCRIPTIONS, async (event, { action, data }) => {
+    try {
+      switch (action) {
+        case DBActions.GENERAL.FIND:
+          return await baseHandlers.subscriptions.find()
+
+        case DBActions.SUBSCRIPTIONS.UPDATE_VIDEOS_BY_CHANNEL:
+          await baseHandlers.subscriptions.updateVideosByChannelId(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_SUBSCRIPTIONS,
+            event,
+            { event: SyncEvents.SUBSCRIPTIONS.UPDATE_VIDEOS_BY_CHANNEL, data }
+          )
+          return null
+
+        case DBActions.SUBSCRIPTIONS.UPDATE_LIVE_STREAMS_BY_CHANNEL:
+          await baseHandlers.subscriptions.updateLiveStreamsByChannelId(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_SUBSCRIPTIONS,
+            event,
+            { event: SyncEvents.SUBSCRIPTIONS.UPDATE_LIVE_STREAMS_BY_CHANNEL, data }
+          )
+          return null
+
+        case DBActions.SUBSCRIPTIONS.UPDATE_SHORTS_BY_CHANNEL:
+          await baseHandlers.subscriptions.updateShortsByChannelId(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_SUBSCRIPTIONS,
+            event,
+            { event: SyncEvents.SUBSCRIPTIONS.UPDATE_SHORTS_BY_CHANNEL, data }
+          )
+          return null
+
+        case DBActions.SUBSCRIPTIONS.UPDATE_COMMUNITY_POSTS_BY_CHANNEL:
+          await baseHandlers.subscriptions.updateCommunityPostsByChannelId(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_SUBSCRIPTIONS,
+            event,
+            { event: SyncEvents.SUBSCRIPTIONS.UPDATE_COMMUNITY_POSTS_BY_CHANNEL, data }
+          )
+          return null
+
+        case DBActions.GENERAL.DELETE_MULTIPLE:
+          await baseHandlers.subscriptions.deleteMultipleChannels(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_SUBSCRIPTIONS,
+            event,
+            { event: SyncEvents.GENERAL.DELETE_MULTIPLE, data }
+          )
+          return null
+
+        case DBActions.GENERAL.DELETE_ALL:
+          await baseHandlers.subscriptions.deleteAll()
+          syncOtherWindows(
+            IpcChannels.SYNC_SUBSCRIPTIONS,
+            event,
+            { event: SyncEvents.GENERAL.DELETE_ALL, data }
+          )
+          return null
+
+        case DBActions.GENERAL.PERSIST:
+          await baseHandlers.subscriptions.persist()
+          return null
+
+        default:
+          // eslint-disable-next-line no-throw-literal
+          throw 'invalid subscriptions db action'
+      }
+    } catch (err) {
+      if (typeof err === 'string') throw err
+      else throw err.toString()
+    }
+  })
+
+  // *********** //
+
   function syncOtherWindows(channel, event, payload) {
     const otherWindows = BrowserWindow.getAllWindows().filter((window) => {
       return window.webContents.id !== event.sender.id

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -178,6 +178,7 @@ export default defineComponent({
       this.grabAllProfiles(this.$t('Profile.All Channels')).then(async () => {
         this.grabHistory()
         this.grabAllPlaylists()
+        this.grabAllSubscriptions()
 
         if (process.env.IS_ELECTRON) {
           ipcRenderer = require('electron').ipcRenderer
@@ -560,6 +561,7 @@ export default defineComponent({
       'grabAllProfiles',
       'grabHistory',
       'grabAllPlaylists',
+      'grabAllSubscriptions',
       'getYoutubeUrlInfo',
       'getExternalPlayerCmdArgumentsData',
       'fetchInvidiousInstances',

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -29,7 +29,14 @@ const getters = {
   profileById: (state) => (id) => {
     const profile = state.profileList.find(p => p._id === id)
     return profile
-  }
+  },
+
+  getSubscribedChannelIdSet: (state) => {
+    const mainProfile = state.profileList.find((profile) => {
+      return profile._id === MAIN_PROFILE_ID
+    })
+    return mainProfile.subscriptions.reduce((set, channel) => set.add(channel.id), new Set())
+  },
 }
 
 function profileSort(a, b) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -568,6 +568,40 @@ const customActions = {
             console.error('playlists: invalid sync event received')
         }
       })
+
+      ipcRenderer.on(IpcChannels.SYNC_SUBSCRIPTIONS, (_, { event, data }) => {
+        switch (event) {
+          case SyncEvents.SUBSCRIPTIONS.UPDATE_VIDEOS_BY_CHANNEL:
+            commit('updateVideoCacheByChannel', data)
+            break
+
+          case SyncEvents.SUBSCRIPTIONS.UPDATE_LIVE_STREAMS_BY_CHANNEL:
+            commit('updateLiveCacheByChannel', data)
+            break
+
+          case SyncEvents.SUBSCRIPTIONS.UPDATE_SHORTS_BY_CHANNEL:
+            commit('updateShortsCacheByChannel', data)
+            break
+
+          case SyncEvents.SUBSCRIPTIONS.UPDATE_COMMUNITY_POSTS_BY_CHANNEL:
+            commit('updatePostsCacheByChannel', data)
+            break
+
+          case SyncEvents.GENERAL.DELETE_MULTIPLE:
+            commit('clearCachesForManyChannels', data)
+            break
+
+          case SyncEvents.GENERAL.DELETE_ALL:
+            commit('clearVideoCache', data)
+            commit('clearShortsCache', data)
+            commit('clearLiveCache', data)
+            commit('clearPostsCache', data)
+            break
+
+          default:
+            console.error('subscriptions: invalid sync event received')
+        }
+      })
     }
   }
 }


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Make subscription cache sync across multiple windows and persistent over app restarts

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Many cases, generally:
- Disable `Fetch Feed Automatically`
- Switch/mess around with profiles if wanted
- Load videos, live, shorts, community posts
- Open new window(s) to see effects
- Reboot app
- Switch to different profiles to see effects

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
- No idea how to handle `updateSubscriptionShortsCacheWithChannelPageShorts`
- No idea why community posts in other window have like count like this
  ![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/5d26efb3-85d7-427a-a65a-0e58225d9052)

