### PR TITLE
Cleanup unused code in the store

### DIFF
--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -14,32 +14,16 @@ const state = {
 const getters = {
   getSubscriptionCacheReady: (state) => state.subscriptionCacheReady,
 
-  getVideoCache: (state) => {
-    return state.videoCache
-  },
-
   getVideoCacheByChannel: (state) => (channelId) => {
     return state.videoCache[channelId]
-  },
-
-  getShortsCache: (state) => {
-    return state.shortsCache
   },
 
   getShortsCacheByChannel: (state) => (channelId) => {
     return state.shortsCache[channelId]
   },
 
-  getLiveCache: (state) => {
-    return state.liveCache
-  },
-
   getLiveCacheByChannel: (state) => (channelId) => {
     return state.liveCache[channelId]
-  },
-
-  getPostsCache: (state) => {
-    return state.postsCache
   },
 
   getPostsCacheByChannel: (state) => (channelId) => {
@@ -175,7 +159,7 @@ const actions = {
     }
   },
 
-  async clearSubscriptionsCache({ commit }, payload) {
+  async clearSubscriptionsCache({ commit }) {
     try {
       await DBSubscriptionCacheHandlers.deleteAll()
       commit('clearCaches')

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -52,10 +52,6 @@ const state = {
   externalPlayerNames: [],
   externalPlayerValues: [],
   externalPlayerCmdArguments: {},
-  lastVideoRefreshTimestampByProfile: {},
-  lastShortRefreshTimestampByProfile: {},
-  lastLiveRefreshTimestampByProfile: {},
-  lastCommunityRefreshTimestampByProfile: {},
   lastPopularRefreshTimestamp: '',
   lastTrendingRefreshTimestamp: '',
   subscriptionFirstAutoFetchRunData: {
@@ -73,10 +69,6 @@ const getters = {
 
   getOutlinesHidden(state) {
     return state.outlinesHidden
-  },
-
-  getCurrentVolume(state) {
-    return state.currentVolume
   },
 
   getSessionSearchHistory(state) {


### PR DESCRIPTION
# Cleanup unused code in the store

## Pull Request Type

- [x] Code cleanup

## Description

* The `last{Video,Short,Live,Community}RefreshTimestampByProfile` state entries have been unused since #5185.
* The `get{Video,Short,Live,Community}Cache` getters have never been used.
* The `getCurrentVolume` getter seems to have been unused ever since its addition to the code base in 77e7168c738ac70c08962f601d4f353ff205f21c and the state property that it references has never existed from what I can tell.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 