### PR TITLE
Fix error when fetching deleted comment replies in local API

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -260,6 +260,12 @@ export default defineComponent({
         /** @type {import('youtubei.js').YTNodes.CommentThread} */
         const commentThread = this.replyTokens.get(comment.id)
 
+        if (commentThread == null) {
+          this.replyTokens.delete(comment.id)
+          comment.hasReplyToken = false
+          return
+        }
+
         if (comment.replies.length > 0) {
           await commentThread.getContinuation()
           comment.replies = comment.replies.concat(commentThread.replies.map(reply => parseLocalComment(reply)))


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
There is an error when trying to get replies for a comment but all replies deleted
This PR removes that error toast for Local API (no idea how to fix IV API)


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/FreeTubeApp/FreeTube/assets/1018543/7e4a3113-3bf6-4956-910c-09809ef17fcd)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Find video with a comment with all replies deleted e.g. https://youtu.be/_09sYEkt3Ow, `Hi TrainDaily` on first page
- Press view reply(s) a few times to ensure no error toast hidden

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
