### PR TITLE
Added buttons to hide hidden channels/text

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.js
+++ b/src/renderer/components/distraction-settings/distraction-settings.js
@@ -111,6 +111,12 @@ export default defineComponent({
     showDistractionFreeTitles: function () {
       return this.$store.getters.getShowDistractionFreeTitles
     },
+    showHiddenChannels: function () {
+      return this.$store.getters.getShowHiddenChannels
+    },
+    showHiddenText: function () {
+      return this.$store.getters.getShowHiddenText
+    },
     channelsHidden: function () {
       return JSON.parse(this.$store.getters.getChannelsHidden).map((ch) => {
         // Legacy support
@@ -224,6 +230,8 @@ export default defineComponent({
       'updateHideSubscriptionsShorts',
       'updateHideSubscriptionsLive',
       'updateHideSubscriptionsCommunity',
+      'updateShowHiddenChannels',
+      'updateShowHiddenText'
     ])
   }
 })

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -255,11 +255,11 @@
         :tag-name-placeholder="$t('Settings.Distraction Free Settings.Hide Channels Placeholder')"
         :show-action-button="true"
         :tag-list="channelsHidden"
+        :show-tags="showHiddenChannels"
         :tooltip="$t('Tooltips.Distraction Free Settings.Hide Channels')"
         :validate-tag-name="validateChannelId"
         :find-tag-info="findChannelTagInfo"
         :are-channel-tags="true"
-        :show-hidden-content="showHiddenChannels"
         @invalid-name="handleInvalidChannel"
         @error-find-tag-info="handleChannelAPIError"
         @change="handleChannelsHidden"
@@ -272,9 +272,9 @@
         :tag-name-placeholder="$t('Settings.Distraction Free Settings.Hide Videos and Playlists Containing Text Placeholder')"
         :show-action-button="true"
         :tag-list="forbiddenTitles"
+        :show-tags="showHiddenText"
         :min-input-length="3"
         :tooltip="$t('Tooltips.Distraction Free Settings.Hide Videos and Playlists Containing Text')"
-        :show-hidden-content="showHiddenText"
         @change="handleForbiddenTitles"
       />
     </ft-flex-box>

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -228,6 +228,25 @@
       </div>
     </div>
     <br class="hide-on-mobile">
+    <h4
+      class="groupTitle"
+    >
+      {{ $t('Settings.Distraction Free Settings.Sections.Content Filter') }}
+    </h4>
+    <div class="switchColumnGrid">
+      <ft-toggle-switch
+        :label="$t('Settings.Distraction Free Settings.Show hidden channels')"
+        :compact="true"
+        :default-value="showHiddenChannels"
+        @change="updateShowHiddenChannels"
+      />
+      <ft-toggle-switch
+        :label="$t('Settings.Distraction Free Settings.Show hidden text')"
+        :compact="true"
+        :default-value="showHiddenText"
+        @change="updateShowHiddenText"
+      />
+    </div>
     <ft-flex-box>
       <ft-input-tags
         :disabled="channelHiderDisabled"
@@ -240,6 +259,7 @@
         :validate-tag-name="validateChannelId"
         :find-tag-info="findChannelTagInfo"
         :are-channel-tags="true"
+        :show-hidden-content="showHiddenChannels"
         @invalid-name="handleInvalidChannel"
         @error-find-tag-info="handleChannelAPIError"
         @change="handleChannelsHidden"
@@ -254,6 +274,7 @@
         :tag-list="forbiddenTitles"
         :min-input-length="3"
         :tooltip="$t('Tooltips.Distraction Free Settings.Hide Videos and Playlists Containing Text')"
+        :show-hidden-content="showHiddenText"
         @change="handleForbiddenTitles"
       />
     </ft-flex-box>

--- a/src/renderer/components/ft-input-tags/ft-input-tags.js
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.js
@@ -28,7 +28,7 @@ export default defineComponent({
       type: String,
       required: true
     },
-    showHiddenContent: {
+    showTags: {
       type: String,
       required: true
     },

--- a/src/renderer/components/ft-input-tags/ft-input-tags.js
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.js
@@ -28,6 +28,10 @@ export default defineComponent({
       type: String,
       required: true
     },
+    showHiddenContent: {
+      type: String,
+      required: true
+    },
     minInputLength: {
       type: Number,
       default: 1

--- a/src/renderer/components/ft-input-tags/ft-input-tags.vue
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.vue
@@ -22,7 +22,7 @@
       @click="updateTags"
     />
     <div
-      v-if="showHiddenContent"
+      v-if="showTags"
       class="ft-tag-box"
     >
       <ul>

--- a/src/renderer/components/ft-input-tags/ft-input-tags.vue
+++ b/src/renderer/components/ft-input-tags/ft-input-tags.vue
@@ -21,7 +21,10 @@
       :force-action-button-icon-name="['fas', 'arrow-right']"
       @click="updateTags"
     />
-    <div class="ft-tag-box">
+    <div
+      v-if="showHiddenContent"
+      class="ft-tag-box"
+    >
       <ul>
         <li
           v-for="tag in tagList"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -296,6 +296,8 @@ const state = {
   screenshotFolderPath: '',
   screenshotFilenamePattern: '%Y%M%D-%H%N%S',
   settingsSectionSortEnabled: false,
+  showHiddenChannels: true,
+  showHiddenText: true,
   fetchSubscriptionsAutomatically: true,
   settingsPassword: '',
   useDeArrowTitles: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -484,6 +484,7 @@ Settings:
       Channel Page: Channel Page
       Watch Page: Watch Page
       General: General
+      Content Filter: Content Filter
     Hide Video Views: Hide Video Views
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers
@@ -520,6 +521,8 @@ Settings:
     Hide Subscriptions Shorts: Hide Subscriptions Shorts
     Hide Subscriptions Live: Hide Subscriptions Live
     Hide Subscriptions Community: Hide Subscriptions Community
+    Show hidden channels: Show hidden channels
+    Show hidden text: Show hidden text
   Data Settings:
     Data Settings: Data
     Select Import Type: Select Import Type


### PR DESCRIPTION
# Added buttons to hide hidden channels/text

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
#5652 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

- Added toggle switches to hide/show the channels and text hidden by filters set by user
- Grouped the toggles together with the filtering into a new section



## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
**Before**
![before](https://github.com/user-attachments/assets/c9eddacd-9f83-4239-8ef1-738d587e4628)
**After**
![after](https://github.com/user-attachments/assets/075b9e38-5317-49b1-bc88-cf0e6eb31ba3)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Toggles are on by default.
Toggles hide/show the filtered channels and text.

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOs
- **OS Version:** 15.1
- **FreeTube version:** v0.22.0 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
