### PR TITLE
Fix search box crash

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -100,10 +100,6 @@ export default defineComponent({
       return this.isSearch && this.barColor
     },
 
-    idDataList: function () {
-      return `${this.id}_datalist`
-    },
-
     inputDataPresent: function () {
       return this.inputData.length > 0
     },

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -43,7 +43,6 @@
         :id="id"
         ref="input"
         :value="inputDataDisplayed"
-        :list="idDataList"
         class="ft-input"
         :maxlength="maxlength"
         :type="inputType"
@@ -70,7 +69,6 @@
     <div class="options">
       <ul
         v-if="inputData !== '' && visibleDataList.length > 0 && searchState.showOptions"
-        :id="idDataList"
         class="list"
         @mouseenter="searchState.isPointerInList = true"
         @mouseleave="searchState.isPointerInList = false"


### PR DESCRIPTION
# Fix search box crash

## Pull Request Type

- [x] Bugfix

## Related issue
- closes #6065

## Description
So this one was a weird one to investigate and I'm still not sure how any of the things are connected but this seems to fix it. The crashlog says that it crashed in an sqlite function, it only crashes with the on-screen keyboard in Windows, it only happens with the main search bar not the Invidious instances one despite both having search suggestions and the fix is removing some invalid HTML that doesn't cause any problems with physical keyboards in Windows?

The `list` attribute on the `<input>` element is meant to contain the ID of a `<datalist>` element, in FreeTube we were pointing it to the ID of a `<ul>` element. This seems to cause problems with the on-screen keyboard in Windows, no idea why that invalid HTML crashes the entire page with the on-screen keyboard but has zero impact with a physical keyboard.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#list

## Testing
As I don't have access to a Mac, I haven't be able to confirm if this fixes the crash that macOS users were mentioning on that issue or if it is unrelated.

1. Launch FreeTube
2. Launch the Windows 10 On-Screen keyboard app
3. Type a letter with the on-screen keyboard
4. Press backspace on the on-screen keyboard
5. Type another letter with the on-screen keyboard
6. The page should not crash

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 94fe62aff4c5b721033090a896738bd8006d4c3d