### PR TITLE
Fix context menu adding video scroll bar

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -12,8 +12,9 @@
   /*
     Fixes the seek bar thumbnails causing a horizontal scroll bar
     to appear after exiting full screen and full window.
+    But also vertically in case context menu overflows.
   */
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .player {


### PR DESCRIPTION
# Fix video player displaying a vertical scrollbar when context menu outside player container 

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #6006 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Hey, I've been interested in extra features but before taming the beast, I figured I'd just try something easy first.
So turns out with the recent update to the video player to use the shaka player, when the context menu is brought too close to the bottom, it adds a scroll bar to the video container.
This PR just aims to make both horizontal and vertical `overflow` css properties of the video player component to `hidden` rather than just the horizontal part.


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/user-attachments/assets/bff6a3f9-4f7a-4ab2-a284-6967d53dfc87) ![image](https://github.com/user-attachments/assets/a2af65dc-a87b-4aa8-a46b-edb6f6a47a05)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
This was tested, and indeed closes #6006.

## Desktop
<!-- Please complete the following information-->
- **OS**: Linux
- **OS Version**: 6.11.2-4-MANJARO
- **FreeTube version**: 0.22 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
So, I initially wanted to re-position the context menu slightly higher or to the left if it were to be respectively too close to the bottom or to the right ends. I naively thought I could replace the "contextmenu" event listener but spending hours on this just pointed me to ugly hacks at best so I didn't carry on.

For reference, the context menu div position callback is defined in the `Shaka.ui.ContextMenu` constructor
Shaka player docs: https://shaka-player-demo.appspot.com/docs/api/ui_context_menu.js.html#line48
Shaka player code: https://github.com/shaka-project/shaka-player/blob/main/ui/context_menu.js#L48
I'm not gonna try fixing that upstream, but if anyone has any idea, I'm all hears.

Alternatively, we could
- set the `overflow` css property to `visible` so the context menu will always be visible, and no scrollbar, but requires additional testing going in and out fullscreen;
- prevent the context menu from appearing if too close from the edges, as requested in the #6006 but same as above, not sure how to access the event handler brings the context menu.
