### PR TITLE
Cleanup unused channel hiding code in ft-list-video-numbered

### DIFF
--- a/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.js
+++ b/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.js
@@ -74,46 +74,16 @@ export default defineComponent({
     isCurrentVideo: {
       type: Boolean,
       default: false
-    },
-    useChannelsHiddenPreference: {
-      type: Boolean,
-      default: false,
     }
   },
   emits: ['move-video-down', 'move-video-up', 'pause-player', 'remove-from-playlist'],
   data: function () {
     return {
-      visible: false,
-      show: true,
+      visible: this.initialVisibleState,
       stopWatchingInitialVisibleState: null
     }
   },
-  computed: {
-    channelsHidden() {
-      // Some component users like channel view will have this disabled
-      if (!this.useChannelsHiddenPreference) { return [] }
-
-      return JSON.parse(this.$store.getters.getChannelsHidden).map((ch) => {
-        // Legacy support
-        if (typeof ch === 'string') {
-          return { name: ch, preferredName: '', icon: '' }
-        }
-        return ch
-      })
-    },
-
-    // As we only use this component in Playlist and watch-video-playlist,
-    // where title filtering is never desired, we don't have any title filtering logic here,
-    // like we do in ft-list-video-lazy
-
-    shouldBeVisible() {
-      return !(this.channelsHidden.some(ch => ch.name === this.data.authorId) ||
-        this.channelsHidden.some(ch => ch.name === this.data.author))
-    }
-  },
   created() {
-    this.visible = this.initialVisibleState
-
     if (!this.initialVisibleState) {
       this.stopWatchingInitialVisibleState = this.$watch('initialVisibleState', (newValue) => {
         this.visible = newValue
@@ -124,14 +94,8 @@ export default defineComponent({
   },
   methods: {
     onVisibilityChanged: function (visible) {
-      if (visible && this.shouldBeVisible) {
+      if (visible) {
         this.visible = visible
-        if (this.stopWatchingInitialVisibleState) {
-          this.stopWatchingInitialVisibleState()
-          this.stopWatchingInitialVisibleState = null
-        }
-      } else if (visible) {
-        this.show = false
         if (this.stopWatchingInitialVisibleState) {
           this.stopWatchingInitialVisibleState()
           this.stopWatchingInitialVisibleState = null

--- a/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.vue
+++ b/src/renderer/components/ft-list-video-numbered/ft-list-video-numbered.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-show="show"
     v-observe-visibility="initialVisibleState || visible ? false : {
       callback: onVisibilityChanged,
       once: true,


### PR DESCRIPTION
# Cleanup unused channel hiding code in ft-list-video-numbered

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Cleanup

## Description
From what I could tell, we had a prop that allowed you to turn on channel hidding in the `ft-list-video-numbered` component, but it defaulted to `false` and in neither of the two places that we used the component, did we set that prop to `true`. So if it's not used, it doesn't seem worth keeping around. Initially I thought this would help with the performance problems experienced in #4578, but in my testing it didn't seem to make a difference, so I'm categorizing this pull request as a cleanup instead of a performance improvement.

https://github.com/FreeTubeApp/FreeTube/blob/b0b2af153c402fcca5ab070757639e681ca0c7cd/src/renderer/components/watch-video-playlist/watch-video-playlist.vue#L126-L144

https://github.com/FreeTubeApp/FreeTube/blob/b0b2af153c402fcca5ab070757639e681ca0c7cd/src/renderer/views/Playlist/Playlist.vue#L91-L111

## Testing <!-- for code that is not small enough to be easily understandable -->
Not sure what to put here for this pull request, maybe make sure that channels still aren't hidden inside playlists?

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b0b2af153c402fcca5ab070757639e681ca0c7cd