### PR TITLE
Properly handle Arabic hashtags

### DIFF
--- a/src/renderer/views/Hashtag/Hashtag.js
+++ b/src/renderer/views/Hashtag/Hashtag.js
@@ -63,7 +63,7 @@ export default defineComponent({
     },
 
     getHashtag: async function() {
-      const hashtag = this.$route.params.hashtag
+      const hashtag = decodeURIComponent(this.$route.params.hashtag)
       if (this.backendFallback || this.backendPreference === 'local') {
         await this.getLocalHashtag(hashtag)
       } else {


### PR DESCRIPTION
# Properly handle arabic hashtags

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #5544

## Description
Arabic hashtags are URL encoded, currently we don't handle that on the hashtag page, this pull request fixes that by passing the hashtag path parameter through `decodeURIComponent` before we use it.

## Screenshots <!-- If appropriate -->
See the screenshot in the linked issue

## Testing <!-- for code that is not small enough to be easily understandable -->
Click the Arabic hashtag at the bottom of this video description https://youtu.be/woVO0up0Vj4 it should open normally.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.21.3