### PR TITLE
Fix wrong live stream playlist used for subscriptions

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -875,9 +875,9 @@ export function getChannelPlaylistId(channelId, type, sortBy) {
       }
     case 'live':
       if (sortBy === 'popular') {
-        return channelId.replace(/^UC/, 'UULV')
-      } else {
         return channelId.replace(/^UC/, 'UUPV')
+      } else {
+        return channelId.replace(/^UC/, 'UULV')
       }
     case 'shorts':
       if (sortBy === 'popular') {


### PR DESCRIPTION
# Fix wrong live stream playlist used for subscriptions

## Pull Request Type
- [x] Bugfix

## Description
UUPV is used for popular
UULV is used for latest streams

We had this swapped.

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** latest nightly
