### PR TITLE
Lowercase hls manifest type to match the parser name shaka player registers

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -38,7 +38,7 @@ import {
 } from '../../helpers/api/invidious'
 
 const MANIFEST_TYPE_DASH = 'application/dash+xml'
-const MANIFEST_TYPE_HLS = 'application/x-mpegURL'
+const MANIFEST_TYPE_HLS = 'application/x-mpegurl'
 
 export default defineComponent({
   name: 'Watch',


### PR DESCRIPTION
# Lowercase hls manifest type to match the parser name shaka player registers

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The hls manifest type does not match what is registered in shaka.
https://github.com/shaka-project/shaka-player/blob/v4.10.12/lib/hls/hls_parser.js#L5031-L5032


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Ensure live streams still work

## Additional context
<!-- Add any other context about the pull request here. -->

<details><summary>I ran into this issue when testing shaka in android webview. I don't believe this typically crops up in electron.</summary>

https://github.com/shaka-project/shaka-player/blob/0a67e774a2533c45d49cea9092638a9ddc0a63b2/lib/player.js#L2262-L2276

The problematic function call (`shaka.media.ManifestParser.isSupported(mimeType)`) doesn't seem to occur in electron because `video.canPlay("application/x-mpegURL")` returns `""`, so it just automatically returns instead of checking if the type is supported.
   </details>