### PR TITLE
Fix nightly builds by updating package list before installing build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Install libarchive-tools
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt -y install libarchive-tools; echo "Version Number ${{ toJson(job) }} ${{ toJson(needs) }}"
+      run: sudo apt update; sudo apt -y install libarchive-tools; echo "Version Number ${{ toJson(job) }} ${{ toJson(needs) }}"
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')


### PR DESCRIPTION
# Fix nightly builds by updating package list before installing build dependencies

## Pull Request Type

- [x] Bugfix

## Related issue
https://github.com/FreeTubeApp/FreeTube/actions/workflows/build.yml

## Description
Ubuntu pulled a version of libarchive13 because of a vulnerability (https://ubuntu.com/security/notices/USN-7087-1), as that is the version that is listed in the cached apt repo files the install would fail. This pull request fixes the issue by running `apt update` before installing `libarchive-tools`, so that apt will install the newer version of libarchive13.

## Testing
Build on this branch on my fork to confirm that the fix works: https://github.com/absidue/FreeTube/actions/runs/11651164346