### PR TITLE
Make playlist import match existing playlist by ID first

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -961,8 +961,13 @@ export default defineComponent({
             this.addVideo(payload)
           }
         })
-        // Update playlist's `lastUpdatedAt`
-        this.updatePlaylist({ _id: existingPlaylist._id })
+        // Update playlist's `lastUpdatedAt` & other attributes
+        this.updatePlaylist({
+          _id: existingPlaylist._id,
+          // Only these attributes would be updated (besides videos)
+          playlistName: playlistObject.playlistName,
+          description: playlistObject.description,
+        })
       })
 
       showToast(this.$t('Settings.Data Settings.All playlists has been successfully imported'))

--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -837,12 +837,12 @@ export default defineComponent({
       ]
 
       const optionalKeys = [
+        '_id',
         'description',
         'createdAt',
       ]
 
       const ignoredKeys = [
-        '_id',
         'title',
         'type',
         'protected',
@@ -910,6 +910,10 @@ export default defineComponent({
         }
 
         const existingPlaylist = this.allPlaylists.find((playlist) => {
+          if (playlistObject._id != null && playlist._id === playlistObject._id) {
+            return true
+          }
+
           return playlist.playlistName === playlistObject.playlistName
         })
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/5783#discussion_r1794156157

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Playlists can be renamed somewhere else and exported
This PR makes import match playlist by ID first if ID exists & also update name & description

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Create new playlist, give it a name, optionally description
- Export single playlist (https://github.com/FreeTubeApp/FreeTube/pull/5779)
- Update playlist name & description
- Import exported file
- Check name & description changed back to the exported one

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
