### PR TITLE
Local API: Extract playlists on the auto-generated "Music" channel

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -675,6 +675,24 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
 }
 
 /**
+ * @param {import('youtubei.js').YTNodes.CompactStation} compactStation
+ * @param {string} channelId
+ * @param {string} channelName
+ */
+export function parseLocalCompactStation(compactStation, channelId, channelName) {
+  return {
+    type: 'playlist',
+    dataSource: 'local',
+    title: compactStation.title.text,
+    thumbnail: compactStation.thumbnail[1].url,
+    channelName,
+    channelId,
+    playlistId: compactStation.endpoint.payload.playlistId,
+    videoCount: extractNumberFromString(compactStation.video_count.text)
+  }
+}
+
+/**
  * @param {YT.Search} response
  */
 function handleSearchResponse(response) {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -38,6 +38,7 @@ import {
   parseLocalChannelShorts,
   parseLocalChannelVideos,
   parseLocalCommunityPosts,
+  parseLocalCompactStation,
   parseLocalListPlaylist,
   parseLocalListVideo,
   parseLocalSubscriberCount
@@ -666,9 +667,25 @@ export default defineComponent({
           this.getChannelReleasesLocal()
         }
 
-        if (!this.hideChannelPlaylists && channel.has_playlists) {
-          tabs.push('playlists')
-          this.getChannelPlaylistsLocal()
+        if (!this.hideChannelPlaylists) {
+          if (channel.has_playlists) {
+            tabs.push('playlists')
+            this.getChannelPlaylistsLocal()
+          } else if (channelId === 'UC-9-kyTW8ZkZNDHQJ6FgpwQ') {
+            // Special handling for "The Music Channel" (https://youtube.com/music)
+            tabs.push('playlists')
+            const playlists = channel.playlists.map(playlist => parseLocalListPlaylist(playlist))
+
+            const compactStations = channel.memo.get('CompactStation')
+            if (compactStations) {
+              for (const compactStation of compactStations) {
+                playlists.push(parseLocalCompactStation(compactStation, channelId, channelName))
+              }
+            }
+
+            this.showPlaylistSortBy = false
+            this.latestPlaylists = playlists
+          }
         }
 
         if (!this.hideChannelCommunity && channel.has_community) {

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -340,7 +340,7 @@ export default defineComponent({
         this.playlistDescription = result.info.description ?? ''
         this.firstVideoId = result.items[0].id
         this.playlistThumbnail = result.info.thumbnails[0].url
-        this.viewCount = extractNumberFromString(result.info.views)
+        this.viewCount = result.info.views.toLowerCase() === 'no views' ? 0 : extractNumberFromString(result.info.views)
         this.videoCount = extractNumberFromString(result.info.total_items)
         this.lastUpdated = result.info.last_updated ?? ''
         this.channelName = channelName ?? ''


### PR DESCRIPTION
# Local API: Extract playlists on the auto-generated "Music" channel

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Description
This pull request adds support for extracting and displaying playlists on the auto-generated system "Music" channel. Unlike #5241 which adds support for a whole category of channels, this pull request is only for one specific one.

I also noticed that some of the playlists listed there were showing `NaN views` on the playlists page, so I fixed that so it correctly shows `0 views` when YouTube says `No views`.

## Screenshots <!-- If appropriate -->
![music-channel-with-playlists](https://github.com/FreeTubeApp/FreeTube/assets/48293849/c43067c0-9365-4770-886d-58873a9dd1df)

## Testing <!-- for code that is not small enough to be easily understandable -->
Open `https://www.youtube.com/music` in FreeTube and notice the playlists tab.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 00509090456527e4418804faba4532aabf3dde35