### PR TITLE
Fix Invidious API error toasts saying undefined

### DIFF
--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -323,8 +323,8 @@ export default defineComponent({
         }).catch((err) => {
           console.error(err)
           const errorMessage = this.$t('Invidious API Error (Click to copy)')
-          showToast(`${errorMessage}: ${err.responseText}`, 10000, () => {
-            copyToClipboard(err.responseText)
+          showToast(`${errorMessage}: ${err}`, 10000, () => {
+            copyToClipboard(err)
           })
           switch (failedAttempts) {
             case 0:

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -324,8 +324,8 @@ export default defineComponent({
         }).catch((err) => {
           console.error(err)
           const errorMessage = this.$t('Invidious API Error (Click to copy)')
-          showToast(`${errorMessage}: ${err.responseText}`, 10000, () => {
-            copyToClipboard(err.responseText)
+          showToast(`${errorMessage}: ${err}`, 10000, () => {
+            copyToClipboard(err)
           })
           switch (failedAttempts) {
             case 0:

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -366,11 +366,11 @@ export default defineComponent({
           }
 
           this.isLoading = false
-        }).catch((xhr) => {
-          console.error(xhr)
+        }).catch((error) => {
+          console.error(error)
           const errorMessage = this.$t('Invidious API Error (Click to copy)')
-          showToast(`${errorMessage}: ${xhr.responseText}`, 10000, () => {
-            copyToClipboard(xhr.responseText)
+          showToast(`${errorMessage}: ${error}`, 10000, () => {
+            copyToClipboard(error)
           })
           this.isLoading = false
         })

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -164,8 +164,8 @@ export default defineComponent({
       }).catch((err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
-        showToast(`${errorMessage}: ${err.responseText}`, 10000, () => {
-          copyToClipboard(err.responseText)
+        showToast(`${errorMessage}: ${err}`, 10000, () => {
+          copyToClipboard(err)
         })
 
         if (process.env.SUPPORTS_LOCAL_API && (this.backendPreference === 'invidious' && this.backendFallback)) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -908,8 +908,8 @@ export default defineComponent({
         .catch(err => {
           console.error(err)
           const errorMessage = this.$t('Invidious API Error (Click to copy)')
-          showToast(`${errorMessage}: ${err.responseText}`, 10000, () => {
-            copyToClipboard(err.responseText)
+          showToast(`${errorMessage}: ${err}`, 10000, () => {
+            copyToClipboard(err)
           })
           console.error(err)
           if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {


### PR DESCRIPTION
# Fix Invidious API error toasts saying undefined

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Fixes some of the Invidious error handlers trying to access the non-existent `.responseText` property, which resulted it in displaying and copying `undefined` instead of the actual error message. Looks like we haven't changed those handlers since we switched away from jquery, as the `responseText` field was a jquery thing 😬. Now all Invidious API error toasts should show the actual error message, some of them were already doing it correctly.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.0