### PR TITLE
Larger search/URL bar

### DIFF
--- a/src/renderer/components/top-nav/top-nav.scss
+++ b/src/renderer/components/top-nav/top-nav.scss
@@ -23,7 +23,7 @@
 
   @media only screen and (width >= 961px) {
     display: grid;
-    grid-template-columns: 1fr 440px 1fr;
+    grid-template-columns: 1fr 1.5fr .5fr;
   }
 
   @include top-nav-is-colored {
@@ -190,7 +190,7 @@
 
 .middle {
   flex: 1;
-  max-inline-size: 440px;
+  max-inline-size: 720px;
 
   .searchContainer {
     align-items: center;


### PR DESCRIPTION
## Larger search/URL bar #5341

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
closes #5341

## Description
modify `top-nav` SCSS so that the grid gives more space to search bar. This PR also increases its max width.

## Screenshots <!-- If appropriate -->
before:
![before](https://github.com/FreeTubeApp/FreeTube/assets/170770027/eca40307-bc6e-474a-8b07-592644b38a61)
after (manually using DevTools, I don't want to build):
![after](https://github.com/FreeTubeApp/FreeTube/assets/170770027/16f9e2ea-028d-4d99-a6b7-3516bb66afc4)


## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint (does not apply)
- **OS Version:** 21.3
- **FreeTube version:** v0.21.0 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
I also want to add `flex-shrink` for first item for "hide FreeTube logo" because SPACE WASTE.