### PR TITLE
More flexible hardware acceleration for Linux

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -199,9 +199,11 @@ function runApp() {
   let startupUrl
 
   if (process.platform === 'linux') {
-    // Enable hardware acceleration via VA-API
+    // Enable hardware acceleration via VA-API with OpenGL if no other feature flags are found
     // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/vaapi.md
-    app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecodeLinuxGL')
+    if (!app.commandLine.hasSwitch('enable-features')) {
+      app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecodeLinuxGL')
+    }
   }
 
   const userDataPath = app.getPath('userData')


### PR DESCRIPTION
# More flexible VA-API hardware video acceleration for Linux

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #5437.

## Description

Video hardware acceleration is only enabled if no other Electron feature flags are found. The OpenGL mode is used by default.

Users can now override the feature flag list passed to Electron and e.g. use Vulkan instead of OpenGL.

## Testing

Testing was done with both the bundled Electron library in `freetube-0.21.1-linux-portable-x64.zip` and with the system package `electron31` from Arch Linux.

**Using the official freetube portable package**
- `./freetube` - no feature flags are found, `VaapiVideoDecodeLinuxGL` is enabled - VA-API does not work (in my case). This is the default behavior.
- `./freetube --enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,VaapiIgnoreDriverChecks` - custom feature flags are detected and left unmodified - VA-API works

**Using the system package electron31**
- `electron31 --enable-features=Vulkan,VulkanFromANGLE,DefaultANGLEVulkan,VaapiIgnoreDriverChecks resources/app.asar` - custom feature flags are detected and left unmodified - VA-API works

## Desktop
- **OS:** Arch Linux
- **OS Version:** rolling
- **FreeTube version:** v0.21.1 Beta
- **GPU driver:** amdgpu
- **Display server:** X