### PR TITLE
Move the channel details into their own component

### DIFF
--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -1,0 +1,190 @@
+.bannerContainer {
+  background: center / cover no-repeat var(--banner-url, transparent);
+  block-size: 13vw;
+  min-block-size: 110px;
+  max-block-size: 32vh;
+  inline-size: 100%;
+}
+
+.bannerContainer.default {
+  background-color: #000;
+  background-image: url('../../assets/img/defaultBanner.png');
+  background-repeat: repeat;
+  background-size: contain;
+}
+
+.infoContainer {
+  position: relative;
+  background-color: var(--card-bg-color);
+  margin-block-start: 10px;
+  padding-block: 0;
+  padding-inline: 16px;
+}
+
+.info {
+  display: flex;
+  flex-flow: row wrap;
+  inline-size: 100%;
+  justify-content: space-between;
+}
+
+.infoHasError {
+  padding-block-end: 10px;
+}
+
+.thumbnail {
+  inline-size: 100px;
+  block-size: 100px;
+  border-radius: 200px;
+  object-fit: cover;
+}
+
+.name {
+  font-weight: bold;
+  inline-size: 100%;
+  font-size: 25px;
+}
+
+.subCount {
+  color: var(--tertiary-text-color);
+  inset-block-start: 50px;
+  inset-inline-start: 120px;
+}
+
+.infoActionsContainer {
+  display: flex;
+  gap: 30px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.shareIcon {
+  align-self: center;
+}
+
+.channelSearch {
+  margin-block-start: 10px;
+  max-inline-size: 250px;
+  inline-size: 220px;
+  margin-inline-start: auto;
+  align-self: flex-end;
+  flex: 1 1 0%;
+}
+
+.infoTabs {
+  position: relative;
+  inline-size: 100%;
+  block-size: auto;
+  justify-content: unset;
+  gap: 32px;
+  padding-block: 0.3em;
+  padding-inline: 0;
+  flex-wrap: nowrap;
+}
+
+.tabs {
+  display: flex;
+  flex: 0 1 66%;
+  flex-wrap: wrap;
+}
+
+.tab {
+  padding: 15px;
+  font-size: 15px;
+  cursor: pointer;
+  align-self: flex-end;
+  text-align: center;
+  color: var(--tertiary-text-color);
+  border-block-end: 3px solid transparent;
+}
+
+.tab:hover,
+.tab:focus {
+  font-weight: bold;
+  border-block-end: 3px solid var(--tertiary-text-color);
+}
+
+.selectedTab {
+  color: var(--primary-text-color);
+  border-block-end: 3px solid var(--primary-color);
+  font-weight: bold;
+  box-sizing: border-box;
+}
+
+.thumbnailContainer {
+  display: flex;
+}
+
+.lineContainer {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  padding-inline-start: 1em;
+}
+
+.name,
+.subCount {
+  margin: 0;
+}
+
+@media only screen and (width <=800px) {
+  .infoTabs {
+    block-size: auto;
+    flex-flow: column-reverse;
+    gap: 0;
+  }
+
+  .channelSearch {
+    inline-size: 100%;
+    max-inline-size: none;
+  }
+
+  .tabs {
+    flex: 1 1 0;
+  }
+
+  .tab {
+    flex: 1 1 0%;
+  }
+}
+
+@media only screen and (width <=680px) {
+  .info {
+    flex-direction: column;
+    margin-block: 20px 10px;
+  }
+
+  .infoActionsContainer {
+    flex-direction: row-reverse;
+    justify-content: left;
+    gap: 10px;
+    margin-block-start: 5px;
+  }
+}
+
+@media only screen and (width <=400px) {
+  .info {
+    justify-content: center;
+    gap: 10px;
+  }
+
+  .infoActionsContainer {
+    justify-content: center;
+  }
+
+  .clineContainer {
+    padding-inline-start: 0;
+  }
+
+  .thumbnailContainer {
+    flex-direction: column;
+  }
+
+  .thumbnailContainer,
+  .infoActionsContainer {
+    flex-wrap: wrap;
+    align-items: center;
+    text-align: center;
+    gap: 10px;
+  }
+}

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -1,0 +1,357 @@
+<template>
+  <FtCard>
+    <div
+      class="bannerContainer"
+      :class="{
+        default: !bannerUrl
+      }"
+      :style="{ '--banner-url': `url('${bannerUrl}')` }"
+    />
+
+    <div
+      class="infoContainer"
+    >
+      <div
+        class="info"
+        :class="{ infoHasError: hasErrorMessage }"
+      >
+        <div
+          class="thumbnailContainer"
+        >
+          <img
+            v-if="thumbnailUrl"
+            class="thumbnail"
+            :src="thumbnailUrl"
+            alt=""
+          >
+          <FontAwesomeIcon
+            v-else
+            class="thumbnail"
+            :icon="['fas', 'circle-user']"
+          />
+          <div
+            class="lineContainer"
+          >
+            <h1
+              class="name"
+            >
+              {{ name }}
+            </h1>
+
+            <p
+              v-if="subCount !== null && !hideChannelSubscriptions"
+              class="subCount"
+            >
+              {{ $tc('Global.Counts.Subscriber Count', subCount, { count: formattedSubCount }) }}
+            </p>
+          </div>
+        </div>
+
+        <div class="infoActionsContainer">
+          <FtShareButton
+            v-if="!hideSharingActions && showShareMenu"
+            :id="id"
+            share-target-type="Channel"
+            class="shareIcon"
+          />
+
+          <FtSubscribeButton
+            v-if="!hideUnsubscribeButton && (!hasErrorMessage || isSubscribed)"
+            :channel-id="id"
+            :channel-name="name"
+            :channel-thumbnail="thumbnailUrl"
+          />
+        </div>
+      </div>
+
+      <FtFlexBox
+        v-if="!hasErrorMessage"
+        class="infoTabs"
+      >
+        <div
+          class="tabs"
+          role="tablist"
+          :aria-label="$t('Channel.Channel Tabs')"
+        >
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('videos')"
+            id="videosTab"
+            class="tab"
+            :class="{ selectedTab: currentTab === 'videos' }"
+            role="tab"
+            :aria-selected="String(currentTab === 'videos')"
+            aria-controls="videoPanel"
+            :tabindex="(currentTab === 'videos' || currentTab === 'search') ? 0 : -1"
+            @click="changeTab('videos')"
+            @keydown.left.right="focusTab('videos', $event)"
+            @keydown.enter.space.prevent="changeTab('videos')"
+          >
+            {{ $t("Channel.Videos.Videos").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('shorts')"
+            id="shortsTab"
+            class="tab"
+            :class="{ selectedTab: currentTab === 'shorts' }"
+            role="tab"
+            :aria-selected="String(currentTab === 'shorts')"
+            aria-controls="shortPanel"
+            :tabindex="currentTab === 'shorts' ? 0 : -1"
+            @click="changeTab('shorts')"
+            @keydown.left.right="focusTab('shorts', $event)"
+            @keydown.enter.space.prevent="changeTab('shorts')"
+          >
+            {{ $t("Global.Shorts").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('live')"
+            id="liveTab"
+            class="tab"
+            :class="{ selectedTab: currentTab === 'live' }"
+            role="tab"
+            :aria-selected="String(currentTab === 'live')"
+            aria-controls="livePanel"
+            :tabindex="currentTab === 'live' ? 0 : -1"
+            @click="changeTab('live')"
+            @keydown.left.right="focusTab('live', $event)"
+            @keydown.enter.space.prevent="changeTab('live')"
+          >
+            {{ $t("Channel.Live.Live").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('releases')"
+            id="releasesTab"
+            class="tab"
+            role="tab"
+            :aria-selected="String(currentTab === 'releases')"
+            aria-controls="releasePanel"
+            :tabindex="currentTab === 'releases' ? 0 : -1"
+            :class="{ selectedTab: currentTab === 'releases' }"
+            @click="changeTab('releases')"
+            @keydown.left.right="focusTab('releases', $event)"
+            @keydown.enter.space.prevent="changeTab('releases')"
+          >
+            {{ $t("Channel.Releases.Releases").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('podcasts')"
+            id="podcastsTab"
+            class="tab"
+            role="tab"
+            :aria-selected="String(currentTab === 'podcasts')"
+            aria-controls="podcastPanel"
+            :tabindex="currentTab === 'podcasts' ? 0 : -1"
+            :class="{ selectedTab: currentTab === 'podcasts' }"
+            @click="changeTab('podcasts')"
+            @keydown.left.right="focusTab('podcasts', $event)"
+            @keydown.enter.space.prevent="changeTab('podcasts')"
+          >
+            {{ $t("Channel.Podcasts.Podcasts").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('playlists')"
+            id="playlistsTab"
+            class="tab"
+            role="tab"
+            :aria-selected="String(currentTab === 'playlists')"
+            aria-controls="playlistPanel"
+            :tabindex="currentTab === 'playlists' ? 0 : -1"
+            :class="{ selectedTab: currentTab === 'playlists' }"
+            @click="changeTab('playlists')"
+            @keydown.left.right="focusTab('playlists', $event)"
+            @keydown.enter.space.prevent="changeTab('playlists')"
+          >
+            {{ $t("Channel.Playlists.Playlists").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            v-if="visibleTabs.includes('community')"
+            id="communityTab"
+            class="tab"
+            role="tab"
+            :aria-selected="String(currentTab === 'community')"
+            aria-controls="communityPanel"
+            :tabindex="currentTab === 'community' ? 0 : -1"
+            :class="{ selectedTab: currentTab === 'community' }"
+            @click="changeTab('community')"
+            @keydown.left.right="focusTab('community', $event)"
+            @keydown.enter.space.prevent="changeTab('community')"
+          >
+            {{ $t("Global.Community").toUpperCase() }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
+            id="aboutTab"
+            class="tab"
+            role="tab"
+            :aria-selected="String(currentTab === 'about')"
+            aria-controls="aboutPanel"
+            :tabindex="currentTab === 'about' ? 0 : -1"
+            :class="{ selectedTab: currentTab === 'about' }"
+            @click="changeTab('about')"
+            @keydown.left.right="focusTab('about', $event)"
+            @keydown.enter.space.prevent="changeTab('about')"
+          >
+            {{ $t("Channel.About.About").toUpperCase() }}
+          </div>
+        </div>
+
+        <FtInput
+          v-if="showSearchBar"
+          ref="searchBar"
+          :placeholder="$t('Channel.Search Channel')"
+          :show-clear-text-button="true"
+          class="channelSearch"
+          :maxlength="255"
+          @click="search"
+        />
+      </FtFlexBox>
+    </div>
+  </FtCard>
+</template>
+
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import FtCard from '../ft-card/ft-card.vue'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import FtShareButton from '../ft-share-button/ft-share-button.vue'
+import FtSubscribeButton from '../ft-subscribe-button/ft-subscribe-button.vue'
+import FtInput from '../ft-input/ft-input.vue'
+
+import store from '../../store/index'
+
+import { ctrlFHandler, formatNumber } from '../../helpers/utils'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  name: {
+    type: String,
+    default: null
+  },
+  bannerUrl: {
+    type: String,
+    default: null
+  },
+  hasErrorMessage: {
+    type: Boolean,
+    default: false
+  },
+  thumbnailUrl: {
+    type: String,
+    default: null
+  },
+  subCount: {
+    type: Number,
+    default: null
+  },
+  showShareMenu: {
+    type: Boolean,
+    default: true
+  },
+  showSearchBar: {
+    type: Boolean,
+    default: true
+  },
+  isSubscribed: {
+    type: Boolean,
+    default: false
+  },
+  visibleTabs: {
+    type: Array,
+    default: () => ([])
+  },
+  currentTab: {
+    type: String,
+    default: 'videos'
+  }
+})
+
+const emit = defineEmits(['change-tab', 'search'])
+
+const hideChannelSubscriptions = computed(() => {
+  return store.getters.getHideChannelSubscriptions
+})
+
+const hideSharingActions = computed(() => {
+  return store.getters.getHideSharingActions
+})
+
+const hideUnsubscribeButton = computed(() => {
+  return store.getters.getHideUnsubscribeButton
+})
+
+const formattedSubCount = computed(() => {
+  if (hideChannelSubscriptions.value) {
+    return null
+  }
+  return formatNumber(props.subCount)
+})
+
+/**
+ * @param {string} tab
+ */
+function changeTab(tab) {
+  emit('change-tab', tab)
+}
+
+/**
+ * @param {string} currentTab
+ * @param {KeyboardEvent} event
+ */
+function focusTab(currentTab, event) {
+  if (event.altKey) {
+    return
+  }
+
+  event.preventDefault()
+
+  const visibleTabs = props.visibleTabs
+
+  const index = visibleTabs.indexOf(currentTab)
+
+  // focus left or right tab with wrap around
+  const tab = (event.key === 'ArrowLeft')
+    ? visibleTabs[(index > 0 ? index : visibleTabs.length) - 1]
+    : visibleTabs[(index + 1) % visibleTabs.length]
+
+  document.getElementById(`${tab}Tab`).focus()
+  store.dispatch('showOutlines')
+}
+
+/**
+ * @param {string} query
+ */
+function search(query) {
+  emit('search', query)
+}
+
+const searchBar = ref(null)
+
+/**
+ * @param {KeyboardEvent} event
+ */
+function keyboardShortcutHandler(event) {
+  ctrlFHandler(event, searchBar.value)
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', keyboardShortcutHandler)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', keyboardShortcutHandler)
+})
+</script>
+
+<style scoped src="./ChannelDetails.css" />

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -11,128 +11,11 @@
   max-inline-size: 92vw;
 }
 
-.channelBannerContainer {
-  background: center / cover no-repeat var(--banner-url, transparent);
-  block-size: 13vw;
-  min-block-size: 110px;
-  max-block-size: 32vh;
-  inline-size: 100%;
-}
-
-.channelBannerContainer.default {
-  background-color: #000;
-  background-image: url('../../assets/img/defaultBanner.png');
-  background-repeat: repeat;
-  background-size: contain;
-}
-
-.channelInfoContainer {
-  position: relative;
-  background-color: var(--card-bg-color);
-  margin-block-start: 10px;
-  padding-block: 0;
-  padding-inline: 16px;
-}
-
-.channelInfo {
-  display: flex;
-  flex-flow: row wrap;
-  inline-size: 100%;
-  justify-content: space-between;
-}
-
-.channelInfoHasError {
-  padding-block-end: 10px;
-}
-
-.channelThumbnail {
-  inline-size: 100px;
-  block-size: 100px;
-  border-radius: 200px;
-  object-fit: cover;
-}
-
-.channelName {
-  font-weight: bold;
-  inline-size: 100%;
-  font-size: 25px;
-}
-
-.channelSubCount {
-  color: var(--tertiary-text-color);
-  inset-block-start: 50px;
-  inset-inline-start: 120px;
-}
-
-.channelInfoActionsContainer {
-  display: flex;
-  gap: 30px;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.subscribeButton {
-  block-size: fit-content;
-}
-
-.shareIcon {
-  align-self: center;
-}
-
-.channelSearch {
-  margin-block-start: 10px;
-  max-inline-size: 250px;
-  inline-size: 220px;
-  margin-inline-start: auto;
-  align-self: flex-end;
-  flex: 1 1 0%;
-}
-
 .select-container {
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
   margin-block-end: 10px;
-}
-
-.channelInfoTabs {
-  position: relative;
-  inline-size: 100%;
-  block-size: auto;
-  justify-content: unset;
-  gap: 32px;
-  padding-block: 0.3em;
-  padding-inline: 0;
-  flex-wrap: nowrap;
-}
-
-.tabs {
-  display: flex;
-  flex: 0 1 66%;
-  flex-wrap: wrap;
-}
-
-.tab {
-  padding: 15px;
-  font-size: 15px;
-  cursor: pointer;
-  align-self: flex-end;
-  text-align: center;
-  color: var(--tertiary-text-color);
-  border-block-end: 3px solid transparent;
-}
-
-.tab:hover,
-.tab:focus {
-  font-weight: bold;
-  border-block-end: 3px solid var(--tertiary-text-color);
-}
-
-.selectedTab {
-  color: var(--primary-text-color);
-  border-block-end: 3px solid var(--primary-color);
-  font-weight: bold;
-  box-sizing: border-box;
 }
 
 .elementListLoading {
@@ -153,105 +36,16 @@
   margin-block-start: 16px;
 }
 
-.thumbnailContainer {
-  display: flex;
-}
-
-.channelLineContainer {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  padding-inline-start: 1em;
-}
-
-.channelLineContainer h1,
-.channelLineContainer p {
-  margin: 0;
-}
-
-.communityThumbnail {
-  border-radius: 200px;
-  block-size: 12%;
-  inline-size: 12%;
-}
-
-.ft-community-image {
-  display: block;
-  margin-inline: auto;
-}
-
-.community-post-container {
-  padding-inline: 30%;
-}
-
 @media only screen and (width <= 800px) {
-  .channelInfoTabs {
-    block-size: auto;
-    flex-flow: column-reverse;
-    gap: 0;
-  }
-
-  .channelSearch {
-    inline-size: 100%;
-    max-inline-size: none;
-  }
-
-  .tabs {
-    flex: 1 1 0;
-  }
-
-  .tab {
-    flex: 1 1 0%;
-  }
-
   .communityPanel {
     margin-block-start: 1rem;
   }
 }
 
 @media only screen and (width <= 680px) {
-  .channelInfo {
-    flex-direction: column;
-    margin-block: 20px 10px;
-  }
-
   .card {
     max-inline-size: none;
     inline-size: 100%;
-  }
-
-  .channelInfoActionsContainer {
-    flex-direction: row-reverse;
-    justify-content: left;
-    gap: 10px;
-    margin-block-start: 5px;
-  }
-}
-
-@media only screen and (width <= 400px) {
-  .channelInfo {
-    justify-content: center;
-    gap: 10px;
-  }
-
-  .channelInfoActionsContainer {
-    justify-content: center;
-  }
-
-  .channelLineContainer {
-    padding-inline-start: 0;
-  }
-
-  .thumbnailContainer {
-    flex-direction: column;
-  }
-
-  .thumbnailContainer,
-  .channelInfoActionsContainer {
-    flex-wrap: wrap;
-    align-items: center;
-    text-align: center;
-    gap: 10px;
   }
 }
 

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1,24 +1,20 @@
 import { defineComponent } from 'vue'
 import { mapActions } from 'vuex'
 import FtCard from '../../components/ft-card/ft-card.vue'
-import FtInput from '../../components/ft-input/ft-input.vue'
 import FtSelect from '../../components/ft-select/ft-select.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import FtElementList from '../../components/ft-element-list/ft-element-list.vue'
 import FtAgeRestricted from '../../components/ft-age-restricted/ft-age-restricted.vue'
-import FtShareButton from '../../components/ft-share-button/ft-share-button.vue'
-import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe-button.vue'
 import ChannelAbout from '../../components/channel-about/channel-about.vue'
+import ChannelDetails from '../../components/ChannelDetails/ChannelDetails.vue'
 import FtAutoLoadNextPageWrapper from '../../components/ft-auto-load-next-page-wrapper/ft-auto-load-next-page-wrapper.vue'
 
 import autolinker from 'autolinker'
 import {
   setPublishedTimestampsInvidious,
   copyToClipboard,
-  ctrlFHandler,
   extractNumberFromString,
-  formatNumber,
   showToast,
   getIconForSortPreference
 } from '../../helpers/utils'
@@ -50,16 +46,14 @@ export default defineComponent({
   name: 'Channel',
   components: {
     'ft-card': FtCard,
-    'ft-input': FtInput,
     'ft-select': FtSelect,
     'ft-flex-box': FtFlexBox,
     'ft-loader': FtLoader,
     'ft-element-list': FtElementList,
     'ft-age-restricted': FtAgeRestricted,
-    'ft-share-button': FtShareButton,
-    'ft-subscribe-button': FtSubscribeButton,
     'channel-about': ChannelAbout,
     'ft-auto-load-next-page-wrapper': FtAutoLoadNextPageWrapper,
+    ChannelDetails
   },
   data: function () {
     return {
@@ -155,10 +149,6 @@ export default defineComponent({
       return this.$store.getters.getBackendFallback
     },
 
-    hideUnsubscribeButton: function() {
-      return this.$store.getters.getHideUnsubscribeButton
-    },
-
     showFamilyFriendlyOnly: function() {
       return this.$store.getters.getShowFamilyFriendlyOnly
     },
@@ -203,13 +193,6 @@ export default defineComponent({
       ]
     },
 
-    formattedSubCount: function () {
-      if (this.hideChannelSubscriptions) {
-        return null
-      }
-      return formatNumber(this.subCount)
-    },
-
     showFetchMoreButton: function () {
       switch (this.currentTab) {
         case 'videos':
@@ -231,13 +214,6 @@ export default defineComponent({
       }
 
       return false
-    },
-    hideChannelSubscriptions: function () {
-      return this.$store.getters.getHideChannelSubscriptions
-    },
-
-    hideSharingActions: function () {
-      return this.$store.getters.getHideSharingActions
     },
 
     hideChannelShorts: function () {
@@ -441,7 +417,6 @@ export default defineComponent({
   },
   mounted: function () {
     this.isLoading = true
-    document.addEventListener('keydown', this.keyboardShortcutHandler)
 
     if (this.$route.query.url) {
       this.resolveChannelUrl(this.$route.query.url, this.$route.params.currentTab)
@@ -467,9 +442,6 @@ export default defineComponent({
         this.autoRefreshOnSortByChangeEnabled = true
       })
     }
-  },
-  beforeDestroy() {
-    document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
     resolveChannelUrl: async function (url, tab = undefined) {
@@ -1856,29 +1828,7 @@ export default defineComponent({
       }
     },
 
-    changeTab: function (tab, event) {
-      if (event instanceof KeyboardEvent) {
-        if (event.altKey) {
-          return
-        }
-
-        // use arrowkeys to navigate
-        event.preventDefault()
-        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-          const index = this.tabInfoValues.indexOf(tab)
-
-          // focus left or right tab with wrap around
-          tab = (event.key === 'ArrowLeft')
-            ? this.tabInfoValues[(index > 0 ? index : this.tabInfoValues.length) - 1]
-            : this.tabInfoValues[(index + 1) % this.tabInfoValues.length]
-
-          const tabNode = document.getElementById(`${tab}Tab`)
-          tabNode.focus()
-          this.showOutlines()
-          return
-        }
-      }
-
+    changeTab: function (tab) {
       // `newTabNode` can be `null` when `tab` === "search"
       const newTabNode = document.getElementById(`${tab}Tab`)
       this.currentTab = tab
@@ -1991,10 +1941,6 @@ export default defineComponent({
           this.isLoading = false
         }
       })
-    },
-
-    keyboardShortcutHandler: function (event) {
-      ctrlFHandler(event, this.$refs.channelSearchBar)
     },
 
     getIconForSortPreference: (s) => getIconForSortPreference(s),

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -4,216 +4,23 @@
       v-if="isLoading && !errorMessage"
       :fullscreen="true"
     />
-    <ft-card
+    <ChannelDetails
       v-else-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
+      :id="id"
+      :name="channelName"
+      :banner-url="bannerUrl"
+      :has-error-message="!!errorMessage"
+      :thumbnail-url="thumbnailUrl"
+      :sub-count="subCount"
+      :show-share-menu="showShareMenu"
+      :show-search-bar="showSearchBar"
+      :is-subscribed="isSubscribed"
+      :visible-tabs="tabInfoValues"
+      :current-tab="currentTab"
       class="card channelDetails"
-    >
-      <div
-        class="channelBannerContainer"
-        :class="{
-          default: !bannerUrl
-        }"
-        :style="{ '--banner-url': `url('${bannerUrl}')` }"
-      />
-
-      <div
-        class="channelInfoContainer"
-      >
-        <div
-          class="channelInfo"
-          :class="{ channelInfoHasError: errorMessage }"
-        >
-          <div
-            class="thumbnailContainer"
-          >
-            <img
-              v-if="thumbnailUrl"
-              class="channelThumbnail"
-              :src="thumbnailUrl"
-              alt=""
-            >
-            <font-awesome-icon
-              v-else
-              class="channelThumbnail"
-              :icon="['fas', 'circle-user']"
-            />
-            <div
-              class="channelLineContainer"
-            >
-              <h1
-                class="channelName"
-              >
-                {{ channelName }}
-              </h1>
-
-              <p
-                v-if="subCount !== null && !hideChannelSubscriptions"
-                class="channelSubCount"
-              >
-                {{ $tc('Global.Counts.Subscriber Count', subCount, { count: formattedSubCount }) }}
-              </p>
-            </div>
-          </div>
-
-          <div class="channelInfoActionsContainer">
-            <ft-share-button
-              v-if="!hideSharingActions && showShareMenu"
-              :id="id"
-              share-target-type="Channel"
-              class="shareIcon"
-            />
-
-            <ft-subscribe-button
-              v-if="!hideUnsubscribeButton && (!errorMessage || isSubscribed)"
-              :channel-id="id"
-              :channel-name="channelName"
-              :channel-thumbnail="thumbnailUrl"
-            />
-          </div>
-        </div>
-
-        <ft-flex-box
-          v-if="!errorMessage"
-          class="channelInfoTabs"
-        >
-          <div
-            class="tabs"
-            role="tablist"
-            :aria-label="$t('Channel.Channel Tabs')"
-          >
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('videos')"
-              id="videosTab"
-              class="tab"
-              :class="(currentTab==='videos')?'selectedTab':''"
-              role="tab"
-              :aria-selected="String(currentTab === 'videos')"
-              aria-controls="videoPanel"
-              :tabindex="(currentTab === 'videos' || currentTab === 'search') ? 0 : -1"
-              @click="changeTab('videos')"
-              @keydown.left.right.enter.space="changeTab('videos', $event)"
-            >
-              {{ $t("Channel.Videos.Videos").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('shorts') && !hideChannelShorts"
-              id="shortsTab"
-              class="tab"
-              :class="(currentTab==='shorts')?'selectedTab':''"
-              role="tab"
-              :aria-selected="String(currentTab === 'shorts')"
-              aria-controls="shortPanel"
-              :tabindex="currentTab === 'shorts' ? 0 : -1"
-              @click="changeTab('shorts')"
-              @keydown.left.right.enter.space="changeTab('shorts', $event)"
-            >
-              {{ $t("Global.Shorts").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('live') && !hideLiveStreams"
-              id="liveTab"
-              class="tab"
-              :class="(currentTab==='live')?'selectedTab':''"
-              role="tab"
-              :aria-selected="String(currentTab === 'live')"
-              aria-controls="livePanel"
-              :tabindex="currentTab === 'live' ? 0 : -1"
-              @click="changeTab('live')"
-              @keydown.left.right.enter.space="changeTab('live', $event)"
-            >
-              {{ $t("Channel.Live.Live").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('releases') && !hideChannelReleases"
-              id="releasesTab"
-              class="tab"
-              role="tab"
-              :aria-selected="String(currentTab === 'releases')"
-              aria-controls="releasePanel"
-              :tabindex="currentTab === 'releases' ? 0 : -1"
-              :class="(currentTab==='releases')?'selectedTab':''"
-              @click="changeTab('releases')"
-              @keydown.left.right.enter.space="changeTab('releases', $event)"
-            >
-              {{ $t("Channel.Releases.Releases").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('podcasts') && !hideChannelPodcasts"
-              id="podcastsTab"
-              class="tab"
-              role="tab"
-              :aria-selected="String(currentTab === 'podcasts')"
-              aria-controls="podcastPanel"
-              :tabindex="currentTab === 'podcasts' ? 0 : -1"
-              :class="(currentTab==='podcasts')?'selectedTab':''"
-              @click="changeTab('podcasts')"
-              @keydown.left.right.enter.space="changeTab('podcasts', $event)"
-            >
-              {{ $t("Channel.Podcasts.Podcasts").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('playlists') && !hideChannelPlaylists"
-              id="playlistsTab"
-              class="tab"
-              role="tab"
-              :aria-selected="String(currentTab === 'playlists')"
-              aria-controls="playlistPanel"
-              :tabindex="currentTab === 'playlists' ? 0 : -1"
-              :class="(currentTab==='playlists')?'selectedTab':''"
-              @click="changeTab('playlists')"
-              @keydown.left.right.enter.space="changeTab('playlists', $event)"
-            >
-              {{ $t("Channel.Playlists.Playlists").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="tabInfoValues.includes('community') && !hideChannelCommunity"
-              id="communityTab"
-              class="tab"
-              role="tab"
-              :aria-selected="String(currentTab === 'community')"
-              aria-controls="communityPanel"
-              :tabindex="currentTab === 'community' ? 0 : -1"
-              :class="(currentTab==='community')?'selectedTab':''"
-              @click="changeTab('community')"
-              @keydown.left.right.enter.space="changeTab('community', $event)"
-            >
-              {{ $t("Global.Community").toUpperCase() }}
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              id="aboutTab"
-              class="tab"
-              role="tab"
-              :aria-selected="String(currentTab === 'about')"
-              aria-controls="aboutPanel"
-              :tabindex="currentTab === 'about' ? 0 : -1"
-              :class="(currentTab==='about')?'selectedTab':''"
-              @click="changeTab('about')"
-              @keydown.left.right.enter.space="changeTab('about', $event)"
-            >
-              {{ $t("Channel.About.About").toUpperCase() }}
-            </div>
-          </div>
-
-          <ft-input
-            v-if="showSearchBar"
-            ref="channelSearchBar"
-            :placeholder="$t('Channel.Search Channel')"
-            :show-clear-text-button="true"
-            class="channelSearch"
-            :maxlength="255"
-            @click="newSearch"
-          />
-        </ft-flex-box>
-      </div>
-    </ft-card>
+      @change-tab="changeTab"
+      @search="newSearch"
+    />
     <ft-card
       v-if="!isLoading && !errorMessage && (isFamilyFriendly || !showFamilyFriendlyOnly)"
       class="card"


### PR DESCRIPTION
# Move the channel details into their own component

## Pull Request Type

- [x] Refactor

## Related issue
https://github.com/orgs/FreeTubeApp/projects/4?pane=issue&itemId=68600889

## Description
This pull request moves the channel details section (header and tabs) into their own component, continuing the efforts to split the channel page up into multiple components.

As we'll hopefully be moving the Vue 3 soon, I decided to the use the `<script setup>` composition API style for this new component. That means inside that component we can already benefit from better auto-complete and once we upgrade to Vue 3 we'll also get better performance and bundle size improvements.

## Testing <!-- for code that is not small enough to be easily understandable -->
* Open various channels and make sure they are displayed correctly
* Open an invalid channel (e.g. copying the URL of a valid channel and removing a few characters from the ID) and make sure it appears correctly.
* Switch from one channel directly to another (e.g. by clicking another channel on the side bar while you are already viewing a different channel) and ensure that it updates correctly.
* Check that the `Hide Channel Subscribers` distraction free setting hides the subscriber count.
* Check that the `Hide Unsubscribe Button` parental control setting hides the subscribe/unsubscribe button.
* Check that the various channel tab hiding distraction free settings work.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0e72be464e76d5a0c64fbde98f133d2e7e8bb2fb