### PR TITLE
Hide recommendations from the Watch component, instead of hiding itself

### DIFF
--- a/src/renderer/components/watch-video-recommendations/watch-video-recommendations.js
+++ b/src/renderer/components/watch-video-recommendations/watch-video-recommendations.js
@@ -24,9 +24,6 @@ export default defineComponent({
   computed: {
     playNextVideo: function () {
       return this.$store.getters.getPlayNextVideo
-    },
-    hideRecommendedVideos: function () {
-      return this.$store.getters.getHideRecommendedVideos
     }
   },
   methods: {

--- a/src/renderer/components/watch-video-recommendations/watch-video-recommendations.vue
+++ b/src/renderer/components/watch-video-recommendations/watch-video-recommendations.vue
@@ -1,6 +1,5 @@
 <template>
   <ft-card
-    v-if="!hideRecommendedVideos"
     class="relative watchVideoRecommendations"
   >
     <div class="VideoRecommendationsTopBar">

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -180,7 +180,7 @@
         @pause-player="pausePlayer"
       />
       <watch-video-recommendations
-        v-if="!isLoading"
+        v-if="!isLoading && !hideRecommendedVideos"
         :show-autoplay="!watchingPlaylist"
         :data="recommendedVideos"
         class="watchVideoSideBar watchVideoRecommendations"


### PR DESCRIPTION
# Hide recommendations from the Watch component, instead of hiding itself

## Pull Request Type

- [x] Performance improvement

## Description
Currently the "Hide Recommended Videos" setting creates the `watch-video-recommendations` component with the props, starts rendering the template and then encounters the `v-if` that stops it actually rendering anything onto the page. This pull request instead moves the `v-if` into the parent component (`Watch`), that way no work is done concerning that component, not even creating the component instance, when the "Hide Recommended Videos" setting is enabled.

## Testing
Check that the "Hide Recommended Videos" setting still works in both it's on and off state.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0404544e082901440e94757d18bb59cd82838376