### PR TITLE
Do not overwrite cache entries when hitting RSS ratelimits

### DIFF
--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -206,10 +206,13 @@ export default defineComponent({
         channelCount++
         const percentageComplete = (channelCount / channelsToLoadFromRemote.length) * 100
         this.setProgressBarPercentage(percentageComplete)
-        this.updateSubscriptionLiveCacheByChannel({
-          channelId: channel.id,
-          videos: videos
-        })
+
+        if (videos != null) {
+          this.updateSubscriptionLiveCacheByChannel({
+            channelId: channel.id,
+            videos: videos
+          })
+        }
 
         if (name || thumbnailUrl) {
           subscriptionUpdates.push({
@@ -219,7 +222,7 @@ export default defineComponent({
           })
         }
 
-        return videos
+        return videos ?? []
       }))).flat()
 
       this.videoList = updateVideoListAfterProcessing(videoListFromRemote)
@@ -276,6 +279,12 @@ export default defineComponent({
 
       try {
         const response = await fetch(feedUrl)
+
+        if (response.status === 403) {
+          return {
+            videos: null
+          }
+        }
 
         if (response.status === 404) {
           // playlists don't exist if the channel was terminated but also if it doesn't have the tab,

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -183,10 +183,13 @@ export default defineComponent({
         channelCount++
         const percentageComplete = (channelCount / channelsToLoadFromRemote.length) * 100
         this.setProgressBarPercentage(percentageComplete)
-        this.updateSubscriptionShortsCacheByChannel({
-          channelId: channel.id,
-          videos: videos
-        })
+
+        if (videos != null) {
+          this.updateSubscriptionShortsCacheByChannel({
+            channelId: channel.id,
+            videos: videos
+          })
+        }
 
         if (name) {
           subscriptionUpdates.push({
@@ -195,7 +198,7 @@ export default defineComponent({
           })
         }
 
-        return videos
+        return videos ?? []
       }))).flat()
 
       this.videoList = updateVideoListAfterProcessing(videoListFromRemote)
@@ -212,6 +215,12 @@ export default defineComponent({
 
       try {
         const response = await fetch(feedUrl)
+
+        if (response.status === 403) {
+          return {
+            videos: null
+          }
+        }
 
         if (response.status === 404) {
           // playlists don't exist if the channel was terminated but also if it doesn't have the tab,

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -210,10 +210,13 @@ export default defineComponent({
         channelCount++
         const percentageComplete = (channelCount / channelsToLoadFromRemote.length) * 100
         this.setProgressBarPercentage(percentageComplete)
-        this.updateSubscriptionVideosCacheByChannel({
-          channelId: channel.id,
-          videos: videos
-        })
+
+        if (videos != null) {
+          this.updateSubscriptionVideosCacheByChannel({
+            channelId: channel.id,
+            videos: videos
+          })
+        }
 
         if (name || thumbnailUrl) {
           subscriptionUpdates.push({
@@ -223,7 +226,7 @@ export default defineComponent({
           })
         }
 
-        return videos
+        return videos ?? []
       }))).flat()
 
       this.videoList = updateVideoListAfterProcessing(videoListFromRemote)
@@ -280,6 +283,12 @@ export default defineComponent({
 
       try {
         const response = await fetch(feedUrl)
+
+        if (response.status === 403) {
+          return {
+            videos: null
+          }
+        }
 
         if (response.status === 404) {
           // playlists don't exist if the channel was terminated but also if it doesn't have the tab,


### PR DESCRIPTION
# Do not overwrite cache entries when hitting RSS ratelimits

## Pull Request Type

- [x] Bugfix

## Related issue
Related to #5749

## Description
When hitting the RSS ratelimits we currently treat it the same as if the channel had no uploads and overwrite the existing cache entries with empty arrays, this pull request fixes that so that we don't overwrite them if YouTube returns a 403.

## Testing
I haven't directly tested this, as I am not personally blocked but it should work.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 30f95e5700ac57bc18700fa24e64af91fd3388f4