### PR TITLE
Use randomArrayItem helper in more places to reduce duplicate code

### DIFF
--- a/src/renderer/components/ft-age-restricted/ft-age-restricted.js
+++ b/src/renderer/components/ft-age-restricted/ft-age-restricted.js
@@ -1,4 +1,5 @@
 import { defineComponent } from 'vue'
+import { randomArrayItem } from '../../helpers/utils'
 
 export default defineComponent({
   name: 'FtAgeRestricted',
@@ -14,8 +15,7 @@ export default defineComponent({
   },
   computed: {
     emoji: function () {
-      const emojis = ['😵', '😦', '🙁', '☹️', '😦', '🤫', '😕']
-      return emojis[Math.floor(Math.random() * emojis.length)]
+      return randomArrayItem(['😵', '😦', '🙁', '☹️', '😦', '🤫', '😕'])
     },
 
     restrictedMessage: function () {

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -9,7 +9,7 @@ import FtButton from '../ft-button/ft-button.vue'
 
 import debounce from 'lodash.debounce'
 import allLocales from '../../../../static/locales/activeLocales.json'
-import { showToast } from '../../helpers/utils'
+import { randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 
 export default defineComponent({
@@ -214,8 +214,7 @@ export default defineComponent({
       // synchronous), unfortunately, we have to copy/paste the logic
       // from the `setRandomCurrentInvidiousInstance` action onto here
       const instanceList = this.invidiousInstancesList
-      const randomIndex = Math.floor(Math.random() * instanceList.length)
-      this.setCurrentInvidiousInstance(instanceList[randomIndex])
+      this.setCurrentInvidiousInstance(randomArrayItem(instanceList))
     }
   },
   methods: {

--- a/src/renderer/store/modules/invidious.js
+++ b/src/renderer/store/modules/invidious.js
@@ -1,4 +1,4 @@
-import { createWebURL, fetchWithTimeout } from '../../helpers/utils'
+import { createWebURL, fetchWithTimeout, randomArrayItem } from '../../helpers/utils'
 
 const state = {
   currentInvidiousInstance: '',
@@ -60,8 +60,7 @@ const actions = {
 
   setRandomCurrentInvidiousInstance({ commit, state }) {
     const instanceList = state.invidiousInstancesList
-    const randomIndex = Math.floor(Math.random() * instanceList.length)
-    commit('setCurrentInvidiousInstance', instanceList[randomIndex])
+    commit('setCurrentInvidiousInstance', randomArrayItem(instanceList))
   }
 }
 


### PR DESCRIPTION
# Use randomArrayItem helper in more places to reduce duplicate code

## Pull Request Type

- [x] Refactoring

## Description
The `randomArrayItem` helper was introduced in the iOS streams pull request. Unfortunately I forgot to change all places that use a random array item to use that new function, this pull request corrects that.

## Testing <!-- for code that is not small enough to be easily understandable -->
These changes are probably simple enough that you can guage from the code alone whether it will work or not but if you do want to test it here are the steps:
1. Turn on the Show Family-Friendly Only setting and open an age-restricted video
2. Empty the current Invidious instance text box, wait a moment (the saving is debounced), click away from the settings page and then go back, it should have picked a random instance.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 7a1217e4d456845bf97795067b379ee5afd76e5b