### PR TITLE
Pass arguments to data stores normally to avoid extra objects

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -183,7 +183,7 @@ class Playlists {
     return db.playlists.removeAsync({ _id, protected: { $ne: true } })
   }
 
-  static deleteVideoIdByPlaylistId({ _id, videoId, playlistItemId }) {
+  static deleteVideoIdByPlaylistId(_id, videoId, playlistItemId) {
     if (playlistItemId != null) {
       return db.playlists.updateAsync(
         { _id },
@@ -231,7 +231,7 @@ class SubscriptionCache {
     return db.subscriptionCache.findAsync({})
   }
 
-  static updateVideosByChannelId({ channelId, entries, timestamp }) {
+  static updateVideosByChannelId(channelId, entries, timestamp) {
     return db.subscriptionCache.updateAsync(
       { _id: channelId },
       { $set: { videos: entries, videosTimestamp: timestamp } },
@@ -239,7 +239,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateLiveStreamsByChannelId({ channelId, entries, timestamp }) {
+  static updateLiveStreamsByChannelId(channelId, entries, timestamp) {
     return db.subscriptionCache.updateAsync(
       { _id: channelId },
       { $set: { liveStreams: entries, liveStreamsTimestamp: timestamp } },
@@ -247,7 +247,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateShortsByChannelId({ channelId, entries, timestamp }) {
+  static updateShortsByChannelId(channelId, entries, timestamp) {
     return db.subscriptionCache.updateAsync(
       { _id: channelId },
       { $set: { shorts: entries, shortsTimestamp: timestamp } },
@@ -255,7 +255,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateShortsWithChannelPageShortsByChannelId({ channelId, entries }) {
+  static updateShortsWithChannelPageShortsByChannelId(channelId, entries) {
     return db.subscriptionCache.findOneAsync({ _id: channelId }, { shorts: 1 }).then((doc) => {
       if (doc == null) { return }
 
@@ -288,7 +288,7 @@ class SubscriptionCache {
     })
   }
 
-  static updateCommunityPostsByChannelId({ channelId, entries, timestamp }) {
+  static updateCommunityPostsByChannelId(channelId, entries, timestamp) {
     return db.subscriptionCache.updateAsync(
       { _id: channelId },
       { $set: { communityPosts: entries, communityPostsTimestamp: timestamp } },

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -173,7 +173,7 @@ class Playlists {
     )
   }
 
-  static deleteVideoIdByPlaylistId({ _id, videoId, playlistItemId }) {
+  static deleteVideoIdByPlaylistId(_id, videoId, playlistItemId) {
     return ipcRenderer.invoke(
       IpcChannels.DB_PLAYLISTS,
       {
@@ -226,7 +226,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateVideosByChannelId({ channelId, entries, timestamp }) {
+  static updateVideosByChannelId(channelId, entries, timestamp) {
     return ipcRenderer.invoke(
       IpcChannels.DB_SUBSCRIPTION_CACHE,
       {
@@ -236,7 +236,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateLiveStreamsByChannelId({ channelId, entries, timestamp }) {
+  static updateLiveStreamsByChannelId(channelId, entries, timestamp) {
     return ipcRenderer.invoke(
       IpcChannels.DB_SUBSCRIPTION_CACHE,
       {
@@ -246,7 +246,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateShortsByChannelId({ channelId, entries, timestamp }) {
+  static updateShortsByChannelId(channelId, entries, timestamp) {
     return ipcRenderer.invoke(
       IpcChannels.DB_SUBSCRIPTION_CACHE,
       {
@@ -256,7 +256,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateShortsWithChannelPageShortsByChannelId({ channelId, entries }) {
+  static updateShortsWithChannelPageShortsByChannelId(channelId, entries) {
     return ipcRenderer.invoke(
       IpcChannels.DB_SUBSCRIPTION_CACHE,
       {
@@ -266,7 +266,7 @@ class SubscriptionCache {
     )
   }
 
-  static updateCommunityPostsByChannelId({ channelId, entries, timestamp }) {
+  static updateCommunityPostsByChannelId(channelId, entries, timestamp) {
     return ipcRenderer.invoke(
       IpcChannels.DB_SUBSCRIPTION_CACHE,
       {

--- a/src/datastores/handlers/web.js
+++ b/src/datastores/handlers/web.js
@@ -101,8 +101,8 @@ class Playlists {
     return baseHandlers.playlists.delete(_id)
   }
 
-  static deleteVideoIdByPlaylistId({ _id, videoId, playlistItemId }) {
-    return baseHandlers.playlists.deleteVideoIdByPlaylistId({ _id, videoId, playlistItemId })
+  static deleteVideoIdByPlaylistId(_id, videoId, playlistItemId) {
+    return baseHandlers.playlists.deleteVideoIdByPlaylistId(_id, videoId, playlistItemId)
   }
 
   static deleteVideoIdsByPlaylistId(_id, videoIds) {
@@ -127,43 +127,24 @@ class SubscriptionCache {
     return baseHandlers.subscriptionCache.find()
   }
 
-  static updateVideosByChannelId({ channelId, entries, timestamp }) {
-    return baseHandlers.subscriptionCache.updateVideosByChannelId({
-      channelId,
-      entries,
-      timestamp,
-    })
+  static updateVideosByChannelId(channelId, entries, timestamp) {
+    return baseHandlers.subscriptionCache.updateVideosByChannelId(channelId, entries, timestamp)
   }
 
-  static updateLiveStreamsByChannelId({ channelId, entries, timestamp }) {
-    return baseHandlers.subscriptionCache.updateLiveStreamsByChannelId({
-      channelId,
-      entries,
-      timestamp,
-    })
+  static updateLiveStreamsByChannelId(channelId, entries, timestamp) {
+    return baseHandlers.subscriptionCache.updateLiveStreamsByChannelId(channelId, entries, timestamp)
   }
 
-  static updateShortsByChannelId({ channelId, entries, timestamp }) {
-    return baseHandlers.subscriptionCache.updateShortsByChannelId({
-      channelId,
-      entries,
-      timestamp,
-    })
+  static updateShortsByChannelId(channelId, entries, timestamp) {
+    return baseHandlers.subscriptionCache.updateShortsByChannelId(channelId, entries, timestamp)
   }
 
-  static updateShortsWithChannelPageShortsByChannelId({ channelId, entries }) {
-    return baseHandlers.subscriptionCache.updateShortsWithChannelPageShortsByChannelId({
-      channelId,
-      entries,
-    })
+  static updateShortsWithChannelPageShortsByChannelId(channelId, entries) {
+    return baseHandlers.subscriptionCache.updateShortsWithChannelPageShortsByChannelId(channelId, entries)
   }
 
-  static updateCommunityPostsByChannelId({ channelId, entries, timestamp }) {
-    return baseHandlers.subscriptionCache.updateCommunityPostsByChannelId({
-      channelId,
-      entries,
-      timestamp,
-    })
+  static updateCommunityPostsByChannelId(channelId, entries, timestamp) {
+    return baseHandlers.subscriptionCache.updateCommunityPostsByChannelId(channelId, entries, timestamp)
   }
 
   static deleteMultipleChannels(channelIds) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1298,11 +1298,7 @@ function runApp() {
           return null
 
         case DBActions.PLAYLISTS.DELETE_VIDEO_ID:
-          await baseHandlers.playlists.deleteVideoIdByPlaylistId({
-            _id: data._id,
-            videoId: data.videoId,
-            playlistItemId: data.playlistItemId,
-          })
+          await baseHandlers.playlists.deleteVideoIdByPlaylistId(data._id, data.videoId, data.playlistItemId)
           syncOtherWindows(
             IpcChannels.SYNC_PLAYLISTS,
             event,
@@ -1355,7 +1351,7 @@ function runApp() {
           return await baseHandlers.subscriptionCache.find()
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_VIDEOS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateVideosByChannelId(data)
+          await baseHandlers.subscriptionCache.updateVideosByChannelId(data.channelId, data.entries, data.timestamp)
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -1364,7 +1360,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_LIVE_STREAMS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateLiveStreamsByChannelId(data)
+          await baseHandlers.subscriptionCache.updateLiveStreamsByChannelId(data.channelId, data.entries, data.timestamp)
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -1373,7 +1369,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_SHORTS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateShortsByChannelId(data)
+          await baseHandlers.subscriptionCache.updateShortsByChannelId(data.channelId, data.entries, data.timestamp)
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -1382,7 +1378,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_SHORTS_WITH_CHANNEL_PAGE_SHORTS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateShortsWithChannelPageShortsByChannelId(data)
+          await baseHandlers.subscriptionCache.updateShortsWithChannelPageShortsByChannelId(data.channelId, data.entries)
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,
@@ -1391,7 +1387,7 @@ function runApp() {
           return null
 
         case DBActions.SUBSCRIPTION_CACHE.UPDATE_COMMUNITY_POSTS_BY_CHANNEL:
-          await baseHandlers.subscriptionCache.updateCommunityPostsByChannelId(data)
+          await baseHandlers.subscriptionCache.updateCommunityPostsByChannelId(data.channelId, data.entries, data.timestamp)
           syncOtherWindows(
             IpcChannels.SYNC_SUBSCRIPTION_CACHE,
             event,

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -408,7 +408,7 @@ const actions = {
   async removeVideo({ commit }, payload) {
     try {
       const { _id, videoId, playlistItemId } = payload
-      await DBPlaylistHandlers.deleteVideoIdByPlaylistId({ _id, videoId, playlistItemId })
+      await DBPlaylistHandlers.deleteVideoIdByPlaylistId(_id, videoId, playlistItemId)
       commit('removeVideo', payload)
     } catch (errMessage) {
       console.error(errMessage)

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -88,11 +88,7 @@ const actions = {
 
   async updateSubscriptionVideosCacheByChannel({ commit }, { channelId, videos, timestamp = new Date() }) {
     try {
-      await DBSubscriptionCacheHandlers.updateVideosByChannelId({
-        channelId,
-        entries: videos,
-        timestamp,
-      })
+      await DBSubscriptionCacheHandlers.updateVideosByChannelId(channelId, videos, timestamp)
       commit('updateVideoCacheByChannel', { channelId, entries: videos, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -101,11 +97,7 @@ const actions = {
 
   async updateSubscriptionShortsCacheByChannel({ commit }, { channelId, videos, timestamp = new Date() }) {
     try {
-      await DBSubscriptionCacheHandlers.updateShortsByChannelId({
-        channelId,
-        entries: videos,
-        timestamp,
-      })
+      await DBSubscriptionCacheHandlers.updateShortsByChannelId(channelId, videos, timestamp)
       commit('updateShortsCacheByChannel', { channelId, entries: videos, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -114,10 +106,7 @@ const actions = {
 
   async updateSubscriptionShortsCacheWithChannelPageShorts({ commit }, { channelId, videos }) {
     try {
-      await DBSubscriptionCacheHandlers.updateShortsWithChannelPageShortsByChannelId({
-        channelId,
-        entries: videos,
-      })
+      await DBSubscriptionCacheHandlers.updateShortsWithChannelPageShortsByChannelId(channelId, videos)
       commit('updateShortsCacheWithChannelPageShorts', { channelId, entries: videos })
     } catch (errMessage) {
       console.error(errMessage)
@@ -126,11 +115,7 @@ const actions = {
 
   async updateSubscriptionLiveCacheByChannel({ commit }, { channelId, videos, timestamp = new Date() }) {
     try {
-      await DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId({
-        channelId,
-        entries: videos,
-        timestamp,
-      })
+      await DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId(channelId, videos, timestamp)
       commit('updateLiveCacheByChannel', { channelId, entries: videos, timestamp })
     } catch (errMessage) {
       console.error(errMessage)
@@ -139,11 +124,7 @@ const actions = {
 
   async updateSubscriptionPostsCacheByChannel({ commit }, { channelId, posts, timestamp = new Date() }) {
     try {
-      await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId({
-        channelId,
-        entries: posts,
-        timestamp,
-      })
+      await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId(channelId, posts, timestamp)
       commit('updatePostsCacheByChannel', { channelId, entries: posts, timestamp })
     } catch (errMessage) {
       console.error(errMessage)


### PR DESCRIPTION
# Pass arguments to data stores normally to avoid extra objects

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

- [x] Performance improvement
- [x] Refactoring

## Description

This pull request refactors some of the datastore methods to accept normal arguments instead of objects, this avoid creating extra objects and results in more efficient code. As an added benefit this also shaves a few bytes off the bundles (`main.js` -50 bytes, `renderer.js`: -338 bytes and `web.js`: -676 bytes).

In a follow up pull request (it'll conflict with this one, so I'll open it after this has been merged) I'll refactor the web datastores to re-export most of the base datastores, as only the settings one differs from its base class, that should provide another small performance and bundle size improvement to FreeTube Android (it's based on the web/non-electron build).

## Testing

Refresh your subscriptions and check that the caches are updated correctly.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** cfc2d62f0bfc38257bfdd60a7d06d24763fa0011