### PR TITLE
Move Invidious API calls into Invidious file

### DIFF
--- a/src/renderer/components/subscriptions-live/subscriptions-live.js
+++ b/src/renderer/components/subscriptions-live/subscriptions-live.js
@@ -4,12 +4,11 @@ import SubscriptionsTabUI from '../subscriptions-tab-ui/subscriptions-tab-ui.vue
 
 import {
   getChannelPlaylistId,
-  setPublishedTimestampsInvidious,
   copyToClipboard,
   getRelativeTimeFromDate,
   showToast
 } from '../../helpers/utils'
-import { invidiousAPICall, invidiousFetch } from '../../helpers/api/invidious'
+import { getInvidiousChannelLive, invidiousFetch } from '../../helpers/api/invidious'
 import { getLocalChannelLiveStreams } from '../../helpers/api/local'
 import { parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
 
@@ -338,17 +337,8 @@ export default defineComponent({
 
     getChannelLiveInvidious: function (channel, failedAttempts = 0) {
       return new Promise((resolve, reject) => {
-        const subscriptionsPayload = {
-          resource: 'channels',
-          id: channel.id,
-          subResource: 'streams',
-          params: {}
-        }
-
-        invidiousAPICall(subscriptionsPayload).then((result) => {
-          const videos = result.videos.filter(e => e.type === 'video')
-
-          setPublishedTimestampsInvidious(videos)
+        getInvidiousChannelLive(channel.id).then((result) => {
+          const videos = result.videos
 
           let name
 

--- a/src/renderer/components/subscriptions-videos/subscriptions-videos.js
+++ b/src/renderer/components/subscriptions-videos/subscriptions-videos.js
@@ -3,13 +3,12 @@ import { mapActions, mapMutations } from 'vuex'
 import SubscriptionsTabUI from '../subscriptions-tab-ui/subscriptions-tab-ui.vue'
 
 import {
-  setPublishedTimestampsInvidious,
   copyToClipboard,
   getRelativeTimeFromDate,
   showToast,
   getChannelPlaylistId
 } from '../../helpers/utils'
-import { invidiousAPICall, invidiousFetch } from '../../helpers/api/invidious'
+import { getInvidiousChannelVideos, invidiousFetch } from '../../helpers/api/invidious'
 import { getLocalChannelVideos } from '../../helpers/api/local'
 import { parseYouTubeRSSFeed, updateVideoListAfterProcessing } from '../../helpers/subscriptions'
 
@@ -342,16 +341,7 @@ export default defineComponent({
 
     getChannelVideosInvidiousScraper: function (channel, failedAttempts = 0) {
       return new Promise((resolve, reject) => {
-        const subscriptionsPayload = {
-          resource: 'channels',
-          id: channel.id,
-          subResource: 'videos',
-          params: {}
-        }
-
-        invidiousAPICall(subscriptionsPayload).then((result) => {
-          setPublishedTimestampsInvidious(result.videos)
-
+        getInvidiousChannelVideos(channel.id).then((result) => {
           let name
 
           if (result.videos.length > 0) {

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -9,7 +9,7 @@ import { IpcChannels, KeyboardShortcuts, MOBILE_WIDTH_THRESHOLD } from '../../..
 import { localizeAndAddKeyboardShortcutToActionTitle, openInternalPath } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 import { clearLocalSearchSuggestionsSession, getLocalSearchSuggestions } from '../../helpers/api/local'
-import { invidiousAPICall } from '../../helpers/api/invidious'
+import { getInvidiousSearchSuggestions } from '../../helpers/api/invidious'
 
 const NAV_HISTORY_DISPLAY_LIMIT = 15
 const HALF_OF_NAV_HISTORY_DISPLAY_LIMIT = Math.floor(NAV_HISTORY_DISPLAY_LIMIT / 2)
@@ -326,15 +326,7 @@ export default defineComponent({
         return
       }
 
-      const searchPayload = {
-        resource: 'search/suggestions',
-        id: '',
-        params: {
-          q: query
-        }
-      }
-
-      invidiousAPICall(searchPayload).then((results) => {
+      getInvidiousSearchSuggestions(query).then((results) => {
         this.searchSuggestionsDataList = results.suggestions
       }).catch((err) => {
         console.error(err)

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -3,7 +3,7 @@ import { mapMutations } from 'vuex'
 import FtLoader from '../ft-loader/ft-loader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtListVideoNumbered from '../ft-list-video-numbered/ft-list-video-numbered.vue'
-import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
+import { copyToClipboard, showToast } from '../../helpers/utils'
 import {
   getLocalPlaylist,
   parseLocalPlaylistVideo,
@@ -471,7 +471,6 @@ export default defineComponent({
         this.channelName = result.author
         this.channelId = result.authorId
 
-        setPublishedTimestampsInvidious(result.videos)
         this.playlistItems = this.playlistItems.concat(result.videos)
 
         this.isLoading = false

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -38,7 +38,7 @@ export function invidiousFetch(url) {
   }
 }
 
-export function invidiousAPICall({ resource, id = '', params = {}, doLogError = true, subResource = '' }) {
+function invidiousAPICall({ resource, id = '', params = {}, doLogError = true, subResource = '' }) {
   return new Promise((resolve, reject) => {
     const requestUrl = getCurrentInstanceUrl() + '/api/v1/' + resource + '/' + id + (!isNullOrEmpty(subResource) ? `/${subResource}` : '') + '?' + new URLSearchParams(params).toString()
     invidiousFetch(requestUrl)
@@ -100,11 +100,135 @@ export async function invidiousGetChannelInfo(channelId) {
   })
 }
 
-export async function invidiousGetPlaylistInfo(playlistId) {
+/**
+ * @param {string} tab
+ * @param {string} channelId
+ * @param {string | undefined | null} continuation
+ * @param {string | undefined} sortBy
+ */
+async function getInvidiousChannelTab(tab, channelId, continuation, sortBy) {
+  const params = {}
+
+  if (continuation) {
+    params.continuation = continuation
+  }
+
+  if (sortBy) {
+    params.sort_by = sortBy
+  }
+
   return await invidiousAPICall({
+    resource: 'channels',
+    id: channelId,
+    subResource: tab,
+    params
+  })
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined} sortBy
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelVideos(channelId, sortBy, continuation) {
+  const response = await getInvidiousChannelTab('videos', channelId, continuation, sortBy)
+
+  setMultiplePublishedTimestamps(response.videos)
+
+  return response
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined} sortBy
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelShorts(channelId, sortBy, continuation) {
+  const response = await getInvidiousChannelTab('shorts', channelId, continuation, sortBy)
+
+  // workaround for Invidious sending incorrect information
+  // https://github.com/iv-org/invidious/issues/3801
+  response.videos.forEach(video => {
+    video.isUpcoming = false
+    delete video.published
+    delete video.premiereTimestamp
+  })
+
+  return response
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined} sortBy
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelLive(channelId, sortBy, continuation) {
+  const response = await getInvidiousChannelTab('streams', channelId, continuation, sortBy)
+
+  setMultiplePublishedTimestamps(response.videos)
+
+  return response
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined} sortBy
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelPlaylists(channelId, sortBy, continuation) {
+  return await getInvidiousChannelTab('playlists', channelId, continuation, sortBy)
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelReleases(channelId, continuation) {
+  return await getInvidiousChannelTab('releases', channelId, continuation)
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelPodcasts(channelId, continuation) {
+  return await getInvidiousChannelTab('podcasts', channelId, continuation)
+}
+
+/**
+ * @param {string} channelId
+ * @param {string} query
+ * @param {number} page
+ */
+export async function searchInvidiousChannel(channelId, query, page) {
+  const response = await invidiousAPICall({
+    resource: 'channels',
+    id: channelId,
+    subResource: 'search',
+    params: {
+      q: query,
+      page
+    }
+  })
+
+  response.forEach((item) => {
+    if (item.type === 'video') {
+      setPublishedTimestamp(item)
+    }
+  })
+
+  return response
+}
+
+export async function invidiousGetPlaylistInfo(playlistId) {
+  const playlist = await invidiousAPICall({
     resource: 'playlists',
     id: playlistId,
   })
+
+  setMultiplePublishedTimestamps(playlist.videos)
+
+  return playlist
 }
 
 export async function invidiousGetVideoInformation(videoId) {
@@ -140,6 +264,118 @@ export async function invidiousGetCommentReplies({ id, replyToken }) {
 
   const response = await invidiousAPICall(payload)
   return { commentData: parseInvidiousCommentData(response), continuation: response.continuation ?? null }
+}
+
+/**
+ * @param {string} query
+ * @returns {Promise<string[]>}
+ */
+export async function getInvidiousSearchSuggestions(query) {
+  return await invidiousAPICall({
+    resource: 'search/suggestions',
+    id: '',
+    params: {
+      q: query
+    }
+  })
+}
+
+/**
+ * @returns {Promise<any[]>}
+ */
+export async function getInvidiousPopularFeed() {
+  const response = await invidiousAPICall({
+    resource: 'popular',
+    id: '',
+    params: {}
+  })
+
+  const items = response.filter((item) => {
+    return item.type === 'video' || item.type === 'shortVideo' || item.type === 'channel' || item.type === 'playlist'
+  })
+
+  items.forEach((item) => {
+    if (item.type === 'video' || item.type === 'shortVideo') {
+      setPublishedTimestamp(item)
+    }
+  })
+
+  return items
+}
+
+/**
+ * @param {'default' | 'music' | 'gaming' | 'movies'} tab
+ * @param {string} region
+ * @returns {Promise<any[] | null>}
+ */
+export async function getInvidiousTrending(tab, region) {
+  const params = {
+    resource: 'trending',
+    id: '',
+    params: {
+      region
+    }
+  }
+
+  if (tab !== 'default') {
+    params.params.type = tab.charAt(0).toUpperCase() + tab.substring(1)
+  }
+
+  const response = await invidiousAPICall(params)
+
+  if (!response) {
+    return null
+  }
+
+  const items = response.filter((item) => {
+    return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
+  })
+
+  items.forEach((item) => {
+    if (item.type === 'video') {
+      setPublishedTimestamp(item)
+    }
+  })
+
+  return items
+}
+
+/**
+ * @param {string} query
+ * @param {number} page
+ * @param {any} searchSettings
+ * @returns {Promise<any[] | null>}
+ */
+export async function getInvidiousSearchResults(query, page, searchSettings) {
+  let results = await invidiousAPICall({
+    resource: 'search',
+    id: 'string',
+    params: {
+      q: query,
+      page,
+      sort_by: searchSettings.sortBy,
+      date: searchSettings.time,
+      duration: searchSettings.duration,
+      type: searchSettings.type,
+      features: searchSettings.features.join(',')
+    }
+  })
+
+  if (!results) {
+    return null
+  }
+
+  results = results.filter((item) => {
+    return item.type === 'video' || item.type === 'channel' || item.type === 'playlist' || item.type === 'hashtag'
+  })
+
+  results.forEach((item) => {
+    if (item.type === 'video') {
+      setPublishedTimestamp(item)
+    }
+  })
+
+  return results
 }
 
 /**
@@ -377,14 +613,16 @@ function parseInvidiousCommunityAttachments(data) {
 }
 
 export async function getHashtagInvidious(hashtag, page = 1) {
-  const payload = {
+  const response = await invidiousAPICall({
     resource: 'hashtag',
     id: hashtag,
     params: {
       page
     }
-  }
-  const response = await invidiousAPICall(payload)
+  })
+
+  setMultiplePublishedTimestamps(response.results)
+
   return response.results
 }
 
@@ -474,5 +712,35 @@ export function mapInvidiousLegacyFormat(format) {
     height: parseInt(stringHeight),
     width: parseInt(stringWidth),
     url: format.url
+  }
+}
+
+/**
+ * @param {{
+ *  liveNow: boolean,
+ *  isUpcoming: boolean,
+ *  premiereTimestamp: number,
+ *  published: number
+ * }[]} videos
+ */
+function setMultiplePublishedTimestamps(videos) {
+  videos.forEach(setPublishedTimestamp)
+}
+
+/**
+ * @param {{
+ *  liveNow: boolean,
+ *  isUpcoming: boolean,
+ *  premiereTimestamp: number,
+ *  published: number
+ * }} video
+ */
+function setPublishedTimestamp(video) {
+  if (video.liveNow) {
+    video.published = new Date().getTime()
+  } else if (video.isUpcoming) {
+    video.published = video.premiereTimestamp * 1000
+  } else if (typeof video.published === 'number') {
+    video.published *= 1000
   }
 }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -101,26 +101,6 @@ export function calculatePublishedDate(publishedText, isLive = false, isUpcoming
 }
 
 /**
- * @param {{
- *  liveNow: boolean,
- *  isUpcoming: boolean,
- *  premiereTimestamp: number,
- *  published: number
- * }[]} videos
- */
-export function setPublishedTimestampsInvidious(videos) {
-  videos.forEach(video => {
-    if (video.liveNow) {
-      video.published = new Date().getTime()
-    } else if (video.isUpcoming) {
-      video.published = video.premiereTimestamp * 1000
-    } else if (typeof video.published === 'number') {
-      video.published *= 1000
-    }
-  })
-}
-
-/**
  * @param {import('youtubei.js/dist/src/parser/classes/PlayerStoryboardSpec').StoryboardData} storyboard
  * @param {number} videoLengthSeconds
  * @returns {string}

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -53,7 +53,7 @@ import store from '../../store/index'
 import { useRoute } from 'vue-router/composables'
 import packageDetails from '../../../../package.json'
 import { getHashtagLocal, parseLocalListVideo } from '../../helpers/api/local'
-import { copyToClipboard, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
+import { copyToClipboard, showToast } from '../../helpers/utils'
 import { isNullOrEmpty } from '../../helpers/strings'
 import { getHashtagInvidious } from '../../helpers/api/invidious'
 import { useI18n } from '../../composables/use-i18n-polyfill'
@@ -118,7 +118,6 @@ async function getHashtag() {
 async function getInvidiousHashtag(hashtagInRoute, page) {
   try {
     const fetchedVideos = await getHashtagInvidious(hashtagInRoute, page)
-    setPublishedTimestampsInvidious(fetchedVideos)
     hashtag.value = '#' + hashtagInRoute
     isLoading.value = false
     apiUsed.value = 'invidious'

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -18,7 +18,6 @@ import {
 import {
   extractNumberFromString,
   getIconForSortPreference,
-  setPublishedTimestampsInvidious,
   showToast,
   deepCopy,
 } from '../../helpers/utils'
@@ -387,8 +386,6 @@ export default defineComponent({
 
         const dateString = new Date(result.updated * 1000)
         this.lastUpdated = dateString.toLocaleDateString(this.currentLocale, { year: 'numeric', month: 'short', day: 'numeric' })
-
-        setPublishedTimestampsInvidious(result.videos)
 
         this.playlistItems = result.videos
 

--- a/src/renderer/views/Search/Search.js
+++ b/src/renderer/views/Search/Search.js
@@ -7,11 +7,10 @@ import FtAutoLoadNextPageWrapper from '../../components/ft-auto-load-next-page-w
 import {
   copyToClipboard,
   searchFiltersMatch,
-  setPublishedTimestampsInvidious,
   showToast,
 } from '../../helpers/utils'
 import { getLocalSearchContinuation, getLocalSearchResults } from '../../helpers/api/local'
-import { invidiousAPICall } from '../../helpers/api/invidious'
+import { getInvidiousSearchResults } from '../../helpers/api/invidious'
 import packageDetails from '../../../../package.json'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
@@ -225,37 +224,17 @@ export default defineComponent({
         this.isLoading = true
       }
 
-      const searchPayload = {
-        resource: 'search',
-        id: '',
-        params: {
-          q: payload.query,
-          page: this.searchPage,
-          sort_by: payload.searchSettings.sortBy,
-          date: payload.searchSettings.time,
-          duration: payload.searchSettings.duration,
-          type: payload.searchSettings.type,
-          features: payload.searchSettings.features.join(',')
-        }
-      }
-
-      invidiousAPICall(searchPayload).then((result) => {
-        if (!result) {
+      getInvidiousSearchResults(payload.query, this.searchPage, payload.searchSettings).then((results) => {
+        if (!results) {
           return
         }
 
         this.apiUsed = 'invidious'
 
-        const returnData = result.filter((item) => {
-          return item.type === 'video' || item.type === 'channel' || item.type === 'playlist' || item.type === 'hashtag'
-        })
-
-        setPublishedTimestampsInvidious(returnData.filter(item => item.type === 'video'))
-
         if (this.searchPage !== 1) {
-          this.shownResults = this.shownResults.concat(returnData)
+          this.shownResults = this.shownResults.concat(results)
         } else {
-          this.shownResults = returnData
+          this.shownResults = results
         }
 
         this.isLoading = false
@@ -272,7 +251,7 @@ export default defineComponent({
 
         this.$store.commit('addToSessionSearchHistory', historyPayload)
 
-        this.updateSubscriptionDetails(returnData)
+        this.updateSubscriptionDetails(results)
       }).catch((err) => {
         console.error(err)
         const errorMessage = this.$t('Invidious API Error (Click to copy)')

--- a/src/renderer/views/Trending/Trending.js
+++ b/src/renderer/views/Trending/Trending.js
@@ -7,9 +7,9 @@ import FtIconButton from '../../components/ft-icon-button/ft-icon-button.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtRefreshWidget from '../../components/ft-refresh-widget/ft-refresh-widget.vue'
 
-import { copyToClipboard, getRelativeTimeFromDate, setPublishedTimestampsInvidious, showToast } from '../../helpers/utils'
+import { copyToClipboard, getRelativeTimeFromDate, showToast } from '../../helpers/utils'
 import { getLocalTrending } from '../../helpers/api/local'
-import { invidiousAPICall } from '../../helpers/api/invidious'
+import { getInvidiousTrending } from '../../helpers/api/invidious'
 import { KeyboardShortcuts } from '../../../constants'
 
 export default defineComponent({
@@ -135,30 +135,14 @@ export default defineComponent({
     getTrendingInfoInvidious: function () {
       this.isLoading = true
 
-      const trendingPayload = {
-        resource: 'trending',
-        id: '',
-        params: { region: this.region }
-      }
-
-      if (this.currentTab !== 'default') {
-        trendingPayload.params.type = this.currentTab.charAt(0).toUpperCase() + this.currentTab.slice(1)
-      }
-
-      invidiousAPICall(trendingPayload).then((result) => {
-        if (!result) {
+      getInvidiousTrending(this.currentTab, this.region).then((items) => {
+        if (!items) {
           return
         }
 
-        const returnData = result.filter((item) => {
-          return item.type === 'video' || item.type === 'channel' || item.type === 'playlist'
-        })
-
-        setPublishedTimestampsInvidious(returnData.filter(item => item.type === 'video'))
-
-        this.shownResults = returnData
+        this.shownResults = items
         this.isLoading = false
-        this.$store.commit('setTrendingCache', { value: returnData, page: this.currentTab })
+        this.$store.commit('setTrendingCache', { value: items, page: this.currentTab })
         nextTick(() => {
           this.$refs[this.currentTab]?.focus()
         })


### PR DESCRIPTION
# Move Invidious API calls into Invidious file

## Pull Request Type

- [x] Refactor

## Description

This pull request moves that Invidious API calls into Invidious file. That reduces the code inside the components themselves and also hides some of the implemenation details, such as parsing the published dates, making for a cleaner API. As an added benefit this also reduces code duplication between the channel and subscription pages.

## Testing

Please test all parts of the app that make API calls with the Invidious API

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** fd94f3e7cc4ef32c8639e2d066f8e51dfc80af28