### PR TITLE
Limit which URLs FreeTube will open externally

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -86,6 +86,12 @@ const PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD = 500
 // YouTube search character limit is 100 characters
 const SEARCH_CHAR_LIMIT = 100
 
+// Displayed on the about page and used in the main.js file to only allow bitcoin URLs with this wallet address to be opened
+const ABOUT_BITCOIN_ADDRESS = '1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS'
+
+// Displayed on the about page and used in the main.js file to only allow monero URLs with this wallet address to be opened
+const ABOUT_MONERO_ADDRESS = '48WyAPdjwc6VokeXACxSZCFeKEXBiYPV6GjfvBsfg4CrUJ95LLCQSfpM9pvNKy5GE5H4hNaw99P8RZyzmaU9kb1pD7kzhCB'
+
 export {
   IpcChannels,
   DBActions,
@@ -93,5 +99,7 @@ export {
   MAIN_PROFILE_ID,
   MOBILE_WIDTH_THRESHOLD,
   PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD,
-  SEARCH_CHAR_LIMIT
+  SEARCH_CHAR_LIMIT,
+  ABOUT_BITCOIN_ADDRESS,
+  ABOUT_MONERO_ADDRESS
 }

--- a/src/renderer/views/About/About.js
+++ b/src/renderer/views/About/About.js
@@ -1,6 +1,7 @@
 import { defineComponent } from 'vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import packageDetails from '../../../../package.json'
+import { ABOUT_BITCOIN_ADDRESS, ABOUT_MONERO_ADDRESS } from '../../../constants'
 
 export default defineComponent({
   name: 'About',
@@ -74,12 +75,12 @@ export default defineComponent({
         {
           icon: ['fab', 'bitcoin'],
           title: `${this.$t('About.Donate')} - BTC`,
-          content: '<a href="bitcoin:1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS">1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS</a>'
+          content: `<a href="bitcoin:${ABOUT_BITCOIN_ADDRESS}">${ABOUT_BITCOIN_ADDRESS}</a>`
         },
         {
           icon: ['fab', 'monero'],
           title: `${this.$t('About.Donate')} - XMR`,
-          content: '<a href="monero:48WyAPdjwc6VokeXACxSZCFeKEXBiYPV6GjfvBsfg4CrUJ95LLCQSfpM9pvNKy5GE5H4hNaw99P8RZyzmaU9kb1pD7kzhCB">48WyAPdjwc6VokeXACxSZCFeKEXBiYPV6GjfvBsfg4CrUJ95LLCQSfpM9pvNKy5GE5H4hNaw99P8RZyzmaU9kb1pD7kzhCB</a>'
+          content: `<a href="monero:${ABOUT_MONERO_ADDRESS}">${ABOUT_MONERO_ADDRESS}</a>`
         }
       ]
     }


### PR DESCRIPTION
# Limit which URLs FreeTube will open externally

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Security improvement

## Description
This pull request implements [Electron security guideline 15: "Do not use `shell.openExternal` with untrusted content"](https://www.electronjs.org/docs/latest/tutorial/security#15-do-not-use-shellopenexternal-with-untrusted-content). As FreeTube displays user generated content that can also contain links (video descriptions and comments), we can't lock this down properly but we can at least limit the URL schemes that can be opened from FreeTube.
Here are the allowed URL schemes:
* `https:` All URLs allowed, links using this scheme exist on the about page as well as in video descriptions and comments.
* `http:` All URLs allowed, links using this scheme exist in video descriptions and comments.
* `tel:` All URLs allowed, Autolinker turns phone numbers into links so if they appear in video descriptions they will get linked (we can turn off that behaviour if we don't want that, YouTube doesn't turn them into links).
* `mailto:` All URLs allowed, the email address on the about page and Autolinker turns email addresses into links so if they appear in video descriptions they will get linked (we can turn off that behaviour if we don't want that, YouTube doesn't turn them into links).
* `bitcoin:` Only allowed with the wallet address that appears on the about page
* `monero:` Only allowed with the wallet address that appears on the about page

## Testing <!-- for code that is not small enough to be easily understandable -->
### Check that desired links still open correctly
Check that the links on the about page and in video descriptions still open according to your `External link handling` preference.

### Check that unwanted URLs don't get opened
1. Open the dev tools
2. Run this with your desired URL or text `require('electron').ipcRenderer.send('open-external-link', 'https://example.com')`
    - On Windows you can try `ms-settings:` (URL scheme to launch the settings app)
    - On macOS you can try `notes://` (URL scheme to launch the notes app)
    - On Linux you can try `man:which` (URL to open the man page for the `which` command)
    - Text that isn't a URL e.g. `some random text`
3. For text that is not a URL or URL schemes that aren't allow listed, nothing should happen.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0b62ea78d83867a97217c500aa67f5343fe65066