### PR TITLE
Add setting for opening freetube:// links in new window

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -142,6 +142,10 @@ export default defineComponent({
 
     externalLinkHandling: function () {
       return this.$store.getters.getExternalLinkHandling
+    },
+
+    openLinksInNewWindow: function () {
+      return this.$store.getters.getOpenLinksInNewWindow
     }
   },
   watch: {
@@ -514,7 +518,7 @@ export default defineComponent({
     enableOpenUrl: function () {
       ipcRenderer.on(IpcChannels.OPEN_URL, (event, url) => {
         if (url) {
-          this.handleYoutubeLink(url, { doCreateNewWindow: true })
+          this.handleYoutubeLink(url, { doCreateNewWindow: this.openLinksInNewWindow })
         }
       })
 

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -514,7 +514,7 @@ export default defineComponent({
     enableOpenUrl: function () {
       ipcRenderer.on(IpcChannels.OPEN_URL, (event, url) => {
         if (url) {
-          this.handleYoutubeLink(url)
+          this.handleYoutubeLink(url, { doCreateNewWindow: true })
         }
       })
 

--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -200,6 +200,10 @@ export default defineComponent({
         this.$t('Settings.General Settings.External Link Handling.Ask Before Opening Link'),
         this.$t('Settings.General Settings.External Link Handling.No Action')
       ]
+    },
+
+    openLinksInNewWindow: function () {
+      return this.$store.getters.getOpenLinksInNewWindow
     }
   },
   created: function () {
@@ -269,6 +273,7 @@ export default defineComponent({
       'updateCurrentLocale',
       'updateExternalLinkHandling',
       'updateGeneralAutoLoadMorePaginatedItemsEnabled',
+      'updateOpenLinksInNewWindow',
     ])
   }
 })

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -38,6 +38,12 @@
           :compact="true"
           @change="updateEnableSearchSuggestions"
         />
+        <ft-toggle-switch
+          :label="$t('Settings.General Settings.Open Links In New Window')"
+          :default-value="openLinksInNewWindow"
+          :compact="true"
+          @change="updateOpenLinksInNewWindow"
+        />
       </div>
     </div>
     <div class="switchGrid">

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -232,6 +232,7 @@ const state = {
   listType: 'grid',
   maxVideoPlaybackRate: 3,
   onlyShowLatestFromChannel: false,
+  openLinksInNewWindow: false,
   playNextVideo: false,
   proxyHostname: '127.0.0.1',
   proxyPort: '9050',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -283,6 +283,7 @@ Settings:
     Fallback to Non-Preferred Backend on Failure: Fallback to Non-Preferred Backend
       on Failure
     Enable Search Suggestions: Enable Search Suggestions
+    Open Links In New Window: Open freetube:// Links in a New Window
     Auto Load Next Page:
       Label: Auto Load Next Page
       Tooltip: Load additional pages and comments automatically.


### PR DESCRIPTION
# Add setting for opening freetube:// links in new window

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #1501

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds a toggle under General Settings to open `freetube://` links in a new window instead of in the replacing the contents of an existing window.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![openlinksinnewwindow](https://github.com/user-attachments/assets/cf23b2fb-c02d-49aa-9dfd-15c0948baa97)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Test that freetube:// links opened from other applications are opened in a new window when the added setting is toggled on.

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 10.15.7
- **FreeTube version:** e646a0f2befebc6373c527a9a0b23086f485e82c

## Additional context
<!-- Add any other context about the pull request here. -->
I used some code from @pakoito's #5592.