### PR TITLE
Fix video start time handling

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2371,18 +2371,6 @@ export default defineComponent({
 
       if (props.format !== 'legacy') {
         player.addEventListener('streaming', () => {
-          if (props.startTime !== null) {
-            if (player.isLive() || player.getManifestType() === 'HLS') {
-              player.updateStartTime(null)
-            } else {
-              const { end } = player.seekRange()
-
-              if (props.startTime > (end - 10)) {
-                player.updateStartTime(end - 10)
-              }
-            }
-          }
-
           hasMultipleAudioTracks.value = player.getAudioLanguagesAndRoles().length > 1
 
           if (props.format === 'dash') {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -113,8 +113,6 @@ export default defineComponent({
       playlistItemId: null,
       /** @type {number|null} */
       timestamp: null,
-      /** @type {number|null} */
-      startTimeSeconds: null,
       playNextTimeout: null,
       playNextCountDownIntervalId: null,
       infoAreaSticky: true,
@@ -232,6 +230,26 @@ export default defineComponent({
 
       return this.$store.getters.getPlaylist(this.playlistId)
     },
+    startTimeSeconds: function () {
+      if (this.isLoading || this.isLive) {
+        return null
+      }
+
+      if (this.timestamp !== null && this.timestamp < this.videoLengthSeconds) {
+        return this.timestamp
+      } else if (this.saveWatchedProgress && this.historyEntryExists) {
+        // For UX consistency, no progress reading if writing disabled
+
+        /** @type {number} */
+        const watchProgress = this.historyEntry.watchProgress
+
+        if (watchProgress > 0 && watchProgress < this.videoLengthSeconds - 2) {
+          return watchProgress
+        }
+      }
+
+      return null
+    }
   },
   watch: {
     async $route() {
@@ -254,11 +272,9 @@ export default defineComponent({
       this.vrProjection = null
       this.downloadLinks = []
       this.videoCurrentChapterIndex = 0
-      this.startTimeSeconds = null
       this.videoGenreIsMusic = false
 
       this.checkIfTimestamp()
-      this.setStartTime()
       this.checkIfPlaylist()
 
       switch (this.backendPreference) {
@@ -279,7 +295,6 @@ export default defineComponent({
     this.activeFormat = this.defaultVideoFormat
 
     this.checkIfTimestamp()
-    this.setStartTime()
   },
   mounted: function () {
     this.onMountedDependOnLocalStateLoading()
@@ -1067,23 +1082,6 @@ export default defineComponent({
 
         this.updateLocalPlaylistLastPlayedAtSometimes()
       }
-    },
-
-    setStartTime: function () {
-      if (this.timestamp !== null && this.timestamp > 0) {
-        this.startTimeSeconds = this.timestamp
-        return
-      } else if (this.saveWatchedProgress && this.historyEntryExists) {
-        // For UX consistency, no progress reading if writing disabled
-        const watchProgress = this.historyEntry.watchProgress
-
-        if (watchProgress > 0) {
-          this.startTimeSeconds = watchProgress
-          return
-        }
-      }
-
-      this.startTimeSeconds = null
     },
 
     checkIfPlaylist: function () {


### PR DESCRIPTION
# Fix video start time handling

## Pull Request Type

- [x] Bugfix

## Related issue

closes #5718

## Description
This pull request fixes the video start time handling. Video URLs with timestamps should start at their timestamp, partially watched videos should start at the timestamp that you stopped at and finished videos should start from the beginning. Currently all 3 were behaving incorrectly.

## Testing
1. Open a video URL with a timestamp e.g. `https://www.youtube.com/watch?v=jNQXAC9IVRw&t=5`.
2. Open a video and seek part way through, leave the watch page and then go back to the same video, it should start where you left off.
3. Open a video and seek to the end, leave the watch page and come back, it should start from the beginning.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** ddb495a09939df797a9e30ef9d669eed676b1a78