### PR TITLE
Fix long comments overflowing and breaking the layout

### DIFF
--- a/src/renderer/components/watch-video-comments/watch-video-comments.css
+++ b/src/renderer/components/watch-video-comments/watch-video-comments.css
@@ -96,7 +96,7 @@
   font-size: 14px;
   margin-block-start: -10px;
   margin-inline-start: 70px;
-  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .commentPinned {


### PR DESCRIPTION
# Fix long comments overflowing and breaking the layout

## Pull Request Type

- [x] Bugfix

## Related issue
closes #5296

## Description
This pull requests fixes comments with long "words" overflowing horizontally and breaking the layout. It looks like we had some existing code which was supposed to fix that but that didn't seem to be doing anything anymore.

## Screenshots

Before:
![before](https://github.com/user-attachments/assets/b42bb4fb-70c6-479b-80e9-f50dab4e9274)

After:
![after](https://github.com/user-attachments/assets/c03f82c9-21e2-4bc4-a22c-72e7b8e50bff)

## Testing
1. Turn on `Hide Recommended Videos` in the `Distraction Free Settings`
2. Open the video provided in the linked bug report: https://youtu.be/ASeJV9KGAOc
3. Load the comments
4. Check that they don't break the layout anymore.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b3f92e3ec9cfe4ff4b2b74f495a167fc4c9fae49