### PR TITLE
Fix Hide Unsubscribe Button not hiding the button in search results

### DIFF
--- a/src/renderer/components/FtListChannel/FtListChannel.vue
+++ b/src/renderer/components/FtListChannel/FtListChannel.vue
@@ -61,6 +61,7 @@
         />
       </div>
       <FtSubscribeButton
+        v-if="!hideUnsubscribeButton"
         class="channelSubscribeButton"
         :channel-id="id"
         :channel-name="name"
@@ -104,6 +105,11 @@ const listType = computed(() => {
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideChannelSubscriptions = computed(() => {
   return store.getters.getHideChannelSubscriptions
+})
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideUnsubscribeButton = computed(() => {
+  return store.getters.getHideUnsubscribeButton
 })
 
 let id = ''


### PR DESCRIPTION
# Fix Hide Unsubscribe Button not hiding the button in search results

## Pull Request Type

- [x] Bugfix

## Related issue

closes #6290

## Description

This pull request fixes the `Hide Unsubscribe Button` in the `Parental Control` settings not affecting the channel tiles in search results.

## Testing
1. Turn on `Hide Unsubscribe Button` in the `Parental Control` settings
2. Search for a channel e.g. `Linus Tech Tips`
3. Check that channel tile in the search results doesn't have a subscribe or unsubscribe button.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 28f0b97ce8aa2545c48a853ff939dd1b67f3a450