### PR TITLE
Update Flatpak PR Workflow to work with updated module

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -42,10 +42,10 @@ jobs:
         _input-text: ${{ fromJson(steps.api_results.outputs.result).tag_name }}
         -beta: ''
         v: ''
-    - name: Create Release Branch
-      run: |
-        git checkout -b release-v${{ steps.sub.outputs.result }}
-        git push --set-upstream origin release-v${{ steps.sub.outputs.result }}
+    # - name: Create Release Branch
+      # run: |
+        # git checkout -b release-v${{ steps.sub.outputs.result }}
+        # git push --set-upstream origin release-v${{ steps.sub.outputs.result }}
     - name: Download x64 Release
       uses: fabriciobastian/download-release-asset-action@v1.0.6
       with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -102,20 +102,20 @@ jobs:
       run: |
         rm freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip
         rm freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip
-    - name: Commit Files
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
+    #- name: Commit Files
+      # uses: stefanzweifel/git-auto-commit-action@v5
+      # with:
         # Optional but recommended
         # Defaults to "Apply automatic changes"
-        commit_message: Update files for v${{ steps.sub.outputs.result }}
-        token: ${{ secrets.FLATHUB_TOKEN }}
+        # commit_message: Update files for v${{ steps.sub.outputs.result }}
+        # token: ${{ secrets.FLATHUB_TOKEN }}
 
         # Optional options appended to `git-commit`
         # See https://git-scm.com/docs/git-commit for a list of available options
-        commit_options: '--no-verify --signoff'
+        # commit_options: '--no-verify --signoff'
 
         # Optional: Disable dirty check and always try to create a commit and push
-        skip_dirty_check: true
+        # skip_dirty_check: true
     - name: Upload Manifest Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -116,16 +116,6 @@ jobs:
 
         # Optional: Disable dirty check and always try to create a commit and push
         skip_dirty_check: true
-    - name: Upload Manifest Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: io.freetubeapp.FreeTube.metainfo
-        path: io.freetubeapp.FreeTube.metainfo.xml
-    - name: Upload YAML Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: io.freetubeapp.FreeTube.yml
-        path: io.freetubeapp.FreeTube.yml
     - name: Create PR
       run: |
         echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -80,7 +80,7 @@ jobs:
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip"' io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-test-x64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update x64 Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:
@@ -90,14 +90,14 @@ jobs:
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip"' io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-test-arm64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update ARM Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[1].sha256 = "${{ env.HASH_ARM64 }}"' io.freetubeapp.FreeTube.yml
     - name: Add Patch Notes to XML File
-      run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
+      run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-test" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
     - name: Remove Release Files
       run: |
         rm freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -80,22 +80,22 @@ jobs:
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[0].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip'
+        cmd: yq -i modules[0].sources[0].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip' io.freetubeapp.FreeTube.yml
     - name: Update x64 Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[0].sha256 ${{ env.HASH_X64 }}
+        cmd: yq -i modules[0].sources[0].sha256 ${{ env.HASH_X64 }} io.freetubeapp.FreeTube.yml
     - name: Update ARM File Location in yml File
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[1].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip'
+        cmd: yq -i modules[0].sources[1].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip' io.freetubeapp.FreeTube.yml
     - name: Update ARM Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[1].sha256 ${{ env.HASH_ARM64 }}
+        cmd: yq -i modules[0].sources[1].sha256 ${{ env.HASH_ARM64 }} io.freetubeapp.FreeTube.yml
     - name: Add Patch Notes to XML File
       run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
     - name: Remove Release Files
@@ -121,6 +121,11 @@ jobs:
       with:
         name: io.freetubeapp.FreeTube.metainfo
         path: io.freetubeapp.FreeTube.metainfo.xml
+    - name: Upload YAML Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: io.freetubeapp.FreeTube.yml
+        path: io.freetubeapp.FreeTube.yml
     # - name: Create PR
       # run: |
         # echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -80,7 +80,7 @@ jobs:
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i 'modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip"' io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update x64 Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -77,22 +77,22 @@ jobs:
         date +"%Y-%m-%d" >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
     - name: Update x64 File Location in yml File
