### PR TITLE
Remove unused database compacting IPC channel

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -37,8 +37,7 @@ const DBActions = {
     UPSERT: 'db-action-upsert',
     DELETE: 'db-action-delete',
     DELETE_MULTIPLE: 'db-action-delete-multiple',
-    DELETE_ALL: 'db-action-delete-all',
-    PERSIST: 'db-action-persist'
+    DELETE_ALL: 'db-action-delete-all'
   },
 
   HISTORY: {

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -9,10 +9,6 @@ class Settings {
     return db.settings.updateAsync({ _id }, { _id, value }, { upsert: true })
   }
 
-  static persist() {
-    return db.settings.compactDatafileAsync()
-  }
-
   // ******************** //
   // Unique Electron main process handlers
   static _findAppReadyRelatedSettings() {
@@ -75,10 +71,6 @@ class History {
   static deleteAll() {
     return db.history.removeAsync({}, { multi: true })
   }
-
-  static persist() {
-    return db.history.compactDatafileAsync()
-  }
 }
 
 class Profiles {
@@ -96,10 +88,6 @@ class Profiles {
 
   static delete(id) {
     return db.profiles.removeAsync({ _id: id })
-  }
-
-  static persist() {
-    return db.profiles.compactDatafileAsync()
   }
 }
 
@@ -177,18 +165,14 @@ class Playlists {
   static deleteAll() {
     return db.playlists.removeAsync({}, { multi: true })
   }
-
-  static persist() {
-    return db.playlists.compactDatafileAsync()
-  }
 }
 
 function compactAllDatastores() {
   return Promise.allSettled([
-    Settings.persist(),
-    History.persist(),
-    Profiles.persist(),
-    Playlists.persist(),
+    db.settings.compactDatafileAsync(),
+    db.history.compactDatafileAsync(),
+    db.profiles.compactDatafileAsync(),
+    db.playlists.compactDatafileAsync(),
   ])
 }
 

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -65,13 +65,6 @@ class History {
       { action: DBActions.GENERAL.DELETE_ALL }
     )
   }
-
-  static persist() {
-    return ipcRenderer.invoke(
-      IpcChannels.DB_HISTORY,
-      { action: DBActions.GENERAL.PERSIST }
-    )
-  }
 }
 
 class Profiles {
@@ -100,13 +93,6 @@ class Profiles {
     return ipcRenderer.invoke(
       IpcChannels.DB_PROFILES,
       { action: DBActions.GENERAL.DELETE, data: id }
-    )
-  }
-
-  static persist() {
-    return ipcRenderer.invoke(
-      IpcChannels.DB_PROFILES,
-      { action: DBActions.GENERAL.PERSIST }
     )
   }
 }

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -44,10 +44,6 @@ class History {
   static deleteAll() {
     return baseHandlers.history.deleteAll()
   }
-
-  static persist() {
-    baseHandlers.history.persist()
-  }
 }
 
 class Profiles {
@@ -65,10 +61,6 @@ class Profiles {
 
   static delete(id) {
     return baseHandlers.profiles.delete(id)
-  }
-
-  static persist() {
-    baseHandlers.profiles.persist()
   }
 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1053,10 +1053,6 @@ function runApp() {
           )
           return null
 
-        case DBActions.GENERAL.PERSIST:
-          baseHandlers.history.persist()
-          return null
-
         default:
           // eslint-disable-next-line no-throw-literal
           throw 'invalid history db action'
@@ -1101,10 +1097,6 @@ function runApp() {
             event,
             { event: SyncEvents.GENERAL.DELETE, data }
           )
-          return null
-
-        case DBActions.GENERAL.PERSIST:
-          baseHandlers.profiles.persist()
           return null
 
         default:


### PR DESCRIPTION
# Remove unused database compacting IPC channel

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Cleanup

## Description
As we only call the methods to compact the datastores in Electron's main process, this pull request move the compaction code into the `compactAllDatastores` function, removes the `persist` methods in the datastores and removes the now unused IPC code.

## Testing <!-- for code that is not small enough to be easily understandable -->
If you want you can test that the databases still get compacted when the app closes.

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:** 0b62ea78d83867a97217c500aa67f5343fe65066