### PR TITLE
Fix Player: Tooltips get cut off with long text

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -266,8 +266,8 @@
   :deep(.shaka-tooltips-on button:focus-visible::after),
   :deep(.shaka-tooltips-on button:hover::after) {
     margin-bottom: 8px;
-    // Fixes long tooltips on the right got cut off
-    // Assumes tooltips on the left are all short enough
+    /*Fixes long tooltips on the right got cut off*/
+    /*Assumes tooltips on the left are all short enough*/
     left: 1px;
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -266,8 +266,8 @@
   :deep(.shaka-tooltips-on button:focus-visible::after),
   :deep(.shaka-tooltips-on button:hover::after) {
     margin-bottom: 8px;
-    /*Fixes long tooltips on the right got cut off*/
-    /*Assumes tooltips on the left are all short enough*/
+    
+    /* Fixes long tooltips on the right got cut off by adjusting their positioning */
     left: 1px;
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -266,6 +266,7 @@
   :deep(.shaka-tooltips-on button:focus-visible::after),
   :deep(.shaka-tooltips-on button:hover::after) {
     margin-bottom: 8px;
+    left: 1px;
   }
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -266,6 +266,8 @@
   :deep(.shaka-tooltips-on button:focus-visible::after),
   :deep(.shaka-tooltips-on button:hover::after) {
     margin-bottom: 8px;
+    // Fixes long tooltips on the right got cut off
+    // Assumes tooltips on the left are all short enough
     left: 1px;
   }
 }


### PR DESCRIPTION
# Tooltip bug fixed

## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/6331

## Description
The application was inspected via devtools to find where the bug happens, I fixed it in the code afterwards. Now Tooltip pops up correctly, even with more symbols in it.

## Screenshots
Before and After bugfix
![before](https://github.com/user-attachments/assets/234a5ed5-6ef2-4bc7-aa4c-8034b79dacff)
![after](https://github.com/user-attachments/assets/ecdf1e4e-f168-4935-bc81-19a5fd7d9763)

## Testing
Tried different options right in the browser devtools, found out that there's a css feature conflict that causes unnecessary overlapping. A little time to inspect the codebase, quite a few simple moves and here we go, it works properly. Tested a different amount of symbols. Works fine until there's one milliion symbols, but there's no need in such an amount. Tested in Russian langauge and in German (as in the following issue), works as it should.

## Desktop
- OS: Windows
- OS Version: 10
- FreeTube version: v0.22.0 Beta
