### PR TITLE
Fix hashtag page not using Invidious API when it should

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -388,7 +388,7 @@ export function filterInvidiousFormats(formats) {
   })
 }
 
-export async function getHashtagInvidious(hashtag, page) {
+export async function getHashtagInvidious(hashtag, page = 1) {
   const payload = {
     resource: 'hashtag',
     id: hashtag,

--- a/src/renderer/views/Hashtag/Hashtag.js
+++ b/src/renderer/views/Hashtag/Hashtag.js
@@ -64,7 +64,7 @@ export default defineComponent({
 
     getHashtag: async function() {
       const hashtag = decodeURIComponent(this.$route.params.hashtag)
-      if (this.backendFallback || this.backendPreference === 'local') {
+      if (this.backendPreference === 'local') {
         await this.getLocalHashtag(hashtag)
       } else {
         await this.getInvidiousHashtag(hashtag)


### PR DESCRIPTION
# Fix hashtag page not using Invidious API when it should

## Pull Request Type
- [x] Bugfix

## Description
When Invidious API is preferred back end, it would use local api for hashtag page if fallback was enabled. This PR fixes it so that it will use IV API.

## Testing 
- with iv api + fallback
- go to a hashtag page
- make sure it doesn't use local api

## Desktop
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** latest
