### PR TITLE
Turn `vue/no-useless-template-attributes` eslint rule back on

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,7 +76,6 @@ export default [
       'no-undef': 'warn',
       'object-shorthand': 'off',
       'vue/no-template-key': 'warn',
-      'vue/no-useless-template-attributes': 'off',
       'vue/multi-word-component-names': 'off',
       'vuejs-accessibility/no-onchange': 'off',
 

--- a/src/renderer/components/ft-checkbox-list/ft-checkbox-list.vue
+++ b/src/renderer/components/ft-checkbox-list/ft-checkbox-list.vue
@@ -6,7 +6,6 @@
     <!--  eslint-disable vue/no-template-key -->
     <template
       v-for="(label, index) in labels"
-      class="checkboxContainer"
     >
       <input
         :id="values[index] + id"

--- a/src/renderer/components/ft-radio-button/ft-radio-button.vue
+++ b/src/renderer/components/ft-radio-button/ft-radio-button.vue
@@ -6,7 +6,6 @@
     <!--  eslint-disable vue/no-template-key -->
     <template
       v-for="(label, index) in labels"
-      class="radioButtonContainer"
     >
       <input
         :id="values[index] + id"


### PR DESCRIPTION
# Turn `vue/no-useless-template-attributes` eslint rule back on

## Pull Request Type

- [x] Other

## Description

While reviewing the ESLint upgrade pull request, I noticed that both our old and new ESLint configs disabled the `vue/no-useless-template-attributes` rule. As there is no good reason to keep useless code around I've removed that from our ESLint config as it is enabled by default by the Vue recommended config.

As soon as you add a Vue directive, e.g. `v-if` or `v-for`, to a `<template>` tag it is only used at build time, so adding things like the `class` attribute to a `<template v-for...>` tag won't do anything, so there is no point keeping code like that in the code base.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 8a4e66e5e3da165c3b87f5fee63488483c31dfe1