### PR TITLE
Fix full window for videos with a 4:3 aspect ratio

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -4,7 +4,7 @@
     class="ftVideoPlayer"
     :class="{
       fullWindow: fullWindowEnabled,
-      sixteenByNine: forceAspectRatio
+      sixteenByNine: forceAspectRatio && !fullWindowEnabled
     }"
   >
     <!-- eslint-disable-next-line vuejs-accessibility/media-has-caption -->


### PR DESCRIPTION
# Fix full window for videos with a 4:3 aspect ratio

## Pull Request Type

- [x] Bugfix

## Related issue
closes #5974

## Description
For videos with a 4:3 aspect ratio we force the player container to be 16:9 and display black bars on the left and right side of the video instead of matching the aspect ratio of the video, to prevent the UI overflowing. As full window mode needs to be able to take up the entire window we have to remove the forced aspect ratio in that situation.

Screenshot and test case taken from the linked issue.

## Screenshots

![full-window-bug](https://github.com/user-attachments/assets/a5f3266c-fc83-42ed-879e-1c60c37dff15)

## Testing
1. Open https://www.youtube-nocookie.com/embed/e22pjkN0AQY
2. Trigger full window mode
3. It should take up the whole window

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.22.0