### PR TITLE
Fix subscriptions CSV import shortening channel names

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -220,7 +220,7 @@ export default defineComponent({
         return [...yt.matchAll(splitCSVRegex)].map(s => {
           let newVal = s[1]
           if (newVal.startsWith('"')) {
-            newVal = newVal.substring(1, newVal.length - 2).replaceAll('""', '"')
+            newVal = newVal.substring(1, newVal.length - 1).replaceAll('""', '"')
           }
           return newVal
         })


### PR DESCRIPTION
# Fix subscriptions CSV import shortening channel names

## Pull Request Type

- [x] Bugfix

## Description
This pull request fixes the subscriptions CSV import removing the last character from channel names when they are quoted. We probably never noticed this problem before as we used to make API requests during the import, so the name was replaced with the one from the API response.

Noticed this while working on another pull request.

## Screenshots
![youtub](https://github.com/user-attachments/assets/7c04fcaa-6a32-4ce2-b68c-202de2499127)

## Testing
1. Download this file (remove the .txt file extension) and import it into FreeTube: [subscriptions.csv.txt](https://github.com/user-attachments/files/17261510/subscriptions.csv.txt)
2. Check in the side bar that the YouTube channel (the only one in the file) is actually called YouTube

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 43c6262eb5c46461b44ec40d0e5ee097b66dbd9a