### PR TITLE
Fix cursor hiding when first opening video

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2382,6 +2382,8 @@ export default defineComponent({
 
       window.addEventListener('beforeunload', stopPowerSaveBlocker)
 
+      container.value.classList.add('no-cursor')
+
       await performFirstLoad()
     })
 


### PR DESCRIPTION
# Fix cursor hiding when opening video

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
further resolves #5838
fixes cursor hiding in the first case of @geominorai's [comment](https://github.com/FreeTubeApp/FreeTube/issues/5838#issuecomment-2440914964)

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds the `no-cursor` class to the video container during initialization. This fixes scenarios wherein the cursor would not be hidden if it was within the video container area before the player finished loading.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Click on a video on the subscriptions page such that the cursor will be in the video player area when the video loads (without moving the cursor after clicking), observe that the cursor is properly hidden.

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 10.15.7
- **FreeTube version:** 5b474cdfc1edeeb14ebfa98cb30ef6fa66bba956

## Additional context
<!-- Add any other context about the pull request here. -->
I don't know how to go about fixing cursor hiding when the cursor is over the seek bar, it might be best to comment about that issue upstream at shaka-project/shaka-player#7394