### PR TITLE
Update top nav to move query text to new window instead of remaining in old window

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -136,7 +136,7 @@ export default defineComponent({
     this.debounceSearchResults = debounce(this.getSearchSuggestions, 200)
   },
   methods: {
-    goToSearch: async function (query, { event }) {
+    goToSearch: async function (queryText, { event }) {
       const doCreateNewWindow = event && event.shiftKey
 
       if (window.innerWidth <= MOBILE_WIDTH_THRESHOLD) {
@@ -148,7 +148,7 @@ export default defineComponent({
 
       clearLocalSearchSuggestionsSession()
 
-      this.getYoutubeUrlInfo(query).then((result) => {
+      this.getYoutubeUrlInfo(queryText).then((result) => {
         switch (result.urlType) {
           case 'video': {
             const { videoId, timestamp, playlistId } = result
@@ -164,7 +164,8 @@ export default defineComponent({
             openInternalPath({
               path: `/watch/${videoId}`,
               query,
-              doCreateNewWindow
+              doCreateNewWindow,
+              searchQueryText: queryText,
             })
             break
           }
@@ -175,7 +176,8 @@ export default defineComponent({
             openInternalPath({
               path: `/playlist/${playlistId}`,
               query,
-              doCreateNewWindow
+              doCreateNewWindow,
+              searchQueryText: queryText,
             })
             break
           }
@@ -187,7 +189,7 @@ export default defineComponent({
               path: `/search/${encodeURIComponent(searchQuery)}`,
               query,
               doCreateNewWindow,
-              searchQueryText: searchQuery
+              searchQueryText: searchQuery,
             })
             break
           }
@@ -196,7 +198,8 @@ export default defineComponent({
             const { hashtag } = result
             openInternalPath({
               path: `/hashtag/${encodeURIComponent(hashtag)}`,
-              doCreateNewWindow
+              doCreateNewWindow,
+              searchQueryText: `#${hashtag}`,
             })
 
             break
@@ -209,8 +212,9 @@ export default defineComponent({
               path: `/channel/${channelId}/${subPath}`,
               doCreateNewWindow,
               query: {
-                url
-              }
+                url,
+              },
+              searchQueryText: queryText,
             })
             break
           }
@@ -218,7 +222,7 @@ export default defineComponent({
           case 'invalid_url':
           default: {
             openInternalPath({
-              path: `/search/${encodeURIComponent(query)}`,
+              path: `/search/${encodeURIComponent(queryText)}`,
               query: {
                 sortBy: this.searchSettings.sortBy,
                 time: this.searchSettings.time,
@@ -227,9 +231,14 @@ export default defineComponent({
                 features: this.searchSettings.features,
               },
               doCreateNewWindow,
-              searchQueryText: query
+              searchQueryText: queryText,
             })
           }
+        }
+
+        if (doCreateNewWindow) {
+          // Query text copied to new window = can be removed from current window
+          this.updateSearchInputText('')
         }
       })
     },


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When entering text into top nav and opening a new window via shift click/enter
It's weird to me that the query text stayed on the old window instead of inside the top nav of the new window

This PR makes FT "moves" the query text to the new window (only if new window created) and for hashtag I use `#hashtag` due to how `case 'search'` works (can be changed back to query text which can be URL let me know)

## Screenshots <!-- If appropriate -->

https://github.com/user-attachments/assets/58ab0de9-3b72-44e9-8086-91eb42924003

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Enter different kinds of text (URLs, hash tags...) into top-nav
- Shift click/enter to open new window
- Ensure text on new window top-nav and not on old window one

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
