### PR TITLE
Cleanup a few vue-i18n usages

### DIFF
--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -104,7 +104,7 @@ export function translateSponsorBlockCategory(category) {
     case 'outro':
       return i18n.t('Video.Sponsor Block category.outro')
     case 'recap':
-      return this.$t('Video.Sponsor Block category.recap')
+      return i18n.t('Video.Sponsor Block category.recap')
     case 'selfpromo':
       return i18n.t('Video.Sponsor Block category.self-promotion')
     case 'interaction':

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -328,7 +328,7 @@ export default defineComponent({
 
       if (this.id === '@@@') {
         this.showShareMenu = false
-        this.setErrorMessage(this.$i18n.t('Channel.This channel does not exist'))
+        this.setErrorMessage(this.$t('Channel.This channel does not exist'))
         return
       }
 
@@ -427,7 +427,7 @@ export default defineComponent({
 
     if (this.id === '@@@') {
       this.showShareMenu = false
-      this.setErrorMessage(this.$i18n.t('Channel.This channel does not exist'))
+      this.setErrorMessage(this.$t('Channel.This channel does not exist'))
       return
     }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1497,7 +1497,7 @@ export default defineComponent({
       let translationName, translationCode
       // otherwise just fallback to the FreeTube display language and hope that YouTube will be able to handle it
       if (!translationLanguage) {
-        translationName = this.$i18n.t('Locale Name')
+        translationName = this.$t('Locale Name')
         translationCode = userLanguages.values().next()
       } else {
         translationName = translationLanguage.language_name.text


### PR DESCRIPTION
# Cleanup a few vue-i18n usages

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Refactoring

## Description
* Replace `this.$i18n.t()` with `this.$t()` as the former doesn't seem to work properly in Vue 3.
* Fix the SponsorBlock recap translation code not working as it was using `this.$t()` instead of `i18n.t()` outside of a Vue component.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 41fe47877a50ccd73f289aef92b048236f4aba44