### PR TITLE
Change default value of display big video play button to false

### DIFF
--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -181,7 +181,7 @@ const state = {
   defaultTheatreMode: false,
   defaultVideoFormat: 'dash',
   disableSmoothScrolling: false,
-  displayVideoPlayButton: true,
+  displayVideoPlayButton: false,
   enableSearchSuggestions: true,
   enableSubtitlesByDefault: false,
   enterFullscreenOnDisplayRotate: false,


### PR DESCRIPTION
# Change default value of display big video play button to false

## Pull Request Type
- [x] Other

## Related issue
https://github.com/FreeTubeApp/FreeTube/pull/6002#issuecomment-2442897709
https://github.com/FreeTubeApp/FreeTube/pull/6002#issuecomment-2442923419

## Description
This PR changes the default value for whether to display the big play button to false

## Desktop
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** latest

