### PR TITLE
Fix blocking error when navigating away from an age-restricted video

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1408,9 +1408,9 @@ export default defineComponent({
       this.handleWatchProgress()
 
       if (!this.isUpcoming && !this.isLoading) {
-        const player = this.$refs.videoPlayer.player
+        const player = this.$refs.videoPlayer?.player
 
-        if (player !== null && !player.paused() && player.isInPictureInPicture()) {
+        if (player && !player.paused() && player.isInPictureInPicture()) {
           setTimeout(() => {
             player.play()
             player.on('leavepictureinpicture', (event) => {


### PR DESCRIPTION
# Fix blocking error when navigating away from an age-restricted video

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #5319

## Description
`handleRouteChange` assumes there is always a player available, which causes problems when you try to navigate away from an age-restricted video with `Show family friendly content only` enabled, as we don't create a player in that situation. That caused an error to get thrown, which in turn meant that the `next` function was not getting called in the `beforeRouteLeave` hook, making it impossible to navigate away from the watch page.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Turn on `Show family friendly content only` in the parental controls settings
2. Open an age-restricted video (e.g. one from here: https://www.youtube.com/playlist?list=PLSSgDEhQJbsLBwXECx1gisvaB8M2wtY9b)
3. Make sure the age-restricted message is shown
4. Try navigating away from the watch page e.g. back button or by clicking one of the navigation buttons on the side bar
5. The navigation should work.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.0