### PR TITLE
Update ft-list-video.scss

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.scss
+++ b/src/renderer/components/ft-list-video/ft-list-video.scss
@@ -6,7 +6,7 @@
 
 .thumbnailImage {
   // Makes img element sized correctly before image loading starts
-  aspect-ratio: 16/9 auto;
+  aspect-ratio: auto;
 }
 
 .videoTagLine {


### PR DESCRIPTION
# Fixed DeArrow thumbnails for Shorts

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #5568

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The fix removes the preloaded 16 by 9 aspect ratio for thumbnails so that YouTube Shorts DeArrow thumbnails display in their intended aspect ratios.

## Additional context
<!-- Add any other context about the pull request here. -->
I have not tested it, because I don't know how.