### PR TITLE
Change default locale to system

### DIFF
--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -309,9 +309,9 @@ const state = {
 
 const stateWithSideEffects = {
   currentLocale: {
-    defaultValue: 'en-US',
+    defaultValue: 'system',
     sideEffectsHandler: async function ({ dispatch }, value) {
-      const defaultLocale = 'en-US'
+      const fallbackLocale = 'en-US'
 
       let targetLocale = value
       if (value === 'system') {
@@ -342,20 +342,20 @@ const stateWithSideEffects = {
           targetLocale = targetLocaleOptions[0]
         } else {
           // Go back to default value if locale is unavailable
-          targetLocale = defaultLocale
+          targetLocale = fallbackLocale
           // Translating this string isn't necessary
           // because the user will always see it in the default locale
           // (in this case, English (US))
-          showToast(`Locale not found, defaulting to ${defaultLocale}`)
+          showToast(`Locale not found, defaulting to ${fallbackLocale}`)
         }
       }
 
       const loadPromises = []
 
-      if (targetLocale !== defaultLocale) {
+      if (targetLocale !== fallbackLocale) {
         // "en-US" is used as a fallback for missing strings in other locales
         loadPromises.push(
-          loadLocale(defaultLocale)
+          loadLocale(fallbackLocale)
         )
       }
 


### PR DESCRIPTION
# Change default locale to system

## Pull Request Type
- [x] Other - default setting update

## Description
By default we should probably be using the language of the user's system if possible, otherwise we fallback to en-US. There were some issues with the system locale in the past which is why it wasn't made the default sooner but it seems to be working now.
I also updated the name of a variable to make it more clear that it's the fallback locale

## Testing
- Backup settings.db if you need it. (make sure to backup the dev one)
- Delete the dev settings.db (make sure it's the dev one)
- Go to settings > General Settings > Language preference
- That setting should default to System default

## Desktop
- **OS:** Linux Mint
- **OS Version:** 22
- **FreeTube version:** 0.22.0
