### PR TITLE
Bug fix: fix resetting search type when features are set

### DIFF
--- a/src/renderer/components/ft-checkbox-list/ft-checkbox-list.vue
+++ b/src/renderer/components/ft-checkbox-list/ft-checkbox-list.vue
@@ -16,7 +16,7 @@
         :disabled="disabled"
         class="checkbox"
         type="checkbox"
-        :checked="initialValues.includes(values[index]) ?? null"
+        :checked="selectedValues.includes(values[index]) ?? null"
         @change="change"
       >
       <label

--- a/src/renderer/components/ft-search-filters/ft-search-filters.js
+++ b/src/renderer/components/ft-search-filters/ft-search-filters.js
@@ -165,8 +165,8 @@ export default defineComponent({
 
     updateFeatures: function(value) {
       if (!this.isVideoOrMovieOrAll(this.searchSettings.type)) {
-        const featuresCheck = this.$refs.featuresCheck
-        featuresCheck.removeSelectedValues()
+        const typeRadio = this.$refs.typeRadio
+        typeRadio.updateSelectedValue('all')
         this.$store.commit('setSearchType', 'all')
       }
 


### PR DESCRIPTION
# Bug fix: fix resetting search type when features are set

## Pull Request Type
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5125#issuecomment-2134004722)

## Description
Fixes some issues with unsetting values

## Testing
- open search filters
- check a feature
- change search type to channel
- feature gets unselected
- check another feature
- type gets set back to all

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** Latest nightly
