### PR TITLE
Various minor performance improvements to the subscription page

### DIFF
--- a/src/renderer/components/subscriptions-community/subscriptions-community.js
+++ b/src/renderer/components/subscriptions-community/subscriptions-community.js
@@ -13,7 +13,7 @@ export default defineComponent({
   },
   data: function () {
     return {
-      isLoading: false,
+      isLoading: true,
       postList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -101,8 +101,6 @@ export default defineComponent({
     },
   },
   mounted: async function () {
-    this.isLoading = true
-
     this.loadPostsFromCacheSometimes()
   },
   methods: {
@@ -120,11 +118,8 @@ export default defineComponent({
     },
 
     async loadPostsFromCacheForAllActiveProfileChannels() {
-      const postList = []
-      this.activeSubscriptionList.forEach((channel) => {
-        const channelCacheEntry = this.$store.getters.getPostsCacheByChannel(channel.id)
-
-        postList.push(...channelCacheEntry.posts)
+      const postList = this.cacheEntriesForAllActiveProfileChannels.flatMap((cacheEntry) => {
+        return cacheEntry.posts
       })
 
       postList.sort((a, b) => {
@@ -143,7 +138,6 @@ export default defineComponent({
       }
 
       const channelsToLoadFromRemote = this.activeSubscriptionList
-      const postList = []
       let channelCount = 0
       this.isLoading = true
 
@@ -193,13 +187,13 @@ export default defineComponent({
         }
 
         return posts
-      }))).flatMap((o) => o)
-      postList.push(...postListFromRemote)
-      postList.sort((a, b) => {
+      }))).flat()
+
+      postListFromRemote.sort((a, b) => {
         return b.publishedTime - a.publishedTime
       })
 
-      this.postList = postList
+      this.postList = postListFromRemote
       this.isLoading = false
       this.updateShowProgressBar(false)
       this.lastRemoteRefreshSuccessTimestamp = new Date()

--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -20,7 +20,7 @@ export default defineComponent({
   },
   data: function () {
     return {
-      isLoading: false,
+      isLoading: true,
       videoList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -111,8 +111,6 @@ export default defineComponent({
     },
   },
   mounted: async function () {
-    this.isLoading = true
-
     this.loadVideosFromCacheSometimes()
   },
   methods: {
@@ -130,12 +128,10 @@ export default defineComponent({
     },
 
     async loadVideosFromCacheForAllActiveProfileChannels() {
-      const videoList = []
-      this.activeSubscriptionList.forEach((channel) => {
-        const channelCacheEntry = this.$store.getters.getLiveCacheByChannel(channel.id)
-
-        videoList.push(...channelCacheEntry.videos)
+      const videoList = this.cacheEntriesForAllActiveProfileChannels.flatMap((cacheEntry) => {
+        return cacheEntry.videos
       })
+
       this.videoList = updateVideoListAfterProcessing(videoList)
       this.isLoading = false
     },
@@ -148,7 +144,6 @@ export default defineComponent({
       }
 
       const channelsToLoadFromRemote = this.activeSubscriptionList
-      const videoList = []
       let channelCount = 0
       this.isLoading = true
 
@@ -202,10 +197,9 @@ export default defineComponent({
         }
 
         return videos
-      }))).flatMap((o) => o)
-      videoList.push(...videoListFromRemote)
+      }))).flat()
 
-      this.videoList = updateVideoListAfterProcessing(videoList)
+      this.videoList = updateVideoListAfterProcessing(videoListFromRemote)
       this.isLoading = false
       this.updateShowProgressBar(false)
       this.lastRemoteRefreshSuccessTimestamp = new Date()

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -18,7 +18,7 @@ export default defineComponent({
   },
   data: function () {
     return {
-      isLoading: false,
+      isLoading: true,
       videoList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -105,8 +105,6 @@ export default defineComponent({
     },
   },
   mounted: async function () {
-    this.isLoading = true
-
     this.loadVideosFromCacheSometimes()
   },
   methods: {
@@ -124,12 +122,10 @@ export default defineComponent({
     },
 
     async loadVideosFromCacheForAllActiveProfileChannels() {
-      const videoList = []
-      this.activeSubscriptionList.forEach((channel) => {
-        const channelCacheEntry = this.$store.getters.getShortsCacheByChannel(channel.id)
-
-        videoList.push(...channelCacheEntry.videos)
+      const videoList = this.cacheEntriesForAllActiveProfileChannels.flatMap((cacheEntry) => {
+        return cacheEntry.videos
       })
+
       this.videoList = updateVideoListAfterProcessing(videoList)
       this.isLoading = false
     },
@@ -142,7 +138,6 @@ export default defineComponent({
       }
 
       const channelsToLoadFromRemote = this.activeSubscriptionList
-      const videoList = []
       let channelCount = 0
       this.isLoading = true
       this.updateShowProgressBar(true)
@@ -178,10 +173,9 @@ export default defineComponent({
         }
 
         return videos
-      }))).flatMap((o) => o)
-      videoList.push(...videoListFromRemote)
+      }))).flat()
 
-      this.videoList = updateVideoListAfterProcessing(videoList)
+      this.videoList = updateVideoListAfterProcessing(videoListFromRemote)
       this.isLoading = false
       this.updateShowProgressBar(false)
       this.lastRemoteRefreshSuccessTimestamp = new Date()

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -20,7 +20,7 @@ export default defineComponent({
   },
   data: function () {
     return {
-      isLoading: false,
+      isLoading: true,
       videoList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -115,8 +115,6 @@ export default defineComponent({
     },
   },
   mounted: async function () {
-    this.isLoading = true
-
     this.loadVideosFromCacheSometimes()
   },
   methods: {
@@ -134,12 +132,10 @@ export default defineComponent({
     },
 
     async loadVideosFromCacheForAllActiveProfileChannels() {
-      const videoList = []
-      this.activeSubscriptionList.forEach((channel) => {
-        const channelCacheEntry = this.$store.getters.getVideoCacheByChannel(channel.id)
-
-        videoList.push(...channelCacheEntry.videos)
+      const videoList = this.cacheEntriesForAllActiveProfileChannels.flatMap((cacheEntry) => {
+        return cacheEntry.videos
       })
+
       this.videoList = updateVideoListAfterProcessing(videoList)
       this.isLoading = false
     },
@@ -152,7 +148,6 @@ export default defineComponent({
       }
 
       const channelsToLoadFromRemote = this.activeSubscriptionList
-      const videoList = []
       let channelCount = 0
       this.isLoading = true
 
@@ -206,10 +201,9 @@ export default defineComponent({
         }
 
         return videos
-      }))).flatMap((o) => o)
-      videoList.push(...videoListFromRemote)
+      }))).flat()
 
-      this.videoList = updateVideoListAfterProcessing(videoList)
+      this.videoList = updateVideoListAfterProcessing(videoListFromRemote)
       this.isLoading = false
       this.updateShowProgressBar(false)
       this.lastRemoteRefreshSuccessTimestamp = new Date()


### PR DESCRIPTION
# Various minor performance improvements to the subscription page

## Pull Request Type

- [x] Performance improvements

## Description

This pull request adds a few minor performance improvements to the subscriptions page. I've been using these in my own build for a few weeks now and haven't noticed any problems with them. The changes in this pull request can be grouped into 4 groups and are the same across all 4 subscription tabs.

1. Initialise `isLoading` with `true` instead of setting it to `true` in the mounted hook. This avoids Vue rendering an empty subscription tab, then a loading one and then again with the content, as it now only has to render the loading one and then the one with the content.
2. Switch from using `Array#flatMap()` with a passthrough function to just using `Array#flat()` directly.
3. As we fetch the channel cache entries from the cache in the `cacheEntriesForAllActiveProfileChannels` computed property, we can just use the entries from that, instead of loading them from the cache again in `loadVideosFromCacheForAllActiveProfileChannels()`.
4. At the moment we create an empty array, then push all of the fetched data into that array in one big call to `Array#push`, I decided that it would make more sense to just use the array with the fetched data directly, instead of copying it into an empty array first.

## Testing

Check that refreshing your subscriptions and loading them from the cache both still work correctly.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 9ca2c7452968e976896191d87281fe8eecf4fea1