### PR TITLE
Add live chat support for upcoming videos

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -546,7 +546,7 @@ export default defineComponent({
           }
         }
 
-        if (!this.hideLiveChat && this.isLive && result.livechat) {
+        if (!this.hideLiveChat && (this.isLive || this.isUpcoming) && result.livechat) {
           this.liveChat = result.getLiveChat()
         } else {
           this.liveChat = null

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -179,7 +179,7 @@
       class="sidebarArea"
     >
       <watch-video-live-chat
-        v-if="!isLoading && !hideLiveChat && isLive"
+        v-if="!isLoading && !hideLiveChat && (isLive || isUpcoming)"
         :live-chat="liveChat"
         :video-id="videoId"
         :channel-id="channelId"


### PR DESCRIPTION
# Add live chat support for upcoming videos

## Pull Request Type
- [x] Feature Implementation

## Description
Upcoming videos can have a livechat so this PR will show the livechat if it is available (upcoming videos can have livechat and comments so both will be displayed).

## Screenshots 
![image](https://github.com/user-attachments/assets/7e38d556-01c5-4607-b922-874110baece0)


## Testing 
- find an upcoming video that has live chat enabled
- make sure you can view the chat

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 41
- **FreeTube version:** 0.22.x (latest nightly)
