### PR TITLE
Proxy live streams when "Proxy Videos Through Invidious" is enabled

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -496,7 +496,16 @@ export default defineComponent({
             //   this.manifestSrc = src
             //   this.manifestMimeType = MANIFEST_TYPE_DASH
             // } else {
-            this.manifestSrc = result.streaming_data.hls_manifest_url
+            let hlsManifestUrl = result.streaming_data.hls_manifest_url
+
+            if (this.proxyVideos) {
+              const url = new URL(hlsManifestUrl)
+              url.searchParams.set('local', 'true')
+
+              hlsManifestUrl = url.toString().replace(url.origin, this.currentInvidiousInstanceUrl)
+            }
+
+            this.manifestSrc = hlsManifestUrl
             this.manifestMimeType = MANIFEST_TYPE_HLS
             // }
           }
@@ -811,7 +820,16 @@ export default defineComponent({
             // // Proxying doesn't work for live or post live DVR DASH, so use HLS instead
             // // https://github.com/iv-org/invidious/pull/4589
             // if (this.proxyVideos) {
-            this.manifestSrc = result.hlsUrl
+
+            let hlsManifestUrl = result.hlsUrl
+
+            if (this.proxyVideos) {
+              const url = new URL(hlsManifestUrl)
+              url.searchParams.set('local', 'true')
+              hlsManifestUrl = url.toString()
+            }
+
+            this.manifestSrc = hlsManifestUrl
             this.manifestMimeType = MANIFEST_TYPE_HLS
 
             // The HLS manifests only contain combined audio+video streams, so we can't do audio only


### PR DESCRIPTION
# Proxy live streams when "Proxy Videos Through Invidious" is enabled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [x] Feature Implementation

## Description
Currently FreeTube doesn't proxy live streams through Invidious, this pull request adds support for that. As you can tell from the code it requires some hackiness to get it to work:
1. Invidious swaps out the path parameters for query parameters, which means the URL no longer looks like a file path with a file extension, so shaka-player isn't able to guess the mime type based on the file extension, it does then try to do a HEAD request to check the `Content-Type` header but that's `application/octet-stream`, so also not useful.
2. Then I came up with a fix that worked with Invidious instances that use the built-in video proxy in Invidious but broke with ones using the Piped video proxy
3. The fix to get it working on the Piped video proxy broke with Invidious' own video proxy again
4. Finally I found something that worked with both video proxies and allowed shaka-player to actually play it

The code has various comments that explain what each bit does, so hopefully we'll all know what it does and why it is there in the future.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Turn on the "Proxy Videos Through Invidious" setting
6. Watch live videos e.g. https://youtu.be/jfKfPfyJRdk with both the local and the Invidious API
7. Check the `Network` tab of the devtools that the `index.m3u8` and `seg.ts` requests are going to your currently selected Invidious instance.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 45c8cafa5b23b9d4564e4a4872c77a934b5eb50b