### PR TITLE
Support copying post links from the context menu

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -87,7 +87,7 @@ function runApp() {
           const path = urlParts[1]
 
           if (path) {
-            visible = ['/channel', '/watch', '/hashtag'].some(p => path.startsWith(p)) ||
+            visible = ['/channel', '/watch', '/hashtag', '/post'].some(p => path.startsWith(p)) ||
               // Only show copy link entry for non user playlists
               (path.startsWith('/playlist') && !/playlistType=user/.test(path))
           }
@@ -156,6 +156,21 @@ function runApp() {
             }
 
             return url.toString()
+          }
+          case 'post': {
+            if (query) {
+              const authorId = new URLSearchParams(query).get('authorId')
+
+              if (authorId) {
+                if (toYouTube) {
+                  return `${origin}/channel/${authorId}/community?lb=${id}`
+                } else {
+                  return `${origin}/post/${id}?ucid=${authorId}`
+                }
+              }
+            }
+
+            return `${origin}/post/${id}`
           }
         }
       }


### PR DESCRIPTION
# Support copying post links from the context menu

## Pull Request Type

- [x] Feature Implementation

## Description
This pull request adds support for copying in-app post links with the context menu. In the future it might make sense to add the share button to the post page, but I wasn't sure how to fit it into the UI, so I decided that it could be done in a future pull request.

## Screenshots
Before:
![before](https://github.com/user-attachments/assets/bda589de-7155-4fa5-81dc-4c28f9cb815a)

After:
![after](https://github.com/user-attachments/assets/68c854cc-7f0c-450e-a7ca-9c194559783b)

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Visit https://www.youtube.com/@YouTube/community
2. Right click on the comment icon
3. Test that the produced links are valid by opening the links in your browser or inside FreeTube

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 4503ff161a8ca52e6d00ccde4a12577ebee65e1c