-      uses: mikefarah/yq@v4.44.1
+      uses: mikefarah/yq@v4.44.2
       with:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-test-x64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update x64 Hash in yml File
-      uses: mikefarah/yq@v4.44.1
+      uses: mikefarah/yq@v4.44.2
       with:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[0].sha256 = "${{ env.HASH_X64 }}"' io.freetubeapp.FreeTube.yml
     - name: Update ARM File Location in yml File
-      uses: mikefarah/yq@v4.44.1
+      uses: mikefarah/yq@v4.44.2
       with:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-test-arm64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update ARM Hash in yml File
-      uses: mikefarah/yq@v4.44.1
+      uses: mikefarah/yq@v4.44.2
       with:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[1].sha256 = "${{ env.HASH_ARM64 }}"' io.freetubeapp.FreeTube.yml

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -80,7 +80,7 @@ jobs:
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i modules[0].sources[0].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip' io.freetubeapp.FreeTube.yml
+        cmd: yq -i 'modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update x64 Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -80,7 +80,7 @@ jobs:
       uses: mikefarah/yq@v4.44.2
       with:
         # The Command which should be run
-        cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-test-x64.zip"' io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update x64 Hash in yml File
       uses: mikefarah/yq@v4.44.2
       with:
@@ -90,7 +90,7 @@ jobs:
       uses: mikefarah/yq@v4.44.2
       with:
         # The Command which should be run
-        cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-test-arm64.zip"' io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update ARM Hash in yml File
       uses: mikefarah/yq@v4.44.2
       with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -116,6 +116,11 @@ jobs:
 
         # Optional: Disable dirty check and always try to create a commit and push
         skip_dirty_check: true
+    - name: Upload Manifest Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: io.freetubeapp.FreeTube.metainfo
+        path: io.freetubeapp.FreeTube.metainfo.xml
     # - name: Create PR
       # run: |
         # echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -42,10 +42,10 @@ jobs:
         _input-text: ${{ fromJson(steps.api_results.outputs.result).tag_name }}
         -beta: ''
         v: ''
-    # - name: Create Release Branch
-      # run: |
-        # git checkout -b release-v${{ steps.sub.outputs.result }}
-        # git push --set-upstream origin release-v${{ steps.sub.outputs.result }}
+    - name: Create Release Branch
+      run: |
+        git checkout -b release-v${{ steps.sub.outputs.result }}
+        git push --set-upstream origin release-v${{ steps.sub.outputs.result }}
     - name: Download x64 Release
       uses: fabriciobastian/download-release-asset-action@v1.0.6
       with:
@@ -97,25 +97,25 @@ jobs:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[1].sha256 = "${{ env.HASH_ARM64 }}"' io.freetubeapp.FreeTube.yml
     - name: Add Patch Notes to XML File
-      run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-test" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
+      run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
     - name: Remove Release Files
       run: |
         rm freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip
         rm freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip
-    #- name: Commit Files
-      # uses: stefanzweifel/git-auto-commit-action@v5
-      # with:
+    - name: Commit Files
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
         # Optional but recommended
         # Defaults to "Apply automatic changes"
-        # commit_message: Update files for v${{ steps.sub.outputs.result }}
-        # token: ${{ secrets.FLATHUB_TOKEN }}
+        commit_message: Update files for v${{ steps.sub.outputs.result }}
+        token: ${{ secrets.FLATHUB_TOKEN }}
 
         # Optional options appended to `git-commit`
         # See https://git-scm.com/docs/git-commit for a list of available options
-        # commit_options: '--no-verify --signoff'
+        commit_options: '--no-verify --signoff'
 
         # Optional: Disable dirty check and always try to create a commit and push
-        # skip_dirty_check: true
+        skip_dirty_check: true
     - name: Upload Manifest Artifact
       uses: actions/upload-artifact@v4
       with:
@@ -126,9 +126,9 @@ jobs:
       with:
         name: io.freetubeapp.FreeTube.yml
         path: io.freetubeapp.FreeTube.yml
