### PR TITLE
Fix about page not reacting to locale changes

### DIFF
--- a/src/renderer/views/About/About.js
+++ b/src/renderer/views/About/About.js
@@ -12,8 +12,12 @@ export default defineComponent({
   },
   data: function () {
     return {
-      versionNumber: `v${packageDetails.version}`,
-      chunks: [
+      versionNumber: `v${packageDetails.version}`
+    }
+  },
+  computed: {
+    chunks: function () {
+      return [
         {
           icon: ['fab', 'github'],
           title: this.$t('About.Source code'),
@@ -74,7 +78,7 @@ export default defineComponent({
           title: `${this.$t('About.Donate')} - BTC`,
           content: `<a href="bitcoin:${ABOUT_BITCOIN_ADDRESS}">${ABOUT_BITCOIN_ADDRESS}</a>`
         }
-      ],
+      ]
     }
   }
 })


### PR DESCRIPTION
# Fix about page not reacting to locale changes

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Noticed this while testing something else, so as it turned out to be an easy fix, I decided to open a pull request for it. 

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open two windows
2. Navigate to the About page in the first window
3. Navigate to the General Settings in the second window
4. Change the locale in the second window
5. All elements on the About page in the first window should switch to the new locale (previously none of the tiles/chunks would update)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.1