### PR TITLE
Small cleanup after the YouTube.js update

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -994,12 +994,6 @@ function runApp() {
     try {
       const contents = await asyncFs.readFile(filePath)
 
-      // Probably a corrupted/broken cache entry, pretend it's absent
-      // A valid entry should be a few KB large
-      if (contents.byteLength < 500) {
-        return undefined
-      }
-
       return contents.buffer
     } catch (e) {
       console.error(e)

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -94,12 +94,8 @@ async function createInnertube({ withPlayer = false, location = undefined, safet
         const client = bodyJson.context.client
 
         client.clientVersion = clientVersion
-        client.deviceMake = 'Apple'
         client.deviceModel = 'iPhone16,2' // iPhone 15 Pro Max
-        client.osName = 'iOS'
         client.osVersion = iosVersion
-        delete client.browserName
-        delete client.browserVersion
 
         init.body = JSON.stringify(bodyJson)
       }


### PR DESCRIPTION
# Small cleanup after the YouTube.js update

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Chore

## Description
* YouTube.js now sets more of the iOS request fields correctly, so we no longer have to do it ourselves, we of course still need to set the fields that we want to override ourselves. https://github.com/LuanRT/YouTube.js/pull/705
* YouTube.js now ignores cache entries created by older versions of the library and doesn't create broken cache entries anymore, so we no longer need our own check to avoid broken cache entries. https://github.com/LuanRT/YouTube.js/pull/702 and https://github.com/LuanRT/YouTube.js/commit/a89a5ac2ddd1391378af31dc82d00e3f511c66be

## Testing <!-- for code that is not small enough to be easily understandable -->
Open a video, if it works then these changes didn't break anything :).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.3