### PR TITLE
Fix channel home page list view

### DIFF
--- a/src/renderer/components/ChannelHome/ChannelHome.vue
+++ b/src/renderer/components/ChannelHome/ChannelHome.vue
@@ -39,7 +39,7 @@
         <FtElementList
           :data="shelf.content"
           :use-channels-hidden-preference="false"
-          :display="shelf.isCommunity ? 'list' : null"
+          :display="shelf.isCommunity ? 'list' : ''"
         />
       </details>
     </div>


### PR DESCRIPTION
# Fix channel home page list view

## Pull Request Type
- [x] Bugfix

## Related issue
closes #6310 

## Testing
With local api selected:
- change `Settings > General Settings > Video View Type` to list
- go to a channel with a home page (ex: mrbeast)
- make sure the video shelves load correctly

## Desktop
- **OS:** Fedora Linux KDE
- **OS Version:** 41
- **FreeTube version:** 0.22.0 (latest nightly)

