### PR TITLE
Fix incompatibility with upcoming YouTube.js version

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,4 +1,4 @@
-import { ClientType, Endpoints, Innertube, Misc, Parser, UniversalCache, Utils, YT, YTNodes } from 'youtubei.js'
+import { ClientType, Innertube, Misc, Parser, UniversalCache, Utils, YT, YTNodes } from 'youtubei.js'
 import Autolinker from 'autolinker'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
@@ -365,12 +365,12 @@ export async function getLocalChannelVideos(id) {
   const innertube = await createInnertube()
 
   try {
-    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
-      browse_id: id,
+    const response = await innertube.actions.execute('/browse', {
+      browseId: id,
       params: 'EgZ2aWRlb3PyBgQKAjoA'
       // protobuf for the videos tab (this is the one that YouTube uses,
       // it has some empty fields in the protobuf but it doesn't work if you remove them)
-    }))
+    })
 
     const videosTab = new YT.Channel(null, response)
     const { id: channelId = id, name, thumbnailUrl } = parseLocalChannelHeader(videosTab, true)
@@ -422,12 +422,12 @@ export async function getLocalChannelLiveStreams(id) {
   const innertube = await createInnertube()
 
   try {
-    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
-      browse_id: id,
+    const response = await innertube.actions.execute('/browse', {
+      browseId: id,
       params: 'EgdzdHJlYW1z8gYECgJ6AA%3D%3D'
       // protobuf for the live tab (this is the one that YouTube uses,
       // it has some empty fields in the protobuf but it doesn't work if you remove them)
-    }))
+    })
 
     let liveStreamsTab = new YT.Channel(innertube.actions, response)
     const { id: channelId = id, name, thumbnailUrl } = parseLocalChannelHeader(liveStreamsTab, true)
@@ -470,12 +470,12 @@ export async function getLocalChannelCommunity(id) {
   const innertube = await createInnertube()
 
   try {
-    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
-      browse_id: id,
+    const response = await innertube.actions.execute('/browse', {
+      browseId: id,
       params: 'Egljb21tdW5pdHnyBgQKAkoA'
       // protobuf for the community tab (this is the one that YouTube uses,
       // it has some empty fields in the protobuf but it doesn't work if you remove them)
-    }))
+    })
 
     const communityTab = new YT.Channel(null, response)
 


### PR DESCRIPTION
# Fix incompatibility with upcoming YouTube.js version

## Pull Request Type

- [x] Bugfix

## Related issue
https://github.com/LuanRT/YouTube.js/pull/812

## Description
The upcoming YouTube.js 12.0.0 update removes the `*Endpoint` constants and functions that we were using to build the payloads for the subscriptions page API calls. This pull request switches to just passing the information to the `actions.execute()` method directly (so doing what the builder function used to do ourselves), which makes FreeTube compatible with YouTube.js 12.0.0 and the change is also compatible with the current version of YouTube.js that we are using.

## Testing
1. Make sure you are using the local API with a profile with less than 125 subscriptions and with RSS disabled
2. Refresh the videos, live and shorts tabs on the subscriptions page, they should work correctly

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b34b16e8a0e15ed62af34a62447f7f8fe86dd045