### PR TITLE
Set download links on Watch even if there are no caption links

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -661,9 +661,8 @@ export default defineComponent({
               })
 
               downloadLinks.push(...captionLinks)
-
-              this.downloadLinks = downloadLinks
             }
+            this.downloadLinks = downloadLinks
           } else {
             // video might be region locked or something else. This leads to no formats being available
             showToast(


### PR DESCRIPTION
# Set download links on Watch page even if there are no caption links

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other


## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The line `this.downloadLinks = downloadLinks` is only being ran when videos have captions. This PR addresses this by moving this line outside of the `result.captions` condition.

## Screenshots <!-- If appropriate -->
on a video with no caption tracks:
|before:|after|
|--|--|
|![image](https://github.com/user-attachments/assets/eb65233e-5454-4a3a-8877-54eda1c38e0a)|![image](https://github.com/user-attachments/assets/04150378-fba1-4983-bb6e-b6ec7e7846a6)|

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Find a video which has no caption tracks ( ex: https://youtu.be/sVx1mJDeUjY )
2. Ensure it shows the download links icon button

_(you could also test a video with captions to make sure it still shows the download links icon button \[ex: https://youtu.be/-lNE26RHH7E \])_

