### PR TITLE
Local API: Fix error when a community post has no likes

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1485,7 +1485,8 @@ function parseLocalCommunityPost(post) {
     postId: post.id,
     authorThumbnails: post.author.thumbnails,
     publishedTime: calculatePublishedDate(post.published.text),
-    voteCount: parseLocalSubscriberCount(post.vote_count.text),
+    // YouTube hides the vote/like count on posts when it is zero
+    voteCount: post.vote_count ? parseLocalSubscriberCount(post.vote_count.text) : 0,
     postContent: parseLocalAttachment(post.attachment),
     commentCount: replyCount,
     author: post.author.name,


### PR DESCRIPTION
# Local API: Fix error when a community post has no likes

## Pull Request Type

- [x] Bugfix

## Description
For posts that have no likes YouTube doesn't include the like count in the API response, which currently results in the local API erroring.

Usually when information is missing from the API response we treat it as unknown (e.g. missing view count for some videos on the videos channel tab, but definitely has thousands of views when you look at the watch page), however in this case I think it is fair to assume that it means that it is zero as other community posts on that channel have low like counts (e.g. 16, 15, 9, 3, 3, 21, 8, 4, 7).

## Screenshots

![error](https://github.com/user-attachments/assets/f9c05a2d-f984-4f1e-a0b5-bbabc9b2ed09)

## Testing
https://www.youtube.com/@funx/community

The affected post is the 6th post, which was posted 5 months ago.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 30f95e5700ac57bc18700fa24e64af91fd3388f4