### PR TITLE
Dearrow: check for 204 error instead of 404

### DIFF
--- a/src/renderer/helpers/sponsorblock.js
+++ b/src/renderer/helpers/sponsorblock.js
@@ -66,8 +66,8 @@ export async function deArrowThumbnail(videoId, timestamp) {
   try {
     const response = await fetch(requestUrl)
 
-    // 404 means that there are no thumbnails found for the video
-    if (response.status === 404) {
+    // 204 means that there are no thumbnails found for the video
+    if (response.status === 204) {
       return undefined
     }
 


### PR DESCRIPTION
# Dearrow: check for 204 error instead of 404

## Pull Request Type
- [x] Bugfix

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/5031

## Description
Dearrow switched from returning error code 400 to 204 here: https://github.com/ajayyy/DeArrowThumbnailCache/commit/6d6ffab7326f1fb2bc6b4be91933f50691f83425 

## Testing
- turn dearrow on
- search something (ex: FreeTube)
- Notice how there's no more broken thumbnails

## Desktop
- **OS:** Linux Mint
- **OS Version:** 21.3
- **FreeTube version:** latest nightly


