### PR TITLE
Fix: Video description collapsible and no longer hijacks page scroll

### DIFF
--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -9,3 +9,18 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+
+.getDescriptionTitle {
+  margin: 0;
+  padding-block: 8px;
+  text-align: center;
+  text-decoration: underline;
+  cursor: pointer;
+  color: var(--title-color);
+}
+
+.short {
+  block-size: 230px;
+  overflow: hidden;
+  mask-image: linear-gradient(180deg, rgb(2 0 36 / 100%) 80%, rgb(255 255 255 / 0%) 100%);
+}

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -4,6 +4,7 @@
     class="videoDescription"
   >
     <FtTimestampCatcher
+      ref="descriptionContainer"
       :class="{ description: true, short: !showFullDescription }"
       :input-html="shownDescription"
       @timestamp-event="onTimestamp"
@@ -25,7 +26,7 @@
 <script setup>
 import autolinker from 'autolinker'
 
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtTimestampCatcher from '../ft-timestamp-catcher/ft-timestamp-catcher.vue'
 
@@ -43,7 +44,8 @@ const props = defineProps({
 const emit = defineEmits(['timestamp-event'])
 
 let shownDescription = ''
-const showFullDescription = ref(false)
+const descriptionContainer = ref()
+const showFullDescription = ref(true)
 
 if (props.descriptionHtml !== '') {
   const parsed = parseDescriptionHtml(props.descriptionHtml)
@@ -77,6 +79,23 @@ function onTimestamp(timestamp) {
 function expandDescription() {
   showFullDescription.value = true
 }
+
+/**
+ * Returns true when description content does not overflow description container
+ * Useful for hiding the 'Click to View Description' button for short descriptions
+ */
+function isShortDescription() {
+  const videoDescriptionMaxHeight = 300
+  const computedDescriptionHeight = descriptionContainer.value.$el.getBoundingClientRect().height
+  return computedDescriptionHeight < videoDescriptionMaxHeight
+}
+
+onMounted(() => {
+  // To verify whether or not the description is too short for the
+  // 'Click to View Description' button, we need to check the description's
+  // computed CSS height. The only way to make this work is to check on mount.
+  showFullDescription.value = isShortDescription()
+})
 
 /**
  * @param {string} descriptionText

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -4,16 +4,28 @@
     class="videoDescription"
   >
     <FtTimestampCatcher
-      class="description"
+      :class="{ description: true, short: !showFullDescription }"
       :input-html="shownDescription"
       @timestamp-event="onTimestamp"
     />
+    <h4
+      v-if="!showFullDescription"
+      class="getDescriptionTitle"
+      role="button"
+      tabindex="0"
+      @click="expandDescription"
+      @keydown.space.prevent="expandDescription"
+      @keydown.enter.prevent="expandDescription"
+    >
+      {{ $t("Description.Click to View Description") }}
+    </h4>
   </FtCard>
 </template>
 
 <script setup>
 import autolinker from 'autolinker'
 
+import { ref } from 'vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtTimestampCatcher from '../ft-timestamp-catcher/ft-timestamp-catcher.vue'
 
@@ -31,6 +43,7 @@ const props = defineProps({
 const emit = defineEmits(['timestamp-event'])
 
 let shownDescription = ''
+const showFullDescription = ref(false)
 
 if (props.descriptionHtml !== '') {
   const parsed = parseDescriptionHtml(props.descriptionHtml)
@@ -56,6 +69,13 @@ if (props.descriptionHtml !== '') {
  */
 function onTimestamp(timestamp) {
   emit('timestamp-event', timestamp)
+}
+
+/**
+ * Enables user to scroll entire contents of description
+ */
+function expandDescription() {
+  showFullDescription.value = true
 }
 
 /**

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -995,6 +995,8 @@ Comments:
   Subscribed: Subscribed
   Hearted: Hearted
 Up Next: Up Next
+Description:
+  Click to View Description: Click to View Description
 
 #Tooltips
 Tooltips:

--- a/static/locales/en_GB.yaml
+++ b/static/locales/en_GB.yaml
@@ -1059,6 +1059,8 @@ Comments:
   View {replyCount} replies: View {replyCount} replies
   Subscribed: Subscribed
 Up Next: 'Up Next'
+Description:
+  Click to View Description: Click to View Description
 
 # Toast Messages
 Local API Error (Click to copy): 'Local API Error (Click to copy)'


### PR DESCRIPTION
# Fix: Video description collapsible and no longer hijacks page scroll

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #4821 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Long video descriptions will now have their overflow hidden to prevent hijacking the scroll of the page. To see the full description and reintroduce the scrollbar, the user must click 'Click to View Description' shown at the bottom of the description. The 'Click to View Description' button is only shown for descriptions with a computed CSS height greater than or equal to 300 pixels.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
CURRENT:
![image](https://github.com/user-attachments/assets/6df0026b-ec17-4b92-ae6a-5646af9a2c00)

CHANGE (Description not expanded):
![image](https://github.com/user-attachments/assets/c8ee6fa5-233f-470c-8f68-a35b55ef2509)

CHANGE (Description expanded):
![image](https://github.com/user-attachments/assets/2b8d9890-6d4d-44b8-a9df-20f38dbdc58c)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
I tested this change on a video with a long description (description exceeds CSS height of 300px) and a video with a short description. I verified: 
- Clicking 'Click to View Description' makes the description scrollable and that the button removes itself.
- Short descriptions do not show the 'Click to View Description' button.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10
- **OS Version:** 22H2, Build 19045.4842
- **FreeTube version:** v0.21.3 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
