### PR TITLE
Update hardware acceleration flag for Linux

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -212,7 +212,7 @@ function runApp() {
     // Enable hardware acceleration via VA-API with OpenGL if no other feature flags are found
     // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/vaapi.md
     if (!app.commandLine.hasSwitch('enable-features')) {
-      app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecodeLinuxGL')
+      app.commandLine.appendSwitch('enable-features', 'AcceleratedVideoDecodeLinuxGL')
     }
   }
 


### PR DESCRIPTION
# Update hardware acceleration flag for Linux

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Chromium [changed the flag](https://chromium-review.googlesource.com/c/chromium/src/+/5893615) in v131.

Please merge this after updating Electron to v34, which is [scheduled for release on January 14, 2025](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#timeline).