### PR TITLE
Fix tap to seek not using skip interval setting

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -245,6 +245,12 @@ export default defineComponent({
       return store.getters.getDefaultSkipInterval
     })
 
+    watch(defaultSkipInterval, (newValue) => {
+      ui.configure({
+        tapSeekDistance: newValue
+      })
+    })
+
     /** @type {import('vue').ComputedRef<number | 'auto'>} */
     const defaultQuality = computed(() => {
       const value = store.getters.getDefaultQuality
@@ -839,6 +845,7 @@ export default defineComponent({
           addBigPlayButton: displayVideoPlayButton.value,
           enableFullscreenOnRotation: enterFullscreenOnDisplayRotate.value,
           playbackRates: playbackRates.value,
+          tapSeekDistance: defaultSkipInterval.value,
 
           // we have our own ones (shaka-player's ones are quite limited)
           enableKeyboardPlaybackControls: false,


### PR DESCRIPTION
# Fix tap to seek not using skip interval setting

## Pull Request Type

- [x] Bugfix

## Related issue

- https://github.com/MarmadileManteater/FreeTubeAndroid/issues/442

## Description

This pull request fixes the tap to seek feature not using the configured skip interval, I consider this a bug fix and not a feature implementation, as it is expected behaviour and this is a regression compared to what we were doing for video.js. Seeking with the keyboard arrow keys multiplies the skip interval with the playback rate, I decided not to do that for the touch controls, as shaka-player recreates the entire UI every time you call `configure`, so if we had to do it every time the user changed the playback rate that wouldn't be a great experience, additionally as you can see from the code snippet linked below, we didn't use the playback rate for the touch controls with video.js either.

https://github.com/FreeTubeApp/FreeTube/blob/8b66548607ef16136f9efbdc011bfd47dd1474a4/src/renderer/components/ft-video-player/ft-video-player.js#L474-L477

## Testing

1. Enable the mobile emulation in the dev tools
2. Then open a video (the order of these two steps is important, as shaka-player won't activate the tap to seek feature if it doesn't detect touch support)
3. Open a second window to the settings page
4. Test various default skip interval values to check that the player uses your configured value

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b4217ef8522403cb5748e480f387ef83fa07a9a3