### PR TITLE
Fix subscription tab hiding not working on launch

### DIFF
--- a/src/renderer/views/Subscriptions/Subscriptions.js
+++ b/src/renderer/views/Subscriptions/Subscriptions.js
@@ -96,7 +96,11 @@ export default defineComponent({
     } else {
       // Restore currentTab
       const lastCurrentTabId = sessionStorage.getItem('Subscriptions/currentTab')
-      if (lastCurrentTabId !== null) { this.changeTab(lastCurrentTabId) }
+      if (lastCurrentTabId !== null) {
+        this.changeTab(lastCurrentTabId)
+      } else if (!this.visibleTabs.includes(this.currentTab)) {
+        this.currentTab = this.visibleTabs[0]
+      }
     }
   },
   methods: {


### PR DESCRIPTION
# Fix subscription tab hiding not working on launch

## Pull Request Type

- [x] Bugfix

## Related issue
closes #5883

## Description

This pull request fixes the "Hide Subscription (Videos, Live, Shorts and Community)" settings not working on launch correctly on launch, as it was only checking those settings for the tab bar and when you came back to the subscriptions page, but not for the tab content.

## Testing
1. Make sure you have content on the videos subscriptions tab (either refresh to make sure the cache is fully populated or turn on automatic subscription fetching).
2. Turn on the "Hide Subscription Videos" setting in the "Distraction Free" settings section
3. Restart FreeTube
4. You should see the shorts tab and content from it. Previously you would have seen the shorts tab selected but the video list from the videos tab.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b9adcb3d89bcb1878cdbaceb83342fd2a8f51477