### PR TITLE
Cleanup Invidious backwards compatibility

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -18,7 +18,6 @@ import {
   findMostSimilarAudioBandwidth,
   getSponsorBlockSegments,
   logShakaError,
-  qualityLabelToDimension,
   repairInvidiousManifest,
   sortCaptions,
   translateSponsorBlockCategory
@@ -1258,8 +1257,6 @@ export default defineComponent({
       /** @type {object[]} */
       const legacyFormats = props.legacyFormats
 
-      // TODO: switch to using height and width when Invidious starts returning them, instead of parsing the quality label
-
       let previousQuality
       if (previousFormat === 'dash') {
         const previousTrack = player.getVariantTracks().find(track => track.active)
@@ -1271,13 +1268,15 @@ export default defineComponent({
         previousQuality = defaultQuality.value
       }
 
+      const isPortrait = legacyFormats[0].height > legacyFormats[0].width
+
       let matches = legacyFormats.filter(variant => {
-        return previousQuality === qualityLabelToDimension(variant.qualityLabel)
+        return previousQuality === isPortrait ? variant.width : variant.height
       })
 
       if (matches.length === 0) {
         matches = legacyFormats.filter(variant => {
-          return previousQuality > qualityLabelToDimension(variant.qualityLabel)
+          return previousQuality > isPortrait ? variant.width : variant.height
         })
 
         if (matches.length > 0) {
@@ -1407,26 +1406,8 @@ export default defineComponent({
 
       stats.bitrate = (bitrate / 1000).toFixed(2)
 
-      if (typeof width === 'undefined' || typeof height === 'undefined') {
-        // Invidious doesn't provide any height or width information for their legacy formats, so lets read it from the video instead
-        // they have a size property but it's hard-coded, so it reports false information for shorts for example
-        const video_ = video.value
-
-        if (hasLoaded.value) {
-          stats.resolution.width = video_.videoWidth
-          stats.resolution.height = video_.videoHeight
-        } else {
-          video_.addEventListener('loadeddata', () => {
-            stats.resolution.width = video_.videoWidth
-            stats.resolution.height = video_.videoHeight
-          }, {
-            once: true
-          })
-        }
-      } else {
-        stats.resolution.width = width
-        stats.resolution.height = height
-      }
+      stats.resolution.width = width
+      stats.resolution.height = height
     }
 
     function updateStats() {
@@ -2385,19 +2366,8 @@ export default defineComponent({
       } else {
         // force the player aspect ratio to 16:9 to avoid overflowing the layout, when the video is too tall
 
-        // Invidious doesn't provide any height or width information for their legacy formats, so lets read it from the video instead
-        // they have a size property but it's hard-coded, so it reports false information for shorts for example
-
         const firstFormat = props.legacyFormats[0]
-        if (typeof firstFormat.width === 'undefined' || typeof firstFormat.height === 'undefined') {
-          videoElement.addEventListener('loadeddata', () => {
-            forceAspectRatio.value = videoElement.videoWidth / videoElement.videoHeight < 1.5
-          }, {
-            once: true
-          })
-        } else {
-          forceAspectRatio.value = firstFormat.width / firstFormat.height < 1.5
-        }
+        forceAspectRatio.value = firstFormat.width / firstFormat.height < 1.5
       }
 
       if (useSponsorBlock.value && sponsorSkips.value.seekBar.length > 0) {
@@ -2595,7 +2565,7 @@ export default defineComponent({
             const legacyFormat = activeLegacyFormat.value
 
             if (!useAutoQuality) {
-              dimension = qualityLabelToDimension(legacyFormat.qualityLabel)
+              dimension = legacyFormat.height > legacyFormat.width ? legacyFormat.width : legacyFormat.height
             }
           } else if (oldFormat !== 'legacy') {
             const track = player.getVariantTracks().find(track => track.active)

--- a/src/renderer/components/ft-shaka-video-player/player-components/LegacyQualitySelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/LegacyQualitySelection.js
@@ -22,15 +22,8 @@ export class LegacyQualitySelection extends shaka.ui.SettingsMenu {
 
     const sortedLegacyFormats = [...legacyFormats]
 
-    // Invidious doesn't return the height or width for the legacy formats, so we have to use the bitrate instead
-    if (typeof legacyFormats[0].width === 'undefined' || typeof legacyFormats[0].height === 'undefined') {
-      sortedLegacyFormats.sort((a, b) => {
-        return b.bitrate - a.bitrate
-      })
-    } else {
-      const isPortrait = legacyFormats[0].height > legacyFormats[0].width
-      sortedLegacyFormats.sort((a, b) => isPortrait ? b.width - a.width : b.height - a.height)
-    }
+    const isPortrait = legacyFormats[0].height > legacyFormats[0].width
+    sortedLegacyFormats.sort((a, b) => isPortrait ? b.width - a.width : b.height - a.height)
 
     /** @private */
     this.legacyFormats_ = sortedLegacyFormats

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -372,22 +372,6 @@ function parseInvidiousCommunityAttachments(data) {
   console.error(data)
 }
 
-/**
- * Invidious doesn't include the correct height or width for all formats in their API response and are also missing the fps and qualityLabel for the AV1 formats.
- * When the local API is supported we generate our own manifest with the local API manifest generator, based on the Invidious API response and the height, width and fps extracted from Invidious' DASH manifest.
- * As Invidious only includes h264 and AV1 in their DASH manifest, we have to always filter out the VP9 formats, due to missing information.
- * @param {any[]} formats
- */
-export function filterInvidiousFormats(formats) {
-  return formats.filter(format => {
-    const mimeType = format.type
-
-    return mimeType.startsWith('audio/') ||
-      mimeType.startsWith('video/mp4; codecs="avc') ||
-      mimeType.startsWith('video/mp4; codecs="av01')
-  })
-}
-
 export async function getHashtagInvidious(hashtag, page = 1) {
   const payload = {
     resource: 'hashtag',
@@ -473,18 +457,9 @@ export function convertInvidiousToLocalFormat(format) {
 
 /**
  * @param {any} format
- * @param {boolean} trustApiResponse
  */
-export function mapInvidiousLegacyFormat(format, trustApiResponse) {
-  let width
-  let height
-
-  if (trustApiResponse) {
-    const [stringWidth, stringHeight] = format.size.split('x')
-
-    width = parseInt(stringWidth)
-    height = parseInt(stringHeight)
-  }
+export function mapInvidiousLegacyFormat(format) {
+  const [stringWidth, stringHeight] = format.size.split('x')
 
   return {
     itag: format.itag,
@@ -492,8 +467,8 @@ export function mapInvidiousLegacyFormat(format, trustApiResponse) {
     fps: format.fps,
     bitrate: parseInt(format.bitrate),
     mimeType: format.type,
-    height,
-    width,
+    height: parseInt(stringHeight),
+    width: parseInt(stringWidth),
     url: format.url
   }
 }

--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -120,14 +120,6 @@ export function translateSponsorBlockCategory(category) {
 }
 
 /**
- * @param {string} qualityLabel
- * @returns {number}
- */
-export function qualityLabelToDimension(qualityLabel) {
-  return parseInt(qualityLabel.split('p')[0])
-}
-
-/**
  * Moves the captions that are the most similar to the display language to the top
  * and sorts the remaining ones alphabetically.
  * @param {{

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -28,10 +28,8 @@ import {
 } from '../../helpers/api/local'
 import {
   convertInvidiousToLocalFormat,
-  filterInvidiousFormats,
   generateInvidiousDashManifestLocally,
   getProxyUrl,
-  invidiousFetch,
   invidiousGetVideoInformation,
   mapInvidiousLegacyFormat,
   youtubeImageUrlToInvidious
@@ -844,12 +842,7 @@ export default defineComponent({
           } else {
             this.videoLengthSeconds = result.lengthSeconds
 
-            // Detect if the Invidious server is running a new enough version of Invidious
-            // to include this pull request: https://github.com/iv-org/invidious/pull/4586
-            // which fixed the API returning incorrect height, width and fps information
-            const trustApiResponse = result.adaptiveFormats.some(stream => typeof stream.size === 'string')
-
-            this.legacyFormats = result.formatStreams.map(format => mapInvidiousLegacyFormat(format, trustApiResponse))
+            this.legacyFormats = result.formatStreams.map(mapInvidiousLegacyFormat)
 
             if (!process.env.SUPPORTS_LOCAL_API || this.proxyVideos) {
               this.legacyFormats.forEach(format => {
@@ -894,7 +887,7 @@ export default defineComponent({
               return object
             }))
 
-            this.manifestSrc = await this.createInvidiousDashManifest(result, trustApiResponse)
+            this.manifestSrc = await this.createInvidiousDashManifest(result)
             this.manifestMimeType = MANIFEST_TYPE_DASH
           }
 
@@ -1337,25 +1330,14 @@ export default defineComponent({
       return `data:application/dash+xml;charset=UTF-8,${encodeURIComponent(xmlData)}`
     },
 
-    createInvidiousDashManifest: async function (result, trustApiResponse = false) {
+    createInvidiousDashManifest: async function (result) {
       let url = `${this.currentInvidiousInstanceUrl}/api/manifest/dash/id/${this.videoId}`
 
       // If we are in Electron,
       // we can use YouTube.js' DASH manifest generator to generate the manifest.
       // Using YouTube.js' gives us support for multiple audio tracks (currently not supported by Invidious)
       if (process.env.SUPPORTS_LOCAL_API) {
-        const adaptiveFormats = await this.getAdaptiveFormatsInvidious(result, trustApiResponse)
-
-        let parsedManifest
-
-        if (!trustApiResponse) {
-          // Invidious' API response doesn't include the height and width (and fps and qualityLabel for AV1) of video streams
-          // so we need to extract them from Invidious' manifest
-          const response = await invidiousFetch(url)
-          const originalText = await response.text()
-
-          parsedManifest = new DOMParser().parseFromString(originalText, 'application/xml')
-        }
+        const adaptiveFormats = await this.getAdaptiveFormatsInvidious(result)
 
         /** @type {import('youtubei.js').Misc.Format[]} */
         const formats = []
@@ -1366,19 +1348,6 @@ export default defineComponent({
         let hasMultipleAudioTracks = false
 
         for (const format of adaptiveFormats) {
-          if (!trustApiResponse && format.type.startsWith('video/')) {
-            const representation = parsedManifest.querySelector(`Representation[id="${format.itag}"][bandwidth="${format.bitrate}"]`)
-
-            format.height = parseInt(representation.getAttribute('height'))
-            format.width = parseInt(representation.getAttribute('width'))
-            format.fps = parseInt(representation.getAttribute('frameRate'))
-
-            // the quality label is missing for AV1 formats
-            if (!format.qualityLabel) {
-              format.qualityLabel = format.width > format.height ? `${format.height}p` : `${format.width}p`
-            }
-          }
-
           const localFormat = convertInvidiousToLocalFormat(format)
 
           if (localFormat.has_audio) {
@@ -1446,7 +1415,7 @@ export default defineComponent({
       }
     },
 
-    getAdaptiveFormatsInvidious: async function (existingInfoResult = null, trustApiResponse = false) {
+    getAdaptiveFormatsInvidious: async function (existingInfoResult = null) {
       let result
       if (existingInfoResult) {
         result = existingInfoResult
@@ -1454,30 +1423,19 @@ export default defineComponent({
         result = await invidiousGetVideoInformation(this.videoId)
       }
 
-      if (trustApiResponse) {
-        result.adaptiveFormats.forEach((format) => {
-          format.bitrate = parseInt(format.bitrate)
+      result.adaptiveFormats.forEach((format) => {
+        format.bitrate = parseInt(format.bitrate)
 
-          // audio streams don't have a size property
-          if (typeof format.size === 'string') {
-            const [stringWidth, stringHeight] = format.size.split('x')
+        // audio streams don't have a size property
+        if (typeof format.size === 'string') {
+          const [stringWidth, stringHeight] = format.size.split('x')
 
-            format.width = parseInt(stringWidth)
-            format.height = parseInt(stringHeight)
-          }
-        })
+          format.width = parseInt(stringWidth)
+          format.height = parseInt(stringHeight)
+        }
+      })
 
-        return result.adaptiveFormats
-      } else {
-        return filterInvidiousFormats(result.adaptiveFormats)
-          .map((format) => {
-            format.bitrate = parseInt(format.bitrate)
-            if (typeof format.resolution === 'string') {
-              format.height = parseInt(format.resolution.replace('p', ''))
-            }
-            return format
-          })
-      }
+      return result.adaptiveFormats
     },
 
     createLocalStoryboardUrls: function (storyboardInfo) {


### PR DESCRIPTION
# Cleanup Invidious backwards compatibility

## Pull Request Type

- [x] Code cleanup

## Related issue
* https://github.com/iv-org/invidious/pull/4586

## Description
This pull request removes the backwards compatibility that we had to handle Invidious returning incorrect height and width values for the legacy format streams and not returning the height and width at all for the adaptive formats. The reason to do so is that the pull request that fixed that was released in Invidious v2.20240825.0 which was released on the 25th of August 2024, so about 3 months ago.

Considering all the issues that Invidious has been having recently it seems highly unlikely that anyone would still be running an Invidious version older than that. However just to be on the safe side, I decided that it's definitely best to wait until after the upcoming release to merge this, just to give instance maintainers and users a bit more time.

## Testing
Open a video with the Invidious API and check that all 3 media format types work and that video height and width are shown in the stats for the legacy formats.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b9adcb3d89bcb1878cdbaceb83342fd2a8f51477