### PR TITLE
Various performance improvements to the store

### DIFF
--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -91,10 +91,10 @@ const actions = {
     commit('setProfileList', profiles)
   },
 
-  async batchUpdateSubscriptionDetails({ getters, dispatch }, channels) {
+  async batchUpdateSubscriptionDetails({ dispatch, state }, channels) {
     if (channels.length === 0) { return }
 
-    const profileList = getters.getProfileList
+    const profileList = state.profileList
 
     for (const profile of profileList) {
       const currentProfileCopy = deepCopy(profile)
@@ -128,9 +128,9 @@ const actions = {
     }
   },
 
-  async updateSubscriptionDetails({ getters, dispatch }, { channelThumbnailUrl, channelName, channelId }) {
+  async updateSubscriptionDetails({ dispatch, state }, { channelThumbnailUrl, channelName, channelId }) {
     const thumbnail = channelThumbnailUrl?.replace(/=s\d*/, '=s176') ?? null // change thumbnail size if different
-    const profileList = getters.getProfileList
+    const profileList = state.profileList
     for (const profile of profileList) {
       const currentProfileCopy = deepCopy(profile)
       const channel = currentProfileCopy.subscriptions.find((channel) => {

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -401,7 +401,7 @@ const actions = {
     commit('setShowProgressBar', value)
   },
 
-  async getRegionData ({ commit }, { locale }) {
+  async getRegionData ({ commit }, locale) {
     const localePathExists = process.env.GEOLOCATION_NAMES.includes(locale)
 
     const url = createWebURL(`/static/geolocations/${localePathExists ? locale : 'en-US'}.json`)


### PR DESCRIPTION
# Various performance improvements to the store

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Performance improvement

## Description
As my store typings pull request seems to not work for some people (some IDEs can't handle the complicated type gynastics that were required to get that pull request to work), I've decided to extract the performance improvements from that pull request into their own one and add a few other minor improvements to the mix. That way we get those improvements regardless of whether we ever merge the other pull request.

Here is the list of improvements:
* Pass the locale string to the `getRegionData` action directly instead of wrapping it in an object. Using an object is only necessary when an action takes multiple parameters.
* Access the state directly instead of going through the getters, in some of the places that we weren't already doing that.
* The list of settings that have side-effects never changes at runtime, so we have no reason to store it in the state and access it through a getter. We can just store it in a normal variable and access it directly to avoid the extra overhead.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that changing the locale still fetches the appropriate region translations.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.3