### PR TITLE
Switch settings sections and form elements to created lifecycle hook

### DIFF
--- a/src/renderer/components/external-player-settings/external-player-settings.js
+++ b/src/renderer/components/external-player-settings/external-player-settings.js
@@ -15,9 +15,6 @@ export default defineComponent({
     'ft-toggle-switch': FtToggleSwitch,
     'ft-flex-box': FtFlexBox
   },
-  data: function () {
-    return {}
-  },
   computed: {
     externalPlayerNames: function () {
       const fallbackNames = this.$store.getters.getExternalPlayerNames

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -141,7 +141,7 @@ export default defineComponent({
       }
     }
   },
-  mounted: function () {
+  created: function () {
     this.id = this._uid
     this.inputData = this.value
     this.updateVisibleDataList()

--- a/src/renderer/components/ft-slider/ft-slider.js
+++ b/src/renderer/components/ft-slider/ft-slider.js
@@ -53,7 +53,7 @@ export default defineComponent({
       this.currentValue = this.defaultValue
     }
   },
-  mounted: function () {
+  created: function () {
     this.id = this._uid
     this.currentValue = this.defaultValue
   },

--- a/src/renderer/components/ft-toggle-switch/ft-toggle-switch.js
+++ b/src/renderer/components/ft-toggle-switch/ft-toggle-switch.js
@@ -48,7 +48,7 @@ export default defineComponent({
       this.currentValue = this.defaultValue
     }
   },
-  mounted: function () {
+  created: function () {
     this.id = this._uid
     this.currentValue = this.defaultValue
   },

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -202,7 +202,7 @@ export default defineComponent({
       ]
     }
   },
-  mounted: function () {
+  created: function () {
     this.setCurrentInvidiousInstanceBounce =
       debounce(this.setCurrentInvidiousInstance, 500)
   },

--- a/src/renderer/components/theme-settings/theme-settings.js
+++ b/src/renderer/components/theme-settings/theme-settings.js
@@ -134,7 +134,7 @@ export default defineComponent({
       return this.baseTheme !== 'hotPink'
     }
   },
-  mounted: function () {
+  created: function () {
     this.disableSmoothScrollingToggleValue = this.disableSmoothScrolling
   },
   methods: {


### PR DESCRIPTION
# Switch settings sections and form elements to created lifecycle hook

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Performance improvement

## Related issue
Part of [Development Chore: Performance: Switch from `mounted` to `created` hook, where possible to avoid unnecessary component updates](https://github.com/FreeTubeApp/FreeTube/projects/10#card-88967620)

## Description
The `mounted` lifecycle hook is triggered after the component has been rendered and has been added to the DOM, the `created` lifecycle hook is after the component instance has been created, so props and computed properties can be accessed as well as the watchers being active. So to set the default value of a form element for example, we want to use the `created` lifecycle hook, as setting that in the `mounted` hook will trigger a re-render and changes to the DOM.

There are of course exceptions, if you want to show a loading symbol, then fetching the data and setting values in the mounted hook is a great idea, because then the user will see the loading icon while your stuff is running.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open the settings
2. Check that the text inputs, switches and sliders are showing the correct values.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.20.0