### PR TITLE
Add autoplay toggle to the video player

### DIFF
--- a/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.css
+++ b/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.css
@@ -7,12 +7,6 @@
   grid-gap: 8px;
 }
 
-.autoPlayToggle {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
 .VideoRecommendationsTopBar {
   display: flex;
   justify-content: space-between;

--- a/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.vue
+++ b/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.vue
@@ -6,14 +6,6 @@
       <h3>
         {{ $t("Up Next") }}
       </h3>
-      <FtToggleSwitch
-        v-if="showAutoplay"
-        class="autoPlayToggle"
-        :label="$t('Video.Autoplay')"
-        :compact="true"
-        :default-value="playNextVideo"
-        @change="updatePlayNextVideo"
-      />
     </div>
     <FtListVideoLazy
       v-for="(video, index) in data"
@@ -27,35 +19,17 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
 
 import FtCard from '../ft-card/ft-card.vue'
 import FtListVideoLazy from '../ft-list-video-lazy/ft-list-video-lazy.vue'
-import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 
-import store from '../../store/index'
 
 defineProps({
   data: {
     type: Array,
     required: true
-  },
-  showAutoplay: {
-    type: Boolean,
-    default: false
   }
 })
-
-const playNextVideo = computed(() => {
-  return store.getters.getPlayNextVideo
-})
-
-/**
- * @param {boolean} value
- */
-function updatePlayNextVideo(value) {
-  store.dispatch('updatePlayNextVideo', value)
-}
 </script>
 
 <style scoped src="./WatchVideoRecommendations.css" />

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -37,6 +37,11 @@
   flex-direction: column-reverse;
 }
 
+:deep(.shaka-overflow-menu),
+:deep(.shaka-settings-menu) {
+  max-height: 200px;
+}
+
 .sixteenByNine {
   aspect-ratio: 16 / 9;
 }

--- a/src/renderer/components/ft-shaka-video-player/player-components/AutoplayToggle.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AutoplayToggle.js
@@ -1,0 +1,77 @@
+import shaka from 'shaka-player'
+
+import i18n from '../../../i18n/index'
+
+export class AutoplayToggle extends shaka.ui.Element {
+  /**
+   * @param {EventTarget} events
+   * @param {HTMLElement} parent
+   * @param {shaka.ui.Controls} controls
+   */
+  constructor(autoplayEnabled, events, parent, controls) {
+    super(parent, controls)
+
+    /** @private */
+    this.button_ = document.createElement('button')
+    this.button_.classList.add('autoplay-toggle')
+    this.button_.classList.add('shaka-tooltip')
+
+    /** @private */
+    this.icon_ = document.createElement('i')
+    this.icon_.classList.add('material-icons-round')
+    this.icon_.textContent = 'pause_circle'
+
+    this.button_.appendChild(this.icon_)
+
+    const label = document.createElement('label')
+    label.classList.add('shaka-overflow-button-label')
+    label.classList.add('shaka-overflow-menu-only')
+
+    /** @private */
+    this.nameSpan_ = document.createElement('span')
+    label.appendChild(this.nameSpan_)
+
+    /** @private */
+    this.currentState_ = document.createElement('span')
+    this.currentState_.classList.add('shaka-current-selection-span')
+    label.appendChild(this.currentState_)
+
+    this.button_.appendChild(label)
+
+    this.parent.appendChild(this.button_)
+
+    /** @private */
+    this.autoplayEnabled_ = autoplayEnabled
+
+    // listeners
+
+    this.eventManager.listen(this.button_, 'click', () => {
+      events.dispatchEvent(new CustomEvent('toggleAutoplay', {
+        detail: !this.autoplayEnabled_
+      }))
+    })
+
+    this.eventManager.listen(events, 'toggleAutoplay', (/** @type {CustomEvent} */ event) => {
+      this.autoplayEnabled_ = event.detail
+
+      this.updateLocalisedStrings_()
+    })
+
+    this.eventManager.listen(events, 'localeChanged', () => {
+      this.updateLocalisedStrings_()
+    })
+
+    this.updateLocalisedStrings_()
+  }
+
+  /** @private */
+  updateLocalisedStrings_() {
+    this.nameSpan_.textContent = i18n.t('Video.Autoplay')
+
+    this.icon_.textContent = this.autoplayEnabled_ ? 'play_circle' : 'pause_circle'
+
+    this.currentState_.textContent = this.localization.resolve(this.autoplayEnabled_ ? 'ON' : 'OFF')
+
+    this.button_.ariaLabel = this.autoplayEnabled_ ? i18n.t('Video.Player.Autoplay is on') : i18n.t('Video.Player.Autoplay is off')
+  }
+}

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -33,6 +33,8 @@
           :title="videoTitle"
           :theatre-possible="theatrePossible"
           :use-theatre-mode="useTheatreMode"
+          :autoplay-possible="autoplayPossible"
+          :autoplay-enabled="autoplayEnabled"
           :vr-projection="vrProjection"
           class="videoPlayer"
           @error="handlePlayerError"
@@ -40,6 +42,7 @@
           @timeupdate="updateCurrentChapter"
           @ended="handleVideoEnded"
           @toggle-theatre-mode="useTheatreMode = !useTheatreMode"
+          @toggle-autoplay="toggleAutoplay"
         />
         <div
           v-if="!isLoading && (isUpcoming || errorMessage)"
@@ -201,7 +204,6 @@
       />
       <watch-video-recommendations
         v-if="!isLoading && !hideRecommendedVideos"
-        :show-autoplay="!watchingPlaylist"
         :data="recommendedVideos"
         class="watchVideoSideBar watchVideoRecommendations"
         :class="{

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -889,6 +889,8 @@ Video:
   Player:
     TranslatedCaptionTemplate: '{language} (translated from "{originalLanguage}")'
     Audio Tracks: Audio Tracks
+    Autoplay is off: Autoplay is off
+    Autoplay is on: Autoplay is on
     Theatre Mode: Theater Mode
     Exit Theatre Mode: Exit Theater Mode
     Full Window: Full Window


### PR DESCRIPTION
# Add autoplay toggle to the video player

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Feature Implementation

## Related issue
closes #1181

## Description
Adds autoplay toggle to the media player. 
- Behavior: 
  - When in a playlist, the `Autoplay Playlist Videos` setting is the one exposed/manipulated. Otherwise, the `Autoplay Recommended Videos` setting is the one exposed/manipulated.
  - The autoplay button is hidden when autoplay is not possible.
    - Note: "possible" being defined as the existing checks in `Watch.js` to call `this.$refs.watchVideoPlaylistplayNextVideo`.
  - When the autoplay countdown timer is going down, disabling autoplay will abort the countdown.
- (Adopted from #4342) Updated very confusing autoplay labels' `EN-US` values to more understandable meanings (see Screenshots section for details) 
- For icon considerations, only the deprecated list of Material icons are available, so we don't have access to `autoplay`/`autopause`. I decided on `play_circle`/`play_pause` instead. One other considered alternative was `toggle_on`/`toggle_off`, but it would have been less descriptive.
- **Minor bug fix:** Previously, the Shaka mobile overflow menu intersected with the top bar on many mobile devices (e.g., in the quality settings or playback rate settings), blocking the top entries from being visible. This has now been fixed.

## Screenshots <!-- If appropriate -->

Autoplay off:

![Autoplay off](https://github.com/user-attachments/assets/dae9f045-c081-4e34-ad59-742948075010)

Autoplay on:

![Autoplay on](https://github.com/user-attachments/assets/6bec30dd-e861-40fe-a919-bdfe4ce27160)

Mobile overflow menu:

![Mobile overflow menu](https://github.com/user-attachments/assets/8bfab5d6-fc34-4c64-bfd7-f440fa13b80d)

Autoplay Settings Label/Ordering Changes:
(Autoplay Videos -> Start Videos Automatically, moved to bottom)
(Play Next Video -> Autoplay Recommended Videos, moved to top)
(Autoplay Playlists -> Autoplay Playlist Videos)

|Before|After|
|-----------|--------|
|![Screenshot_20241014_100718](https://github.com/user-attachments/assets/4ad3dd7a-87b5-408b-a2a0-22ee6226097a)|![Screenshot_20241014_100659](https://github.com/user-attachments/assets/6af14cee-56f2-4944-a6c9-5a8dbe6eb3dd)|



## Testing <!-- for code that is not small enough to be easily understandable -->
- Test that disabling autoplay aborts the autoplay countdown
- Test that the Autoplay toggle does not appear for a non-playlist video when `Hide Recommended Videos` is enabled
- Test that the Autoplay toggle does not appear for a playlist video when it's the last video in the playlist and loop is disabled
  - Check that it does appear when loop is then enabled
- Test that using the autoplay toggle causes the video to autoplay / not autoplay accordingly and updates the corresponding setting (playlist versus non-playlist)


## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW

## Additional context
I considered firing `handleEnded` on enabling autoplay on an ended video in order to start the autoplay countdown, but I decided against it. Partially because it's a race condition risk to wait sufficiently long for `isAutoplayEnabled` to update, partially because it's not that important.
