### PR TITLE
Fix arrow keys not working in the Create New Playlist prompt

### DIFF
--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -56,14 +56,9 @@ export default defineComponent({
   },
   mounted: function () {
     this.lastActiveElement = document.activeElement
-    this.$nextTick(() => {
+    nextTick(() => {
       document.addEventListener('keydown', this.closeEventFunction, true)
-      document.querySelector('.prompt').addEventListener('keydown', this.arrowKeys, true)
-      this.promptButtons = Array.from(
-        document.querySelector('.prompt .promptCard .ft-flex-box').childNodes
-      ).filter((e) => {
-        return e.id && e.id.startsWith('prompt')
-      })
+      this.promptButtons = Array.from(this.$refs.promptCard.$el.querySelectorAll('.btn.ripple'))
       this.focusItem(0)
     })
   },
@@ -121,14 +116,19 @@ export default defineComponent({
       }
     },
     arrowKeys: function(e) {
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        e.preventDefault()
-        const currentIndex = this.promptButtons.findIndex((cur) => {
-          return cur === e.target
-        })
-        const direction = (e.key === 'ArrowLeft') ? -1 : 1
-        this.focusItem(parseInt(currentIndex) + direction)
+      const currentIndex = this.promptButtons.findIndex((cur) => {
+        return cur === e.target
+      })
+
+      // Only react if a button was focused when the arrow key was pressed
+      if (currentIndex === -1) {
+        return
       }
+
+      e.preventDefault()
+
+      const direction = (e.key === 'ArrowLeft') ? -1 : 1
+      this.focusItem(parseInt(currentIndex) + direction)
     },
 
     ...mapActions([

--- a/src/renderer/components/ft-prompt/ft-prompt.vue
+++ b/src/renderer/components/ft-prompt/ft-prompt.vue
@@ -6,8 +6,10 @@
       tabindex="-1"
       @click="handleHide"
       @keydown.enter="handleHide"
+      @keydown.left.right.capture="arrowKeys"
     >
       <ft-card
+        ref="promptCard"
         class="promptCard"
         :class="{ autosize, [theme]: true }"
         role="dialog"
@@ -33,7 +35,6 @@
           <ft-flex-box>
             <ft-button
               v-for="(option, index) in optionNames"
-              :id="'prompt-' + sanitizedLabel + '-' + index"
               :key="index"
               :label="option"
               :text-color="optionButtonTextColor(index)"


### PR DESCRIPTION
# Fix arrow keys not working in the Create New Playlist prompt

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #5232

## Description
This pull request addresses two issues with using the arrow keys in the `Create New Playlist` prompt, firstly that you weren't able to move the cursor around in the text box and secondly that you weren't able to move the focus between the create and cancel buttons.
The first issue was solved by making sure we only detect arrow keys for navigating between the buttons, when the focus is actually on a button.
The second issue was solved by changing how the prompt decides which buttons are elegible for the arrow key treatment, previously it only detected the buttons if they were direct descendents of an `ft-flex-box` and had an `id` that started with `prompt`, now it will detect all `ft-button`s inside of the prompt.

## Testing <!-- for code that is not small enough to be easily understandable -->
### Text box
1. Enter some text into the text box
2. Try moving the cursor with the left and right arrow keys

### Buttons
1. Focus the create or cancel buttons by pressing <kbd>Tab</kbd>
2. Try moving the focus between the two buttons by using the left and right arrow keys

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** bf3304dfefd03c72204f54a4c4791595887115f1