### PR TITLE
Specify locale for strings that may differ from the chosen display locale

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -23,6 +23,7 @@
     >
       <span
         class="changeLogText"
+        lang="en"
         v-html="updateChangelog"
       />
       <ft-flex-box>

--- a/src/renderer/components/ft-select/ft-select.js
+++ b/src/renderer/components/ft-select/ft-select.js
@@ -47,6 +47,10 @@ export default defineComponent({
     iconColor: {
       type: String,
       default: null
+    },
+    isLocaleSelector: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['change'],

--- a/src/renderer/components/ft-select/ft-select.vue
+++ b/src/renderer/components/ft-select/ft-select.vue
@@ -15,6 +15,7 @@
         v-for="(name, index) in selectNames"
         :key="index"
         :value="selectValues[index]"
+        :lang="isLocaleSelector && selectValues[index] !== 'system' ? selectValues[index].replace('_', '-') : null"
       >
         {{ name }}
       </option>

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -81,6 +81,7 @@
         :select-names="localeNames"
         :select-values="localeOptions"
         :icon="['fas', 'language']"
+        is-locale-selector
         @change="updateCurrentLocale"
       />
       <ft-select

--- a/src/renderer/views/About/About.js
+++ b/src/renderer/views/About/About.js
@@ -21,7 +21,7 @@ export default defineComponent({
         {
           icon: ['fab', 'github'],
           title: this.$t('About.Source code'),
-          content: `<a href="https://github.com/FreeTubeApp/FreeTube">GitHub: FreeTubeApp/FreeTube</a><br>${this.$t('About.Licensed under the')} <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">${this.$t('About.AGPLv3')}</a>`
+          content: `<a href="https://github.com/FreeTubeApp/FreeTube" lang="en">GitHub: FreeTubeApp/FreeTube</a><br>${this.$t('About.Licensed under the')} <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">${this.$t('About.AGPLv3')}</a>`
         },
         {
           icon: ['fas', 'file-download'],


### PR DESCRIPTION
# Specify locale for strings that may differ from the chosen display locale

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation

## Description
The [MDN page for the HTML `lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#accessibility_concerns), mentions that the Web Content Accessibility Guidelines require the page language to be specified and also that parts of the page in other languages require their language to be specified too, so that screenreaders can correctly pronounce and translate the text. FreeTube already fullfills the first part, as we set the `lang` attribute on the HTML element, however we don't currently fullfill the latter part.

This pull request adds the `lang` attribute where we know that the language of the text may differ from the user's chosen locale preference and we know the language of the text e.g. locale preference selector (the locale names are in their own language), changelog (always in English). It does not add it in places where it may differ but we don't know the language of the text such as any text received from YouTube e.g. video titles, descriptions, channel names, comments etc, for those we just have to hope that the user is watching content in the same language as their locale preference.

I decided to test the before and after with the Narrator built into Windows 10 with both the narrator and FreeTube set to English and was surprised at the results. Before these changes, for languages with non-Latin characters in their names such as Arabic and Bulgarian, it just annouced their position in the select box (x out of total), so you have no idea what you are currently focused on, whereas afterwards it announced the position and the English translation of the language name.

## Screenshots <!-- If appropriate -->
![locale preference selector html with lang attributes](https://github.com/user-attachments/assets/c55f198e-a06b-4b13-91b6-8d572d608804)

## Testing <!-- for code that is not small enough to be easily understandable -->
### Quick and easy:
With the dev tools check that the `<option>` tags in the local preference select box have appropriate `lang` attributes.

### Getting your hands dirty
Use a screen reader of your choice (e.g. built-in Narrator on Windows or VoiceOver on macOS) and see how it handles the newly added `lang` attributes.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 492f2245d16d7d6a5d0da4a088095c3be39e5dd8