### PR TITLE
Switch the data export to the Web File System API

### DIFF
--- a/src/renderer/components/data-settings/data-settings.js
+++ b/src/renderer/components/data-settings/data-settings.js
@@ -13,13 +13,12 @@ import {
   escapeHTML,
   getTodayDateStrLocalTimezone,
   readFileWithPicker,
-  showSaveDialog,
   showToast,
-  writeFileFromDialog,
+  writeFileWithPicker,
 } from '../../helpers/utils'
 
 const IMPORT_DIRECTORY_ID = 'data-settings-import'
-const IMPORT_START_IN_DIRECTORY = 'downloads'
+const START_IN_DIRECTORY = 'downloads'
 
 export default defineComponent({
   name: 'DataSettings',
@@ -94,7 +93,7 @@ export default defineComponent({
             'application/xml': ['.xml', '.opml']
           },
           IMPORT_DIRECTORY_ID,
-          IMPORT_START_IN_DIRECTORY
+          START_IN_DIRECTORY
         )
       } catch (err) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
@@ -435,32 +434,19 @@ export default defineComponent({
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'freetube-subscriptions-' + dateStr + '.db'
 
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: this.$t('Settings.Data Settings.Subscription File'),
-            extensions: ['db']
-          }
-        ]
-      }
-
-      await this.promptAndWriteToFile(options, subscriptionsDb, this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        subscriptionsDb,
+        this.$t('Settings.Data Settings.Subscription File'),
+        'application/x-freetube-db',
+        '.db',
+        this.$t('Settings.Data Settings.Subscriptions have been successfully exported')
+      )
     },
 
     exportYouTubeSubscriptions: async function () {
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'youtube-subscriptions-' + dateStr + '.json'
-
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: this.$t('Settings.Data Settings.Subscription File'),
-            extensions: ['json']
-          }
-        ]
-      }
 
       const subscriptionsObject = this.profileList[0].subscriptions.map((channel) => {
         const object = {
@@ -498,22 +484,19 @@ export default defineComponent({
         return object
       })
 
-      await this.promptAndWriteToFile(options, JSON.stringify(subscriptionsObject), this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        JSON.stringify(subscriptionsObject),
+        this.$t('Settings.Data Settings.Subscription File'),
+        'application/json',
+        '.json',
+        this.$t('Settings.Data Settings.Subscriptions have been successfully exported')
+      )
     },
 
     exportOpmlYouTubeSubscriptions: async function () {
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'youtube-subscriptions-' + dateStr + '.opml'
-
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: this.$t('Settings.Data Settings.Subscription File'),
-            extensions: ['opml']
-          }
-        ]
-      }
 
       let opmlData = '<opml version="1.1"><body><outline text="YouTube Subscriptions" title="YouTube Subscriptions">'
 
