### PR TITLE
Fix 'Object has been destroyed' when FreeTube is passed a URL with no windows open on macOS

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1511,7 +1511,9 @@ function runApp() {
     if (mainWindow === 'all-windows-closed') {
       app.once('browser-window-created', (_, mainWindow) => {
         mainWindow.webContents.once('did-finish-load', () => {
-          setTimeout(function() { mainWindow.webContents.send(IpcChannels.OPEN_URL, baseUrl(url), { isLaunchLink: true }) }, 1000)
+          // A timeout here is necessary or the new window won't receive the URL
+          setTimeout(function() { mainWindow.webContents.send(
+            IpcChannels.OPEN_URL, baseUrl(url), { isLaunchLink: true }) }, 1000)
         })
       })
       createWindow()


### PR DESCRIPTION
# Fix 'Object has been destroyed' when FreeTube is passed a URL with no windows open on macOS

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Relates to @srolandmarshall's [comment](https://github.com/FreeTubeApp/FreeTube/issues/4762#issuecomment-2464673877) on #4762 (but unrelated to the issue commented on).

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Because FreeTube does not quit automatically when all windows are closed (as on other plaforms), the main process tries to fire an IPC message to a non-existent `mainWindow` when it receives an `open-url` event or a command line URL argument. This results in an `Object has been destroyed` error message.
This PR sets `mainWindow` to a string indicating it doesn't exist when all FreeTube windows have been closed, and, if this is the case, has the main process create a new window and pass it a URL to be opened on `open-url` or `second-instance` (with a command line URL argument) event.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
1. Open FreeTube on macOS and close its window without quitting the application (the FreeTube icon should remain visible in the Dock).
2. Pass FreeTube a video URL either as a command line argument or by opening a `freetube://` link (deep link).
3. Check that video opens in a new window without an error.

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 10.13.6
- **FreeTube version:** 0e44e6b841d6799af7498d279bf197bc4b8c2e77

## Additional context
<!-- Add any other context about the pull request here. -->
