### PR TITLE
Fix loading from search cache failing when no features are selected

### DIFF
--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -93,7 +93,7 @@ export default defineComponent({
       time: this.$route.query.time,
       type: this.$route.query.type,
       duration: this.$route.query.duration,
-      features: features,
+      features: features ?? [],
     }
 
     const payload = {


### PR DESCRIPTION
# Fix loading from search cache failing when no features are selected

## Pull Request Type

- [x] Bugfix

## Related issue
close #5305

## Description
When no features are selected and you return to the search page again, it was treating them as `undefined`, this caused the search cache checks to fail as they were comparing `undefined` against an empty array, so it then tried to make an API request to Invidious but that function expects the features to always be an array, so it was throwing an error about calling `join()` on `undefined`. This pull request makes sure that the features are set to an empty array if none are provided, which fixes the search cache look ups and makes the Invidious search happy because it will always receive an array.

## Screenshots
![error](https://github.com/user-attachments/assets/2874ef01-6c6a-42a6-bb0a-c66eece747f3)

## Testing

1. Set the preferred API backend to Invidious
2. Search for something e.g. `linus tech tips`
3. Press the back arrow in the navigation bar
4. Press the forward arrow in the navigation bar
5. It should have correctly restored the search results from the search cache without erroring or trying to make a new API request

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:** b3f92e3ec9cfe4ff4b2b74f495a167fc4c9fae49
