### PR TITLE
Support saving screenshots as WebP files

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1488,7 +1488,7 @@ export default defineComponent({
 
       const format = screenshotFormat.value
       const mimeType = `image/${format === 'jpg' ? 'jpeg' : format}`
-      const imageQuality = format === 'jpg' ? screenshotQuality.value / 100 : 1
+      const imageQuality = format !== 'png' ? screenshotQuality.value / 100 : 1
 
       let filename
       try {

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -51,11 +51,13 @@ export default defineComponent({
       ],
       screenshotFormatNames: [
         'PNG',
-        'JPEG'
+        'JPEG',
+        'WebP'
       ],
       screenshotFormatValues: [
         'png',
-        'jpg'
+        'jpg',
+        'webp'
       ],
       screenshotFolderPlaceholder: '',
       screenshotFilenameExample: '',

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -182,7 +182,7 @@
           :max-value="100"
           :step="1"
           value-extension="%"
-          :disabled="screenshotFormat !== 'jpg'"
+          :disabled="screenshotFormat === 'png'"
           @change="updateScreenshotQuality"
         />
       </ft-flex-box>


### PR DESCRIPTION
# Support saving screenshots as WebP files

## Pull Request Type

- [x] Feature Implementation

## Related issue
- closes #6251

## Description

This pull request adds support for saving screenshots as WebP files. The other two requested formats are not possible as explained in my comment on that feature request (TL;DR Chromium doesn't support encoding to AVIF and doesn't support JPEG XL at all, not even displaying them), so I feel like it is appropriate to close it even if we only implement support for saving as WebP files.

## Testing

Take some screenshots with the WebP format selected, you can also experiment with the quality setting to see how it affects the file size and visual quality.

## Desktop

- **OS:**
- **OS Version:**
- **FreeTube version:**