### PR TITLE
Use import.meta.dirname in mjs scripts

### DIFF
--- a/_scripts/getRegions.mjs
+++ b/_scripts/getRegions.mjs
@@ -12,11 +12,9 @@
  */
 
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
 import { Innertube, Misc } from 'youtubei.js'
 
-const STATIC_DIRECTORY = `${dirname(fileURLToPath(import.meta.url))}/../static`
+const STATIC_DIRECTORY = `${import.meta.dirname}/../static`
 
 const activeLanguagesPath = `${STATIC_DIRECTORY}/locales/activeLocales.json`
 /** @type {string[]} */

--- a/_scripts/injectAllowedPaths.mjs
+++ b/_scripts/injectAllowedPaths.mjs
@@ -6,12 +6,9 @@
  * to ensure that it cannot access other files on the disk, without the users permission (e.g. file picker).
  */
 import { closeSync, ftruncateSync, openSync, readFileSync, readdirSync, writeSync } from 'fs'
-import { dirname, join, relative, resolve } from 'path'
-import { fileURLToPath } from 'url'
+import { join, relative, resolve } from 'path'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-const distDirectory = resolve(__dirname, '..', 'dist')
+const distDirectory = resolve(import.meta.dirname, '..', 'dist')
 const webDirectory = join(distDirectory, 'web')
 
 const paths = readdirSync(distDirectory, {


### PR DESCRIPTION
# Use import.meta.dirname in mjs scripts

## Pull Request Type

- [x] Other

## Description
`import.meta.dirname` is the ES Modules version of the `__dirname` in CommonJS files. We already use it in the `_scripts/patchShaka.mjs` file, this pull request adds it to the `getRegions.mjs` and `injectAllowedPaths.mjs` files too.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 80efbd65124c95a00f2eb16e5b70894c6b0cf239