### PR TITLE
Minor performance improvements to the Hashtag view

### DIFF
--- a/src/renderer/views/Hashtag/Hashtag.js
+++ b/src/renderer/views/Hashtag/Hashtag.js
@@ -43,13 +43,12 @@ export default defineComponent({
     },
   },
   watch: {
-    $route() {
+    '$route.params.hashtag'() {
       this.resetData()
       this.getHashtag()
     }
   },
   mounted: function() {
-    this.resetData()
     this.getHashtag()
   },
   methods: {


### PR DESCRIPTION
# Minor performance improvements to the Hashtag view

## Pull Request Type

- [x] Performance improvement

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/5825#discussion_r1788726244

## Description
This pull request implements two small performance improvements to the hashtag view. The first one is that we don't have to call `resetData()` in the mounted hook, as at the time that the mounted hook is called all the fields still have their default values. The second one is to only watch the `hashtag` param on the current route object, as that is the only property that could change while you are on the hashtag page.

## Testing
1. Paste https://www.youtube.com/hashtag/shorts into the search bar and hit enter
2. It should show the hashtag page for `#shorts`
3. Paste https://www.youtube.com/hashtag/asmr into the search bar and hit enter
4. It should switch to the hashtag page for `#asmr`

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 