### PR TITLE
Add a polyfill for vue-i18n's `useI18n()` composable

### DIFF
--- a/_scripts/eslint-rules/plugin.mjs
+++ b/_scripts/eslint-rules/plugin.mjs
@@ -1,0 +1,11 @@
+import useI18nPolyfillRule from './use-i18n-polyfill-rule.mjs'
+
+export default {
+  meta: {
+    name: 'eslint-plugin-freetube',
+    version: '1.0'
+  },
+  rules: {
+    'use-i18n-polyfill': useI18nPolyfillRule
+  }
+}

--- a/_scripts/eslint-rules/use-i18n-polyfill-rule.mjs
+++ b/_scripts/eslint-rules/use-i18n-polyfill-rule.mjs
@@ -1,0 +1,62 @@
+import { dirname, relative, resolve } from 'path'
+
+const polyfillPath = resolve(import.meta.dirname, '../../src/renderer/composables/use-i18n-polyfill')
+
+function getRelativePolyfillPath(filePath) {
+  const relativePath = relative(dirname(filePath), polyfillPath).replaceAll('\\', '/')
+
+  if (relativePath[0] !== '.') {
+    return `./${relativePath}`
+  }
+
+  return relativePath
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    fixable: 'code'
+  },
+  create(context) {
+    return {
+      'ImportDeclaration[source.value="vue-i18n"]'(node) {
+        const specifierIndex = node.specifiers.findIndex(specifier => specifier.type === 'ImportSpecifier' && specifier.imported.name === 'useI18n')
+
+        if (specifierIndex !== -1) {
+          context.report({
+            node: node.specifiers.length === 1 ? node : node.specifiers[specifierIndex],
+            message: "Please use FreeTube's useI18n polyfill, as vue-i18n's useI18n composable does not work when the vue-i18n is in legacy mode, which is needed for components using the Options API.",
+            fix: context.physicalFilename === '<text>'
+              ? undefined
+              : (fixer) => {
+                  const relativePath = getRelativePolyfillPath(context.physicalFilename)
+
+                  // If the import only imports `useI18n`, we can just update the source/from text
+                  // Else we need to create a new import for `useI18n` and remove useI18n from the original one
+                  if (node.specifiers.length === 1) {
+                    return fixer.replaceText(node.source, `'${relativePath}'`)
+                  } else {
+                    const specifier = node.specifiers[specifierIndex]
+
+                    let specifierText = 'useI18n'
+
+                    if (specifier.imported.name !== specifier.local.name) {
+                      specifierText += ` as ${specifier.local.name}`
+                    }
+
+                    return [
+                      fixer.removeRange([
+                        specifierIndex === 0 ? specifier.start : node.specifiers[specifierIndex - 1].end,
+                        specifierIndex === node.specifiers.length - 1 ? specifier.end : node.specifiers[specifierIndex + 1].start
+                      ]),
+                      fixer.insertTextAfter(node, `\nimport { ${specifierText} } from '${relativePath}'`)
+                    ]
+                  }
+                }
+          })
+        }
+      }
+    }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import eslintPluginJsonc from 'eslint-plugin-jsonc'
 import eslintPluginYml from 'eslint-plugin-yml'
 import yamlEslintParser from 'yaml-eslint-parser'
 import neostandard from 'neostandard'
+import eslintPluginFreeTube from './_scripts/eslint-rules/plugin.mjs'
 
 import activeLocales from './static/locales/activeLocales.json' with { type: 'json' }
 
@@ -40,6 +41,7 @@ export default [
     ],
     plugins: {
       unicorn: eslintPluginUnicorn,
+      freetube: eslintPluginFreeTube
     },
 
     languageOptions: {
@@ -115,6 +117,8 @@ export default [
       '@intlify/vue-i18n/no-deprecated-tc': 'off',
       'vue/require-explicit-emits': 'error',
       'vue/no-unused-emit-declarations': 'error',
+
+      'freetube/use-i18n-polyfill': 'error'
     },
   },
 
@@ -209,7 +213,7 @@ export default [
     }
   },
   {
-    files: ['_scripts/*.mjs'],
+    files: ['_scripts/**/*.mjs'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3,10 +3,9 @@ import path from 'path'
 
 import { computed, defineComponent, onBeforeUnmount, onMounted, reactive, ref, shallowRef, watch } from 'vue'
 import shaka from 'shaka-player'
+import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import store from '../../store/index'
-import i18n from '../../i18n/index'
-
 import { IpcChannels } from '../../../constants'
 import { AudioTrackSelection } from './player-components/AudioTrackSelection'
 import { FullWindowButton } from './player-components/FullWindowButton'
@@ -115,6 +114,8 @@ export default defineComponent({
     'toggle-theatre-mode'
   ],
   setup: function (props, { emit, expose }) {
+    const { locale, t } = useI18n()
+
     /** @type {shaka.Player|null} */
     let player = null
 
@@ -991,7 +992,7 @@ export default defineComponent({
       events.dispatchEvent(new CustomEvent('localeChanged'))
     }
 
-    watch(() => i18n.locale, setLocale)
+    watch(locale, setLocale)
 
     // #endregion player locales
 
@@ -1500,7 +1501,7 @@ export default defineComponent({
         })
       } catch (err) {
         console.error(`Parse failed: ${err.message}`)
-        showToast(i18n.t('Screenshot Error', { error: err.message }))
+        showToast(t('Screenshot Error', { error: err.message }))
         canvas.remove()
         return
       }
@@ -1565,7 +1566,7 @@ export default defineComponent({
             await fs.mkdir(dirPath, { recursive: true })
           } catch (err) {
             console.error(err)
-            showToast(i18n.t('Screenshot Error', { error: err }))
+            showToast(t('Screenshot Error', { error: err }))
             canvas.remove()
             return
           }
@@ -1579,11 +1580,11 @@ export default defineComponent({
 
           fs.writeFile(filePath, arr)
             .then(() => {
-              showToast(i18n.t('Screenshot Success', { filePath }))
+              showToast(t('Screenshot Success', { filePath }))
             })
             .catch((err) => {
               console.error(err)
-              showToast(i18n.t('Screenshot Error', { error: err }))
+              showToast(t('Screenshot Error', { error: err }))
             })
         })
       }, mimeType, imageQuality)
@@ -2314,7 +2315,7 @@ export default defineComponent({
         player.getNetworkingEngine().registerResponseFilter(responseFilter)
       }
 
-      await setLocale(i18n.locale)
+      await setLocale(locale.value)
 
       // check if the component is already getting destroyed
       // which is possible because this function runs asynchronously

--- a/src/renderer/composables/use-i18n-polyfill.js
+++ b/src/renderer/composables/use-i18n-polyfill.js
@@ -1,0 +1,79 @@
+/* eslint-disable @intlify/vue-i18n/no-dynamic-keys */
+import { computed } from 'vue'
+
+import i18n from '../i18n/index'
+
+/**
+ * Polyfill for vue-i18n's useI18n composable, as it is not available in Vue 2
+ * and doesn't work when vue-i18n 9+ (used for Vue 3) is set to `legacy: true`,
+ * which is needed for Options API components.
+ *
+ * Yes, vue-i18n 9 has an `allowComposition` option,
+ * but it comes with limitations that this polyfill doesn't have and was removed in vue-i18n 10.
+ *
+ * @see https://vue-i18n.intlify.dev/guide/migration/vue3#limitations
+ * @see https://vue-i18n.intlify.dev/guide/migration/breaking10.html#drop-allowcomposition-option
+ */
+export function useI18n() {
+  const locale = computed({
+    get() {
+      return i18n.locale
+    },
+    set(locale) {
+      i18n.locale = locale
+    }
+  })
+
+  return {
+    locale,
+    t
+  }
+}
+
+/**
+ * @overload
+ * @param {string} key
+ * @returns {string}
+ *
+ * @overload
+ * @param {string} key
+ * @param {number} plural
+ * @returns {string}
+ *
+ * @overload
+ * @param {string} key
+ * @param {unknown[]} list
+ * @returns {string}
+ *
+ * @overload
+ * @param {string} key
+ * @param {unknown[]} list
+ * @param {number} plural
+ * @returns {string}
+ *
+ * @overload
+ * @param {string} key
+ * @param {Record<string, unknown>} named
+ * @returns {string}
+ *
+ * @overload
+ * @param {string} key
+ * @param {Record<string, unknown>} named
+ * @param {number} plural
+ * @returns {string}
+ *
+ * @param {string} key
+ * @param {number | unknown[] | Record<string, unknown> | undefined} arg1
+ * @param {number | undefined} arg2
+ * @returns {string}
+ */
+function t(key, arg1, arg2) {
+  // Remove these lines in the Vue 3 migration and pass all args to the `.t()` call
+  if (typeof arg1 === 'number') {
+    return i18n.tc(key, arg1)
+  } else if (typeof arg2 === 'number') {
+    return i18n.tc(key, arg2, arg1)
+  }
+
+  return i18n.t(key, arg1)
+}


### PR DESCRIPTION
# Add a polyfill for vue-i18n's useI18n() composable

## Pull Request Type

- [x] Refactoring - Composition API migration

## Description
This pull request introduces a polyfill for `vue-i18n` 9+'s `useI18n` composable as well as a custom auto-fixable ESLint rule to enforce the use of the polyfill.

Why?
- `vue-i18n` 8, the version of `vue-i18n` that is compatible with Vue 2, doesn't have the `useI18n` composable, so this polyfill allows us to already migrate components that need to use vue-i18n in the JavaScript section (e.g. accessing the current locale to pass to `Intl` APIs or using the translate function in computeds like we do for the drop down labels).
- Even once we upgrade to Vue 3, `vue-i18n` 9+'s `useI18n` composable cannot be used while the `vue-i18n` instance is in legacy mode `legacy: true`, but we need legacy mode for components that are still using the Options API (unless we migrate every single component to the Composition API before we use Vue 3, which is unlikely to happen)
- `vue-i18n` 9 does have an `allowComposition` option, however that option comes with some serious limitations (https://vue-i18n.intlify.dev/guide/migration/vue3#limitations) such as requiring the call to `useI18n` to be inside the `nextTick()` callback which is only fired after the component has already been mounted/rendered and was removed in `vue-i18n` 10 (https://vue-i18n.intlify.dev/guide/migration/breaking10.html#drop-allowcomposition-option). The polyfill in this PR doesn't have those limitations.
- Compared to importing the vue-i18n instance and accessing the properties on it directly (what we currently do in the `ft-shaka-video-player.js` file), this provides a drop-in replacement for the `useI18n` function, so once we turn off `legacy` mode, all we need to do is remove the ESLint rule and update the imports to point to `vue-i18n` instead.
- I created an auto-fixable ESLint rule so you don't even have to think about which `useI18n` function you import or that your editor has imported the wrong one, as the ESLint rule will catch it and can fix the import for you.
- The only extra work this introduces for the initial Vue 3 migration is a few minor changes to the polyfill file, all files that import the polyfill should "just work".

## Screenshots
![eslint-error](https://github.com/user-attachments/assets/1380f007-21ff-4753-bc09-d94c49032351)

![eslint-quick-fix](https://github.com/user-attachments/assets/82c0a507-b2ac-4fdc-8dc4-5d828ab7764a)

![using-polyfill](https://github.com/user-attachments/assets/a6acf7b7-6d47-4968-9397-f9d9384033a2)

## Testing
### Testing the polyfill
1. Open two FreeTube windows
2. In the first window navigate to a video
3. In the second window open the general settings
4. Change the display locale and check that the video player updates it's language (e.g. hover over the playback rate selector)
5. Take a screenshot and make sure the toast message is translated

### Testing the ESLint rule
1. Try adding `import { useI18n } from 'vue-i18n'` to a file and check that ESLint detects it and that the fix works (it should change the text after the `from` part).
2. Try adding `import { useI18n, createI18n } from 'vue-i18n'` to a file and check that ESLint detects and and that the fix works (it should edit the existing import to remove the useI18n part and create a second import importing the `useI18n` polyfill)

## Desktop

- **OS:** Windows 10
- **OS Version:** 10
- **FreeTube version:** d6788636f145448be45f3ceb710f672aad3e08c2