### PR TITLE
Make seekbar and player controls appear at bottom of video and take full width

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -47,6 +47,11 @@
   width: 100%;
 }
 
+/* increase height of captions since we remove the padding-bottom below the seekbar */
+:deep(.shaka-controls-container[shown='true']~.shaka-text-container) {
+  bottom: 12.5%;
+}
+
 .sixteenByNine {
   aspect-ratio: 16 / 9;
 }
@@ -217,6 +222,9 @@
     width: 96%;
   }
 
+  :deep(.shaka-controls-container[shown='true']~.shaka-text-container) {
+    bottom: 15%;
+  }
 }
 
 @media only screen and (width <=1350px) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -41,6 +41,10 @@
   /* Place the seek bar above the controls (the default is below) */
   display: flex;
   flex-direction: column-reverse;
+
+  /* remove some bottom padding since the seek bar is above */
+  padding-bottom: 0;
+  width: 100%;
 }
 
 .sixteenByNine {
@@ -207,6 +211,12 @@
   :deep(.playerFullscreenTitleOverlay) {
     font-size: large;
   }
+
+  :deep(.shaka-bottom-controls) {
+    padding-bottom: 2.5%;
+    width: 96%;
+  }
+
 }
 
 @media only screen and (width <=1350px) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -41,15 +41,6 @@
   /* Place the seek bar above the controls (the default is below) */
   display: flex;
   flex-direction: column-reverse;
-
-  /* remove some bottom padding since the seek bar is above */
-  padding-bottom: 0;
-  width: 100%;
-}
-
-/* increase height of captions since we remove the padding-bottom below the seekbar */
-:deep(.shaka-controls-container[shown='true']~.shaka-text-container) {
-  bottom: 12.5%;
 }
 
 .sixteenByNine {
@@ -216,14 +207,20 @@
   :deep(.playerFullscreenTitleOverlay) {
     font-size: large;
   }
+}
 
+@media only screen and (width >= 1000px) {
   :deep(.shaka-bottom-controls) {
-    padding-bottom: 2.5%;
-    width: 96%;
+    /* remove some bottom padding since the seek bar is above */
+    padding-bottom: 0;
+
+    /* make seekbar take full width on non-mobile devices */
+    width: 100%;
   }
 
+  /* increase height of captions area since we remove the padding-bottom below the seekbar */
   :deep(.shaka-controls-container[shown='true']~.shaka-text-container) {
-    bottom: 15%;
+    bottom: 12.5%;
   }
 }
 


### PR DESCRIPTION
# Make seekbar and player controls appear at bottom of video and take full width

## Pull Request Type
- [x] Other - subjective ui change

## Description
A subjective design change to move the seekbar lower and make the controls take the full width of the video on larger screens. This removes padding and increases width of player controls.

## Screenshots
![image](https://github.com/user-attachments/assets/43963404-aec4-4930-a742-def2dfb36aa5)

## Testing
- go to a video and make sure everything is behaving like it's supposed to (no element is overflowing, etc.)

## Desktop
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** 0.22.0