### PR TITLE
Use the ES Modules export of portal-vue instead of the CommonJS one

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -150,8 +150,9 @@ const config = {
   resolve: {
     alias: {
       vue$: 'vue/dist/vue.runtime.esm.js',
+      'portal-vue$': 'portal-vue/dist/portal-vue.esm.js',
 
-      'DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$': path.resolve(__dirname, '../src/datastores/handlers/electron.js'),
+      DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$: path.resolve(__dirname, '../src/datastores/handlers/electron.js'),
 
       'youtubei.js$': 'youtubei.js/web',
 

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -159,8 +159,9 @@ const config = {
   resolve: {
     alias: {
       vue$: 'vue/dist/vue.runtime.esm.js',
+      'portal-vue$': 'portal-vue/dist/portal-vue.esm.js',
 
-      'DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$': path.resolve(__dirname, '../src/datastores/handlers/web.js'),
+      DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$: path.resolve(__dirname, '../src/datastores/handlers/web.js'),
 
       // video.js's mpd-parser uses @xmldom/xmldom so that it can support both node and web browsers
       // As FreeTube only runs in electron and web browsers, we can use the native DOMParser class, instead of the "polyfill"


### PR DESCRIPTION
# Use the ES Modules export of portal-vue instead of the CommonJS one

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Performance improvement

## Description
For some reason webpack was choosing the CommonJS export of `portal-vue` and as that imports Vue, webpack was also adding a wrapper around Vue and simulating an import for it at runtime. This pull request makes webpack use the ES Modules export, that way webpack can then optimize both `portal-vue` and Vue correctly (e.g. dead code elimination, function inlining etc). This reduces the `renderer.js` and `web.js` outputs by 8289 bytes and 8247 bytes respectively and considering how often the Vue code is run (we have 96 Vue components), this should also help a bit performance wise.

## Testing <!-- for code that is not small enough to be easily understandable -->
`yarn dev` -> if the app launches and the UI is shown, the Vue import works
open a prompt to check that `vue-portal` still works

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 621617cd9e4421ec39c9dd03d06013b77a7faa8d