### PR TITLE
Fix 'shaka-video-container' class being removed from video container

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="container"
-    class="ftVideoPlayer"
+    class="ftVideoPlayer shaka-video-container"
     :class="{
       fullWindow: fullWindowEnabled,
       sixteenByNine: forceAspectRatio && !fullWindowEnabled


### PR DESCRIPTION
# Fix 'shaka-video-container' class being removed from video container

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
further resolves #5838 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When Vue adds dynamic classes to the video container for full window mode or forcing a 16:9 aspect ratio, the `shaka-video-container` class is inadvertently removed from the video container element.

Because the [upstream CSS that hides the cursor](https://github.com/shaka-project/shaka-player/blob/main/ui/less/containers.less#L430) is applied to `.shaka-video-container.no-cursor`, this results in the cursor no longer hiding when viewing 4:3 aspect ratio videos or after toggling full window mode on any video.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Before fix:
View a 4:3 aspect ratio video or toggle full window mode on any video, see that the`shaka-video-container` class is improperly removed from the video container element and that the cursor is not properly hidden.

After fix:
View a 4:3 aspect ratio video or toggle full window mode on any video, see that the`shaka-video-container` class remains and that the cursor is properly hidden.

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 10.15.7
- **FreeTube version:** 7278c36299deb7712cde376c09d2da26146b881d

## Additional context
<!-- Add any other context about the pull request here. -->
