### PR TITLE
Fix distraction settings and subscribe button CSS not being scoped

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -261,4 +261,4 @@
 </template>
 
 <script src="./distraction-settings.js" />
-<style src="./distraction-settings.css" />
+<style scoped src="./distraction-settings.css" />

--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.vue
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.vue
@@ -88,4 +88,4 @@
 </template>
 
 <script src="./ft-subscribe-button.js" />
-<style lang="scss" src="./ft-subscribe-button.scss" />
+<style scoped lang="scss" src="./ft-subscribe-button.scss" />


### PR DESCRIPTION
# Fix distraction settings and subscribe button CSS not being scoped

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
Fixes the `distraction-settings` and `ft-subscribe-button` components not scoping their CSS files. That helps avoid the CSS leaking beyond the component and breaking other components. Please note that scoped SCSS/descendent combinators don't play nicely with Vue's scoped CSS so will still leak into other components (which is why the channel details PR still uses `channelSearch` instead of `search` as the class name, because the top nav search bar CSS was offsetting the clear button).

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the subscribe button and the distraction free settings look correct.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.2