### PR TITLE
Fix issue #5969

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1491,7 +1491,7 @@ export default defineComponent({
       // otherwise just fallback to the FreeTube display language and hope that YouTube will be able to handle it
       if (!translationLanguage) {
         translationName = this.$t('Locale Name')
-        translationCode = userLanguages.values().next()
+        translationCode = userLanguages.values().next().value
       } else {
         translationName = translationLanguage.language_name.text
         translationCode = translationLanguage.language_code


### PR DESCRIPTION
# Title
Fix issue #5969 
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #5969 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The crash seems to be an issue when Freetube tries to run the sortCaptions function. The function expect the "langauge" key as a string, but the getTranslatedLocaleCaption function sometimes return an object causing it to crash.

## Screenshots <!-- If appropriate -->
N/A
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
Tested with the link of issue #5969 with traditional chinese and other locale settings
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Flatpak
- **OS Version:** N/A
- **FreeTube version:** v0.22.0 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
