### PR TITLE
Fix some undesired attributes being saved to playlists.db

### DIFF
--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -210,7 +210,11 @@ const actions = {
         }
         // Undesired attributes, even with `null` values
         [
+          'authorUrl',
           'description',
+          'index',
+          'liveNow',
+          'videoThumbnails',
           'viewCount',
         ].forEach(attrName => {
           if (typeof videoData[attrName] !== 'undefined') {


### PR DESCRIPTION
# Fix some undesired attributes being saved to playlists.db

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #5601

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
With Invidious API, certain undesired attributes of videos are fetched when copying playlists. There's already an implementation to get rid of those (in src/renderer/store/modules/playlists.js:actions.getVideos), but the list of those attributes is currently incomplete. The following attributes are missing in the list (relying on the fact that they are not saved when adding videos one by one):
- authorUrl
- index
- liveNow
- videoThumbnails

<!-- ## Screenshots --> <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Tested for both development mode and production mode.

With Invidious API enabled, add a playlist from YT to a local playlist, and add some videos one by one to another local playlist.
Then check that the attribute names of the videos are the same in both playlists.
There is no need to close FT before reading playlists.db if you make sure you are looking at the most up-to-date version of the playlist (which is the last line with the playlist with that name).

## Desktop
<!-- Please complete the following information-->
- **OS: Artix Linux x86_64**
- **Kernel Version: 6.6.51-1-lts**
- **FreeTube version: dev at f57b4368**