### PR TITLE
Autoplay time limit

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -106,12 +106,17 @@ export default defineComponent({
     vrProjection: {
       type: String,
       default: null
+    },
+    blockVideoAutoplay: {
+      type: Boolean,
+      default: false
     }
   },
   emits: [
     'error',
     'loaded',
     'ended',
+    'reset-autoplay-interruption-timeout',
     'timeupdate',
     'toggle-theatre-mode'
   ],
@@ -154,6 +159,15 @@ export default defineComponent({
      * }[]}
      */
     let sortedCaptions
+
+    const blockAutoplay = props.blockVideoAutoplay
+    if (blockAutoplay) {
+      resetAutoplayInterruptionTimeout()
+    }
+
+    function resetAutoplayInterruptionTimeout() {
+      emit('reset-autoplay-interruption-timeout')
+    }
 
     // we don't need to sort if we only have one caption or don't have any
     if (props.captions.length > 1) {
@@ -1959,6 +1973,8 @@ export default defineComponent({
      * @param {KeyboardEvent} event
      */
     function keyboardShortcutHandler(event) {
+      resetAutoplayInterruptionTimeout()
+
       if (!player || !hasLoaded.value) {
         return
       }
@@ -2365,6 +2381,9 @@ export default defineComponent({
       document.removeEventListener('keydown', keyboardShortcutHandler)
       document.addEventListener('keydown', keyboardShortcutHandler)
 
+      document.removeEventListener('click', resetAutoplayInterruptionTimeout)
+      document.addEventListener('click', resetAutoplayInterruptionTimeout)
+
       player.addEventListener('loading', () => {
         hasLoaded.value = false
       })
@@ -2673,6 +2692,7 @@ export default defineComponent({
       document.body.classList.remove('playerFullWindow')
 
       document.removeEventListener('keydown', keyboardShortcutHandler)
+      document.removeEventListener('click', resetAutoplayInterruptionTimeout)
 
       if (resizeObserver) {
         resizeObserver.disconnect()
@@ -2768,6 +2788,7 @@ export default defineComponent({
       stats,
 
       autoplayVideos,
+      blockAutoplay,
       sponsorBlockShowSkippedToast,
 
       skippedSponsorBlockSegments,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -14,7 +14,7 @@
       preload="auto"
       crossorigin="anonymous"
       playsinline
-      :autoplay="autoplayVideos ? true : null"
+      :autoplay="autoplayVideos && !blockAutoplay ? true : null"
       :poster="thumbnail"
       @play="handlePlay"
       @pause="handlePause"

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -95,6 +95,10 @@ export default defineComponent({
       return this.backendPreference !== 'invidious' && !this.backendFallback
     },
 
+    defaultAutoplayInterruptionInterval: function () {
+      return parseInt(this.$store.getters.getDefaultAutoplayInterruptionInterval)
+    },
+
     defaultSkipInterval: function () {
       return parseInt(this.$store.getters.getDefaultSkipInterval)
     },
@@ -286,6 +290,7 @@ export default defineComponent({
     ...mapActions([
       'updateAutoplayVideos',
       'updateAutoplayPlaylists',
+      'updateDefaultAutoplayInterruptionInterval',
       'updatePlayNextVideo',
       'updateEnableSubtitlesByDefault',
       'updateProxyVideos',

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -83,15 +83,6 @@
     </div>
     <ft-flex-box>
       <ft-slider
-        :label="$t('Settings.Player Settings.Fast-Forward / Rewind Interval')"
-        :default-value="defaultSkipInterval"
-        :min-value="1"
-        :max-value="70"
-        :step="1"
-        value-extension="s"
-        @change="updateDefaultSkipInterval"
-      />
-      <ft-slider
         :label="$t('Settings.Player Settings.Next Video Interval')"
         :default-value="defaultInterval"
         :min-value="0"
@@ -99,6 +90,24 @@
         :step="1"
         value-extension="s"
         @change="updateDefaultInterval"
+      />
+      <ft-slider
+        :label="$t('Settings.Player Settings.Autoplay Interruption Timer')"
+        :default-value="defaultAutoplayInterruptionInterval"
+        :min-value="1"
+        :max-value="12"
+        :step="1"
+        value-extension="h"
+        @change="updateDefaultAutoplayInterruptionInterval"
+      />
+      <ft-slider
+        :label="$t('Settings.Player Settings.Fast-Forward / Rewind Interval')"
+        :default-value="defaultSkipInterval"
+        :min-value="1"
+        :max-value="70"
+        :step="1"
+        value-extension="s"
+        @change="updateDefaultSkipInterval"
       />
       <ft-slider
         :label="$t('Settings.Player Settings.Default Volume')"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -172,6 +172,7 @@ const state = {
   baseTheme: 'system',
   mainColor: 'Red',
   secColor: 'Blue',
+  defaultAutoplayInterruptionInterval: 3,
   defaultCaptionSettings: '{}',
   defaultInterval: 5,
   defaultPlayback: 1,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -117,6 +117,8 @@ export default defineComponent({
       playNextCountDownIntervalId: null,
       infoAreaSticky: true,
       commentsEnabled: true,
+      blockVideoAutoplay: false,
+      autoplayInterruptionTimeout: null,
 
       onMountedRun: false,
 
@@ -157,6 +159,9 @@ export default defineComponent({
     },
     proxyVideos: function () {
       return this.$store.getters.getProxyVideos
+    },
+    defaultAutoplayInterruptionInterval: function () {
+      return this.$store.getters.getDefaultAutoplayInterruptionInterval
     },
     defaultInterval: function () {
       return this.$store.getters.getDefaultInterval
@@ -320,6 +325,7 @@ export default defineComponent({
       }
 
       window.addEventListener('beforeunload', this.handleWatchProgress)
+      this.resetAutoplayInterruptionTimeout()
     },
 
     changeTimestamp: function (timestamp) {
@@ -1617,6 +1623,12 @@ export default defineComponent({
 
       const playlist = this.selectedUserPlaylist
       this.updatePlaylistLastPlayedAt({ _id: playlist._id })
+    },
+
+    resetAutoplayInterruptionTimeout() {
+      clearTimeout(this.autoplayInterruptionTimeout)
+      this.autoplayInterruptionTimeout = setTimeout(() => { this.blockVideoAutoplay = true }, this.defaultAutoplayInterruptionInterval * 3_600_000)
+      this.blockVideoAutoplay = false
     },
 
     ...mapActions([

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -34,11 +34,13 @@
           :theatre-possible="theatrePossible"
           :use-theatre-mode="useTheatreMode"
           :vr-projection="vrProjection"
+          :block-video-autoplay="blockVideoAutoplay"
           class="videoPlayer"
           @error="handlePlayerError"
           @loaded="handleVideoLoaded"
           @timeupdate="updateCurrentChapter"
           @ended="handleVideoEnded"
+          @reset-autoplay-interruption-timeout="resetAutoplayInterruptionTimeout"
           @toggle-theatre-mode="useTheatreMode = !useTheatreMode"
         />
         <div

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -408,7 +408,8 @@ Settings:
     Skip by Scrolling Over Video Player: Skip by Scrolling Over Video Player
     Display Play Button In Video Player: Display Play Button In Video Player
     Enter Fullscreen on Display Rotate: Enter Fullscreen on Display Rotate
-    Next Video Interval: Next Video Interval
+    Next Video Interval: Autoplay Countdown Timer
+    Autoplay Interruption Timer: Autoplay Interruption Timer
     Fast-Forward / Rewind Interval: Fast-Forward / Rewind Interval
     Default Volume: Default Volume
     Default Playback Rate: Default Playback Rate


### PR DESCRIPTION
# Autoplay time limit

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation

## Related issue
closes #4270

## Description
Implements time-limited autoplay feature which prevents the next video from playing automatically after X hours of 0 click or keydown events. This is set to a default of 3 hours, but it can be configured to be up to 12. This timer resets back to the start for every click or keydown event made at any time in the window. The closely related `Next Video Interval` EN-US label is also renamed to `Autoplay Countdown Timer` to minimize user confusion regarding its meaning.

This feature will be nice for folks like me who occasionally fall asleep to videos and have to reset watch history for a good chunk of them. It should also reduce net power draw and bandwidth expenditure for asleep or otherwise AFK users who neglected to hit the pause button.

To preemptively answer the question of "why not allow infinity," I don't think allowing indefinite automatic streaming regardless of user interaction is ever a desirable state for 99+% of our users. The default of 3 hours without any detected click or keyboard activity is a fine sweet spot for minimizing streaming to sleeping/AFK users, much more generous than [YouTube's](https://support.google.com/youtube/answer/12819304?hl=en) or [Netflix's](https://help.netflix.com/en/node/114059), to name a couple of similar examples. 12 hours of total inactivity before blocking autoplay should be more than enough for users with very particular edge cases.

## Testing <!-- for code that is not small enough to be easily understandable -->
**_Note: I have this a draft because there are still a couple of autoplay PRs out, so I'd prefer not to make anyone have to re-validate post-merge conflicts._**
- on line 1630 of `Watch.js`:
- https://github.com/FreeTubeApp/FreeTube/blob/27f59e064ba2ea4b2986a3a50da83e96603b73bc/src/renderer/views/Watch/Watch.js#L1630
  - Replace it with this line to make the timeout time much lower:
 
```
this.autoplayInterruptionTimeout = setTimeout(() => { this.blockVideoAutoplay = true }, this.defaultAutoplayInterruptionInterval * 10_000)
```
  - Then enable Recommended Videos Autoplay and/or Playlist Videos Autoplay in settings.
  - Then you can run such validations like:
    - Ensure the timer is reset by any click or key event (e.g., by seeking close to the end of a video by a time slightly greater than the countdown time + autoplay interruption timer combined, then clicking 15 seconds in)
    - Ensure that the next video is blocked from starting automatically if no user interaction is made for an amount of time that is >= the autoplay interruption timer 

## Desktop
<!-- Please complete the following information-->
- **OS:** OpenSUSE
- **OS Version:** TW
