### PR TITLE
Fix saving Invidious thumbnail URLs for subscriptions

### DIFF
--- a/src/renderer/components/subscriptions-community/subscriptions-community.js
+++ b/src/renderer/components/subscriptions-community/subscriptions-community.js
@@ -164,12 +164,8 @@ export default defineComponent({
             let thumbnailUrl = post.authorThumbnails?.[0]?.url
 
             if (name || thumbnailUrl) {
-              if (thumbnailUrl) {
-                if (thumbnailUrl.startsWith('//')) {
-                  thumbnailUrl = 'https:' + thumbnailUrl
-                } else if (thumbnailUrl.startsWith(`${this.currentInvidiousInstanceUrl}/ggpht`)) {
-                  thumbnailUrl = thumbnailUrl.replace(`${this.currentInvidiousInstanceUrl}/ggpht`, 'https://yt3.googleusercontent.com')
-                }
+              if (thumbnailUrl?.startsWith('//')) {
+                thumbnailUrl = 'https:' + thumbnailUrl
               }
 
               subscriptionUpdates.push({

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -113,7 +113,11 @@ const actions = {
         }
 
         if (channelThumbnailUrl) {
-          const thumbnail = channelThumbnailUrl.replace(/=s\d*/, '=s176') // change thumbnail size if different
+          const thumbnail = channelThumbnailUrl
+            // change thumbnail size if different
+            .replace(/=s\d*/, '=s176')
+            // If this is an Invidious URL, convert it to a YouTube one
+            .replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com')
 
           if (channel.thumbnail !== thumbnail) {
             channel.thumbnail = thumbnail
@@ -129,7 +133,12 @@ const actions = {
   },
 
   async updateSubscriptionDetails({ dispatch, state }, { channelThumbnailUrl, channelName, channelId }) {
-    const thumbnail = channelThumbnailUrl?.replace(/=s\d*/, '=s176') ?? null // change thumbnail size if different
+    const thumbnail = channelThumbnailUrl
+      // change thumbnail size if different
+      ?.replace(/=s\d*/, '=s176')
+      // If this is an Invidious URL, convert it to a YouTube one
+      .replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com') ??
+      null
     const profileList = state.profileList
     for (const profile of profileList) {
       const currentProfileCopy = deepCopy(profile)
@@ -173,6 +182,11 @@ const actions = {
   },
 
   async addChannelToProfiles({ commit }, { channel, profileIds }) {
+    // If this is an Invidious URL, convert it to a YouTube one
+    if (!channel.thumbnail.startsWith('https://yt3.googleusercontent.com/')) {
+      channel.thumbnail = channel.thumbnail.replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com')
+    }
+
     try {
       await DBProfileHandlers.addChannelToProfiles(channel, profileIds)
       commit('addChannelToProfiles', { channel, profileIds })


### PR DESCRIPTION
# Fix saving Invidious thumbnail URLs for subscriptions

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
Maybe https://github.com/FreeTubeApp/FreeTube/issues/5601 but the user is talking about the playlists database, but that doesn't save any thumbnail URLs.

## Description
When you subscribe to a channel from the channel page with the Invidious API selected we currently save the Invidious thumbnail URL for that channel. This pull request fixes that so that we always save the YouTube URL.

**Why is it problematic if we save the Invidious URL?** It means we will always fetched the thumbnail from that channel regardless of which Invidious instance the user currently has selected or even when they switch to the local API. It could also result in the thumbnail not showing up at all if the Invidious instance in question goes down.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Set the Invidious API as your preferred API backend
2. Visit a channel of your choice
3. Subscribe to it on the subscriptions page
4. Close FreeTube
5. Check the profiles.db file and make sure that the thumbnail URL points to `yt3.googleusercontent.com` instead of the Invidious instance you were using.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 41fe47877a50ccd73f289aef92b048236f4aba44