@@ -526,22 +509,20 @@ export default defineComponent({
 
       opmlData += '</outline></body></opml>'
 
-      await this.promptAndWriteToFile(options, opmlData, this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        opmlData,
+        this.$t('Settings.Data Settings.Subscription File'),
+        'application/xml',
+        '.opml',
+        this.$t('Settings.Data Settings.Subscriptions have been successfully exported')
+      )
     },
 
     exportCsvYouTubeSubscriptions: async function () {
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'youtube-subscriptions-' + dateStr + '.csv'
 
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: this.$t('Settings.Data Settings.Subscription File'),
-            extensions: ['csv']
-          }
-        ]
-      }
       let exportText = 'Channel ID,Channel URL,Channel title\n'
       this.profileList[0].subscriptions.forEach((channel) => {
         const channelUrl = `https://www.youtube.com/channel/${channel.id}`
@@ -552,22 +533,19 @@ export default defineComponent({
       })
       exportText += '\n'
 
-      await this.promptAndWriteToFile(options, exportText, this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        exportText,
+        this.$t('Settings.Data Settings.Subscription File'),
+        'text/csv',
+        '.csv',
+        this.$t('Settings.Data Settings.Subscriptions have been successfully exported')
+      )
     },
 
     exportNewPipeSubscriptions: async function () {
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'newpipe-subscriptions-' + dateStr + '.json'
-
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: this.$t('Settings.Data Settings.Subscription File'),
-            extensions: ['json']
-          }
-        ]
-      }
 
       const newPipeObject = {
         app_version: '0.19.8',
@@ -586,7 +564,14 @@ export default defineComponent({
         newPipeObject.subscriptions.push(subscription)
       })
 
-      await this.promptAndWriteToFile(options, JSON.stringify(newPipeObject), this.$t('Settings.Data Settings.Subscriptions have been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        JSON.stringify(newPipeObject),
+        this.$t('Settings.Data Settings.Subscription File'),
+        'application/json',
+        '.json',
+        this.$t('Settings.Data Settings.Subscriptions have been successfully exported')
+      )
     },
 
     importHistory: async function () {
@@ -599,7 +584,7 @@ export default defineComponent({
             'application/json': '.json'
           },
           IMPORT_DIRECTORY_ID,
-          IMPORT_START_IN_DIRECTORY
+          START_IN_DIRECTORY
         )
       } catch (err) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
@@ -778,17 +763,14 @@ export default defineComponent({
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'freetube-history-' + dateStr + '.db'
 
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: this.$t('Settings.Data Settings.Playlist File'),
-            extensions: ['db']
-          }
-        ]
-      }
-
-      await this.promptAndWriteToFile(options, historyDb, this.$t('Settings.Data Settings.All watched history has been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        historyDb,
+        this.$t('Settings.Data Settings.History File'),
+        'application/x-freetube-db',
+        '.db',
+        this.$t('Settings.Data Settings.All watched history has been successfully exported')
+      )
     },
 
     importPlaylists: async function () {
@@ -800,7 +782,7 @@ export default defineComponent({
             'application/x-freetube-db': '.db'
           },
           IMPORT_DIRECTORY_ID,
-          IMPORT_START_IN_DIRECTORY
+          START_IN_DIRECTORY
         )
       } catch (err) {
         const message = this.$t('Settings.Data Settings.Unable to read file')
@@ -978,21 +960,18 @@ export default defineComponent({
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'freetube-playlists-' + dateStr + '.db'
 
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: 'Database File',
-            extensions: ['db']
-          }
-        ]
-      }
-
       const playlistsDb = this.allPlaylists.map(playlist => {
         return JSON.stringify(playlist)
       }).join('\n') + '\n'// a trailing line is expected
 
-      await this.promptAndWriteToFile(options, playlistsDb, this.$t('Settings.Data Settings.All playlists has been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        playlistsDb,
+        this.$t('Settings.Data Settings.Playlist File'),
+        'application/x-freetube-db',
+        '.db',
+        this.$t('Settings.Data Settings.All playlists has been successfully exported')
+      )
     },
 
     exportPlaylistsForOlderVersionsSometimes: function () {
@@ -1006,16 +985,6 @@ export default defineComponent({
     exportPlaylistsForOlderVersions: async function () {
       const dateStr = getTodayDateStrLocalTimezone()
       const exportFileName = 'freetube-playlists-as-single-favorites-playlist-' + dateStr + '.db'
-
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: 'Database File',
-            extensions: ['db']
-          }
-        ]
-      }
 
       const favoritesPlaylistData = {
         playlistName: 'Favorites',
@@ -1041,7 +1010,14 @@ export default defineComponent({
         })
       })
 
