### PR TITLE
Bump youtubei.js from 10.5.0 to 12.2.0 + Bump version number to from v022.0 to v0.22.1 + Fix incompatibility with upcoming YouTube.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freetube",
   "productName": "FreeTube",
   "description": "A private YouTube client",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "license": "AGPL-3.0-or-later",
   "main": "./dist/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^10.5.0"
+    "youtubei.js": "^12.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.8",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^12.1.0"
+    "youtubei.js": "^12.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.8",

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,4 +1,4 @@
-import { ClientType, Endpoints, Innertube, Misc, Parser, UniversalCache, Utils, YT } from 'youtubei.js'
+import { ClientType, Innertube, Misc, Parser, UniversalCache, Utils, YT, YTNodes } from 'youtubei.js'
 import Autolinker from 'autolinker'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
@@ -379,12 +379,12 @@ export async function getLocalChannelVideos(id) {
   const innertube = await createInnertube()
 
   try {
-    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
-      browse_id: id,
+    const response = await innertube.actions.execute('/browse', {
+      browseId: id,
       params: 'EgZ2aWRlb3PyBgQKAjoA'
       // protobuf for the videos tab (this is the one that YouTube uses,
       // it has some empty fields in the protobuf but it doesn't work if you remove them)
-    }))
+    })
 
     const videosTab = new YT.Channel(null, response)
     const { id: channelId = id, name, thumbnailUrl } = parseLocalChannelHeader(videosTab, true)
@@ -436,12 +436,12 @@ export async function getLocalChannelLiveStreams(id) {
   const innertube = await createInnertube()
 
   try {
-    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
-      browse_id: id,
+    const response = await innertube.actions.execute('/browse', {
+      browseId: id,
       params: 'EgdzdHJlYW1z8gYECgJ6AA%3D%3D'
       // protobuf for the live tab (this is the one that YouTube uses,
       // it has some empty fields in the protobuf but it doesn't work if you remove them)
-    }))
+    })
 
     let liveStreamsTab = new YT.Channel(innertube.actions, response)
     const { id: channelId = id, name, thumbnailUrl } = parseLocalChannelHeader(liveStreamsTab, true)
@@ -484,12 +484,12 @@ export async function getLocalChannelCommunity(id) {
   const innertube = await createInnertube()
 
   try {
-    const response = await innertube.actions.execute(Endpoints.BrowseEndpoint.PATH, Endpoints.BrowseEndpoint.build({
-      browse_id: id,
+    const response = await innertube.actions.execute('/browse', {
+      browseId: id,
       params: 'Egljb21tdW5pdHnyBgQKAkoA'
       // protobuf for the community tab (this is the one that YouTube uses,
       // it has some empty fields in the protobuf but it doesn't work if you remove them)
-    }))
+    })
 
     const communityTab = new YT.Channel(null, response)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5753,10 +5753,10 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jintr@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jintr/-/jintr-2.1.1.tgz#84d555df06d26128c2a1d0e1eebd6fecdf8eb280"
-  integrity sha512-89cwX4ouogeDGOBsEVsVYsnWWvWjchmwXBB4kiBhmjOKw19FiOKhNhMhpxhTlK2ctl7DS+d/ethfmuBpzoNNgA==
+jintr@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jintr/-/jintr-3.2.0.tgz#38bfc2311c7ed4412ebe0bfc5c2e700f8f433921"
+  integrity sha512-psD1yf05kMKDNsUdW1l5YhO59pHScQ6OIHHb8W5SKSM2dCOFPsqolmIuSHgVA8+3Dc47NJR181CXZ4alCAPTkA==
   dependencies:
     acorn "^8.8.0"
 
@@ -9412,12 +9412,12 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-youtubei.js@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-12.1.0.tgz#46fd1911b11984e47d41d4cbebcc2a4fcf822036"
-  integrity sha512-42SUw7zPpx4b7+XBm9QW+//T2/tixBRoEjJAbfOLmGCiyGZuvfW+oq/IngnXo2Keu+yD7YVAfYFc/NaFjFDxGg==
+youtubei.js@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-12.2.0.tgz#54f058b5d0892b5c7e35019e2be6a2a7f7ba4447"
+  integrity sha512-G+50qrbJCToMYhu8jbaHiS3Vf+RRul+CcDbz3hEGwHkGPh+zLiWwD6SS+YhYF+2/op4ZU5zDYQJrGqJ+wKh7Gw==
   dependencies:
     "@bufbuild/protobuf" "^2.0.0"
-    jintr "^2.1.1"
+    jintr "^3.2.0"
     tslib "^2.5.0"
     undici "^5.19.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9412,10 +9412,10 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-youtubei.js@^10.5.0:
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-10.5.0.tgz#3cf0c79cf73fb26e13d167f37dec7d65419e91b8"
-  integrity sha512-iyA+VF28c15tCCKH9ExM2RKC3zYiHzA/eixGlJ3vERANkuI+xYKzAZ4vtOhmyqwrAddu88R/DkzEsmpph5NWjg==
+youtubei.js@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-12.1.0.tgz#46fd1911b11984e47d41d4cbebcc2a4fcf822036"
+  integrity sha512-42SUw7zPpx4b7+XBm9QW+//T2/tixBRoEjJAbfOLmGCiyGZuvfW+oq/IngnXo2Keu+yD7YVAfYFc/NaFjFDxGg==
   dependencies:
     "@bufbuild/protobuf" "^2.0.0"
     jintr "^2.1.1"


### PR DESCRIPTION
# Bump youtubei.js from 10.5.0 to 12.2.0 + Bump version number to from v022.0 to v0.22.1 + Fix incompatibility with upcoming YouTube.js version

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
#6341 
#6233 
closes #6328 
