### PR TITLE
Fix wayland app icon for flatpak.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "freetube",
   "productName": "FreeTube",
+  "desktopName": "io.freetubeapp.FreeTube",
   "description": "A private YouTube client",
   "version": "0.22.0",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
# Fix wayland app icon for flatpak.

## Pull Request Type
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Currently, the app icon (i.e. titlebar icon in KDE) is incorrect as the
app_id is set to FreeTube instead of matching the desktop file with
io.freetubeapp.FreeTube.

## Screenshots
![Screenshot_20241111_001919](https://github.com/user-attachments/assets/a57984ad-26ed-49ee-a591-da31cd9a0a71)

## Testing
Testing done on an arch linux install.
Untested for distribution packages nor windows and macos builds.

## Desktop
- **OS:** Arch Linux
- **FreeTube version:** v0.22.0 Beta
