### PR TITLE
Update subscription details from search results

### DIFF
--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -170,10 +170,7 @@ export default defineComponent({
     },
 
     isSubscribedInAnyProfile: function () {
-      const profileList = this.$store.getters.getProfileList
-
-      // check the all channels profile
-      return profileList[0].subscriptions.some((channel) => channel.id === this.id)
+      return this.$store.getters.getSubscribedChannelIdSet.has(this.id)
     },
 
     videoLiveShortSelectValues: function () {

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -157,6 +157,8 @@ export default defineComponent({
         }
 
         this.$store.commit('addToSessionSearchHistory', historyPayload)
+
+        this.updateSubscriptionDetails(results)
       } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -194,6 +196,8 @@ export default defineComponent({
         }
 
         this.$store.commit('addToSessionSearchHistory', historyPayload)
+
+        this.updateSubscriptionDetails(results)
       } catch (err) {
         console.error(err)
         const errorMessage = this.$t('Local API Error (Click to copy)')
@@ -263,6 +267,8 @@ export default defineComponent({
         }
 
         this.$store.commit('addToSessionSearchHistory', historyPayload)
+
+        this.updateSubscriptionDetails(returnData)
       }).catch((err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')
@@ -318,6 +324,42 @@ export default defineComponent({
 
       // This is kept in case there is some race condition
       this.isLoading = false
+    },
+
+    /**
+     * @param {any[]} results
+     */
+    updateSubscriptionDetails: function (results) {
+      /** @type {Set<string>} */
+      const subscribedChannelIds = this.$store.getters.getSubscribedChannelIdSet
+
+      const channels = []
+
+      for (const result of results) {
+        if (result.type !== 'channel' || !subscribedChannelIds.has(result.id ?? result.authorId)) {
+          continue
+        }
+
+        if (result.dataSource === 'local') {
+          channels.push({
+            channelId: result.id,
+            channelName: result.name,
+            channelThumbnailUrl: result.thumbnail.replace(/^\/\//, 'https://')
+          })
+        } else {
+          channels.push({
+            channelId: result.authorId,
+            channelName: result.author,
+            channelThumbnailUrl: result.authorThumbnails[0].url.replace(/^\/\//, 'https://')
+          })
+        }
+      }
+
+      if (channels.length === 1) {
+        this.$store.dispatch('updateSubscriptionDetails', channels[0])
+      } else if (channels.length > 1) {
+        this.$store.dispatch('batchUpdateSubscriptionDetails', channels)
+      }
     }
   }
 })


### PR DESCRIPTION
# Update subscription details from search results

## Pull Request Type

- [x] Feature Implementation

## Related issue

- Helps with: #5617

## Description

This pull request updates the subscription details when the search results contain channels that the user is subscribed too. At the moment we only do it for items of the type `channel`, but in the future we could expand it to video results too, as YouTube shows the channel thumbnails on their end but we don't parse that information yet.

## Testing
1. Download this file (remove the .txt file extension) and import it into FreeTube: [subscriptions.csv.txt](https://github.com/user-attachments/files/17261510/subscriptions.csv.txt)
2. Open the search filters
3. Set the type to channels
4. Search for `YouTube`
5. The channel thumbnail should have appeared in the side bar

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 68538c7cdd4539530d16323c64884184579968b4