-      await this.promptAndWriteToFile(options, JSON.stringify([favoritesPlaylistData]), this.$t('Settings.Data Settings.All playlists has been successfully exported'))
+      await this.promptAndWriteToFile(
+        exportFileName,
+        JSON.stringify([favoritesPlaylistData]),
+        this.$t('Settings.Data Settings.Playlist File'),
+        'application/x-freetube-db',
+        '.db',
+        this.$t('Settings.Data Settings.All playlists has been successfully exported')
+      )
     },
 
     convertOldFreeTubeFormatToNew(oldData) {
@@ -1075,22 +1051,32 @@ export default defineComponent({
       return convertedData
     },
 
-    promptAndWriteToFile: async function (saveOptions, content, successMessage) {
-      const response = await showSaveDialog(saveOptions)
-      if (response.canceled || response.filePath === '') {
-        // User canceled the save dialog
-        return
-      }
-
+    promptAndWriteToFile: async function (
+      fileName,
+      content,
+      fileTypeDescription,
+      mimeType,
+      fileExtension,
+      successMessage
+    ) {
       try {
-        await writeFileFromDialog(response, content)
-      } catch (writeErr) {
-        const message = this.$t('Settings.Data Settings.Unable to write file')
-        showToast(`${message}: ${writeErr}`)
-        return
-      }
+        const response = await writeFileWithPicker(
+          fileName,
+          content,
+          fileTypeDescription,
+          mimeType,
+          fileExtension,
+          'data-settings-export',
+          START_IN_DIRECTORY
+        )
 
-      showToast(successMessage)
+        if (response) {
+          showToast(successMessage)
+        }
+      } catch (error) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${error}`)
+      }
     },
 
     isChannelSubscribed(channelId, subscriptions) {

--- a/src/renderer/components/playlist-info/playlist-info.js
+++ b/src/renderer/components/playlist-info/playlist-info.js
@@ -11,8 +11,7 @@ import {
   formatNumber,
   showToast,
   getTodayDateStrLocalTimezone,
-  writeFileFromDialog,
-  showSaveDialog,
+  writeFileWithPicker,
 } from '../../helpers/utils'
 import debounce from 'lodash.debounce'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
@@ -429,34 +428,28 @@ export default defineComponent({
       const title = this.selectedUserPlaylist.playlistName.replaceAll(' ', '_').replaceAll(/["%*/:<>?\\|]/g, '_')
       const exportFileName = 'freetube-playlist-' + title + '-' + dateStr + '.db'
 
-      const options = {
-        defaultPath: exportFileName,
-        filters: [
-          {
-            name: 'Database File',
-            extensions: ['db']
-          }
-        ]
-      }
-
       const data = JSON.stringify(this.selectedUserPlaylist) + '\n'
 
       // See data-settings.js `promptAndWriteToFile`
-      const response = await showSaveDialog(options)
-      if (response.canceled || response.filePath === '') {
-        // User canceled the save dialog
-        return
-      }
 
       try {
-        await writeFileFromDialog(response, data)
-      } catch (writeErr) {
-        const message = this.$t('Settings.Data Settings.Unable to write file')
-        showToast(`${message}: ${writeErr}`)
-        return
-      }
+        const response = await writeFileWithPicker(
+          exportFileName,
+          data,
+          this.$t('Settings.Data Settings.Playlist File'),
+          'application/x-freetube-db',
+          '.db',
+          'single-playlist-export',
+          'downloads'
+        )
 
-      showToast(this.$t('User Playlists.The playlist has been successfully exported'))
+        if (response) {
+          showToast(this.$t('User Playlists.The playlist has been successfully exported'))
+        }
+      } catch (error) {
+        const message = this.$t('Settings.Data Settings.Unable to write file')
+        showToast(`${message}: ${error}`)
+      }
     },
 
     exitEditMode: function () {


### PR DESCRIPTION
# Switch the data export to the Web File System API

## Pull Request Type

- [x] Refactoring

## Related issue
- https://github.com/FreeTubeApp/FreeTube/pull/6222

## Description
Currently the data export uses the Electron dialog API and the Node.js `fs` API in the renderer to export user data, this pull request switches it over to the [Web File System API](https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker). That lets us get rid of one more use of a Node.js API in the renderer, which gets us one step closer to turning off `nodeIntegration` in the renderer (`src/renderer/helpers/utils.js` no longer imports `fs/promises`), this time without needing to build an IPC call as a replacement.

I haven't removed the `showSaveDialog` function yet, as that is currently still used for the download and screenshot file pickers.
You may have noticed that `writeFileWithPicker` accepts both strings and `Blob`s as the content, that is so that I can use it for the screenshot functionality in a follow up pull request. I decided to do that in a follow up pull request as the save to default directory and save to prompted directory screenshot code are current rather intertwined so it will require more refactoring than just swapping out one function.

## Testing

1. `yarn dev`
2. Test exporting your history, subscriptions and playlists
3. Test exporting a user playlist from its playlist page
4. `yarn dev:web`
5. Open the dev server URL in a web browser that doesn't support the Web File System API e.g. Firefox or Safari or if you have access to a FreeTubeAndroid compatible device you can test this pull request with that too.
6. Test exporting your history, subscriptions and playlists
7. Test exporting a user playlist from its playlist page

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 6e2ec287734800ccb374e0e815c79be3eb9dbad5