### PR TITLE
Let translateWindowTitle use the imported i18n instance

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -83,7 +83,7 @@ export default defineComponent({
     windowTitle: function () {
       const routePath = this.$route.path
       if (!routePath.startsWith('/channel/') && !routePath.startsWith('/watch/') && !routePath.startsWith('/hashtag/') && !routePath.startsWith('/playlist/')) {
-        let title = translateWindowTitle(this.$route.meta.title, this.$i18n)
+        let title = translateWindowTitle(this.$route.meta.title)
         if (!title) {
           title = packageDetails.productName
         } else {

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -96,7 +96,7 @@ export default defineComponent({
       return this.$router.getRoutes().filter((route) => includedPageNames.includes(route.name))
     },
     defaultPageNames: function () {
-      return this.defaultPages.map((route) => translateWindowTitle(route.meta.title, this.$i18n))
+      return this.defaultPages.map((route) => translateWindowTitle(route.meta.title))
     },
     defaultPageValues: function () {
       // avoid Vue parsing issues by excluding '/' from path values

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -53,8 +53,7 @@ export default defineComponent({
         {
           page: translateWindowTitle(this.$router.getRoutes()
             .find((route) => route.path === '/' + this.landingPage)
-            .meta.title,
-          this.$i18n
+            .meta.title
           )
         })
     },

--- a/src/renderer/helpers/strings.js
+++ b/src/renderer/helpers/strings.js
@@ -1,3 +1,5 @@
+import i18n from '../i18n/index'
+
 /**
  * This will return true if a string is null, undefined or empty.
  * @param {string|null|undefined} _string the string to process
@@ -24,7 +26,7 @@ export function isKeyboardEventKeyPrintableChar(eventKey) {
   return false
 }
 
-export function translateWindowTitle(title, i18n) {
+export function translateWindowTitle(title) {
   switch (title) {
     case 'Subscriptions':
       return i18n.t('Subscriptions.Subscriptions')

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,9 +1,9 @@
 // import the styles
 import Vue from 'vue'
-import App from './App.vue'
+import i18n from './i18n/index'
 import router from './router/index'
 import store from './store/index'
-import i18n from './i18n/index'
+import App from './App.vue'
 import { IpcChannels } from '../constants'
 import { library } from '@fortawesome/fontawesome-svg-core'
 


### PR DESCRIPTION
# Let translateWindowTitle used imported i18n instance

## Pull Request Type

- [x] Refactoring

## Description

Finally figured out what caused the error (see screenshot) when we added `import i18n from '../i18n/index'` to the `src/renderer/helpers/strings.js` file and meant that we had to pass the vue-i18n instance in as a function parameter. Well okay I'm not sure exactly why it was happening, but moving the `App.vue` import below the `i18n/index.js` one in the `src/renderer/main.js` file, fixes the error message, so presumably something to do with the order that webpack resolves the imports.

## Screenshots
![error-message](https://github.com/user-attachments/assets/01b3b9b9-af78-4d0b-bf32-fffb49fff00e)

## Testing
1. `yarn dev`
2. Check that it starts without the error in the devtools
3. Check that the window titles still get translated (e.g. try changing the locale)

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 1a049c0a72a0b053746666315ad62bcc3e7bad88