### PR TITLE
Optimize saving watch progress and last viewed playlist in the history

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -98,7 +98,6 @@ export default defineComponent({
       lengthSeconds: 0,
       duration: '',
       description: '',
-      watchProgress: 0,
       published: undefined,
       isLive: false,
       is4k: false,
@@ -117,6 +116,14 @@ export default defineComponent({
 
     historyEntryExists: function () {
       return typeof this.historyEntry !== 'undefined'
+    },
+
+    watchProgress: function () {
+      if (!this.historyEntryExists || !this.saveWatchedProgress) {
+        return 0
+      }
+
+      return this.historyEntry.watchProgress
     },
 
     listType: function () {
@@ -494,9 +501,6 @@ export default defineComponent({
     },
   },
   watch: {
-    historyEntry() {
-      this.checkIfWatched()
-    },
     showAddToPlaylistPrompt(value) {
       if (value) { return }
       // Execute on prompt close
@@ -507,7 +511,6 @@ export default defineComponent({
   },
   created: function () {
     this.parseVideoData()
-    this.checkIfWatched()
 
     if ((this.useDeArrowTitles || this.useDeArrowThumbnails) && !this.deArrowCache) {
       this.fetchDeArrowData()
@@ -697,19 +700,6 @@ export default defineComponent({
       }
     },
 
-    checkIfWatched: function () {
-      if (this.historyEntryExists) {
-        const historyEntry = this.historyEntry
-
-        if (this.saveWatchedProgress) {
-          // For UX consistency, no progress reading if writing disabled
-          this.watchProgress = historyEntry.watchProgress
-        }
-      } else {
-        this.watchProgress = 0
-      }
-    },
-
     markAsWatched: function () {
       const videoData = {
         videoId: this.id,
@@ -733,8 +723,6 @@ export default defineComponent({
       this.removeFromHistory(this.id)
 
       showToast(this.$t('Video.Video has been removed from your history'))
-
-      this.watchProgress = 0
     },
 
     togglePlaylistPrompt: function () {

--- a/src/renderer/store/modules/history.js
+++ b/src/renderer/store/modules/history.js
@@ -108,27 +108,29 @@ const mutations = {
   },
 
   updateRecordWatchProgressInHistoryCache(state, { videoId, watchProgress }) {
-    const i = state.historyCacheSorted.findIndex((currentRecord) => {
-      return currentRecord.videoId === videoId
-    })
+    // historyCacheById and historyCacheSorted reference the same object instances,
+    // so modifying an existing object in one of them will update both.
 
-    const targetRecord = Object.assign({}, state.historyCacheSorted[i])
-    targetRecord.watchProgress = watchProgress
-    state.historyCacheSorted.splice(i, 1, targetRecord)
-    vueSet(state.historyCacheById, videoId, targetRecord)
+    const record = state.historyCacheById[videoId]
+
+    // Don't set, if the item was removed from the watch history, as we don't have any video details
+    if (record) {
+      vueSet(record, 'watchProgress', watchProgress)
+    }
   },
 
   updateRecordLastViewedPlaylistIdInHistoryCache(state, { videoId, lastViewedPlaylistId, lastViewedPlaylistType, lastViewedPlaylistItemId }) {
-    const i = state.historyCacheSorted.findIndex((currentRecord) => {
-      return currentRecord.videoId === videoId
-    })
+    // historyCacheById and historyCacheSorted reference the same object instances,
+    // so modifying an existing object in one of them will update both.
 
-    const targetRecord = Object.assign({}, state.historyCacheSorted[i])
-    targetRecord.lastViewedPlaylistId = lastViewedPlaylistId
-    targetRecord.lastViewedPlaylistType = lastViewedPlaylistType
-    targetRecord.lastViewedPlaylistItemId = lastViewedPlaylistItemId
-    state.historyCacheSorted.splice(i, 1, targetRecord)
-    vueSet(state.historyCacheById, videoId, targetRecord)
+    const record = state.historyCacheById[videoId]
+
+    // Don't set, if the item was removed from the watch history, as we don't have any video details
+    if (record) {
+      vueSet(record, 'lastViewedPlaylistId', lastViewedPlaylistId)
+      vueSet(record, 'lastViewedPlaylistType', lastViewedPlaylistType)
+      vueSet(record, 'lastViewedPlaylistItemId', lastViewedPlaylistItemId)
+    }
   },
 
   removeFromHistoryCacheById(state, videoId) {


### PR DESCRIPTION
# Optimize saving watch progress and last viewed playlist in the history

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Performance optimization

## Description
At the moment when we update the watch progress or last view playlist in the watch history, we create a copy of the history entry, update it's properties and then replace the existing entry in `historyCacheSorted` and `historyCacheById` with the new entry. We don't really need to create a copy of the history entry, we can just modify the existing one, which uses slightly less memory and as `historyCacheSorted` and `historyCacheById` reference the same history entry objects in memory, we can update one to update both.

When you assign an object (functions are objects too in JavaScript :) ) to a variable in JavaScript, you aren't saving the actual object in that variable, instead you are just storing a reference to where that object is stored in the memory. This pull request takes advantage of multiple variables referencing the same object in memory. That's different to primitives like numbers that are copied into the variable.

## Testing <!-- for code that is not small enough to be easily understandable -->
Make sure that `Remember History` and `Save Watched Progress` are turned on.

### Last Viewed Playlist
1. Open a playlist and watch a video from it
2. Open the history page
3. Click on the video you just watched
4. It should remember the playlist.

### Watch Progress
1. Watch a video
2. Seek to about the middle
3. Open the history page
4. Check that the progress appears correctly on the thumbnail.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 1caf9618cf13b4cc0e8fa70ae3b0f5e7b3f4f840