### PR TITLE
Use streams from the iOS client to workaround playback issues

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -410,9 +410,24 @@ function runApp() {
       requestHeaders.Origin = 'https://www.youtube.com'
 
       if (url.startsWith('https://www.youtube.com/youtubei/')) {
-        requestHeaders['Sec-Fetch-Site'] = 'same-origin'
-        requestHeaders['Sec-Fetch-Mode'] = 'same-origin'
-        requestHeaders['X-Youtube-Bootstrap-Logged-In'] = 'false'
+        // Make iOS requests work and look more realistic
+        if (requestHeaders['x-youtube-client-name'] === '5') {
+          delete requestHeaders.Referer
+          delete requestHeaders.Origin
+          delete requestHeaders['Sec-Fetch-Site']
+          delete requestHeaders['Sec-Fetch-Mode']
+          delete requestHeaders['Sec-Fetch-Dest']
+          delete requestHeaders['sec-ch-ua']
+          delete requestHeaders['sec-ch-ua-mobile']
+          delete requestHeaders['sec-ch-ua-platform']
+
+          requestHeaders['User-Agent'] = requestHeaders['x-user-agent']
+          delete requestHeaders['x-user-agent']
+        } else {
+          requestHeaders['Sec-Fetch-Site'] = 'same-origin'
+          requestHeaders['Sec-Fetch-Mode'] = 'same-origin'
+          requestHeaders['X-Youtube-Bootstrap-Logged-In'] = 'false'
+        }
       } else {
         // YouTube doesn't send the Content-Type header for the media requests, so we shouldn't either
         delete requestHeaders['Content-Type']

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -308,7 +308,7 @@ export default defineComponent({
       }
 
       try {
-        let result = await getLocalVideoInfo(this.videoId)
+        const result = await getLocalVideoInfo(this.videoId)
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
 
@@ -328,31 +328,7 @@ export default defineComponent({
           return
         }
 
-        let playabilityStatus = result.playability_status
-        let bypassedResult = null
-        let streamingVideoId = this.videoId
-        let trailerIsNull = false
-
-        // if widevine support is added then we should check if playabilityStatus.status is UNPLAYABLE too
-        if (result.has_trailer) {
-          bypassedResult = result.getTrailerInfo()
-          /**
-           * @type {import ('youtubei.js').YTNodes.PlayerLegacyDesktopYpcTrailer}
-           */
-          const trailerScreen = result.playability_status.error_screen
-          streamingVideoId = trailerScreen.video_id
-          // if the trailer is null then it is likely age restricted.
-          trailerIsNull = bypassedResult == null
-          if (!trailerIsNull) {
-            playabilityStatus = bypassedResult.playability_status
-          }
-        }
-
-        if (playabilityStatus.status === 'LOGIN_REQUIRED' || trailerIsNull) {
-          // try to bypass the age restriction
-          bypassedResult = await getLocalVideoInfo(streamingVideoId, true)
-          playabilityStatus = bypassedResult.playability_status
-        }
+        const playabilityStatus = result.playability_status
 
         if (playabilityStatus.status === 'UNPLAYABLE') {
           /**
@@ -481,13 +457,6 @@ export default defineComponent({
         // are different (which is not detected here)
         this.commentsEnabled = result.comments_entry_point_header != null
         // endregion No comment detection
-
-        // the bypassed result is missing some of the info that we extract in the code above
-        // so we only overwrite the result here
-        // we need the bypassed result for the streaming data and the subtitles
-        if (bypassedResult) {
-          result = bypassedResult
-        }
 
         if ((this.isLive || this.isPostLiveDvr) && !this.isUpcoming) {
           try {


### PR DESCRIPTION
# Use streams from the iOS client to workaround playback issues

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #5453
closes #5370

## Description
As YouTube is currently introducing various changes to the WEB client, which cause the random 403s and the random `No valid URL to decipher` errors. This pull request aims to solve both of those issues, by using the DASH streams from the iOS client instead. Age-restricted videos are still expected to have the random 403s problem, as the client we use to bypass the forced login, has the same problems as the WEB client. I've had to add overrides in a few places to get it to actually work, such as the User-Agent, however those overrides should only affect iOS requests.

## Testing <!-- for code that is not small enough to be easily understandable -->
Please test this pull request thoroughly with various different videos (e.g. normal live streams, age-restricted, music).

Age-restricted videos are still expected to have the random 403s problem.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.2