### PR TITLE
Fix "app start in fullscreen"

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -42,7 +42,7 @@ class Settings {
   }
 
   static _updateBounds(value) {
-    return db.settings.updateAsync({ _id: 'bounds' }, { _id: 'bounds', value }, { upsert: true })
+    return {}
   }
   // ******************** //
 }


### PR DESCRIPTION
This fixes #3220 but breaks window position memory.

I don't need the app to remember the window position, since I use a tiling window manager.

A more realistic fix:

Probably don't need to save `{fullscreen: true, maximized: true}` inside `value`