### PR TITLE
Fix scss deprecation warnings

### DIFF
--- a/src/renderer/components/ft-icon-button/ft-icon-button.scss
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.scss
@@ -101,11 +101,11 @@
   &.favorite,
   &.favorite:hover,
   &.favorite:focus-visible {
+    color: var(--favorite-icon-color);
+
     &:not(.disabled) {
       color: var(--favorite-icon-color);
     }
-
-    color: var(--favorite-icon-color);
   }
 }
 

--- a/src/renderer/components/ft-refresh-widget/ft-refresh-widget.scss
+++ b/src/renderer/components/ft-refresh-widget/ft-refresh-widget.scss
@@ -1,8 +1,6 @@
 @use '../../scss-partials/utils';
 
 .floatingRefreshSection {
-  @include utils.fixed-top-bar;
-
   box-sizing: border-box;
   padding-block: 5px;
   padding-inline: 10px;
@@ -13,6 +11,8 @@
   align-items: center;
   gap: 5px;
   justify-content: flex-end;
+
+  @include utils.fixed-top-bar;
 }
 
 .floatingRefreshSection:has(.lastRefreshTimestamp + .refreshButton) {

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -56,9 +56,9 @@ $watched-transition-duration: 0.5s;
   padding: 6px;
 
   &.watched {
-    @include low-contrast-when-watched(var(--primary-text-color));
-
     background-color: var(--bg-color);
+
+    @include low-contrast-when-watched(var(--primary-text-color));
 
     .thumbnailImage {
       opacity: 0.3;
@@ -227,13 +227,13 @@ $watched-transition-duration: 0.5s;
     }
 
     .title {
-      @include low-contrast-when-watched(var(--primary-text-color));
-
       font-size: 20px;
       grid-area: title;
       text-decoration: none;
       word-break: break-word;
       word-wrap: break-word;
+
+      @include low-contrast-when-watched(var(--primary-text-color));
 
       @include is-sidebar-item {
         font-size: 15px;
@@ -247,11 +247,11 @@ $watched-transition-duration: 0.5s;
       overflow-wrap: anywhere;
       text-align: start;
 
+      @include low-contrast-when-watched(var(--secondary-text-color));
+
       @include is-sidebar-item {
         font-size: 12px;
       }
-
-      @include low-contrast-when-watched(var(--secondary-text-color));
 
       .channelName {
         @include low-contrast-when-watched(var(--secondary-text-color));
@@ -259,12 +259,12 @@ $watched-transition-duration: 0.5s;
     }
 
     .description {
-      @include low-contrast-when-watched(var(--secondary-text-color));
-
       font-size: 14px;
       grid-area: description;
       max-block-size: 50px;
       overflow-y: hidden;
+
+      @include low-contrast-when-watched(var(--secondary-text-color));
     }
   }
 


### PR DESCRIPTION
# Fix scss deprecation warnings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Fixes the deprecation warnings that sass was spitting out during every build. Here's their docs page on the change: https://sass-lang.com/documentation/breaking-changes/mixed-decls/

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that I didn't break anything

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:**