### PR TITLE
Add a GPU Internals entry to the View menu

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1513,6 +1513,16 @@ function runApp() {
               }
             }
           },
+          {
+            label: 'GPU Internals (chrome://gpu)',
+            click() {
+              const gpuWindow = new BrowserWindow({
+                show: true,
+                autoHideMenuBar: true
+              })
+              gpuWindow.loadURL('chrome://gpu')
+            }
+          },
           { type: 'separator' },
           { role: 'resetzoom' },
           { role: 'resetzoom', accelerator: 'CmdOrCtrl+num0', visible: false },


### PR DESCRIPTION
# Add a GPU Internals entry to the View menu

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
https://github.com/FreeTubeApp/FreeTube/issues/5397#issuecomment-2266713946

## Description
As Linux users are having lots of graphical issues and hardware acceleration problems, people have been asking how to access the chrome://gpu page, my original suggestion was to paste a code snippet into the devtools (see link above), which is okay for one time use. However due to the many problems Linux users seem to be having, that debug page is likely going to see more usage in the future. This pull request makes it a lot easier to access that page by adding an entry to under the View menu in the app menu, which opens a new window to that page.

## Screenshots <!-- If appropriate -->
![view-menu-with-GPU-internals-entry](https://github.com/user-attachments/assets/7a64e4be-7caa-4769-af18-4dbc07489496)

## Testing <!-- for code that is not small enough to be easily understandable -->
Activate the View -> GPU Internals (chrome://gpu) menu item and make sure it opens a new window with the GPU internals page.