### PR TITLE
Fix mouse backward and forward buttons not updating the in-app buttons

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -21,9 +21,6 @@ const IpcChannels = {
   OPEN_URL: 'open-url',
   CHANGE_VIEW: 'change-view',
 
-  HISTORY_BACK: 'history-back',
-  HISTORY_FORWARD: 'history-forward',
-
   DB_SETTINGS: 'db-settings',
   DB_HISTORY: 'db-history',
   DB_PROFILES: 'db-profiles',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1494,9 +1494,7 @@ function runApp() {
             click: (_menuItem, browserWindow, _event) => {
               if (browserWindow == null) { return }
 
-              browserWindow.webContents.send(
-                IpcChannels.HISTORY_BACK
-              )
+              browserWindow.webContents.goBack()
             },
             type: 'normal',
           },
@@ -1506,9 +1504,7 @@ function runApp() {
             click: (_menuItem, browserWindow, _event) => {
               if (browserWindow == null) { return }
 
-              browserWindow.webContents.send(
-                IpcChannels.HISTORY_FORWARD
-              )
+              browserWindow.webContents.goForward()
             },
             type: 'normal',
           },

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -183,7 +183,6 @@ export default defineComponent({
           ipcRenderer = require('electron').ipcRenderer
           this.setupListenersToSyncWindows()
           this.activateKeyboardShortcuts()
-          this.activateIPCListeners()
           this.openAllLinksExternally()
           this.enableSetSearchQueryText()
           this.enableOpenUrl()
@@ -197,10 +196,6 @@ export default defineComponent({
           this.checkForNewUpdates()
           this.checkForNewBlogPosts()
         }, 500)
-      })
-
-      this.$router.afterEach((to, from) => {
-        this.$refs.topNav?.navigateHistory()
       })
 
       this.$router.onReady(() => {
@@ -331,16 +326,6 @@ export default defineComponent({
       document.addEventListener('keydown', this.handleKeyboardShortcuts)
       document.addEventListener('mousedown', () => {
         this.hideOutlines()
-      })
-    },
-
-    activateIPCListeners: function () {
-      // handle menu event updates from main script
-      ipcRenderer.on(IpcChannels.HISTORY_BACK, (_event) => {
-        this.$refs.topNav.historyBack()
-      })
-      ipcRenderer.on(IpcChannels.HISTORY_FORWARD, (_event) => {
-        this.$refs.topNav.historyForward()
       })
     },
 

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -17,13 +17,20 @@ export default defineComponent({
     FtProfileSelector
   },
   data: () => {
+    let isArrowBackwardDisabled = true
+    let isArrowForwardDisabled = true
+
+    // If the Navigation API isn't supported (Firefox and Safari)
+    // keep the back and forwards buttons always enabled
+    if (!('navigation' in window)) {
+      isArrowBackwardDisabled = false
+      isArrowForwardDisabled = false
+    }
+
     return {
-      component: this,
       showSearchContainer: true,
-      historyIndex: 1,
-      isForwardOrBack: false,
-      isArrowBackwardDisabled: true,
-      isArrowForwardDisabled: true,
+      isArrowBackwardDisabled,
+      isArrowForwardDisabled,
       searchSuggestionsDataList: [],
       lastSuggestionQuery: ''
     }
@@ -94,6 +101,14 @@ export default defineComponent({
 
     newWindowText: function () {
       return this.$t('Open New Window')
+    }
+  },
+  watch: {
+    $route: function () {
+      if ('navigation' in window) {
+        this.isArrowForwardDisabled = !window.navigation.canGoForward
+        this.isArrowBackwardDisabled = !window.navigation.canGoBack
+      }
     }
   },
   mounted: function () {
@@ -295,41 +310,12 @@ export default defineComponent({
       this.showSearchContainer = !this.showSearchContainer
     },
 
-    navigateHistory: function () {
-      if (!this.isForwardOrBack) {
-        this.historyIndex = window.history.length
-        this.isArrowBackwardDisabled = false
-        this.isArrowForwardDisabled = true
-      } else {
-        this.isForwardOrBack = false
-      }
-    },
-
     historyBack: function () {
-      this.isForwardOrBack = true
-      window.history.back()
-
-      if (this.historyIndex > 1) {
-        this.historyIndex--
-        this.isArrowForwardDisabled = false
-        if (this.historyIndex === 1) {
-          this.isArrowBackwardDisabled = true
-        }
-      }
+      this.$router.back()
     },
 
     historyForward: function () {
-      this.isForwardOrBack = true
-      window.history.forward()
-
-      if (this.historyIndex < window.history.length) {
-        this.historyIndex++
-        this.isArrowBackwardDisabled = false
-
-        if (this.historyIndex === window.history.length) {
-          this.isArrowForwardDisabled = true
-        }
-      }
+      this.$router.forward()
     },
 
     toggleSideNav: function () {


### PR DESCRIPTION
# Fix mouse backward and forward buttons not updating the in-app buttons

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #4408

## Description
Inspired by a comment on the navigation history dropdown pull request about fixing the mouse button issue by switching to an Electron-only API, I decided to see if there was an alternative way to solve it that without making existing functionality Electron only. I found the Navigation API which is supported in Electron, Android WebView as well as Chromium browsers (both desktop and mobile) https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API#browser_compatibility. While it isn't supported in Firefox and Safari, that will only affect the web build in the unofficial FreeTubeAndroid fork and I think there is a good argument to be made that the back and forward buttons aren't needed there anyway because you can just use the ones built-into the web browser, so in those two browsers, the back and forward buttons will always be enabled, so they are still usable, they just won't get disabled when you can't navigate in a certain direction.

With that out of the way, here is some information to the pull request itself. As the Navigation API provides `canGoForward` and `canGoBack` properties, we no longer need our logic that relies on trying to track the navigation index ourselves. It also means we no longer need to send an IPC message from the main process into the window when the user triggers the navigation through the app menu or the keyboard shortcuts and can just use the convenient `.goBack()` and `.goForward()` methods on the webContents instance, as the Navigation keeps track of whether you can go forwards or back for us.

## Testing <!-- for code that is not small enough to be easily understandable -->
If you have a mouse that has extra buttons to let you navigate back and forwards, test that those work and that the back and forward buttons in the app update their enabled and disabled state correctly.
_I know it doesn't count for much as I opened the pull request, but my mouse has those buttons and for me it worked correctly._

**Regression tests:**
1. Test that pressing the back and forwards buttons still work and that they update their disabled state correctly.
2. Test that the <kbd>Alt</kbd>+<kbd>Left arrow</kbd> and <kbd>Alt</kbd>+<kbd>Right arrow</kbd> keyboard shortcuts update the back and forward button disabled state correctly.
3. Test that the `Back` and `Forward` entries in the `View` app menu still work and update the back and forward button disabled state correctly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** bf3304dfefd03c72204f54a4c4791595887115f1