### PR TITLE
Local API: Display more video tags in search results

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1022,8 +1022,6 @@ export function parseLocalListVideo(item) {
       lengthSeconds: isNaN(movie.duration.seconds) ? '' : movie.duration.seconds,
       liveNow: false,
       isUpcoming: false,
-      is4k: movie.is_4k,
-      hasCaptions: movie.has_captions
     }
   } else {
     /** @type {import('youtubei.js').YTNodes.Video} */
@@ -1056,6 +1054,11 @@ export function parseLocalListVideo(item) {
       isUpcoming: video.is_upcoming || video.is_premiere,
       premiereDate: video.upcoming,
       is4k: video.is_4k,
+      is8k: video.badges.some(badge => badge.label === '8K'),
+      isNew: video.badges.some(badge => badge.label === 'New'),
+      isVr180: video.badges.some(badge => badge.label === 'VR180'),
+      isVr360: video.badges.some(badge => badge.label === '360°'),
+      is3d: video.badges.some(badge => badge.label === '3D'),
       hasCaptions: video.has_captions
     }
   }


### PR DESCRIPTION
# Local API: Display more video tags in search results

## Pull Request Type

- [x] Feature Implementation

## Related issue
* Follow up to https://github.com/FreeTubeApp/FreeTube/pull/5590

## Description
This pull request implements the missing tags for the local API that were added in #5590 for the Invidious API.

## Testing
1. Make sure you are using the local API
2. Set the 3D feature search filter
3. Search for `3d`, you should see videos with the VR180, 3D and 8K labels
4. Search for `360`, you should see videos with the 360° label
5. Set the Time search filter to Last Hour
6. Search for `test`, you should see videos with the New label

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b9adcb3d89bcb1878cdbaceb83342fd2a8f51477