### PR TITLE
Add channel avatars to Subscription tab

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -13,6 +13,7 @@ import {
 } from '../../helpers/utils'
 import { deArrowData, deArrowThumbnail } from '../../helpers/sponsorblock'
 import debounce from 'lodash.debounce'
+import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 
 export default defineComponent({
   name: 'FtListVideo',
@@ -92,6 +93,7 @@ export default defineComponent({
       title: '',
       channelName: null,
       channelId: null,
+      channelThumbnail: null,
       viewCount: 0,
       parsedViewCount: '',
       uploadedTime: '',
@@ -219,6 +221,10 @@ export default defineComponent({
 
     youtubeEmbedUrl: function () {
       return `https://www.youtube-nocookie.com/embed/${this.id}`
+    },
+
+    profileSubscriptions: function () {
+      return deepCopy(this.$store.getters.getActiveProfile.subscriptions)
     },
 
     progressPercentage: function () {
@@ -511,6 +517,7 @@ export default defineComponent({
   },
   created: function () {
     this.parseVideoData()
+    this.getChannelThumbnail()
 
     if ((this.useDeArrowTitles || this.useDeArrowThumbnails) && !this.deArrowCache) {
       this.fetchDeArrowData()
@@ -697,6 +704,15 @@ export default defineComponent({
         this.parsedViewCount = this.data.viewCountText.replace(' views', '')
       } else {
         this.hideViews = true
+      }
+    },
+
+    getChannelThumbnail: async function () {
+      const thisChannel = this.profileSubscriptions.find((profile) => profile.id === this.channelId)
+      this.channelThumbnail = thisChannel?.thumbnail?.replace(/=s\d+/, '=s35')
+
+      if (this.backendPreference === 'invidious' && this.channelThumbnail) {
+        this.channelThumbnail = youtubeImageUrlToInvidious(this.channelThumbnail, this.currentInvidiousInstance)
       }
     },
 

--- a/src/renderer/components/ft-list-video/ft-list-video.scss
+++ b/src/renderer/components/ft-list-video/ft-list-video.scss
@@ -27,3 +27,18 @@
 .videoTagLine .videoTag:first-child {
   margin-inline-start: 0;
 }
+
+.channelThumbnail {
+  border-radius: 999px;
+  display: inline-block;
+  max-inline-size: 24px;
+  max-block-size: 24px;
+  margin-block-end: 0 !important;
+  margin-inline-end: 0.5rem;
+}
+
+.channelNameAndThumbnail {
+  display: flex;
+  align-items: center;
+  margin-block-end: 8px;
+}

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -124,7 +124,17 @@
           class="channelName"
           :to="`/channel/${channelId}`"
         >
-          <span>{{ channelName }}</span>
+          <span class="channelNameAndThumbnail">
+            <img
+              v-if="channelThumbnail"
+              :src="channelThumbnail"
+              alt=""
+              class="channelThumbnail"
+            >
+            <span>
+              {{ channelName }}
+            </span>
+          </span>
         </router-link>
         <span v-else-if="channelName !== null">
           {{ channelName }}
@@ -133,7 +143,7 @@
           v-if="!isLive && !isUpcoming && !isPremium && !hideViews && viewCount != null"
           class="viewCount"
         >
-          <template v-if="channelId !== null || channelName !== null"> • </template>
+          <template v-if="channelId !== null || channelName !== null" />
           {{ $tc('Global.Counts.View Count', viewCount, {count: parsedViewCount}) }}
         </span>
         <span

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -194,9 +194,6 @@ $watched-transition-duration: 0.5s;
   }
 
   .channelThumbnail {
-    display: flex;
-    justify-content: center;
-
     .channelThumbnailLink {
       inline-size: 100%;
       text-align: center;


### PR DESCRIPTION
# Add channel avatars to Subscription tab

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
This PR adds channel avatars beside names in the subscription feed. Supports both APIs

## Screenshots <!-- If appropriate -->
Subscriptions tab
![image](https://github.com/user-attachments/assets/50a3076b-2ff2-476d-b72d-84627ef6ab38)

Search results (no thumbs displayed as discussed [here](https://github.com/FreeTubeApp/FreeTube/discussions/5408#discussioncomment-10047358))
![image](https://github.com/user-attachments/assets/8cbd483d-6925-42e7-a370-f1713bb8ddbe)


## Testing <!-- for code that is not small enough to be easily understandable -->
The pull request has been tested on many channels and properly fallbacks to not displaying a thumb when one isn't available.
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 2004
- **FreeTube version:** v0.21.1 Beta

## Additional context
I'm happy to fix anything as I come from Svelte background and I haven't really touched Vue. 
