### PR TITLE
Show precise view counts for videos on search results page

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1131,7 +1131,7 @@ export function parseLocalListVideo(item) {
       author: video.author.name,
       authorId: video.author.id,
       description: video.description,
-      viewCount: isNaN(video.view_count) ? (video.short_view_count.text == null ? null : parseLocalSubscriberCount(video.short_view_count.text)) : extractNumberFromString(video.view_count.text),
+      viewCount: video.view_count == null ? (video.short_view_count.text == null ? null : parseLocalSubscriberCount(video.short_view_count.text)) : extractNumberFromString(video.view_count.text),
       published,
       lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
       liveNow: video.is_live,


### PR DESCRIPTION
# Show precise view count for videos on search results page

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Shows the precise view counts for videos on the search results page instead of rounded values.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
**Before:**
![ft viewCount 1](https://github.com/user-attachments/assets/6891b8b2-e6d8-448e-93c1-baa4bf6540a1)
**After:**
![ft viewCount 2](https://github.com/user-attachments/assets/b47e4747-360c-4d34-8dbe-30e57afb1a11)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 10.13.6
- **FreeTube version:** c448b3c85f94580bea1e6261a00ba031de3fc194

## Additional context
<!-- Add any other context about the pull request here. -->
