### PR TITLE
Invidious API: Extract streaming data expiry date from URL

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -848,6 +848,8 @@ export default defineComponent({
             // // https://github.com/iv-org/invidious/pull/4589
             // if (this.proxyVideos) {
 
+            this.streamingDataExpiryDate = this.extractExpiryDateFromStreamingUrl(result.adaptiveFormats[0].url)
+
             let hlsManifestUrl = result.hlsUrl
 
             if (this.proxyVideos) {
@@ -875,6 +877,8 @@ export default defineComponent({
             }
           } else {
             this.videoLengthSeconds = result.lengthSeconds
+
+            this.streamingDataExpiryDate = this.extractExpiryDateFromStreamingUrl(result.adaptiveFormats[0].url)
 
             this.legacyFormats = result.formatStreams.map(mapInvidiousLegacyFormat)
 
@@ -943,6 +947,12 @@ export default defineComponent({
             this.isLoading = false
           }
         })
+    },
+
+    extractExpiryDateFromStreamingUrl: function (url) {
+      const expireString = new URL(url).searchParams.get('expire')
+
+      return new Date(parseInt(expireString) * 1000)
     },
 
     /**


### PR DESCRIPTION
# Invidious API: Extract streaming data expiry date from URL

## Pull Request Type

- [x] Bugfix

## Related issue
Related to #5991

## Description
This fixes FreeTube claiming that the streaming data has expired when a 403 happens with the Invidious API even when it hasn't expired.

## Testing
1. Add a `console.log(this.streamingDataExpiryDate)` line below the `this.streamingDataExpiryDate =` line
2. Launch FreeTube
3. Set the backend to Invidious
4. Open a video
5. Check the console and check that the date is in the future (it should be multiple hours in the future).

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 6d1011008668bdaeb2e3b0af2e2a6050e23d9116