### PR TITLE
Update playlist import to only add duplicate playlist items sometimes

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -875,6 +875,7 @@ export default defineComponent({
         // to the app, so we'll only grab the data we need here.
 
         const playlistObject = {}
+        const videoIdToBeAddedSet = new Set()
 
         Object.keys(playlistData).forEach((key) => {
           if ([requiredKeys, optionalKeys, ignoredKeys].every((ks) => !ks.includes(key))) {
@@ -888,6 +889,7 @@ export default defineComponent({
 
               if (videoObjectHasAllRequiredKeys) {
                 videoArray.push(video)
+                videoIdToBeAddedSet.add(video.videoId)
               }
             })
 
@@ -916,20 +918,33 @@ export default defineComponent({
           return
         }
 
+        const duplicateVideoPresentInToBeAdded = playlistObject.videos.length > videoIdToBeAddedSet.size
+        const existingVideoIdSet = existingPlaylist.videos.reduce((video) => videoIdToBeAddedSet.add(video.videoId), new Set())
+        const duplicateVideoPresentInExistingPlaylist = existingPlaylist.videos.length > existingVideoIdSet.size
+        const shouldAddDuplicateVideos = duplicateVideoPresentInToBeAdded || duplicateVideoPresentInExistingPlaylist
+
         playlistObject.videos.forEach((video) => {
           let videoExists = false
-          if (video.playlistItemId != null) {
+          if (shouldAddDuplicateVideos) {
+            if (video.playlistItemId != null) {
+              // Find by `playlistItemId` if present
+              videoExists = existingPlaylist.videos.some((x) => {
+                // Allow duplicate (by videoId) videos to be added
+                return x.videoId === video.videoId && x.playlistItemId === video.playlistItemId
+              })
+            } else {
+              // Older playlist exports have no `playlistItemId` but have `timeAdded`
+              // Which might be duplicate for copied playlists with duplicate `videoId`
+              videoExists = existingPlaylist.videos.some((x) => {
+                // Allow duplicate (by videoId) videos to be added
+                return x.videoId === video.videoId && x.timeAdded === video.timeAdded
+              })
+            }
+          } else {
             // Find by `playlistItemId` if present
             videoExists = existingPlaylist.videos.some((x) => {
               // Allow duplicate (by videoId) videos to be added
-              return x.videoId === video.videoId && x.playlistItemId === video.playlistItemId
-            })
-          } else {
-            // Older playlist exports have no `playlistItemId` but have `timeAdded`
-            // Which might be duplicate for copied playlists with duplicate `videoId`
-            videoExists = existingPlaylist.videos.some((x) => {
-              // Allow duplicate (by videoId) videos to be added
-              return x.videoId === video.videoId && x.timeAdded === video.timeAdded
+              return x.videoId === video.videoId
             })
           }
 


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/5038

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Updates the behaviour of importing playlists **when** existing playlist found

Before: 
- Add playlist item unique by `playlistItemId`

After: 
- If both existing & incoming playlists have unique videos only (i.e. unique `videoId` values)
  Only add playlist items from incoming playlist with `videoId` absent in existing playlist
- If either existing or incoming playlist has duplicate videos, add videos unique by `playlistItemId` (old behaviour)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Download files from https://github.com/FreeTubeApp/FreeTube/issues/5038#issuecomment-2380302656
- Clear playlist `Favorites` coz that's the name of playlist in those files
- Test following cases (skip some if you want, but A probably should not be skipped)

(A) Both existing & incoming playlists have unique videos only
- import PC1 twice
- Or manually add some videos (which is the case of https://github.com/FreeTubeApp/FreeTube/issues/5038)

(B) Only incoming playlist has "duplicate" videos
- import PC1, import PC2

(C) Only existing playlist has "duplicate" videos
- import PC2, import PC1

(D) Only existing playlist has "duplicate" videos
- import PC2 twice (should still have 4 items coz unique by `playlistItemId`)

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
