### PR TITLE
Fix audio track selection

### DIFF
--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -317,3 +317,23 @@ export function repairInvidiousManifest(periods) {
     }
   }
 }
+
+/**
+ * @param {shaka.extern.TrackList} variants
+ * @param {number} bandwidthToMatch
+ */
+export function findMostSimilarAudioBandwidth(variants, bandwidthToMatch) {
+  let closestAudioBandwithDifference = Infinity
+  let closestVariant
+
+  for (const variant of variants) {
+    const difference = Math.abs(variant.audioBandwidth - bandwidthToMatch)
+
+    if (difference < closestAudioBandwithDifference) {
+      closestAudioBandwithDifference = difference
+      closestVariant = variant
+    }
+  }
+
+  return closestVariant
+}


### PR DESCRIPTION
# Fix audio track selection

## Pull Request Type
- [x] Bugfix

## Description
This pull request fixes the selected audio track getting lost when changing quality or format (audio to DASH or DASH to audio).

## Testing
### Quality change
1. Start playing a video in DASH or audio-only mode
2. Select an audio track that isn't the default one
3. Change the quality in the quality selector
4. The audio track should still be the same

### Format change
1. Start playing a video in DASH or audio-only mode
2. Select an audio track that isn't the default one
3. Change to DASH or audio-only mode (whichever one you are not currently using)
4. The audio track should still be the same

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 940169e58bec6bfd2770dfc6c947c02113442865