### PR TITLE
Add support for Key Moments with the local API

### DIFF
--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -12,7 +12,7 @@
       @keydown.space.stop.prevent="toggleShowChapters"
       @keydown.enter.stop.prevent="toggleShowChapters"
     >
-      {{ $t("Chapters.Chapters") }}
+      {{ kind === 'keyMoments' ? $t('Chapters.Key Moments') : $t("Chapters.Chapters") }}
 
       <span class="currentChapter">
         • {{ currentTitle }}
@@ -82,6 +82,10 @@ const props = defineProps({
   currentChapterIndex: {
     type: Number,
     required: true
+  },
+  kind: {
+    type: String,
+    default: 'chapters'
   }
 })
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -151,6 +151,7 @@
         v-if="!hideChapters && !isLoading && videoChapters.length > 0"
         :chapters="videoChapters"
         :current-chapter-index="videoCurrentChapterIndex"
+        :kind="videoChaptersKind"
         class="watchVideo"
         :class="{ theatreWatchVideo: useTheatreMode }"
         @timestamp-event="changeTimestamp"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -940,6 +940,7 @@ Clipboard:
 
 Chapters:
   Chapters: Chapters
+  Key Moments: Key Moments
   'Chapters list visible, current chapter: {chapterName}': 'Chapters list visible, current chapter: {chapterName}'
   'Chapters list hidden, current chapter: {chapterName}': 'Chapters list hidden, current chapter: {chapterName}'
 


### PR DESCRIPTION
# Add support for Key Moments with the local API

## Pull Request Type

- [x] Feature Implementation

## Related issue

closes #4237

## Description

Key Moments on YouTube videos are chapters but auto-generated by YouTube instead of written in the description by the uploader. This pull request adds support for them with the local API.

## Screenshots

![key-moments](https://github.com/user-attachments/assets/89aca9d5-3de4-43b4-9cf0-de3f2e0257ea)

## Testing

Example video from the feature request: `https://www.youtube.com/watch?v=90ihiTwJPCc`

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 2fd01703a9be42344dde9fa50da2d50dc99a62c0