### PR TITLE
Fix live chat scroll down sometimes not removing the Scroll Down arrow

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -306,7 +306,7 @@ export default defineComponent({
       }
     },
 
-    onScroll: function (event) {
+    onScroll: function (event, isScrollEnd = false) {
       const liveChatComments = this.$refs.liveChatComments
       if (event.wheelDelta >= 0 && this.stayAtBottom) {
         this.stayAtBottom = false
@@ -314,10 +314,8 @@ export default defineComponent({
         if (liveChatComments.scrollHeight > liveChatComments.clientHeight) {
           this.showScrollToBottom = true
         }
-      } else if (event.wheelDelta < 0 && !this.stayAtBottom) {
-        if ((liveChatComments.scrollHeight - liveChatComments.scrollTop) === liveChatComments.clientHeight) {
-          this.scrollToBottom()
-        }
+      } else if ((isScrollEnd || event.wheelDelta < 0) && !this.stayAtBottom && (liveChatComments.scrollHeight - liveChatComments.scrollTop) === liveChatComments.clientHeight) {
+        this.scrollToBottom()
       }
     },
 

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
@@ -128,6 +128,7 @@
         class="liveChatComments"
         :style="{ blockSize: chatHeight }"
         @mousewheel="e => onScroll(e)"
+        @scrollend="e => onScroll(e, true)"
       >
         <div
           v-for="(comment, index) in comments"


### PR DESCRIPTION
# Fix live chat scroll down sometimes not removing the Scroll Down arrow

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #3158

## Description
Adds `@scrolldown` event handler to evaluate the position at end of the scroll event as well

## Testing <!-- for code that is not small enough to be easily understandable -->
- Find a live video (I used [this one](https://youtu.be/EWZtieWyISg)), scroll up, and scroll down fast. See that the arrow icon disappears properly

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
