### PR TITLE
Change Sponsorblock Default Category Colors

### DIFF
--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -246,7 +246,7 @@ const state = {
   sponsorBlockShowSkippedToast: true,
   sponsorBlockUrl: 'https://sponsor.ajay.app',
   sponsorBlockSponsor: {
-    color: 'Blue',
+    color: 'Green',
     skip: 'autoSkip'
   },
   sponsorBlockSelfPromo: {
@@ -254,19 +254,19 @@ const state = {
     skip: 'showInSeekBar'
   },
   sponsorBlockInteraction: {
-    color: 'Green',
+    color: 'Purple',
     skip: 'showInSeekBar'
   },
   sponsorBlockIntro: {
-    color: 'Orange',
+    color: 'Cyan',
     skip: 'doNothing'
   },
   sponsorBlockOutro: {
-    color: 'Orange',
+    color: 'Blue',
     skip: 'doNothing'
   },
   sponsorBlockRecap: {
-    color: 'Orange',
+    color: 'Indigo',
     skip: 'doNothing'
   },
   sponsorBlockMusicOffTopic: {


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

#5622 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This PR changes the default sponsorblock segment colors to ones that match the extension's defaults

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Before:
![image](https://github.com/user-attachments/assets/205d3d60-003f-4b79-9e42-73ccfaf6fdfd)

After:
![image](https://github.com/user-attachments/assets/3f5ff5e9-ab29-4d8c-aa20-845aaf2a1df3)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** v0.21.3 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
