### PR TITLE
Set minimum width and height for window

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -690,7 +690,9 @@ function runApp() {
         webSecurity: false,
         backgroundThrottling: false,
         contextIsolation: false
-      }
+      },
+      minWidth: 340,
+      minHeight: 380
     }
 
     const newWindow = new BrowserWindow(


### PR DESCRIPTION
# Set minimum width and height for window

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix

## Related issue
closes #5854

## Description
Sets a minimum width and height for the window.

## Screenshots <!-- If appropriate -->
<img width="339" alt="Screenshot 2024-10-24 at 10 50 09 AM" src="https://github.com/user-attachments/assets/0f06cc0e-1a21-4c2b-b6b0-642df0f4e026">

## Testing <!-- for code that is not small enough to be easily understandable -->
Try to make the browser small. Previously, it could become infinitesimal on at least Mac and Linux.

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** Ventura