### PR TITLE
Improve history import performance and fix some bugs

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -51,6 +51,7 @@ const DBActions = {
   },
 
   HISTORY: {
+    OVERWRITE: 'db-action-history-overwrite',
     UPDATE_WATCH_PROGRESS: 'db-action-history-update-watch-progress',
     UPDATE_PLAYLIST: 'db-action-history-update-playlist',
   },
@@ -78,6 +79,7 @@ const SyncEvents = {
   },
 
   HISTORY: {
+    OVERWRITE: 'sync-history-overwrite',
     UPDATE_WATCH_PROGRESS: 'sync-history-update-watch-progress',
     UPDATE_PLAYLIST: 'sync-history-update-playlist',
   },

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -56,6 +56,12 @@ class History {
     return db.history.updateAsync({ videoId: record.videoId }, record, { upsert: true })
   }
 
+  static async overwrite(records) {
+    await db.history.removeAsync({}, { multi: true })
+
+    await db.history.insertAsync(records)
+  }
+
   static updateWatchProgress(videoId, watchProgress) {
     return db.history.updateAsync({ videoId }, { $set: { watchProgress } }, { upsert: true })
   }

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -32,6 +32,13 @@ class History {
     )
   }
 
+  static overwrite(records) {
+    return ipcRenderer.invoke(
+      IpcChannels.DB_HISTORY,
+      { action: DBActions.HISTORY.OVERWRITE, data: records }
+    )
+  }
+
   static updateWatchProgress(videoId, watchProgress) {
     return ipcRenderer.invoke(
       IpcChannels.DB_HISTORY,

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -29,6 +29,10 @@ class History {
     return baseHandlers.history.upsert(record)
   }
 
+  static overwrite(records) {
+    return baseHandlers.history.overwrite(records)
+  }
+
   static updateWatchProgress(videoId, watchProgress) {
     return baseHandlers.history.updateWatchProgress(videoId, watchProgress)
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1075,6 +1075,15 @@ function runApp() {
           )
           return null
 
+        case DBActions.HISTORY.OVERWRITE:
+          await baseHandlers.history.overwrite(data)
+          syncOtherWindows(
+            IpcChannels.SYNC_HISTORY,
+            event,
+            { event: SyncEvents.HISTORY.OVERWRITE, data }
+          )
+          return null
+
         case DBActions.HISTORY.UPDATE_WATCH_PROGRESS:
           await baseHandlers.history.updateWatchProgress(data.videoId, data.watchProgress)
           syncOtherWindows(

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -50,6 +50,9 @@ export default defineComponent({
     allPlaylists: function () {
       return this.$store.getters.getAllPlaylists
     },
+    historyCacheById: function () {
+      return this.$store.getters.getHistoryCacheById
+    },
     historyCacheSorted: function () {
       return this.$store.getters.getHistoryCacheSorted
     },
@@ -616,7 +619,7 @@ export default defineComponent({
       })
     },
 
-    importFreeTubeHistory(textDecode) {
+    async importFreeTubeHistory(textDecode) {
       textDecode.pop()
 
       const requiredKeys = [
@@ -644,6 +647,8 @@ export default defineComponent({
         'paid',
       ]
 
+      const historyItems = new Map(Object.entries(this.historyCacheById))
+
       textDecode.forEach((history) => {
         const historyData = JSON.parse(history)
         // We would technically already be done by the time the data is parsed,
@@ -667,14 +672,16 @@ export default defineComponent({
           showToast(this.$t('Settings.Data Settings.History object has insufficient data, skipping item'))
           console.error('Missing Keys: ', missingKeys, historyData)
         } else {
-          this.updateHistory(historyObject)
+          historyItems.set(historyObject.videoId, historyObject)
         }
       })
+
+      await this.overwriteHistory(historyItems)
 
       showToast(this.$t('Settings.Data Settings.All watched history has been successfully imported'))
     },
 
-    importYouTubeHistory(historyData) {
+    async importYouTubeHistory(historyData) {
       const filterPredicate = item =>
         item.products.includes('YouTube') &&
         item.titleUrl != null && // removed video doesnt contain url...
@@ -722,6 +729,8 @@ export default defineComponent({
         'activityControls',
       ].concat(Object.keys(keyMapping))
 
+      const historyItems = new Map(Object.entries(this.historyCacheById))
+
       filteredHistoryData.forEach(element => {
         const historyObject = {}
 
@@ -750,9 +759,11 @@ export default defineComponent({
           historyObject.watchProgress = 1
           historyObject.isLive = false
 
-          this.updateHistory(historyObject)
+          historyItems.set(historyObject.videoId, historyObject)
         }
       })
+
+      await this.overwriteHistory(historyItems)
 
       showToast(this.$t('Settings.Data Settings.All watched history has been successfully imported'))
     },
@@ -1069,10 +1080,10 @@ export default defineComponent({
     ...mapActions([
       'updateProfile',
       'updateShowProgressBar',
-      'updateHistory',
       'addPlaylist',
       'addVideo',
       'updatePlaylist',
+      'overwriteHistory'
     ]),
 
     ...mapMutations([

--- a/src/renderer/store/modules/history.js
+++ b/src/renderer/store/modules/history.js
@@ -45,6 +45,27 @@ const actions = {
     }
   },
 
+  /**
+   * @param {any} param0
+   * @param {Map<string, any>} historyItems
+   */
+  async overwriteHistory({ commit }, historyItems) {
+    try {
+      const sortedRecords = Array.from(historyItems.values())
+
+      // sort before sending saving to the database and passing to other windows
+      // so that the other windows can use it as is, without having to sort the array themselves
+      sortedRecords.sort((a, b) => b.timeWatched - a.timeWatched)
+
+      await DBHistoryHandlers.overwrite(sortedRecords)
+
+      commit('setHistoryCacheSorted', sortedRecords)
+      commit('setHistoryCacheById', Object.fromEntries(historyItems))
+    } catch (errMessage) {
+      console.error(errMessage)
+    }
+  },
+
   async removeFromHistory({ commit }, videoId) {
     try {
       await DBHistoryHandlers.delete(videoId)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -476,6 +476,18 @@ const customActions = {
             commit('upsertToHistoryCache', data)
             break
 
+          case SyncEvents.HISTORY.OVERWRITE: {
+            const byId = {}
+            data.forEach(video => {
+              byId[video.videoId] = video
+            })
+
+            // It comes pre-sorted, so we don't have to sort it here
+            commit('setHistoryCacheSorted', data)
+            commit('setHistoryCacheById', byId)
+            break
+          }
+
           case SyncEvents.HISTORY.UPDATE_WATCH_PROGRESS:
             commit('updateRecordWatchProgressInHistoryCache', data)
             break


### PR DESCRIPTION
# Improve history import performance and fix some bugs

## Pull Request Type

- [x] Bugfix
- [x] Performance improvement

## Related issue
closes #5174

## Description
The current history import has a few flaws, which this pull request aims to iron out:
- It is slow and shows the import finished toast way before the import is actually done (in my case minutes earlier), because it shows the toast when it has triggered the asynchronous operations, instead of waiting for them to finish
- Because it uses the same mark as watched logic as the watch page, each item that gets imported is moved to the start of the history array, regardless of whether that is the correct chronological position or not (the data is correct in the database but it means that until you restart FreeTube the history tab shows the history items in the wrong order)

This pull request implements dedicated for the history import which merges together the existing history and the imported history with the help of a `Map`, then overwrites the `historyCacheSorted` and `historyCacheById` properties in the store and runs delete all and insert all on the database (remember we've already merged together the histories), which is a lot faster than an insert or update for every single history entry.

## Testing <!-- for code that is not small enough to be easily understandable -->
**Back up your history first**

Test cases:
1. Import your history into an empty FreeTube/clear your history first before importing (testing how it handles everything being new)
2. Import your history again, this time without deleting your existing history (testing how it handles every imported item already existing)
3. Mark a few videos as watched that aren't in your history yet, import your history again (testing that it retains existing items that weren't in the import).

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 1a36dabdabc689fb5eac1c0a02920482dd6ba30b