### PR TITLE
Use decodingInfo's powerEfficient property when picking streams

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -565,9 +565,11 @@ export default defineComponent({
         },
         autoShowText: shaka.config.AutoShowText.NEVER,
 
-        // Only use variants that are predicted to play smoothly
+        // Prioritise variants that are predicted to play:
+        // - `smooth`: without dropping frames
+        // - `powerEfficient` the spec is quite vague but in Chromium it should prioritise hardware decoding when available
         // https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo
-        preferredDecodingAttributes: format === 'dash' ? ['smooth'] : [],
+        preferredDecodingAttributes: format === 'dash' ? ['smooth', 'powerEfficient'] : [],
 
         // Electron doesn't like YouTube's vp9 VR video streams and throws:
         // "CHUNK_DEMUXER_ERROR_APPEND_FAILED: Projection element is incomplete; ProjectionPoseYaw required."


### PR DESCRIPTION
# Use decodingInfo's powerEfficient property when picking streams

## Pull Request Type

- [x] Feature Implementation

## Description
The MediaCapabilities `decodingInfo` function can be used to query Electron/the browser if it supports playback of a certain audio and video combination and whether it thinks it can do it smoothly (without dropping frames) and power efficiently (the spec doesn't list any specifics but at least in Chromium whether the stream can be played with hardware acceleration is considered, at least according to my research). At the moment FreeTube just tells shaka-player to prefer streams that can be played smoothly (it always filters out unsupported streams). This pull request also tells it to consider the powerEfficient property.

shaka-player picks the best one for each video quality/resolution option, so even if the API predicts that a 4K stream will play dreadfully on a specific device, it will still be included. That means that users can't come up with complaints about missing quality options because of this :).

## Testing
Unfortunately in this case I haven't been able to test the impact, as my device supports hardware accelerated playback for h264, VP9 and AV1.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 59eff14712ae3c65b1847ce69375f4ba66d2882a