### PR TITLE
Use constants for API names

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 // IPC Channels
-const IpcChannels = {
+export const IpcChannels = {
   ENABLE_PROXY: 'enable-proxy',
   DISABLE_PROXY: 'disable-proxy',
   OPEN_EXTERNAL_LINK: 'open-external-link',
@@ -42,7 +42,7 @@ const IpcChannels = {
   SET_INVIDIOUS_AUTHORIZATION: 'set-invidious-authorization'
 }
 
-const DBActions = {
+export const DBActions = {
   GENERAL: {
     CREATE: 'db-action-create',
     FIND: 'db-action-find',
@@ -80,7 +80,7 @@ const DBActions = {
   },
 }
 
-const SyncEvents = {
+export const SyncEvents = {
   GENERAL: {
     CREATE: 'sync-create',
     UPSERT: 'sync-upsert',
@@ -114,27 +114,21 @@ const SyncEvents = {
 }
 
 // Utils
-const MAIN_PROFILE_ID = 'allChannels'
+export const MAIN_PROFILE_ID = 'allChannels'
 
 // Width threshold in px at which we switch to using a more heavily altered view for mobile users
-const MOBILE_WIDTH_THRESHOLD = 680
+export const MOBILE_WIDTH_THRESHOLD = 680
 
 // Height threshold in px at which we switch to using a more heavily altered playlist view for mobile users
-const PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD = 500
+export const PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD = 500
 
 // YouTube search character limit is 100 characters
-const SEARCH_CHAR_LIMIT = 100
+export const SEARCH_CHAR_LIMIT = 100
 
 // Displayed on the about page and used in the main.js file to only allow bitcoin URLs with this wallet address to be opened
-const ABOUT_BITCOIN_ADDRESS = '1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS'
+export const ABOUT_BITCOIN_ADDRESS = '1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS'
 
-export {
-  IpcChannels,
-  DBActions,
-  SyncEvents,
-  MAIN_PROFILE_ID,
-  MOBILE_WIDTH_THRESHOLD,
-  PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD,
-  SEARCH_CHAR_LIMIT,
-  ABOUT_BITCOIN_ADDRESS,
+export const API_DATA_SOURCES = {
+  LOCAL: 'local',
+  INVIDIOUS: 'invidious'
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -11,6 +11,7 @@ import {
   DBActions,
   SyncEvents,
   ABOUT_BITCOIN_ADDRESS,
+  API_DATA_SOURCES,
 } from '../constants'
 import * as baseHandlers from '../datastores/handlers/base'
 import { extractExpiryTimestamp, ImageCache } from './ImageCache'
@@ -1704,7 +1705,7 @@ function runApp() {
             },
             type: 'normal'
           },
-          (!hidePopularVideos && (backendFallback || backendPreference === 'invidious')) && {
+          (!hidePopularVideos && (backendFallback || backendPreference === API_DATA_SOURCES.INVIDIOUS)) && {
             label: 'Most Popular',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/popular', browserWindow)

--- a/src/renderer/components/ft-community-post/ft-community-post.js
+++ b/src/renderer/components/ft-community-post/ft-community-post.js
@@ -15,6 +15,7 @@ import {
   toLocalePublicationString,
 } from '../../helpers/utils'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'FtCommunityPost',
@@ -77,7 +78,7 @@ export default defineComponent({
       return this.$store.getters.getBackendFallback
     },
     isInvidiousAllowed: function() {
-      return this.backendPreference === 'invidious' || this.backendFallback
+      return this.backendPreference === API_DATA_SOURCES.INVIDIOUS || this.backendFallback
     }
   },
   created: function () {
@@ -117,7 +118,7 @@ export default defineComponent({
         this.postText = 'Shared post'
         this.type = 'text'
         let authorThumbnails = ['', 'https://yt3.ggpht.com/ytc/AAUvwnjm-0qglHJkAHqLFsCQQO97G7cCNDuDLldsrn25Lg=s88-c-k-c0x00ffffff-no-rj']
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           authorThumbnails = authorThumbnails.map(thumbnail => {
             thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
             return thumbnail
@@ -128,7 +129,7 @@ export default defineComponent({
       }
       this.postText = autolinker.link(this.data.postText)
       const authorThumbnails = deepCopy(this.data.authorThumbnails)
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         authorThumbnails.forEach(thumbnail => {
           thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
         })

--- a/src/renderer/components/ft-list-channel/ft-list-channel.js
+++ b/src/renderer/components/ft-list-channel/ft-list-channel.js
@@ -3,6 +3,7 @@ import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { formatNumber } from '../../helpers/utils'
 import { parseLocalSubscriberCount } from '../../helpers/api/local'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'FtListChannel',
@@ -44,7 +45,7 @@ export default defineComponent({
     }
   },
   created: function () {
-    if (this.data.dataSource === 'local') {
+    if (this.data.dataSource === API_DATA_SOURCES.LOCAL) {
       this.parseLocalData()
     } else {
       this.parseInvidiousData()

--- a/src/renderer/components/ft-list-playlist/ft-list-playlist.js
+++ b/src/renderer/components/ft-list-playlist/ft-list-playlist.js
@@ -2,6 +2,7 @@ import { defineComponent } from 'vue'
 import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
 import { mapActions } from 'vuex'
 import { showToast } from '../../helpers/utils'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'FtListPlaylist',
@@ -104,7 +105,7 @@ export default defineComponent({
   created: function () {
     if (this.isUserPlaylist) {
       this.parseUserData()
-    } else if (this.data.dataSource === 'local') {
+    } else if (this.data.dataSource === API_DATA_SOURCES.LOCAL) {
       this.parseLocalData()
     } else {
       this.parseInvidiousData()
@@ -158,7 +159,7 @@ export default defineComponent({
       this.title = this.data.playlistName
       if (this.thumbnailCanBeShown && this.data.videos.length > 0) {
         const thumbnailURL = `https://i.ytimg.com/vi/${this.data.videos[0].videoId}/mqdefault.jpg`
-        if (this.backendPreference === 'invidious') {
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           this.thumbnail = thumbnailURL.replace('https://i.ytimg.com', this.currentInvidiousInstanceUrl)
         } else {
           this.thumbnail = thumbnailURL

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -13,6 +13,7 @@ import {
 } from '../../helpers/utils'
 import { deArrowData, deArrowThumbnail } from '../../helpers/sponsorblock'
 import debounce from 'lodash.debounce'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'FtListVideo',
@@ -337,7 +338,7 @@ export default defineComponent({
       }
 
       let baseUrl
-      if (this.backendPreference === 'invidious') {
+      if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         baseUrl = this.currentInvidiousInstanceUrl
       } else {
         baseUrl = 'https://i.ytimg.com'

--- a/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
+++ b/src/renderer/components/ft-playlist-selector/ft-playlist-selector.js
@@ -1,6 +1,7 @@
 import { defineComponent } from 'vue'
 import FtIconButton from '../ft-icon-button/ft-icon-button.vue'
 import { mapActions } from 'vuex'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'FtPlaylistSelector',
@@ -128,7 +129,7 @@ export default defineComponent({
       this.title = this.playlist.playlistName
       if (this.playlist.videos.length > 0) {
         const thumbnailURL = `https://i.ytimg.com/vi/${this.playlist.videos[0].videoId}/mqdefault.jpg`
-        if (this.backendPreference === 'invidious') {
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           this.thumbnail = thumbnailURL.replace('https://i.ytimg.com', this.currentInvidiousInstanceUrl)
         } else {
           this.thumbnail = thumbnailURL

--- a/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
+++ b/src/renderer/components/ft-profile-channel-list/ft-profile-channel-list.js
@@ -8,6 +8,7 @@ import FtButton from '../../components/ft-button/ft-button.vue'
 import FtPrompt from '../../components/ft-prompt/ft-prompt.vue'
 import { deepCopy, showToast } from '../../helpers/utils'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'FtProfileChannelList',
@@ -75,7 +76,7 @@ export default defineComponent({
         return a.name?.toLowerCase().localeCompare(b.name?.toLowerCase(), this.locale)
       })
       subscriptions.forEach((channel) => {
-        if (this.backendPreference === 'invidious') {
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstanceUrl)
         }
         channel.selected = false
@@ -91,7 +92,7 @@ export default defineComponent({
         return a.name?.toLowerCase().localeCompare(b.name?.toLowerCase(), this.locale)
       })
       subscriptions.forEach((channel) => {
-        if (this.backendPreference === 'invidious') {
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstanceUrl)
         }
         channel.selected = false

--- a/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.js
+++ b/src/renderer/components/ft-profile-filter-channels-list/ft-profile-filter-channels-list.js
@@ -8,7 +8,7 @@ import FtButton from '../../components/ft-button/ft-button.vue'
 import FtSelect from '../ft-select/ft-select.vue'
 import { deepCopy, showToast } from '../../helpers/utils'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
-import { MAIN_PROFILE_ID } from '../../../constants'
+import { API_DATA_SOURCES, MAIN_PROFILE_ID } from '../../../constants'
 
 export default defineComponent({
   name: 'FtProfileFilterChannelsList',
@@ -70,7 +70,7 @@ export default defineComponent({
 
         return index === -1
       }).map((channel) => {
-        if (this.backendPreference === 'invidious') {
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstanceUrl)
         }
         channel.selected = false
@@ -91,7 +91,7 @@ export default defineComponent({
 
         return index === -1
       }).map((channel) => {
-        if (this.backendPreference === 'invidious') {
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstanceUrl)
         }
         channel.selected = false

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -11,6 +11,7 @@ import debounce from 'lodash.debounce'
 import allLocales from '../../../../static/locales/activeLocales.json'
 import { randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'GeneralSettings',
@@ -26,11 +27,11 @@ export default defineComponent({
     return {
       backendValues: process.env.SUPPORTS_LOCAL_API
         ? [
-            'invidious',
-            'local'
+            API_DATA_SOURCES.INVIDIOUS,
+            API_DATA_SOURCES.LOCAL
           ]
         : [
-            'invidious'
+            API_DATA_SOURCES.INVIDIOUS
           ],
       viewTypeValues: [
         'grid',
@@ -92,7 +93,7 @@ export default defineComponent({
       let includedPageNames = this.includedDefaultPageNames
       if (this.hideTrendingVideos) includedPageNames = includedPageNames.filter((pageName) => pageName !== 'trending')
       if (this.hidePlaylists) includedPageNames = includedPageNames.filter((pageName) => pageName !== 'userPlaylists')
-      if (!(!this.hidePopularVideos && (this.backendFallback || this.backendPreference === 'invidious'))) includedPageNames = includedPageNames.filter((pageName) => pageName !== 'popular')
+      if (!(!this.hidePopularVideos && (this.backendFallback || this.backendPreference === API_DATA_SOURCES.INVIDIOUS))) includedPageNames = includedPageNames.filter((pageName) => pageName !== 'popular')
       return this.$router.getRoutes().filter((route) => includedPageNames.includes(route.name))
     },
     defaultPageNames: function () {
@@ -103,8 +104,8 @@ export default defineComponent({
       return this.defaultPages.map((route) => route.path.substring(1))
     },
     backendPreference: function () {
-      if (!process.env.SUPPORTS_LOCAL_API && this.$store.getters.getBackendPreference === 'local') {
-        this.handlePreferredApiBackend('invidious')
+      if (!process.env.SUPPORTS_LOCAL_API && this.$store.getters.getBackendPreference === API_DATA_SOURCES.LOCAL) {
+        this.handlePreferredApiBackend(API_DATA_SOURCES.INVIDIOUS)
       }
 
       return this.$store.getters.getBackendPreference

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -8,7 +8,7 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../ft-button/ft-button.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtTooltip from '../ft-tooltip/ft-tooltip.vue'
-import { IpcChannels } from '../../../constants'
+import { API_DATA_SOURCES, IpcChannels } from '../../../constants'
 import path from 'path'
 import { getPicturesPath } from '../../helpers/utils'
 
@@ -92,7 +92,7 @@ export default defineComponent({
     },
 
     showProxyVideosAsDisabled: function () {
-      return this.backendPreference !== 'invidious' && !this.backendFallback
+      return this.backendPreference !== API_DATA_SOURCES.INVIDIOUS && !this.backendFallback
     },
 
     defaultSkipInterval: function () {

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -12,6 +12,7 @@ import {
   showToast,
 } from '../../helpers/utils'
 import debounce from 'lodash.debounce'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'PlaylistInfo',
@@ -203,7 +204,7 @@ export default defineComponent({
       }
 
       let baseUrl = 'https://i.ytimg.com'
-      if (this.backendPreference === 'invidious') {
+      if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         baseUrl = this.currentInvidiousInstanceUrl
       } else if (typeof this.playlistThumbnail === 'string' && this.playlistThumbnail.length > 0) {
         // Use playlist thumbnail provided by YT when available

--- a/src/renderer/components/side-nav/side-nav.js
+++ b/src/renderer/components/side-nav/side-nav.js
@@ -3,6 +3,7 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import SideNavMoreOptions from '../side-nav-more-options/side-nav-more-options.vue'
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { deepCopy } from '../../helpers/utils'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'SideNav',
@@ -45,7 +46,7 @@ export default defineComponent({
         return a.name?.toLowerCase().localeCompare(b.name?.toLowerCase(), this.locale)
       })
 
-      if (this.backendPreference === 'invidious') {
+      if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         subscriptions.forEach((channel) => {
           channel.thumbnail = youtubeImageUrlToInvidious(channel.thumbnail, this.currentInvidiousInstanceUrl)
         })

--- a/src/renderer/components/subscriptions-community/subscriptions-community.js
+++ b/src/renderer/components/subscriptions-community/subscriptions-community.js
@@ -5,6 +5,7 @@ import SubscriptionsTabUI from '../subscriptions-tab-ui/subscriptions-tab-ui.vue
 import { copyToClipboard, getRelativeTimeFromDate, showToast } from '../../helpers/utils'
 import { getLocalChannelCommunity } from '../../helpers/api/local'
 import { invidiousGetCommunityPosts } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'SubscriptionsCommunity',
@@ -172,7 +173,7 @@ export default defineComponent({
 
       const postListFromRemote = (await Promise.all(channelsToLoadFromRemote.map(async (channel) => {
         let posts = []
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           posts = await this.getChannelPostsInvidious(channel)
         } else {
           posts = await this.getChannelPostsLocal(channel)
@@ -241,7 +242,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           return await this.getChannelPostsInvidious(channel)
         }
@@ -262,7 +263,7 @@ export default defineComponent({
           showToast(`${errorMessage}: ${err}`, 10000, () => {
             copyToClipboard(err)
           })
-          if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+          if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
             showToast(this.$t('Falling back to Local API'))
             resolve(this.getChannelPostsLocal(channel))
           } else {

--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -12,6 +12,7 @@ import {
 import { invidiousAPICall, invidiousFetch } from '../../helpers/api/invidious'
 import { getLocalChannelLiveStreams } from '../../helpers/api/local'
 import { parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'SubscriptionsLive',
@@ -189,7 +190,7 @@ export default defineComponent({
         let videos = []
         let name, thumbnailUrl
 
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           if (useRss) {
             ({ videos, name, thumbnailUrl } = await this.getChannelLiveInvidiousRSS(channel))
           } else {

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -10,6 +10,7 @@ import {
   showToast
 } from '../../helpers/utils'
 import { invidiousFetch } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'SubscriptionsShorts',
@@ -174,7 +175,7 @@ export default defineComponent({
         let videos = []
         let name
 
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           ({ videos, name } = await this.getChannelShortsInvidious(channel))
         } else {
           ({ videos, name } = await this.getChannelShortsLocal(channel))

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -12,6 +12,7 @@ import {
 import { invidiousAPICall, invidiousFetch } from '../../helpers/api/invidious'
 import { getLocalChannelVideos } from '../../helpers/api/local'
 import { parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'SubscriptionsVideos',
@@ -193,7 +194,7 @@ export default defineComponent({
         let videos = []
         let name, thumbnailUrl
 
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           if (useRss) {
             ({ videos, name, thumbnailUrl } = await this.getChannelVideosInvidiousRSS(channel))
           } else {

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -4,7 +4,7 @@ import FtInput from '../ft-input/ft-input.vue'
 import FtProfileSelector from '../ft-profile-selector/ft-profile-selector.vue'
 import debounce from 'lodash.debounce'
 
-import { IpcChannels, MOBILE_WIDTH_THRESHOLD } from '../../../constants'
+import { API_DATA_SOURCES, IpcChannels, MOBILE_WIDTH_THRESHOLD } from '../../../constants'
 import { openInternalPath } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 import { clearLocalSearchSuggestionsSession, getLocalSearchSuggestions } from '../../helpers/api/local'
@@ -275,10 +275,10 @@ export default defineComponent({
 
     getSearchSuggestions: function (query) {
       switch (this.backendPreference) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getSearchSuggestionsLocal(query)
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.getSearchSuggestionsInvidious(query)
           break
       }

--- a/src/renderer/components/watch-video-comments/watch-video-comments.js
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.js
@@ -6,6 +6,7 @@ import FtTimestampCatcher from '../../components/ft-timestamp-catcher/ft-timesta
 import { copyToClipboard, showToast } from '../../helpers/utils'
 import { getInvidiousCommunityPostCommentReplies, getInvidiousCommunityPostComments, invidiousGetCommentReplies, invidiousGetComments } from '../../helpers/api/invidious'
 import { getLocalComments, parseLocalComment } from '../../helpers/api/local'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'WatchVideoComments',
@@ -174,7 +175,7 @@ export default defineComponent({
 
     getCommentData: function () {
       this.isLoading = true
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious' || this.isPostComments) {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS || this.isPostComments) {
         if (!this.isPostComments) {
           this.getCommentDataInvidious()
         } else {
@@ -189,7 +190,7 @@ export default defineComponent({
       if (this.commentData.length === 0 || this.nextPageToken === null || typeof this.nextPageToken === 'undefined') {
         showToast(this.$t('Comments.There are no more comments for this video'))
       } else {
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious' || this.isPostComments) {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS || this.isPostComments) {
           if (!this.isPostComments) {
             this.getCommentDataInvidious()
           } else {
@@ -210,7 +211,7 @@ export default defineComponent({
     },
 
     getCommentReplies: function (index) {
-      if (!process.env.SUPPORTS_LOCAL_API || this.commentData[index].dataType === 'invidious' || this.isPostComments) {
+      if (!process.env.SUPPORTS_LOCAL_API || this.commentData[index].dataType === API_DATA_SOURCES.INVIDIOUS || this.isPostComments) {
         if (!this.isPostComments) {
           this.getCommentRepliesInvidious(index)
         } else {
@@ -260,7 +261,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendFallback && this.backendPreference === 'local') {
+        if (this.backendFallback && this.backendPreference === API_DATA_SOURCES.LOCAL) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getCommentDataInvidious()
         } else {
@@ -306,7 +307,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendFallback && this.backendPreference === 'local') {
+        if (this.backendFallback && this.backendPreference === API_DATA_SOURCES.LOCAL) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getCommentDataInvidious()
         } else {
@@ -354,7 +355,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendFallback && this.backendPreference === 'invidious') {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendFallback && this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           showToast(this.$t('Falling back to Local API'))
           this.getCommentDataLocal()
         } else {

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -7,6 +7,7 @@ import autolinker from 'autolinker'
 import { getRandomColorClass } from '../../helpers/colors'
 import { getLocalVideoInfo, parseLocalTextRuns } from '../../helpers/api/local'
 import { formatNumber } from '../../helpers/utils'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'WatchVideoLiveChat',
@@ -100,7 +101,7 @@ export default defineComponent({
       this.isLoading = false
     } else {
       switch (this.backendPreference) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           if (this.liveChat) {
             this.liveChatInstance = this.liveChat
             this.startLiveChatLocal()
@@ -108,7 +109,7 @@ export default defineComponent({
             this.showLiveChatUnavailable()
           }
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           if (this.backendFallback) {
             this.getLiveChatLocal()
           } else {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -11,6 +11,7 @@ import {
 } from '../../helpers/api/local'
 import { invidiousGetPlaylistInfo } from '../../helpers/api/invidious'
 import { getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'WatchVideoPlaylist',
@@ -197,7 +198,7 @@ export default defineComponent({
     },
     playlistId: function (newVal, oldVal) {
       if (oldVal !== newVal) {
-        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+        if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
           this.getPlaylistInformationInvidious()
         } else {
           this.getPlaylistInformationLocal()
@@ -253,7 +254,7 @@ export default defineComponent({
 
       if (this.selectedUserPlaylist != null) {
         this.parseUserPlaylist(this.selectedUserPlaylist)
-      } else if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+      } else if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         this.getPlaylistInformationInvidious()
       } else {
         this.getPlaylistInformationLocal()
@@ -405,7 +406,7 @@ export default defineComponent({
       this.channelName = cachedPlaylist.channelName
       this.channelId = cachedPlaylist.channelId
 
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious' || cachedPlaylist.continuationData === null) {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS || cachedPlaylist.continuationData === null) {
         this.playlistItems = cachedPlaylist.items
       } else {
         const videos = cachedPlaylist.items
@@ -454,7 +455,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getPlaylistInformationInvidious()
         } else {
@@ -481,7 +482,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getPlaylistInformationLocal()
         } else {

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -7,6 +7,7 @@ import {
 import { isNullOrEmpty } from '../strings'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
+import { API_DATA_SOURCES } from '../../../constants'
 
 function getCurrentInstanceUrl() {
   return store.getters.getCurrentInvidiousInstanceUrl
@@ -172,7 +173,7 @@ function parseInvidiousCommentData(response) {
     comment.authorThumb = youtubeImageUrlToInvidious(comment.authorThumbnails.at(-1).url)
     comment.likes = comment.likeCount
     comment.text = autolinker.link(stripHTML(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstanceUrl())))
-    comment.dataType = 'invidious'
+    comment.dataType = API_DATA_SOURCES.INVIDIOUS
     comment.isOwner = comment.authorIsChannelOwner
     comment.numReplies = comment.replies?.replyCount ?? 0
     comment.hasReplyToken = !!comment.replies?.continuation

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,6 +1,6 @@
 import { ClientType, Endpoints, Innertube, Misc, Parser, UniversalCache, Utils, YT } from 'youtubei.js'
 import Autolinker from 'autolinker'
-import { SEARCH_CHAR_LIMIT } from '../../../constants'
+import { API_DATA_SOURCES, SEARCH_CHAR_LIMIT } from '../../../constants'
 
 import { PlayerCache } from './PlayerCache'
 import {
@@ -793,7 +793,7 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
 
     return {
       type: 'playlist',
-      dataSource: 'local',
+      dataSource: API_DATA_SOURCES.LOCAL,
       title: lockupView.metadata.title.text,
       thumbnail: lockupView.content_image.primary_thumbnail.image[0].url,
       channelName,
@@ -830,7 +830,7 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
 
     return {
       type: 'playlist',
-      dataSource: 'local',
+      dataSource: API_DATA_SOURCES.LOCAL,
       title: playlist.title.text,
       thumbnail: thumbnailRenderer ? thumbnailRenderer.thumbnail[0].url : playlist.thumbnails[0].url,
       channelName: internalChannelName,
@@ -849,7 +849,7 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
 export function parseLocalCompactStation(compactStation, channelId, channelName) {
   return {
     type: 'playlist',
-    dataSource: 'local',
+    dataSource: API_DATA_SOURCES.LOCAL,
     title: compactStation.title.text,
     thumbnail: compactStation.thumbnail[1].url,
     channelName,
@@ -1096,7 +1096,7 @@ function parseListItem(item) {
 
       return {
         type: 'channel',
-        dataSource: 'local',
+        dataSource: API_DATA_SOURCES.LOCAL,
         thumbnail: channel.author.best_thumbnail?.url,
         name: channel.author.name,
         id: channel.author.id,
@@ -1338,7 +1338,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
 
   const parsed = {
     id: comment.comment_id,
-    dataType: 'local',
+    dataType: API_DATA_SOURCES.LOCAL,
     authorLink: comment.author.id,
     author: comment.author.name,
     authorId: comment.author.id,

--- a/src/renderer/helpers/channels.js
+++ b/src/renderer/helpers/channels.js
@@ -1,3 +1,4 @@
+import { API_DATA_SOURCES } from '../../constants'
 import { invidiousGetChannelInfo } from './api/invidious'
 import { getLocalChannel, parseLocalChannelHeader } from './api/local'
 
@@ -11,7 +12,7 @@ import { getLocalChannel, parseLocalChannelHeader } from './api/local'
 */
 async function findChannelById(id, backendOptions) {
   try {
-    if (!process.env.SUPPORTS_LOCAL_API || backendOptions.preference === 'invidious') {
+    if (!process.env.SUPPORTS_LOCAL_API || backendOptions.preference === API_DATA_SOURCES.INVIDIOUS) {
       return await invidiousGetChannelInfo(id)
     } else {
       return await getLocalChannel(id)
@@ -22,10 +23,10 @@ async function findChannelById(id, backendOptions) {
       return { invalid: true }
     }
     if (process.env.SUPPORTS_LOCAL_API && backendOptions.fallback) {
-      if (backendOptions.preference === 'invidious') {
+      if (backendOptions.preference === API_DATA_SOURCES.INVIDIOUS) {
         return await getLocalChannel(id)
       }
-      if (backendOptions.preference === 'local') {
+      if (backendOptions.preference === API_DATA_SOURCES.LOCAL) {
         return await invidiousGetChannelInfo(id)
       }
     } else {
@@ -46,7 +47,7 @@ export async function findChannelTagInfo(id, backendOptions) {
   if (!checkYoutubeChannelId(id)) return { invalidId: true }
   try {
     const channel = await findChannelById(id, backendOptions)
-    if (!process.env.SUPPORTS_LOCAL_API || backendOptions.preference === 'invidious') {
+    if (!process.env.SUPPORTS_LOCAL_API || backendOptions.preference === API_DATA_SOURCES.INVIDIOUS) {
       if (channel.invalid) return { invalidId: true }
       return {
         preferredName: channel.author,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -1,6 +1,6 @@
 import i18n, { loadLocale } from '../../i18n/index'
 import allLocales from '../../../../static/locales/activeLocales.json'
-import { MAIN_PROFILE_ID, IpcChannels, SyncEvents } from '../../../constants'
+import { MAIN_PROFILE_ID, IpcChannels, SyncEvents, API_DATA_SOURCES } from '../../../constants'
 import { DBSettingHandlers } from '../../../datastores/handlers/index'
 import { getSystemLocale, showToast } from '../../helpers/utils'
 
@@ -166,7 +166,7 @@ const state = {
   autoplayPlaylists: true,
   autoplayVideos: true,
   backendFallback: process.env.SUPPORTS_LOCAL_API,
-  backendPreference: !process.env.SUPPORTS_LOCAL_API ? 'invidious' : 'local',
+  backendPreference: !process.env.SUPPORTS_LOCAL_API ? API_DATA_SOURCES.INVIDIOUS : API_DATA_SOURCES.LOCAL,
   barColor: false,
   checkForBlogPosts: true,
   checkForUpdates: true,

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -44,6 +44,7 @@ import {
   getLocalPlaylist,
   parseLocalPlaylistVideo
 } from '../../helpers/api/local'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'Channel',
@@ -353,7 +354,7 @@ export default defineComponent({
       this.errorMessage = ''
 
       // Re-enable auto refresh on sort value change AFTER update done
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         this.getChannelInfoInvidious()
         this.autoRefreshOnSortByChangeEnabled = true
       } else {
@@ -369,10 +370,10 @@ export default defineComponent({
       this.isElementListLoading = true
       this.latestVideos = []
       switch (this.apiUsed) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getChannelVideosLocal()
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.channelInvidiousVideos(true)
           break
         default:
@@ -386,10 +387,10 @@ export default defineComponent({
       this.isElementListLoading = true
       this.latestShorts = []
       switch (this.apiUsed) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getChannelShortsLocal()
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.channelInvidiousShorts(true)
           break
         default:
@@ -403,10 +404,10 @@ export default defineComponent({
       this.isElementListLoading = true
       this.latestLive = []
       switch (this.apiUsed) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getChannelLiveLocal()
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.channelInvidiousLive(true)
           break
         default:
@@ -421,10 +422,10 @@ export default defineComponent({
       this.latestPlaylists = []
       this.playlistContinuationData = null
       switch (this.apiUsed) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getChannelPlaylistsLocal()
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.getPlaylistsInvidious()
           break
         default:
@@ -449,7 +450,7 @@ export default defineComponent({
     }
 
     // Enable auto refresh on sort value change AFTER initial update done
-    if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+    if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
       this.getChannelInfoInvidious()
       this.autoRefreshOnSortByChangeEnabled = true
     } else {
@@ -462,7 +463,7 @@ export default defineComponent({
     resolveChannelUrl: async function (url, tab = undefined) {
       let id
 
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         id = await invidiousGetChannelId(url)
       } else {
         id = await getLocalChannelId(url)
@@ -493,7 +494,7 @@ export default defineComponent({
     },
 
     getChannelLocal: async function () {
-      this.apiUsed = 'local'
+      this.apiUsed = API_DATA_SOURCES.LOCAL
       this.isLoading = true
       const expectedId = this.id
 
@@ -699,7 +700,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getChannelInfoInvidious()
         } else {
@@ -752,7 +753,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getChannelInfoInvidious()
         } else {
@@ -824,7 +825,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getChannelInfoInvidious()
         } else {
@@ -900,7 +901,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getChannelInfoInvidious()
         } else {
@@ -977,7 +978,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getChannelInfoInvidious()
         } else {
@@ -1006,7 +1007,7 @@ export default defineComponent({
 
     getChannelInfoInvidious: function () {
       this.isLoading = true
-      this.apiUsed = 'invidious'
+      this.apiUsed = API_DATA_SOURCES.INVIDIOUS
       this.channelInstance = null
 
       const expectedId = this.id
@@ -1098,7 +1099,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getChannelLocal()
         } else {
@@ -1320,7 +1321,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getPlaylistsInvidious()
         } else {
@@ -1369,7 +1370,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           if (!this.channelInstance) {
             this.channelInstance = await getLocalChannel(this.id)
@@ -1410,7 +1411,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getChannelLocal()
         } else {
@@ -1456,7 +1457,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getChannelReleasesInvidious()
         } else {
@@ -1511,7 +1512,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           if (!this.channelInstance) {
             this.channelInstance = await getLocalChannel(this.id)
@@ -1545,7 +1546,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getChannelLocal()
         } else {
@@ -1578,7 +1579,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.channelInvidiousPodcasts()
         } else {
@@ -1624,7 +1625,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           if (!this.channelInstance) {
             this.channelInstance = await getLocalChannel(this.id)
@@ -1658,7 +1659,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.getChannelLocal()
         } else {
@@ -1714,7 +1715,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getCommunityPostsInvidious()
         } else {
@@ -1778,7 +1779,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           if (!this.channelInstance) {
             this.channelInstance = await getLocalChannel(this.id)
@@ -1804,30 +1805,30 @@ export default defineComponent({
       switch (this.currentTab) {
         case 'videos':
           switch (this.apiUsed) {
-            case 'local':
+            case API_DATA_SOURCES.LOCAL:
               this.channelLocalNextPage()
               break
-            case 'invidious':
+            case API_DATA_SOURCES.INVIDIOUS:
               this.channelInvidiousVideos()
               break
           }
           break
         case 'shorts':
           switch (this.apiUsed) {
-            case 'local':
+            case API_DATA_SOURCES.LOCAL:
               this.getChannelShortsLocalMore()
               break
-            case 'invidious':
+            case API_DATA_SOURCES.INVIDIOUS:
               this.channelInvidiousShorts()
               break
           }
           break
         case 'live':
           switch (this.apiUsed) {
-            case 'local':
+            case API_DATA_SOURCES.LOCAL:
               this.getChannelLiveLocalMore()
               break
-            case 'invidious':
+            case API_DATA_SOURCES.INVIDIOUS:
               this.channelInvidiousLive()
               break
           }
@@ -1840,30 +1841,30 @@ export default defineComponent({
           break
         case 'playlists':
           switch (this.apiUsed) {
-            case 'local':
+            case API_DATA_SOURCES.LOCAL:
               this.getChannelPlaylistsLocalMore()
               break
-            case 'invidious':
+            case API_DATA_SOURCES.INVIDIOUS:
               this.getPlaylistsInvidiousMore()
               break
           }
           break
         case 'search':
           switch (this.apiUsed) {
-            case 'local':
+            case API_DATA_SOURCES.LOCAL:
               this.searchChannelLocal()
               break
-            case 'invidious':
+            case API_DATA_SOURCES.INVIDIOUS:
               this.searchChannelInvidious()
               break
           }
           break
         case 'community':
           switch (this.apiUsed) {
-            case 'local':
+            case API_DATA_SOURCES.LOCAL:
               this.getCommunityPostsLocalMore()
               break
-            case 'invidious':
+            case API_DATA_SOURCES.INVIDIOUS:
               this.getCommunityPostsInvidious()
               break
           }
@@ -1889,10 +1890,10 @@ export default defineComponent({
       this.searchResults = []
       this.changeTab('search')
       switch (this.apiUsed) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.searchChannelLocal()
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.searchChannelInvidious()
           break
       }
@@ -1943,7 +1944,7 @@ export default defineComponent({
           copyToClipboard(err)
         })
         if (isNewSearch) {
-          if (this.backendPreference === 'local' && this.backendFallback) {
+          if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
             showToast(this.$t('Falling back to Invidious API'))
             this.searchChannelInvidious()
           } else {
@@ -1979,7 +1980,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.searchChannelLocal()
         } else {

--- a/src/renderer/views/Hashtag/Hashtag.js
+++ b/src/renderer/views/Hashtag/Hashtag.js
@@ -9,6 +9,7 @@ import { getHashtagLocal, parseLocalListVideo } from '../../helpers/api/local'
 import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 import { isNullOrEmpty } from '../../helpers/strings'
 import { getHashtagInvidious } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'Hashtag',
@@ -24,7 +25,7 @@ export default defineComponent({
       hashtag: '',
       hashtagContinuationData: null,
       videos: [],
-      apiUsed: 'local',
+      apiUsed: API_DATA_SOURCES.LOCAL,
       pageNumber: 1,
       isLoading: true
     }
@@ -39,7 +40,7 @@ export default defineComponent({
     },
 
     showFetchMoreButton() {
-      return !isNullOrEmpty(this.hashtagContinuationData) || this.apiUsed === 'invidious'
+      return !isNullOrEmpty(this.hashtagContinuationData) || this.apiUsed === API_DATA_SOURCES.INVIDIOUS
     },
   },
   watch: {
@@ -58,13 +59,13 @@ export default defineComponent({
       this.hashtag = ''
       this.hashtagContinuationData = null
       this.videos = []
-      this.apiUsed = 'local'
+      this.apiUsed = API_DATA_SOURCES.LOCAL
       this.pageNumber = 1
     },
 
     getHashtag: async function() {
       const hashtag = decodeURIComponent(this.$route.params.hashtag)
-      if (this.backendPreference === 'local') {
+      if (this.backendPreference === API_DATA_SOURCES.LOCAL) {
         await this.getLocalHashtag(hashtag)
       } else {
         await this.getInvidiousHashtag(hashtag)
@@ -78,7 +79,7 @@ export default defineComponent({
         setPublishedTimestampsInvidious(videos)
         this.hashtag = '#' + hashtag
         this.isLoading = false
-        this.apiUsed = 'invidious'
+        this.apiUsed = API_DATA_SOURCES.INVIDIOUS
         this.videos = this.videos.concat(videos)
         this.pageNumber += 1
       } catch (error) {
@@ -87,7 +88,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${error}`, 10000, () => {
           copyToClipboard(error)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.resetData()
           this.getLocalHashtag(hashtag)
@@ -120,7 +121,7 @@ export default defineComponent({
         }
 
         this.videos = hashtagData.videos.map(parseLocalListVideo)
-        this.apiUsed = 'local'
+        this.apiUsed = API_DATA_SOURCES.LOCAL
         this.hashtagContinuationData = hashtagData.has_continuation ? hashtagData : null
         this.isLoading = false
       } catch (error) {
@@ -129,7 +130,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${error}`, 10000, () => {
           copyToClipboard(error)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.resetData()
           this.getInvidiousHashtag(hashtag)
@@ -151,7 +152,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${error}`, 10000, () => {
           copyToClipboard(error)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           const hashtag = this.hashtag.substring(1)
           this.resetData()
@@ -163,9 +164,9 @@ export default defineComponent({
     },
 
     handleFetchMore: function() {
-      if (this.apiUsed === 'local') {
+      if (this.apiUsed === API_DATA_SOURCES.LOCAL) {
         this.getLocalHashtagMore()
-      } else if (this.apiUsed === 'invidious') {
+      } else if (this.apiUsed === API_DATA_SOURCES.INVIDIOUS) {
         this.getInvidiousHashtag(this.hashtag.substring(1), this.pageNumber)
       }
     }

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -24,7 +24,7 @@ import {
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import packageDetails from '../../../../package.json'
-import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
+import { API_DATA_SOURCES, MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 
 export default defineComponent({
   name: 'Playlist',
@@ -66,7 +66,7 @@ export default defineComponent({
       channelName: '',
       channelThumbnail: '',
       channelId: '',
-      infoSource: 'local',
+      infoSource: API_DATA_SOURCES.LOCAL,
       playlistItems: [],
       userPlaylistVisibleLimit: 100,
       continuationData: null,
@@ -284,10 +284,10 @@ export default defineComponent({
       }
 
       switch (this.backendPreference) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getPlaylistLocal()
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.getPlaylistInvidious()
           break
       }
@@ -317,7 +317,7 @@ export default defineComponent({
         this.channelName = channelName ?? ''
         this.channelThumbnail = result.info.author?.best_thumbnail?.url ?? ''
         this.channelId = result.info.author?.id
-        this.infoSource = 'local'
+        this.infoSource = API_DATA_SOURCES.LOCAL
 
         this.updateSubscriptionDetails({
           channelThumbnailUrl: this.channelThumbnail,
@@ -341,7 +341,7 @@ export default defineComponent({
         this.isLoading = false
       }).catch((err) => {
         console.error(err)
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           console.warn('Falling back to Invidious API')
           this.getPlaylistInvidious()
         } else {
@@ -360,7 +360,7 @@ export default defineComponent({
         this.channelName = result.author
         this.channelThumbnail = youtubeImageUrlToInvidious(result.authorThumbnails[2].url, this.currentInvidiousInstanceUrl)
         this.channelId = result.authorId
-        this.infoSource = 'invidious'
+        this.infoSource = API_DATA_SOURCES.INVIDIOUS
 
         this.updateSubscriptionDetails({
           channelThumbnailUrl: result.authorThumbnails[2].url,
@@ -380,7 +380,7 @@ export default defineComponent({
         this.isLoading = false
       }).catch((err) => {
         console.error(err)
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           console.warn('Error getting data with Invidious, falling back to local backend')
           this.getPlaylistLocal()
         } else {
@@ -422,7 +422,7 @@ export default defineComponent({
 
     getNextPage: function () {
       switch (this.infoSource) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getNextPageLocal()
           break
         case 'user':
@@ -439,7 +439,7 @@ export default defineComponent({
             this.isLoadingMore = false
           })
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           console.error('Playlist pagination is not currently supported when the Invidious backend is selected.')
           break
       }

--- a/src/renderer/views/Post/Post.js
+++ b/src/renderer/views/Post/Post.js
@@ -5,6 +5,7 @@ import FtLoader from '../../components/ft-loader/ft-loader.vue'
 import WatchVideoComments from '../../components/watch-video-comments/watch-video-comments.vue'
 
 import { getInvidiousCommunityPost } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'Post',
@@ -31,7 +32,7 @@ export default defineComponent({
       return this.$store.getters.getBackendFallback
     },
     isInvidiousAllowed: function() {
-      return this.backendPreference === 'invidious' || this.backendFallback
+      return this.backendPreference === API_DATA_SOURCES.INVIDIOUS || this.backendFallback
     }
   },
   watch: {

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -11,7 +11,7 @@ import {
 } from '../../helpers/utils'
 import { getLocalSearchContinuation, getLocalSearchResults } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
-import { SEARCH_CHAR_LIMIT } from '../../../constants'
+import { API_DATA_SOURCES, SEARCH_CHAR_LIMIT } from '../../../constants'
 
 export default defineComponent({
   name: 'Search',
@@ -24,7 +24,7 @@ export default defineComponent({
   data: function () {
     return {
       isLoading: false,
-      apiUsed: 'local',
+      apiUsed: API_DATA_SOURCES.LOCAL,
       amountOfResults: 0,
       query: '',
       searchPage: 1,
@@ -125,10 +125,10 @@ export default defineComponent({
         this.searchSettings = payload.searchSettings
 
         switch (this.backendPreference) {
-          case 'local':
+          case API_DATA_SOURCES.LOCAL:
             this.performSearchLocal(payload)
             break
-          case 'invidious':
+          case API_DATA_SOURCES.INVIDIOUS:
             this.performSearchInvidious(payload, { resetSearchPage: true })
             break
         }
@@ -141,7 +141,7 @@ export default defineComponent({
       try {
         const { results, continuationData } = await getLocalSearchResults(payload.query, payload.searchSettings, this.showFamilyFriendlyOnly)
 
-        this.apiUsed = 'local'
+        this.apiUsed = API_DATA_SOURCES.LOCAL
 
         this.shownResults = results
         this.nextPageRef = continuationData
@@ -165,7 +165,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.performSearchInvidious(payload)
         } else {
@@ -182,7 +182,7 @@ export default defineComponent({
           return
         }
 
-        this.apiUsed = 'local'
+        this.apiUsed = API_DATA_SOURCES.LOCAL
 
         this.shownResults = this.shownResults.concat(results)
         this.nextPageRef = continuationData
@@ -204,7 +204,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.performSearchInvidious(payload)
         } else {
@@ -240,7 +240,7 @@ export default defineComponent({
           return
         }
 
-        this.apiUsed = 'invidious'
+        this.apiUsed = API_DATA_SOURCES.INVIDIOUS
 
         const returnData = result.filter((item) => {
           return item.type === 'video' || item.type === 'channel' || item.type === 'playlist' || item.type === 'hashtag'
@@ -275,7 +275,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+        if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
           showToast(this.$t('Falling back to Local API'))
           this.performSearchLocal(payload)
         } else {
@@ -294,7 +294,7 @@ export default defineComponent({
         }
       }
 
-      if (this.apiUsed === 'local') {
+      if (this.apiUsed === API_DATA_SOURCES.LOCAL) {
         if (this.nextPageRef !== null) {
           showToast(this.$t('Search Filters["Fetching results. Please wait"]'))
           this.getNextpageLocal(payload)

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -340,7 +340,7 @@ export default defineComponent({
           continue
         }
 
-        if (result.dataSource === 'local') {
+        if (result.dataSource === API_DATA_SOURCES.LOCAL) {
           channels.push({
             channelId: result.id,
             channelName: result.name,

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.js
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.js
@@ -7,6 +7,7 @@ import FtSubscribeButton from '../../components/ft-subscribe-button/ft-subscribe
 import { invidiousGetChannelInfo, youtubeImageUrlToInvidious, invidiousImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getLocalChannel, parseLocalChannelHeader } from '../../helpers/api/local'
 import { ctrlFHandler } from '../../helpers/utils'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'SubscribedChannels',
@@ -119,11 +120,11 @@ export default defineComponent({
       }
       const hostname = new URL(newURL).hostname
       if (hostname === 'yt3.ggpht.com' || hostname === 'yt3.googleusercontent.com') {
-        if (this.backendPreference === 'invidious') { // YT to IV
+        if (this.backendPreference === API_DATA_SOURCES.INVIDIOUS) { // YT to IV
           newURL = youtubeImageUrlToInvidious(newURL, this.currentInvidiousInstanceUrl)
         }
       } else {
-        if (this.backendPreference === 'local') { // IV to YT
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL) { // IV to YT
           newURL = newURL.replace(this.re.ivToYt, `${this.ytBaseURL}/$1`)
         } else { // IV to IV
           newURL = invidiousImageUrlToInvidious(newURL, this.currentInvidiousInstanceUrl)
@@ -135,7 +136,7 @@ export default defineComponent({
 
     updateThumbnail: function(channel) {
       this.errorCount += 1
-      if (this.backendPreference === 'local') {
+      if (this.backendPreference === API_DATA_SOURCES.LOCAL) {
         // avoid too many concurrent requests
         setTimeout(() => {
           getLocalChannel(channel.id).then(response => {

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -10,6 +10,7 @@ import FtRefreshWidget from '../../components/ft-refresh-widget/ft-refresh-widge
 import { copyToClipboard, getRelativeTimeFromDate, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
 import { getLocalTrending } from '../../helpers/api/local'
 import { invidiousAPICall } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 export default defineComponent({
   name: 'Trending',
@@ -90,7 +91,7 @@ export default defineComponent({
         this.$store.commit('clearTrendingCache')
       }
 
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         this.getTrendingInfoInvidious()
       } else {
         this.getTrendingInfoLocal()
@@ -119,7 +120,7 @@ export default defineComponent({
         showToast(`${errorMessage}: ${err}`, 10000, () => {
           copyToClipboard(err)
         })
-        if (this.backendPreference === 'local' && this.backendFallback) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getTrendingInfoInvidious()
         } else {
@@ -168,7 +169,7 @@ export default defineComponent({
           copyToClipboard(err)
         })
 
-        if (process.env.SUPPORTS_LOCAL_API && (this.backendPreference === 'invidious' && this.backendFallback)) {
+        if (process.env.SUPPORTS_LOCAL_API && (this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback)) {
           showToast(this.$t('Falling back to Local API'))
           this.getTrendingInfoLocal()
         } else {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -36,6 +36,7 @@ import {
   mapInvidiousLegacyFormat,
   youtubeImageUrlToInvidious
 } from '../../helpers/api/invidious'
+import { API_DATA_SOURCES } from '../../../constants'
 
 const MANIFEST_TYPE_DASH = 'application/dash+xml'
 const MANIFEST_TYPE_HLS = 'application/x-mpegurl'
@@ -278,10 +279,10 @@ export default defineComponent({
       this.checkIfPlaylist()
 
       switch (this.backendPreference) {
-        case 'local':
+        case API_DATA_SOURCES.LOCAL:
           this.getVideoInformationLocal(this.videoId)
           break
-        case 'invidious':
+        case API_DATA_SOURCES.INVIDIOUS:
           this.getVideoInformationInvidious(this.videoId)
           break
       }
@@ -313,7 +314,7 @@ export default defineComponent({
       // this has to be below checkIfPlaylist() as theatrePossible needs to know if there is a playlist or not
       this.useTheatreMode = this.defaultTheatreMode && this.theatrePossible
 
-      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === 'invidious') {
+      if (!process.env.SUPPORTS_LOCAL_API || this.backendPreference === API_DATA_SOURCES.INVIDIOUS) {
         this.getVideoInformationInvidious()
       } else {
         this.getVideoInformationLocal()
@@ -720,7 +721,7 @@ export default defineComponent({
           copyToClipboard(err)
         })
         console.error(err)
-        if (this.backendPreference === 'local' && this.backendFallback && !err.toString().includes('private')) {
+        if (this.backendPreference === API_DATA_SOURCES.LOCAL && this.backendFallback && !err.toString().includes('private')) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getVideoInformationInvidious()
         } else {
@@ -922,7 +923,7 @@ export default defineComponent({
             copyToClipboard(err)
           })
           console.error(err)
-          if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+          if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === API_DATA_SOURCES.INVIDIOUS && this.backendFallback) {
             showToast(this.$t('Falling back to Local API'))
             this.getVideoInformationLocal()
           } else {


### PR DESCRIPTION
# Use constants for API names

## Pull Request Type
- [x] Other

## Related issue
Since we reuse 'local' and 'invidious' a lot in our code, I thought it'd be a good idea to use constants for those instead

## Description
- Update code so we use constants
- Fixes a bug for Hashtag page where it wouldn't use invidious if you have backend fallback enabled (this is leftover from when we only supported hashtags for local api)

## Desktop
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** latest nightly