### PR TITLE
Assign authorId to posts in the parsing functions

### DIFF
--- a/src/renderer/components/subscriptions-community/subscriptions-community.js
+++ b/src/renderer/components/subscriptions-community/subscriptions-community.js
@@ -235,9 +235,7 @@ export default defineComponent({
           this.errorChannels.push(channel)
           return []
         }
-        entries.forEach(post => {
-          post.authorId = channel.id
-        })
+
         return entries
       } catch (err) {
         console.error(err)
@@ -256,9 +254,6 @@ export default defineComponent({
     getChannelPostsInvidious: function (channel) {
       return new Promise((resolve, reject) => {
         invidiousGetCommunityPosts(channel.id).then(result => {
-          result.posts.forEach(post => {
-            post.authorId = channel.id
-          })
           resolve(result.posts)
         }).catch((err) => {
           console.error(err)

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -274,6 +274,7 @@ function parseInvidiousCommunityData(data) {
     voteCount: data.likeCount,
     postContent: parseInvidiousCommunityAttachments(data.attachment),
     commentCount: data?.replyCount ?? 0, // https://github.com/iv-org/invidious/pull/3635/
+    authorId: data.authorId,
     author: data.author,
     type: 'community'
   }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1489,6 +1489,7 @@ function parseLocalCommunityPost(post) {
     voteCount: post.vote_count ? parseLocalSubscriberCount(post.vote_count.text) : 0,
     postContent: parseLocalAttachment(post.attachment),
     commentCount: replyCount,
+    authorId: post.author.id,
     author: post.author.name,
     type: 'community'
   }

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1697,9 +1697,6 @@ export default defineComponent({
         this.communityContinuationData = communityTab.has_continuation ? communityTab : null
 
         if (this.latestCommunityPosts.length > 0) {
-          this.latestCommunityPosts.forEach(post => {
-            post.authorId = this.id
-          })
           this.updateSubscriptionPostsCacheByChannel({
             channelId: this.id,
             // create a copy so that we only cache the first page
@@ -1761,9 +1758,6 @@ export default defineComponent({
         this.communityContinuationData = continuation
 
         if (this.isSubscribedInAnyProfile && !more && this.latestCommunityPosts.length > 0) {
-          this.latestCommunityPosts.forEach(post => {
-            post.authorId = this.id
-          })
           this.updateSubscriptionPostsCacheByChannel({
             channelId: this.id,
             // create a copy so that we only cache the first page
@@ -2009,9 +2003,6 @@ export default defineComponent({
         })
       }
 
-      this.latestCommunityPosts.forEach(post => {
-        post.authorId = this.id
-      })
       this.updateSubscriptionPostsCacheByChannel({
         channelId: this.id,
         posts: [...this.latestCommunityPosts]


### PR DESCRIPTION
# Assign authorId to posts in the parsing functions

## Pull Request Type

- [x] Refactor

## Description

Currently we assign the authorId (channel ID) to community posts after we have parsed them, this is because when we originally implemented community post suppport into FreeTube we didn't need the channel ID. As we now need the channel ID everywhere that we use community posts in FreeTube we have code in various places to add the channel IDs to the posts after the fact. As the channel IDs are also available in the API response data, this pull request moves the assigning of the authorId into the parsing functions, which lets us clean up all the other code that was assigning the channel ID after the fact.

## Testing
Check that the channel name on community posts is still a link on the subscriptions tab and the channel page with both API backends.

**Side note:** The live channel tab endpoint is currently broken on Invidious' end, so if you get an error about `Request contains an invalid argument` on the channel page you can ignore it as it is unrelated to this pull request: https://github.com/iv-org/invidious/issues/5021

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 