### PR TITLE
Add support for copying hashtag links

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -94,7 +94,7 @@ function runApp() {
           const path = urlParts[1]
 
           if (path) {
-            visible = ['/channel', '/watch'].some(p => path.startsWith(p)) ||
+            visible = ['/channel', '/watch', '/hashtag'].some(p => path.startsWith(p)) ||
               // Only show copy link entry for non user playlists
               (path.startsWith('/playlist') && !/playlistType=user/.test(path))
           }
@@ -131,6 +131,8 @@ function runApp() {
             return `${origin}/playlist?list=${id}`
           case 'channel':
             return `${origin}/channel/${id}`
+          case 'hashtag':
+            return `${origin}/hashtag/${id}`
           case 'watch': {
             let url
 


### PR DESCRIPTION
# Add support for copying hashtag links

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Description
When you right-click on an in-app video, playlist or channel link we display context menu entries to copy the YouTube or Invidious version of that link. At the moment those buttons aren't displayed for in-app hashtag links, which are added by this pull request.

## Screenshots <!-- If appropriate -->
Before:
![before](https://github.com/user-attachments/assets/873ef2ba-54a7-46c2-832b-9cf2e62799c8)

After:
![after](https://github.com/user-attachments/assets/b85c607e-9547-41ca-b3f3-0e6eab6aa1e7)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Search for a hashtag e.g `#asmr`
2. Right click on the hashtag icon or text
3. You should see two new context menu entries `Copy YouTube Link` and `Copy Invidious Link`
4. Test that they both work correctly (e.g. by pasting into a text editor after you've clicked it to check the URL)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.3