### PR TITLE
Switch to non-deprecated Electron navigation history APIs

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1595,7 +1595,7 @@ function runApp() {
             click: (_menuItem, browserWindow, _event) => {
               if (browserWindow == null) { return }
 
-              browserWindow.webContents.goBack()
+              browserWindow.webContents.navigationHistory.goBack()
             },
             type: 'normal',
           },
@@ -1605,7 +1605,7 @@ function runApp() {
             click: (_menuItem, browserWindow, _event) => {
               if (browserWindow == null) { return }
 
-              browserWindow.webContents.goForward()
+              browserWindow.webContents.navigationHistory.goForward()
             },
             type: 'normal',
           },


### PR DESCRIPTION
# Switch to non-deprecated Electron navigation history APIs

## Pull Request Type

- [x] Refactoring

## Related issue
- https://github.com/FreeTubeApp/FreeTube/pull/5613
- https://github.com/electron/electron/blob/main/docs/breaking-changes.md#deprecated-clearhistory-cangoback-goback-cangoforward-goforward-gotoindex-cangotooffset-gotooffset-on-webcontents

## Description
Electron 32 deprecated the `webContents#goForward()` and `webContents#goBack()` methods in favour of the new `webContents#navigationHistory#goForward()` and `webContents#navigationHistory#goForward()` methods. As far as I can tell from looking at the relevant pull requests on their side nothing changed functionally, they just got moved so that the interface is more intuitive.

## Testing <!-- for code that is not small enough to be easily understandable -->
As mentioned above nothing functionally has changed, but you can test this pull request by testing the `Back` and `Forward` entries in the `View` menu of the app menu.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 492f2245d16d7d6a5d0da4a088095c3be39e5dd8