### PR TITLE
Fix text colour in player overflow menu

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -67,6 +67,10 @@
   color: var(--side-nav-hover-text-color) !important;
 }
 
+:deep(.shaka-current-selection-span) {
+  color: var(--tertiary-text-color) !important;
+}
+
 /* End of theming code */
 
 .sixteenByNine {


### PR DESCRIPTION
# Fix text colour in player overflow menu

## Pull Request Type

- [x] Bugfix

## Related issue
- #5986

## Description
This pull request fixes the currently active base theme not being applied to the "current selection" texts in the player overflow menu.

## Screenshots
Before:
![before](https://github.com/user-attachments/assets/71718ba4-09fd-4e1b-8675-13548c9797b5)

After:
![after](https://github.com/user-attachments/assets/383da54d-6b84-4c52-b5f1-a5221aab0ed3)

## Testing
1. Shrink the window small enough for the overflow menu to show up
2. Try various themes and check that the text in the overflow menu is legible

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 41c2e4c97fa4cbd40e9c9380c82c331f73d2a8cf