### PR TITLE
Store comment reply tokens separately to avoid reactivity

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -38,6 +38,15 @@ export default defineComponent({
     },
   },
   emits: ['timestamp-event'],
+  setup: function () {
+    // As we don't need or even want reactivity here,
+    // we can use a Map.
+    const replyTokens = new Map()
+
+    return {
+      replyTokens
+    }
+  },
   data: function () {
     return {
       isLoading: false,
@@ -206,7 +215,18 @@ export default defineComponent({
         }
 
         const parsedComments = comments.contents
-          .map(commentThread => parseLocalComment(commentThread.comment, commentThread))
+          .map(commentThread => {
+            // Use destructuring to create a new object without the replyToken
+            const { replyToken, ...comment } = parseLocalComment(commentThread.comment, commentThread)
+
+            if (comment.hasReplyToken) {
+              this.replyTokens.set(comment.id, replyToken)
+            } else {
+              this.replyTokens.delete(comment.id)
+            }
+
+            return comment
+          })
 
         if (more) {
           this.commentData = this.commentData.concat(parsedComments)
@@ -238,7 +258,7 @@ export default defineComponent({
       try {
         const comment = this.commentData[index]
         /** @type {import('youtubei.js').YTNodes.CommentThread} */
-        const commentThread = comment.replyToken
+        const commentThread = this.replyTokens.get(comment.id)
 
         if (comment.replies.length > 0) {
           await commentThread.getContinuation()
@@ -248,7 +268,14 @@ export default defineComponent({
           comment.replies = commentThread.replies.map(reply => parseLocalComment(reply))
         }
 
-        comment.replyToken = commentThread.has_continuation ? commentThread : null
+        if (commentThread.has_continuation) {
+          this.replyTokens.set(comment.id, commentThread)
+          comment.hasReplyToken = true
+        } else {
+          this.replyTokens.delete(comment.id)
+          comment.hasReplyToken = false
+        }
+
         comment.showReplies = true
       } catch (err) {
         console.error(err)
@@ -271,6 +298,16 @@ export default defineComponent({
         nextPageToken: this.nextPageToken,
         sortNewest: this.sortNewest
       }).then(({ response, commentData }) => {
+        commentData = commentData.map(({ replyToken, ...comment }) => {
+          if (comment.hasReplyToken) {
+            this.replyTokens.set(comment.id, replyToken)
+          } else {
+            this.replyTokens.delete(comment.id)
+          }
+
+          return comment
+        })
+
         this.commentData = this.commentData.concat(commentData)
         this.nextPageToken = response.continuation
         this.isLoading = false
@@ -305,12 +342,23 @@ export default defineComponent({
 
     getCommentRepliesInvidious: function (index) {
       showToast(this.$t('Comments.Getting comment replies, please wait'))
-      const replyToken = this.commentData[index].replyToken
+
+      const comment = this.commentData[index]
+      const replyToken = this.replyTokens.get(comment.id)
+
       invidiousGetCommentReplies({ id: this.id, replyToken: replyToken })
         .then(({ commentData, continuation }) => {
-          this.commentData[index].replies = this.commentData[index].replies.concat(commentData)
-          this.commentData[index].showReplies = true
-          this.commentData[index].replyToken = continuation
+          comment.replies = comment.replies.concat(commentData)
+          comment.showReplies = true
+
+          if (continuation) {
+            this.replyTokens.set(comment.id, continuation)
+            comment.hasReplyToken = true
+          } else {
+            this.replyTokens.delete(comment.id)
+            comment.hasReplyToken = false
+          }
+
           this.isLoading = false
         }).catch((xhr) => {
           console.error(xhr)

--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -252,13 +252,13 @@
             </p>
           </div>
           <div
-            v-if="comment.replyToken !== null"
+            v-if="comment.hasReplyToken"
             class="showMoreReplies"
             role="button"
             tabindex="0"
-            @click="getCommentReplies(index, comment.replies.length)"
-            @keydown.space.prevent="getCommentReplies(index, comment.replies.length)"
-            @keydown.enter.prevent="getCommentReplies(index, comment.replies.length)"
+            @click="getCommentReplies(index)"
+            @keydown.space.prevent="getCommentReplies(index)"
+            @keydown.enter.prevent="getCommentReplies(index)"
           >
             <span>{{ $t("Comments.Show More Replies") }}</span>
           </div>

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -144,6 +144,7 @@ export function invidiousImageUrlToInvidious(url, currentInstance = null) {
 
 function parseInvidiousCommentData(response) {
   return response.comments.map((comment) => {
+    comment.id = comment.commentId
     comment.showReplies = false
     comment.authorLink = comment.authorId
     comment.authorThumb = youtubeImageUrlToInvidious(comment.authorThumbnails.at(-1).url)
@@ -152,6 +153,7 @@ function parseInvidiousCommentData(response) {
     comment.dataType = 'invidious'
     comment.isOwner = comment.authorIsChannelOwner
     comment.numReplies = comment.replies?.replyCount ?? 0
+    comment.hasReplyToken = !!comment.replies?.continuation
     comment.replyToken = comment.replies?.continuation ?? ''
     comment.isHearted = comment.creatorHeart !== undefined
     comment.isMember = comment.isSponsor

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1098,13 +1098,16 @@ export function mapLocalFormat(format) {
 export function parseLocalComment(comment, commentThread = undefined) {
   let hasOwnerReplied = false
   let replyToken = null
+  let hasReplyToken = false
 
   if (commentThread?.has_replies) {
     hasOwnerReplied = commentThread.comment_replies_data.has_channel_owner_replied
     replyToken = commentThread
+    hasReplyToken = true
   }
 
   const parsed = {
+    id: comment.comment_id,
     dataType: 'local',
     authorLink: comment.author.id,
     author: comment.author.name,
@@ -1116,6 +1119,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
     text: Autolinker.link(parseLocalTextRuns(comment.content.runs, 16, { looseChannelNameDetection: true })),
     isHearted: !!comment.is_hearted,
     hasOwnerReplied,
+    hasReplyToken,
     replyToken,
     showReplies: false,
     replies: [],


### PR DESCRIPTION
# Store comment reply tokens separately to avoid reactivity

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix (well for a future bug)

## Related issue
The eventual migration to Vue 3.

## Description
Vue 3 has a different reactivity system than Vue 2, which breaks YouTube.js, shaka-player and Electron's IPC in some cases. The shaka-player pull request already has a workaround to avoid reactivity, returning an object from the `setup` function (the `setup` function was added in Vue 2.7's partial composition API port), instead of storing it in `data`, this pull request does a similar thing for the comment reply tokens for the local API.

For most of the local API stuff where we need to store continuation token (YouTube.js object), we can just switch to using `shallowRef`s in the Vue 3 migration (reacts if you reassign the value but doesn't make the original object reactive), so that we can still use them to decide if we need to show a load more button or not. The comment reply tokes are slightly more complicated though, because we currently store them inside the comments but we still want the comments to be reactive.
To solve that I decide that we could just store them separately, that way we can still keep the comments reactive but the reply tokens are safe in their own separate `Map` without reactivity.

## Testing <!-- for code that is not small enough to be easily understandable -->
Test the comments with both the local and Invidious APIs on a video that has replies and enough replies to fetch more replies e.g. https://youtu.be/YbJOTdZBX1g

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 977c4f4a87d284a89302c121d93440d56d76712f