-    # - name: Create PR
-      # run: |
-        # echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt
-        # gh auth login --with-token < auth.txt
-        # rm auth.txt
-        # gh pr create --title "Release v${{ steps.sub.outputs.result }}" --body "This is an automated PR for the v${{ steps.sub.outputs.result }} release. This PR will be updated and merged once testing is complete."
+    - name: Create PR
+      run: |
+        echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt
+        gh auth login --with-token < auth.txt
+        rm auth.txt
+        gh pr create --title "Release v${{ steps.sub.outputs.result }}" --body "This is an automated PR for the v${{ steps.sub.outputs.result }} release. This PR will be updated and merged once testing is complete."

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -85,17 +85,17 @@ jobs:
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i modules[0].sources[0].sha256 ${{ env.HASH_X64 }} io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[0].sha256 = "${{ env.HASH_X64 }}"' io.freetubeapp.FreeTube.yml
     - name: Update ARM File Location in yml File
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i modules[0].sources[1].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip' io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip"' io.freetubeapp.FreeTube.yml
     - name: Update ARM Hash in yml File
       uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
-        cmd: yq -i modules[0].sources[1].sha256 ${{ env.HASH_ARM64 }} io.freetubeapp.FreeTube.yml
+        cmd: yq -i '.modules[0].sources[1].sha256 = "${{ env.HASH_ARM64 }}"' io.freetubeapp.FreeTube.yml
     - name: Add Patch Notes to XML File
       run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
     - name: Remove Release Files

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -77,22 +77,22 @@ jobs:
         date +"%Y-%m-%d" >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
     - name: Update x64 File Location in yml File
-      uses: mikefarah/yq@4.0.0-beta1
+      uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
         cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[0].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-x64.zip'
     - name: Update x64 Hash in yml File
-      uses: mikefarah/yq@4.0.0-beta1
+      uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
         cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[0].sha256 ${{ env.HASH_X64 }}
     - name: Update ARM File Location in yml File
-      uses: mikefarah/yq@4.0.0-beta1
+      uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
         cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[1].url 'https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-linux-portable-arm64.zip'
     - name: Update ARM Hash in yml File
-      uses: mikefarah/yq@4.0.0-beta1
+      uses: mikefarah/yq@v4.44.1
       with:
         # The Command which should be run
         cmd: yq w -i io.freetubeapp.FreeTube.yml modules[0].sources[1].sha256 ${{ env.HASH_ARM64 }}
@@ -116,9 +116,9 @@ jobs:
 
         # Optional: Disable dirty check and always try to create a commit and push
         skip_dirty_check: true
-    - name: Create PR
-      run: |
-        echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt
-        gh auth login --with-token < auth.txt
-        rm auth.txt
-        gh pr create --title "Release v${{ steps.sub.outputs.result }}" --body "This is an automated PR for the v${{ steps.sub.outputs.result }} release. This PR will be updated and merged once testing is complete."
+    # - name: Create PR
+      # run: |
+        # echo ${{ secrets.FLATHUB_TOKEN }} >> auth.txt
+        # gh auth login --with-token < auth.txt
+        # rm auth.txt
+        # gh pr create --title "Release v${{ steps.sub.outputs.result }}" --body "This is an automated PR for the v${{ steps.sub.outputs.result }} release. This PR will be updated and merged once testing is complete."


### PR DESCRIPTION
# Update Flatpak PR Workflow

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
Closes #5108

## Description
The workflow that automatically creates the PR for the Flatpak release has been using an outdated version of `yq` for a while now. The updated version had several syntax changes and this PR updates the workflow with the new syntax.

## Screenshots <!-- If appropriate -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
I created a fork and tested the changes over there. I uploaded the edited files as artifacts to ensure that they were updated as expected.

## Desktop
N/A

## Additional context
Testing this might be difficult due to the secret tokens needed. If you want to try to test on your own branch, please make sure you comment out the parts of the script that creates the PR over on the Flathub repository.

Documentation for `yq` can be found [here](https://mikefarah.gitbook.io/yq).
