### PR TITLE
Fixes opening an external player on the watch page passes user playlist

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -102,6 +102,10 @@ export default defineComponent({
     videoThumbnail: {
       type: String,
       required: true
+    },
+    inUserPlaylist: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['change-format', 'pause-player', 'set-info-area-sticky', 'scroll-to-info-area'],

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -119,6 +119,7 @@
         :get-playlist-loop="getPlaylistLoop"
         :length-seconds="videoLengthSeconds"
         :video-thumbnail="thumbnail"
+        :in-user-playlist="!!selectedUserPlaylist"
         class="watchVideo"
         :class="{ theatreWatchVideo: useTheatreMode }"
         @change-format="handleFormatChange"


### PR DESCRIPTION
# Fixes opening an external player on the watch page passes user playlist

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/discussions/5188 (it's a discussion so the close keyword doesn't work)

## Description
The code to open an external player in the watch-video-info component was checking `this.inUserPlaylist` to decide whether or not to pass the playlist information to the external player. Unfortunately though `this.inUserPlaylist` didn't exist, so it was passing playlist information to the external player. This pull request adds the missing `inUserPlaylist` property.

## Screenshots <!-- If appropriate -->
Before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/48293849/503e838f-d1d4-47d1-9749-e3fd9049dd65)

After:
![after](https://github.com/FreeTubeApp/FreeTube/assets/48293849/c9865020-8e9c-46e5-91d4-b1f1ee75096b)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Add this code snippet to the top of the `openInExternalPlayer` in `src/renderer/store/modules/utils.js`
    ```js
    console.log(payload)
    return
    ```
3. Open FreeTube
4. Set your external player to anything that isn't `None` (you don't actually have to have the player installed, because of the code snippet above)
5. Watch a user playlist
6. Click the open in external player button in the video info section
7. Check the console and make sure the logged object doesn't contain any playlist information

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 6b2917ad271c0b5a3ab7c4add5969a97b3b81bd9