### PR TITLE
Convert X64 AppImage to static runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,18 @@ jobs:
       if: contains(matrix.runtime, 'arm64')
       run: yarn run build:arm64
 
+    - name: Convert X64 AppImage to static runtime
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
+      run: |
+        sudo apt install desktop-file-utils
+        cd build
+        wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
+        chmod +x *.AppImage && ./FreeTube-${{ steps.versionNumber.outputs.result }}.AppImage --appimage-extract
+        rm -f ./FreeTube*.AppImage
+        ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+          -n ./squashfs-root ./FreeTube-${{ steps.versionNumber.outputs.result }}.AppImage
+        rm -rf ./squashfs-root ./appimagetool.AppImage
+
     - name: Upload Linux .zip x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')


### PR DESCRIPTION
# Convert X64 AppImage to static runtime

## Pull Request Type
- [x] Feature Implementation

## Related issue
Closes #5714 #5641 but not fully since I was only able to do this for the X64 build.

## Description
This change drops libfuse2 dependency from the AppImage, which prevents them from working on newer distros that no longer ship libfuse2.

## Testing
[Artifact](https://github.com/Samueru-sama/FreeTube/actions/runs/11028756249/artifacts/1975640207)

![image](https://github.com/user-attachments/assets/a3f3bfd2-353e-44ab-8e84-a693b73ab3d4)

## Desktop
<!-- Please complete the following information-->
- **OS:** Artix Linux
- **OS Version:** Rolling release (Kernel: Linux 6.10.10-artix1-1)
- **FreeTube version:** 0.21.3-nightly-13

## Additional context
I was not able to fix this on the arm builds because even though I tried using the same runners that the upload actions for those use, it complains that it can't execute the appimage to extract it, which is needed in order to convert it.
