### PR TITLE
Use word-break on live chat error message

### DIFF
--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -34,6 +34,7 @@
   color: var(--tertiary-text-color);
   padding: 0;
   margin: 0;
+  word-break: break-word;
 }
 
 :deep(.liveChatEmoji) {


### PR DESCRIPTION
# Use word-break on live chat error message

## Pull Request Type
- [x] Bugfix

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/6312

## Description
Adds missing word-break for live chat error message

## Screenshots 
![image](https://github.com/user-attachments/assets/7f148404-205f-4f8c-9677-b5753a6cc13f)

## Testing 
I tested by doing the following:
- go to lofi girl live stream
- make sure the chat loads
- turn off wifi (this adds an error message but the error message isn't that long)
- inspect element on the error message and update the text to make it longer (this is the text I used: TypeError: This is a longer error message with httpswwwyoutubecomapi/youtubei/v1/v2/msdjhsdksdhshdjsdgshjdsdhsjkdnsdhjskdshdjksdhsjdkjshdskdhsidkshdusikdsjudiskdsdsdgfgfgf error code 200 success )


## Desktop
- **OS:** Fedora
- **OS Version:** 41
- **FreeTube version:** 0.22.0 (latest nightly)

