### PR TITLE
fix cmd+m shortcut to minimize the window on macos and not mute the video

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2020,9 +2020,11 @@ export default defineComponent({
           break
         case 'M':
         case 'm':
-          // Toggle mute
-          event.preventDefault()
-          video_.muted = !video_.muted
+          // Toggle mute only if metakey is not pressed
+          if (!event.metaKey) {
+            event.preventDefault()
+            video_.muted = !video_.muted
+          }
           break
         case 'C':
         case 'c':


### PR DESCRIPTION
# Cmd+M shortcut now minimize the window on macos and doesn't mute the video anymore.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #5828 
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
Before this pull request when the shortcut `cmd + m` was pressed on macOS the video got muted even though on macOS that shortcut is intended to minimize the window.
What I did is to add a check on whether the `metaKey` was pressed or not and act accordingly.
Now when the `metaKey` is pressed with the `m` key the window minimize and when only the `m` key is pressed the video get muted.
<!-- Please write a clear and concise description of what the pull request does. -->

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS: MacOS**
- **OS Version: Sonoma 14.3.1**
- **FreeTube version: v0.21.3 Beta**

## Additional context
<!-- Add any other context about the pull request here. -->
