### PR TITLE
Fix use of deprecated Invidious route on the videos subscription tab

### DIFF
--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -343,8 +343,9 @@ export default defineComponent({
     getChannelVideosInvidiousScraper: function (channel, failedAttempts = 0) {
       return new Promise((resolve, reject) => {
         const subscriptionsPayload = {
-          resource: 'channels/latest',
+          resource: 'channels',
           id: channel.id,
+          subResource: 'videos',
           params: {}
         }
 


### PR DESCRIPTION
# Fix use of deprecated Invidious route on the videos subscription tab

## Pull Request Type

- [x] Bugfix

## Related issue
- https://github.com/iv-org/invidious/pull/5045

## Description
The Invidious maintainers are removing some of the old routes that have been replaced by new ones for a long time now, this pull request corrects the last remaining use of the old routes in FreeTube.

## Testing
1. Set your preferred API backend to Invidious
2. Select a profile with less than 125 subscriptions and make sure RSS is turned off
3. Refresh your subscriptions

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 1427f257cf872cab681bfb69c2f3e473f1ced1c2
