### PR TITLE
Use dirent.parentPath instead of deprecated .path

### DIFF
--- a/_scripts/injectAllowedPaths.mjs
+++ b/_scripts/injectAllowedPaths.mjs
@@ -22,10 +22,10 @@ const paths = readdirSync(distDirectory, {
       dirent.name !== 'main.js' &&
       dirent.name !== 'main.js.LICENSE.txt' &&
       // filter out any web build files, in case the dist directory contains a web build
-      !dirent.path.startsWith(webDirectory)
+      !dirent.parentPath.startsWith(webDirectory)
   })
   .map(dirent => {
-    const joined = join(dirent.path, dirent.name)
+    const joined = join(dirent.parentPath, dirent.name)
     return '/' + relative(distDirectory, joined).replaceAll('\\', '/')
   })
 


### PR DESCRIPTION
# Use dirent.parentPath instead of deprecated .path

## Pull Request Type

- [x] Other - Build tooling fix

## Description
`Dirent.path` was removed in this Node.js commit https://github.com/nodejs/node/commit/d9540b51ebc1a97bbb109fff0825c2f0090aefa2 it hasn't been released yet but when it does it will break this script, so I'm updating the script now already so we don't have to wonder later on why the production (nightly, release etc) builds are failing.

## Testing
1. `yarn run pack` (don't leave out the `run` part, otherwise you'll just get a tar.gz npm bundle)
2. `npx prettier@2.8.8 --write --no-config dist/main.js`, prettier is more forceful than other formatters which is why I used it to make the mimified file readable (prettier 3 silently fails on the command line, which is why I explicitly specified the last version of v2)
3. Search for `/static/`
4. Check that the injected paths look okay.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 2fd01703a9be42344dde9fa50da2d50dc99a62c0