### PR TITLE
Cleanup the Hide Profile Pictures in Comments code

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.vue
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.vue
@@ -64,20 +64,18 @@
           tabindex="-1"
         >
           <!-- Hide comment photo only if it isn't the video uploader -->
-          <template v-if="hideCommentPhotos && !comment.isOwner">
-            <div
-              class="commentThumbnailHidden"
-            >
-              {{ comment.author.substr(1, 1) }}
-            </div>
-          </template>
-          <template v-else>
-            <img
-              :src="comment.authorThumb"
-              alt=""
-              class="commentThumbnail"
-            >
-          </template>
+          <div
+            v-if="hideCommentPhotos && !comment.isOwner"
+            class="commentThumbnailHidden"
+          >
+            {{ comment.author.substring(1, 2) }}
+          </div>
+          <img
+            v-else
+            :src="comment.authorThumb"
+            alt=""
+            class="commentThumbnail"
+          >
         </router-link>
         <p
           v-if="comment.isPinned"
@@ -186,20 +184,18 @@
               tabindex="-1"
             >
               <!-- Hide comment photo only if it isn't the video uploader -->
-              <template v-if="hideCommentPhotos && !reply.isOwner">
-                <div
-                  class="commentThumbnailHidden"
-                >
-                  {{ reply.author.substr(1, 1) }}
-                </div>
-              </template>
-              <template v-else>
-                <img
-                  :src="reply.authorThumb"
-                  alt=""
-                  class="commentThumbnail"
-                >
-              </template>
+              <div
+                v-if="hideCommentPhotos && !reply.isOwner"
+                class="commentThumbnailHidden"
+              >
+                {{ reply.author.substring(1, 2) }}
+              </div>
+              <img
+                v-else
+                :src="reply.authorThumb"
+                alt=""
+                class="commentThumbnail"
+              >
             </router-link>
             <p class="commentAuthorWrapper">
               <router-link


### PR DESCRIPTION
# Cleanup the Hide Profile Pictures in Comments code

## Pull Request Type

- [x] Refactoring

## Description
This pull request cleans up the `Hide Profile Pictures in Comments` with the following changes:
- `String#substr` has been deprecated for a long time, so replace it with `String#substring` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)
- As the template tags that are used for the `v-if` and `v-else` only have one child each, I removed the templated tags and added the `v-if` and `v-else` to the former child elements directly.

## Testing <!-- for code that is not small enough to be easily understandable -->
Check that the `Hide Profile Pictures in Comments` distraction free setting still works.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 492f2245d16d7d6a5d0da4a088095c3be39e5dd8