### PR TITLE
Fix auto-generated RTL captions position

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1186,7 +1186,8 @@ export default defineComponent({
           if (url.hostname.endsWith('.youtube.com') && url.pathname === '/api/timedtext' &&
             url.searchParams.get('caps') === 'asr' && url.searchParams.get('kind') === 'asr' && url.searchParams.get('fmt') === 'vtt') {
             const stringBody = new TextDecoder().decode(response.data)
-            const cleaned = stringBody.replaceAll(/ align:start position:0%$/gm, '')
+            // position:0% for LTR text and position:100% for RTL text
+            const cleaned = stringBody.replaceAll(/ align:start position:(?:10)?0%$/gm, '')
 
             response.data = new TextEncoder().encode(cleaned).buffer
           }
@@ -2484,7 +2485,8 @@ export default defineComponent({
                 const response = await fetch(caption.url)
                 let text = await response.text()
 
-                text = text.replaceAll(/ align:start position:0%$/gm, '')
+                // position:0% for LTR text and position:100% for RTL text
+                text = text.replaceAll(/ align:start position:(?:10)?0%$/gm, '')
 
                 const url = `data:${caption.mimeType};charset=utf-8,${encodeURIComponent(text)}`
 


### PR DESCRIPTION
# Fix auto-generated RTL captions position

## Pull Request Type

- [x] Bugfix

## Related issue
- closes #6062

## Description
Just like with the auto-generated captions for left-to-right languages YouTube also adds horizontal positioning to their auto-generated captions for right-to-left captions, however they use 100% (right side of captions area) instead of 0% (left side of captions area) so it wasn't getting caught by the existing logic to remove that positioning.

## Screenshots
Before (screenshot taken from the linked issue):
![freetube](https://github.com/user-attachments/assets/29b9ae38-ea8a-447d-abe2-0f550c7d3b29)

After:
![after](https://github.com/user-attachments/assets/7b612859-bd72-496e-a4b9-678e8b0e4627)

## Testing
1. Open https://www.youtube.com/watch?v=MdOC-P3gh4I
2. Select the `Arabic (auto-generated)` subtitle track
3. You should see the subtitles

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** fd94f3e7cc4ef32c8639e2d066f8e51dfc80af28