### PR TITLE
Disable @intlify/vue-i18n/no-deprecated-tc eslint rule as it does not apply to Vue 2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,6 +112,9 @@ module.exports = {
         ignoreText: ['-', '•', '/', 'YouTube', 'Invidious', 'FreeTube']
       }
     ],
+    // Only applicable when we upgrade to Vue 3 and vue-i18n 9+
+    '@intlify/vue-i18n/no-deprecated-tc': 'off',
+
     'vue/require-explicit-emits': 'error',
     'vue/no-unused-emit-declarations': 'error',
   },


### PR DESCRIPTION
# Disable @intlify/vue-i18n/no-deprecated-tc eslint rule as it does not apply to Vue 2

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Development tooling

## Description
Disable the `@intlify/vue-i18n/no-deprecated-tc` eslint rule, as the deprecation it mentions isn't applicable to the version of vue-i18n that is compatible with Vue 2 and the suggested fixes don't work in Vue 2. So implementing the changes suggested by the linting rule, would break the code.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 94e749d6a32cf2d147b743bb384d90543ff2b454