### PR TITLE
Time frame changes in workflows + added stale exempt label

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -20,5 +20,5 @@ jobs:
             This issue has been automatically closed because there has been no response to our request for more information from the original author.
             With only the information that is currently in the issue, we don't have enough information to take action.
             Please reach out if you have or find the answers we need so that we can investigate further.
-          daysUntilClose: 14
+          daysUntilClose: 7
           responseRequiredLabel: "U: Waiting for Response from Author"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
           days-before-issue-stale: 28
-          days-before-pr-stale: 28
+          days-before-pr-stale: 14
           days-before-issue-close: 7
           days-before-pr-close: 14
           stale-issue-label: 'U: stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,4 +24,4 @@ jobs:
           stale-issue-label: 'U: stale'
           stale-pr-label: 'PR: stale'
           exempt-pr-labels: 'PR: WIP'
-          exempt-issue-labels: 'enhancement'
+          exempt-issue-labels: 'enhancement, U: reproduced'


### PR DESCRIPTION
# Time frame changes in workflows + added exempt label

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Workflow changes / Chore

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Changed `daysUntilClose` in `no-response.yml` from 14 to 7 days because i have noticed for a long time now that allot of users never respond after opening their issues. This leads to issues being too long open before they will eventually get closed by this workflow. To address this, I’ve reduced our previous 14-day response window for tech support to 7 days.
- PR's also get abandoned allot so I lowered `days-before-pr-stale` in `stale.yml` from 28 to 14 days which hopefully notifies authors of the PR earlier in the process to let them know that something needs to be done. In addition to that instead of waiting 6 weeks for a PR to close its now 4 weeks.
- Added an extra exempt label in `stale.yml`. This label will be applied to bug reports if one of our team members can reproduce it. 

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Issue will come out of draft status when testing is complete downstream:
- https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/issues/87 
- https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/issues/88

