### PR TITLE
Fix playback of VOD/non-live videos with Invidious

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1383,7 +1383,7 @@ export default defineComponent({
           if (localFormat.has_audio) {
             audioFormats.push(localFormat)
 
-            if (localFormat.is_dubbed || localFormat.is_descriptive || localFormat.is_drc || localFormat.is_secondary) {
+            if (localFormat.is_dubbed || localFormat.is_descriptive || localFormat.is_secondary) {
               hasMultipleAudioTracks = true
             }
           }


### PR DESCRIPTION
# Fix playback of VOD/non-live videos with Invidious

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5649#issuecomment-2330376785

## Description
Fixes the playback of videos with the Invidious API. See linked comment for the error message in question (caused by it trying to translate a language of `null`).

## Testing <!-- for code that is not small enough to be easily understandable -->
Play videos that only have one video track and that aren't live, live videos and videos with multiple audio tracks were not affected.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 