### PR TITLE
Fix subscriptions double loading on launch

### DIFF
--- a/src/renderer/components/subscriptions-community/subscriptions-community.js
+++ b/src/renderer/components/subscriptions-community/subscriptions-community.js
@@ -14,6 +14,7 @@ export default defineComponent({
   data: function () {
     return {
       isLoading: true,
+      alreadyLoadedRemotely: false,
       postList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -97,7 +98,9 @@ export default defineComponent({
     },
 
     subscriptionCacheReady() {
-      this.loadPostsFromCacheSometimes()
+      if (!this.alreadyLoadedRemotely) {
+        this.loadPostsFromCacheSometimes()
+      }
     },
   },
   mounted: async function () {
@@ -115,6 +118,7 @@ export default defineComponent({
         return
       }
 
+      this.alreadyLoadedRemotely = true
       this.loadPostsForSubscriptionsFromRemote()
       this.$store.commit('setSubscriptionForCommunityPostsFirstAutoFetchRun')
     },

--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -21,6 +21,7 @@ export default defineComponent({
   data: function () {
     return {
       isLoading: true,
+      alreadyLoadedRemotely: false,
       videoList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -107,7 +108,9 @@ export default defineComponent({
     },
 
     subscriptionCacheReady() {
-      this.loadVideosFromCacheSometimes()
+      if (!this.alreadyLoadedRemotely) {
+        this.loadVideosFromCacheSometimes()
+      }
     },
   },
   mounted: async function () {
@@ -125,6 +128,7 @@ export default defineComponent({
         return
       }
 
+      this.alreadyLoadedRemotely = true
       this.loadVideosForSubscriptionsFromRemote()
       this.$store.commit('setSubscriptionForLiveStreamsFirstAutoFetchRun')
     },

--- a/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
+++ b/src/renderer/components/subscriptions-shorts/subscriptions-shorts.js
@@ -19,6 +19,7 @@ export default defineComponent({
   data: function () {
     return {
       isLoading: true,
+      alreadyLoadedRemotely: false,
       videoList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -101,7 +102,9 @@ export default defineComponent({
     },
 
     subscriptionCacheReady() {
-      this.loadVideosFromCacheSometimes()
+      if (!this.alreadyLoadedRemotely) {
+        this.loadVideosFromCacheSometimes()
+      }
     },
   },
   mounted: async function () {
@@ -119,6 +122,7 @@ export default defineComponent({
         return
       }
 
+      this.alreadyLoadedRemotely = true
       this.loadVideosForSubscriptionsFromRemote()
       this.$store.commit('setSubscriptionForShortsFirstAutoFetchRun')
     },

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -21,6 +21,7 @@ export default defineComponent({
   data: function () {
     return {
       isLoading: true,
+      alreadyLoadedRemotely: false,
       videoList: [],
       errorChannels: [],
       attemptedFetch: false,
@@ -111,7 +112,9 @@ export default defineComponent({
     },
 
     subscriptionCacheReady() {
-      this.loadVideosFromCacheSometimes()
+      if (!this.alreadyLoadedRemotely) {
+        this.loadVideosFromCacheSometimes()
+      }
     },
   },
   mounted: async function () {
@@ -129,6 +132,7 @@ export default defineComponent({
         return
       }
 
+      this.alreadyLoadedRemotely = true
       this.loadVideosForSubscriptionsFromRemote()
       this.$store.commit('setSubscriptionForVideosFirstAutoFetchRun')
     },


### PR DESCRIPTION
# Fix subscriptions double loading on launch

## Pull Request Type

- [x] Bugfix

## Description

Currently when Fetch Subscriptions Automatically is enabled we start loading remotely and when the subscriptions cache is ready we load from that too, which results in the UI being all buggy, as you have two loading operations running in parallel. This pull request fixes that by not reacting to the subscription cache being ready if we are already loading remotely, which avoids the double loading problem.

## Testing
As how noticable the bugginess is depends on lots of different variables it's difficult to say how to reproduce it consistently, however you can still check that this didn't break anything. So that fetching remotely still works and that if Fetch Subscriptions Automatically is disabled it still loads from the cache when it is ready.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 19a6124d09b411e3153ecb3df93ac2ee3a956768