### PR TITLE
Fix live streams buffering endlessly

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -555,7 +555,6 @@ export default defineComponent({
           dash: {
             manifestPreprocessorTXml: manifestPreprocessorTXml
           },
-          availabilityWindowOverride: seekingIsPossible.value ? NaN : 0
         },
         abr: {
           enabled: useAutoQuality,
@@ -1800,7 +1799,7 @@ export default defineComponent({
       const seekRange = player.seekRange()
 
       // Seeking not possible e.g. with HLS
-      if (seekRange.start === seekRange.end) {
+      if (seekRange.start === seekRange.end || !seekingIsPossible.value) {
         return false
       }
 


### PR DESCRIPTION
# Fix live streams buffering endlessly

## Pull Request Type

- [x] Bugfix

## Related issue
closes #5962

## Description
This pull request fixes live stream playback breaking after a while, resulting in the player buffering endlessly.

## Screenshots
![debug-logs](https://github.com/user-attachments/assets/753d2278-58e9-48fd-9b86-d1b941245a1f)

## Testing
Affects both backends for some users but in my case just Invidious, so I'm going to recommend testing with Invidious here.

1. Set your preferred API backend to Invidious
2. Open a lives stream e.g. lofi hip hop radio 📚 beats to relax/study to: https://youtu.be/jfKfPfyJRdk
3. Check that playback works for more than a minute without endlessly buffering (showing the loading symbol)

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** c3c93d5b902d97dbb9d3989bf26698849d0bdebb