### PR TITLE
Fix settings password handling

### DIFF
--- a/src/renderer/views/Settings/Settings.js
+++ b/src/renderer/views/Settings/Settings.js
@@ -170,14 +170,8 @@ export default defineComponent({
     }
   },
   mounted: function () {
-    this.handleResize()
-    window.addEventListener('resize', this.handleResize)
-    document.addEventListener('scroll', this.markScrolledToSectionAsActive)
-
-    // mark first section as active before any scrolling has taken place
-    if (this.settingsSectionComponents.length > 0) {
-      const firstSection = document.getElementById(this.settingsSectionComponents[0].type)
-      firstSection.classList.add(ACTIVE_CLASS_NAME)
+    if (this.unlocked) {
+      this.handleMounted()
     }
   },
   beforeDestroy: function () {
@@ -185,6 +179,26 @@ export default defineComponent({
     window.removeEventListener('resize', this.handleResize)
   },
   methods: {
+    handleMounted: function () {
+      this.handleResize()
+      window.addEventListener('resize', this.handleResize)
+      document.addEventListener('scroll', this.markScrolledToSectionAsActive)
+
+      // mark first section as active before any scrolling has taken place
+      if (this.settingsSectionComponents.length > 0) {
+        const firstSection = document.getElementById(this.settingsSectionComponents[0].type)
+        firstSection.classList.add(ACTIVE_CLASS_NAME)
+      }
+    },
+
+    handleUnlock: function () {
+      this.unlocked = true
+
+      nextTick(() => {
+        this.handleMounted()
+      })
+    },
+
     navigateToSection: function(sectionType) {
       if (this.isInDesktopView) {
         nextTick(() => {

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -47,7 +47,7 @@
     </template>
     <password-dialog
       v-else
-      @unlocked="unlocked = true"
+      @unlocked="handleUnlock"
     />
   </div>
 </template>


### PR DESCRIPTION
# Fix settings password handling

## Pull Request Type

- [x] Bugfix

## Description
This pull request fixes the error in the console when opening the settings while a settings password is set. This doesn't cause any usability issues as the code that errors is the code that sets which section is selected in the side bar and we run it on every scroll event, so it will not be noticable unless you have the devtools open and see the error.

## Screenshots
![error](https://github.com/user-attachments/assets/7f0a844e-ad54-4b01-8678-8b90b13f6433)

## Testing
1. Set a settings password
2. Navigate to a different page e.g. about
3. Navigate back to the settings
4. You should see no error and after entering the password the active section should be highlighted in the side bar immediately

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:**  8b3c394534afcff1c76e9f4070cb64a64c59811d