### PR TITLE
Fix seek bar thumbnail overflowing when exiting full screen

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -8,6 +8,12 @@
     so we want to make it black as it defaults to transparent
    */
   background-color: #000;
+
+  /*
+    Fixes the seek bar thumbnails causing a horizontal scroll bar
+    to appear after exiting full screen and full window.
+  */
+  overflow-x: hidden;
 }
 
 .player {


### PR DESCRIPTION
# Fix seek bar thumbnail overflowing when exiting full screen

## Pull Request Type

- [x] Bugfix

## Related issue
* https://github.com/FreeTubeApp/FreeTube/discussions/5881#discussioncomment-11015454

## Description
This pull request fixes the thumbnail container causing the UI to overflow after exiting full screen if the user was hovering over the end of the seek bar. This happens because full screen is usually much larger than the size of the window outside of full screen, so the position of the seek bar thumbnail goes from being inside the viewport to outside of it, which results in a horizontal scroll bar showing up to compensate for it overflowing.

## Screenshots
See linked thread for a video demonstrating the bug

## Testing
1. Open a video
2. Resize the window so that the recommended videos section is below the player
3. Enter full screen via the keyboard shortcut by pressing <kbd>f</kbd>
4. Hover over the end of the seek bar
5. Exit full screen via the keyboard shortcut by pressing <kbd>f</kbd>
6. There should be no horizontal scroll bar

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** f6e7344018d24b61e152cf14ff750f086873ad6e