### PR TITLE
Local API: Use IOS HLS manifest for livestreams

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/player-components/AudioTrackSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AudioTrackSelection.js
@@ -100,7 +100,7 @@ export class AudioTrackSelection extends shaka.ui.SettingsMenu {
 
     this.button.setAttribute('shaka-status', this.currentSelection.innerText)
 
-    if (knownLabels.size > 0) {
+    if (knownLabels.size > 1) {
       this.button.classList.remove('shaka-hidden')
     } else {
       this.button.classList.add('shaka-hidden')

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -284,15 +284,12 @@ export async function getLocalVideoInfo(id) {
       info.storyboards = iosInfo.storyboards
     } else if (iosInfo.streaming_data) {
       info.streaming_data.adaptive_formats = iosInfo.streaming_data.adaptive_formats
+      info.streaming_data.hls_manifest_url = iosInfo.streaming_data.hls_manifest_url
+
       // Use the legacy formats from the original web response as the iOS client doesn't have any legacy formats
 
       for (const format of info.streaming_data.adaptive_formats) {
         format.freeTubeUrl = format.url
-      }
-
-      // don't overwrite for live streams
-      if (!info.streaming_data.hls_manifest_url) {
-        info.streaming_data.hls_manifest_url = iosInfo.streaming_data.hls_manifest_url
       }
     }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1176,8 +1176,10 @@ export default defineComponent({
       }
 
       if (this.manifestSrc === null ||
-        // HLS consists of combined audio and video files, so we can't do audio only
-        ((this.isLive || this.isPostLiveDvr) && this.manifestMimeType !== MANIFEST_TYPE_DASH)) {
+        ((this.isLive || this.isPostLiveDvr) &&
+        // The WEB HLS manifests only contain combined audio and video files, so we can't do audio only
+        // The IOS HLS manifests have audio-only streams
+          this.manifestMimeType === MANIFEST_TYPE_HLS && !this.manifestSrc.includes('/demuxed/1'))) {
         showToast(this.$t('Change Format.Audio formats are not available for this video'))
         return
       }
@@ -1316,10 +1318,10 @@ export default defineComponent({
         // live streams don't have legacy formats, so only switch between dash and audio
 
         if (this.activeFormat === 'dash') {
-          console.error('Unable to play audio formats. Reverting to DASH formats...')
+          console.error('Unable to play DASH formats. Reverting to audio formats...')
           this.enableAudioFormat()
         } else {
-          console.error('Unable to play DASH formats. Reverting to audio formats...')
+          console.error('Unable to play audio formats. Reverting to DASH formats...')
           this.enableDashFormat()
         }
       } else {


### PR DESCRIPTION
# Local API: Use IOS HLS manifest for livestreams

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation

## Related issue
closes #5533
https://github.com/FreeTubeApp/FreeTube/issues/661

## Description
While investigating why qualities were disappearing from the quality selector when you changed the quality on live streams, I also looked into why the IOS HLS manifests were failing to play (which is why we haven't been using them). I finally figured out how to get the iOS ones to play, which come with various benefits, such as:
- The quality selector works properly, qualities no longer disappear when you change the quality on a live stream
- We can get audio-only playback on live streams, as the IOS HLS manifests contain audio-only streams unlike the WEB ones
- We get up to 1 hour of DVR/seeking, yes it isn't as much as we would have had with the live DASH manifests (4 hours) or as much as you get on YouTube itself (12 hours) but it's a lot better than not being able to seek at all.

The benefits only apply to the local API though, as we have no control over what HLS manifest Invidious sends us, so the qualities disappearing issue is likely still an issue for people using the Invidious API.

## Testing

### Local API with local streaming
1. Set your preferred API backend to the local API
2. Open a live stream such as this Lofi Girl one: https://youtu.be/jfKfPfyJRdk
3. Try changing the quality, the qualities should stay in the selector when you change.
4. Test both the audio and DASH formats (yes I know in this case DASH is the wrong name but that's what we call it in FreeTube)
5. Test seeking around in the live stream

### Local API with Proxy Videos Through Invidious turned on
1. Set your preferred API backend to the local API
2. Turn on the Proxy Videos Through Invidious setting
3. Open a live stream such as this Lofi Girl one: https://youtu.be/jfKfPfyJRdk
4. Try changing the quality, the qualities should stay in the selector when you change.
5. Test both the audio and DASH formats (yes I know in this case DASH is the wrong name but that's what we call it in FreeTube)
6. Test seeking around in the live stream

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** ad320ac7d749eda57674a94b0295514e0fd73ee3