### PR TITLE
Add support for hms timestamp in query string

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -146,7 +146,28 @@ function runApp() {
               }
 
               if (params.has('timestamp')) {
-                newParams.set('t', params.get('timestamp'))
+                let timestamp = params.get('timestamp')
+                if (timestamp && (timestamp.includes('h') || timestamp.includes('m') || timestamp.includes('s'))) {
+                  if (timestamp && (timestamp.includes('h') || timestamp.includes('m') || timestamp.includes('s'))) {
+                    const { seconds, minutes, hours } = timestamp.match(/(?:(?<hours>(\d+))h)?(?:(?<minutes>(\d+))m)?(?:(?<seconds>(\d+))s)?/).groups
+                    let time = 0
+
+                    if (seconds) {
+                      time += Number(seconds)
+                    }
+
+                    if (minutes) {
+                      time += 60 * Number(minutes)
+                    }
+
+                    if (hours) {
+                      time += 3600 * Number(hours)
+                    }
+
+                    timestamp = time
+                  }
+                }
+                newParams.set('t', timestamp)
                 hasParams = true
               }
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -611,7 +611,26 @@ export function getVideoParamsFromUrl(url) {
 
   function extractParams(videoId) {
     paramsObject.videoId = videoId
-    paramsObject.timestamp = urlObject.searchParams.get('t')
+    let timestamp = urlObject.searchParams.get('t')
+    if (timestamp && (timestamp.includes('h') || timestamp.includes('m') || timestamp.includes('s'))) {
+      const { seconds, minutes, hours } = timestamp.match(/(?:(?<hours>(\d+))h)?(?:(?<minutes>(\d+))m)?(?:(?<seconds>(\d+))s)?/).groups
+      let time = 0
+
+      if (seconds) {
+        time += Number(seconds)
+      }
+
+      if (minutes) {
+        time += 60 * Number(minutes)
+      }
+
+      if (hours) {
+        time += 3600 * Number(hours)
+      }
+
+      timestamp = time
+    }
+    paramsObject.timestamp = timestamp
   }
 
   const extractors = [


### PR DESCRIPTION
# Title

## Pull Request Type
- [x] Feature Implementation

## Related issue
closes #6008 

## Description
Adds support for alternate timestamp urls.

## Testing (i think it might subtracts 2 seconds from it)
- go to https://youtu.be/27iu423Yjtc?t=2h10m20s 
- make sure it goes to 2 hours 10 minutes and 20 seconds

- go to https://youtu.be/27iu423Yjtc?t=3h
-  make sure it goes to 3 hour mark

- go to https://youtu.be/27iu423Yjtc?t=15m
- make sure it goes to 15 minute mark

- go to https://youtu.be/27iu423Yjtc?t=40s
- make sure it goes to 40 second mark  

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** 0.22.0

