### PR TITLE
Update subscription cache when subscribing from the channel page

### DIFF
--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -60,6 +60,7 @@
             :channel-id="id"
             :channel-name="name"
             :channel-thumbnail="thumbnailUrl"
+            @subscribed="subscribed"
           />
         </div>
       </div>
@@ -277,7 +278,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['change-tab', 'search'])
+const emit = defineEmits(['change-tab', 'search', 'subscribed'])
 
 const hideChannelSubscriptions = computed(() => {
   return store.getters.getHideChannelSubscriptions
@@ -297,6 +298,10 @@ const formattedSubCount = computed(() => {
   }
   return formatNumber(props.subCount)
 })
+
+function subscribed() {
+  emit('subscribed')
+}
 
 /**
  * @param {string} tab

--- a/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
+++ b/src/renderer/components/ft-subscribe-button/ft-subscribe-button.js
@@ -42,6 +42,7 @@ export default defineComponent({
       required: false
     }
   },
+  emits: ['subscribed'],
   data: function () {
     return {
       isProfileDropdownOpen: false,
@@ -139,6 +140,7 @@ export default defineComponent({
         this.addChannelToProfiles({ channel, profileIds })
 
         showToast(this.$t('Channel.Added channel to your subscriptions'))
+        this.$emit('subscribed')
       }
 
       if (this.isProfileDropdownEnabled && this.openDropdownOnSubscribe && !this.isProfileDropdownOpen) {

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1991,6 +1991,38 @@ export default defineComponent({
       })
     },
 
+    handleSubscription: function () {
+      // We can't cache the shorts data as YouTube doesn't return published dates on the shorts channel tab
+
+      // Create copies of the arrays so that we only cache the first page
+      // If we use the same array, the store will get angry at us for modifying it outside of the store
+      // when the user clicks load more
+
+      if (this.latestVideos.length > 0 && this.videoSortBy === 'newest') {
+        this.updateSubscriptionVideosCacheByChannel({
+          channelId: this.id,
+          videos: [...this.latestVideos]
+        })
+      }
+
+      if (this.latestLive.length > 0 && this.liveSortBy === 'newest') {
+        this.updateSubscriptionLiveCacheByChannel({
+          channelId: this.id,
+          videos: [...this.latestLive]
+        })
+      }
+
+      if (this.latestCommunityPosts.length > 0) {
+        this.latestCommunityPosts.forEach(post => {
+          post.authorId = this.id
+        })
+        this.updateSubscriptionPostsCacheByChannel({
+          channelId: this.id,
+          posts: [...this.latestCommunityPosts]
+        })
+      }
+    },
+
     getIconForSortPreference: (s) => getIconForSortPreference(s),
 
     ...mapActions([

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -20,6 +20,7 @@
       class="card channelDetails"
       @change-tab="changeTab"
       @search="newSearch"
+      @subscribed="handleSubscription"
     />
     <ft-card
       v-if="!isLoading && !errorMessage && (isFamilyFriendly || !showFamilyFriendlyOnly)"


### PR DESCRIPTION
# Update subscription cache when subscribing from the channel page

## Pull Request Type

- [x] Feature Implementation

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5185#pullrequestreview-2305874622

Inspired by: #4667

## Description
When you visit a channel that you are already subscribed to, we update the subscription cache with the data we fetched to display on that channel. This pull request expands that to cover subscribing to a channel on the channel page too, as we already have the data we might as well add it to the cache. While this doesn't specifically help with the scenario in the video in this comment https://github.com/FreeTubeApp/FreeTube/pull/5185#pullrequestreview-2305874622 (subscribing from the search results), it does solve it for the channel page.

As YouTube doesn't provide any published dates on the shorts tab, we unfortunately cannot cache the data from that tab, however we can still cache the videos, live and community tabs.

## Testing
1. Turn off "Subscription Settings" -> "Fetch Feed Automatically"
2. Refresh your subscriptions
3. Subscribe to a channel that you are not subscribed to yet from the search page
4. Visit the subscriptions page
5. Notice that instead of showing the cached videos it says that you have turned off automatic fetching
6. Unsubscribe from that channel from any page that is **not the channel page**
7. Go back to the subscriptions page and notice that it shows the cached videos again
8. Visit the channel page of a channel you are not subscribed to yet
9. Subscribe to that channel from the channel page
10. Go back to the subscriptions page
11. It should be showing the previously cached videos as well as the videos from the channel you just subscribed to.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** ddb495a09939df797a9e30ef9d669eed676b1a78