### PR TITLE
Add authorId to internal post URL when it is missing

### DIFF
--- a/src/renderer/views/Post/Post.js
+++ b/src/renderer/views/Post/Post.js
@@ -35,7 +35,7 @@ export default defineComponent({
     }
   },
   watch: {
-    async $route() {
+    async '$route.params.id'() {
       // react to route changes...
       this.isLoading = true
       if (this.isInvidiousAllowed) {
@@ -57,6 +57,18 @@ export default defineComponent({
       this.post = await getInvidiousCommunityPost(this.id, this.authorId)
       this.authorId = this.post.authorId
       this.isLoading = false
+
+      // If the authorId is missing from the URL we should add it,
+      // that way if the user comes back to this page by pressing the back button
+      // we don't have to resolve the authorId again
+      if (this.authorId !== this.$route.query.authorId) {
+        this.$router.replace({
+          path: `/post/${this.id}`,
+          query: {
+            authorId: this.authorId
+          }
+        })
+      }
     }
   }
 })


### PR DESCRIPTION
# Add authorId to internal post URL when it is missing

## Pull Request Type

- [x] Feature Implementation

## Description
When you paste a post link into the search bar, we need to make two API requests, this first one is to resolve the URL to figure out the channel ID and the second one is to get the post itself (which needs both the post ID and the channel ID).

This pull request adds the authorId to the in-app post URL after the post has loaded, if it was missing from the URL before. That way if you navigate back to the page again in the future e.g. by pressing the back arrow, we only have to make the API request for the post, as we already know the channel ID.

To avoid the replace action triggering the fetching again when we replace the URL, this pull request only watches the `id` parameter instead of the entire route object.

## Screenshots
Before:
![before](https://github.com/user-attachments/assets/29298131-9a7e-46b7-bd97-1930ff59e38b)

After:
![after](https://github.com/user-attachments/assets/75ea4934-4e82-4891-9d1f-fdd1b2f8217e)

## Testing
1. Paste a post URL into the search bar e.g. https://www.youtube.com/post/UgkxMBvPyJU6K3bhVkR_lI7REEXtt-JoKv36
2. Wait until the post has loaded
3. Run `window.location.hash` in the devtools, you should be able to see both the post ID and the author ID

You can also check the network tab and check that if you navigate back and forth with the arrows in the navigation bar, it should only call both `/api/v1/resolveurl` and `/api/v1/post` the first time, after that it should only call `/api/v1/post`.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 58937d03add6b7c28671bc1ea0cd0f0532eee825