### PR TITLE
Improve create playlist UX

### DIFF
--- a/src/renderer/components/ft-create-playlist-prompt/ft-create-playlist-prompt.js
+++ b/src/renderer/components/ft-create-playlist-prompt/ft-create-playlist-prompt.js
@@ -33,6 +33,16 @@ export default defineComponent({
     newPlaylistVideoObject: function () {
       return this.$store.getters.getNewPlaylistVideoObject
     },
+
+    playlistWithNameExists() {
+      // Don't show the message with no name input
+      const playlistName = this.playlistName
+      if (this.playlistName === '') { return false }
+
+      return this.allPlaylists.some((playlist) => {
+        return playlist.playlistName === playlistName
+      })
+    },
   },
   mounted: function () {
     this.playlistName = this.newPlaylistVideoObject.title
@@ -40,19 +50,17 @@ export default defineComponent({
     nextTick(() => this.$refs.playlistNameInput.focus())
   },
   methods: {
+    handlePlaylistNameInput(input) {
+      this.playlistName = input.trim()
+    },
+
     createNewPlaylist: function () {
       if (this.playlistName === '') {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast["Playlist name cannot be empty. Please input a name."]'))
         return
       }
 
-      const nameExists = this.allPlaylists.findIndex((playlist) => {
-        return playlist.playlistName === this.playlistName
-      })
-      if (nameExists !== -1) {
-        showToast(this.$t('User Playlists.CreatePlaylistPrompt.Toast["There is already a playlist with this name. Please pick a different name."]'))
-        return
-      }
+      // Duplicate playlist check moved to template
 
       const playlistObject = {
         playlistName: this.playlistName,

--- a/src/renderer/components/ft-create-playlist-prompt/ft-create-playlist-prompt.vue
+++ b/src/renderer/components/ft-create-playlist-prompt/ft-create-playlist-prompt.vue
@@ -15,13 +15,19 @@
         :value="playlistName"
         :maxlength="255"
         class="playlistNameInput"
-        @input="(input) => playlistName = input"
+        @input="(input) => handlePlaylistNameInput(input)"
         @click="createNewPlaylist"
       />
+    </ft-flex-box>
+    <ft-flex-box v-if="playlistWithNameExists">
+      <p>
+        {{ $t('User Playlists.CreatePlaylistPrompt.Toast["There is already a playlist with this name. Please pick a different name."]') }}
+      </p>
     </ft-flex-box>
     <ft-flex-box>
       <ft-button
         :label="$t('User Playlists.CreatePlaylistPrompt.Create')"
+        :disabled="playlistWithNameExists"
         @click="createNewPlaylist"
       />
       <ft-button

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -279,7 +279,9 @@ export default defineComponent({
 
       this.showAddToPlaylistPromptForManyVideos({
         videos: this.videos,
-        newPlaylistDefaultProperties: { title: this.title },
+        newPlaylistDefaultProperties: {
+          title: this.channelName === '' ? this.title : `${this.title} | ${this.channelName}`,
+        },
       })
     },
 


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Make it impossible to create playlists with spaces wrapped name
- Show duplicate playlist message sooner (when name input instead of clicking create button)
- Update default new playlist name to include channel name when copying a remote playlist

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/dd6529bd-60b2-45d7-8c76-8f8b9fe5a10e)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/c584617a-ccf2-4cde-ac5f-af6f76a6c401)
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/848a1fb9-6104-45ca-85ab-8aacf8b1e4b7)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Input spaces around playlist name inside create playlist prompt
- ensure created playlist got name trimmed
- ensure cannot create playlist if another playlist with same trimmed name exists (and got message shown)

- Copy local playlist, create playlist - unchanged
- Copy remote playlist, create playlist - ensure channel name included

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
