### PR TITLE
Fix export playlist button visible in edit mode

### DIFF
--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -267,6 +267,8 @@ export default defineComponent({
     },
 
     exportPlaylistButtonVisible: function() {
+      // Most UI should be invisible in edit mode
+      if (this.editMode) { return false }
       // Only online playlists can be shared
       if (!this.isUserPlaylist) { return false }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/6153#issuecomment-2480860359

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Make export button invisible in edit mode as it should be

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After fix
![image](https://github.com/user-attachments/assets/0959e2c1-4b59-44de-9056-26e00c3dd669)

Before fix
![image](https://github.com/user-attachments/assets/f9ee8b5a-77b7-4942-beb2-6e9490456a6c)



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Browse random user playlist
- Enter edit more
- Ensure only necessary buttons/UI visible

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
