### PR TITLE
Apply active FreeTube theme to shaka-player menus

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -43,6 +43,31 @@
   flex-direction: column-reverse;
 }
 
+/*
+  Apply the active FreeTube base theme to shaka-player's menus.
+  Usually we go for classes and not element names,
+  however as we need to override shaka-player's CSS
+  we need to use the same selectors that they do.
+*/
+
+:deep(.shaka-overflow-menu),
+:deep(.shaka-settings-menu) {
+  background: var(--card-bg-color) !important;
+}
+
+:deep(.shaka-overflow-menu button),
+:deep(.shaka-settings-menu button) {
+  color: var(--primary-text-color) !important;
+}
+
+:deep(.shaka-overflow-menu button:hover),
+:deep(.shaka-settings-menu button:hover) {
+  background: var(--side-nav-hover-color) !important;
+  color: var(--side-nav-hover-text-color) !important;
+}
+
+/* End of theming code */
+
 .sixteenByNine {
   aspect-ratio: 16 / 9;
 }


### PR DESCRIPTION
# Apply active FreeTube theme to shaka-player menus

## Pull Request Type

- [x] Feature Implementation

## Related issue
- https://github.com/FreeTubeApp/FreeTube/discussions/5948#discussioncomment-11066775

## Description
This pull request overrides shaka-player's menu colours (white background, black text) to match the currently active base theme in FreeTube. The code isn't great but as we have to override shaka-player's CSS we have to use the same CSS selectors as they do.

## Screenshots
<details><summary>Light</summary>

![light](https://github.com/user-attachments/assets/4e2bcf8f-fa70-4c72-b930-8f98fdae08d2)

</details>
<details><summary>Dark</summary>

![dark](https://github.com/user-attachments/assets/348d9402-8685-43d9-914b-c3d29dd5fa25)

</details>
<details><summary>Black</summary>

![black](https://github.com/user-attachments/assets/af37eb1b-ed37-435b-93b0-f8d2a6983711)

</details>
<details><summary>Nordic</summary>

![nordic](https://github.com/user-attachments/assets/dd7967e3-e177-4bf9-9d8c-75663ea0baf5)

</details>
<details><summary>Hot Pink</summary>

![hot-pink](https://github.com/user-attachments/assets/5313dc07-0216-47bd-afdc-b436df3819f4)

</details>
<details><summary>Pastel Pink</summary>

![pastel-pink](https://github.com/user-attachments/assets/77656bff-27c2-4ba3-a57f-62e89beda004)

</details>
<details><summary>Catppuccin Mocha</summary>

![catppuccin-mocha](https://github.com/user-attachments/assets/d29ba116-478a-4044-a43a-0b03a3b20582)

</details>
<details><summary>Dracula</summary>

![dracula](https://github.com/user-attachments/assets/1b9b140c-c76f-4cf6-8eb7-c3e4887f1db7)

</details>
<details><summary>Solarized Dark</summary>

![solarized-dark](https://github.com/user-attachments/assets/9275a92b-3bb4-4bfe-9db4-125ae2f959b6)

</details>
<details><summary>Solarized Light</summary>

![solarized-light](https://github.com/user-attachments/assets/5316d256-7168-41ea-b11b-5c5c28a168aa)

</details>

## Testing
Test a few of FreeTube's base themes and see how the player menus look

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 80efbd65124c95a00f2eb16e5b70894c6b0cf239