### PR TITLE
Better description for hiding watched vids

### DIFF
--- a/src/renderer/components/subscription-settings/subscription-settings.vue
+++ b/src/renderer/components/subscription-settings/subscription-settings.vue
@@ -27,7 +27,7 @@
       </div>
       <div class="switchColumn">
         <ft-toggle-switch
-          :label="$t('Settings.Subscription Settings.Hide Videos on Watch')"
+          :label="$t('Settings.Subscription Settings.Hide Videos marked as WATCHED')"
           :default-value="hideWatchedSubs"
           :compact="true"
           @change="updateHideWatchedSubs"


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6389

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
**Hide Videos on Watch** confused me and very likely others too so I made some minor changes to the text.

The reason why it should be **Videos marked as WATCHED** and not simply **watched Videos** is because of future features. If there is an option for user to mark a video manually as `WATCHED` (probably watched somewhere else) then this button should also apply.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 23H2
- **FreeTube version:** v0.22.1 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
