### PR TITLE
Update YouTube.js to 10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^10.1.0"
+    "youtubei.js": "^10.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9016,10 +9016,10 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-youtubei.js@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-10.1.0.tgz#38b3d95907441040df1e8031e04e0e6200ed52cf"
-  integrity sha512-MokZMAnpWH11VYvWuW6qjPiiPmgRl5rfDgPQOpif9qXcVHoVw1hi8ePuRSD0AZSZ+uvWGe8rvas2dzp+Jv5JKQ==
+youtubei.js@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-10.2.0.tgz#0f5fbacf3e64c965d6e7378c870a7329ceca7228"
+  integrity sha512-JLKW9AHQ1qrTwBbre1aDkH8UJFmNcc4+kOSaVou5jSY7AzfFPFJK0yvX6afnLst0UVC9wfXHrLiNx93sutVErA==
   dependencies:
     jintr "^2.0.0"
     tslib "^2.5.0"


### PR DESCRIPTION
Same as https://github.com/FreeTubeApp/FreeTube/pull/5465 but targetting the master branch so that we can do a hotfix release with it, please see that pull request for details.