### PR TITLE
Fix stats button text color on some themes

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -67,7 +67,7 @@
   color: var(--side-nav-hover-text-color) !important;
 }
 
-:deep(.shaka-current-selection-span) {
+:deep(.shaka-overflow-menu-only .shaka-current-selection-span) {
   color: var(--tertiary-text-color) !important;
 }
 


### PR DESCRIPTION
# Fix stats button text color on some themes

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
bug introduced in #6213

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The text color change introduced in #6213 inadvertently also applies to the text in the Stats button, which can render it nearly invisible depending on your theme. This PR makes it so that the text color change applies only to the intended texts in the overflow menu.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
**Before:**
<img width="521" alt="Screen Shot 2024-12-09 at 11 28 20 am" src="https://github.com/user-attachments/assets/1d366143-22c4-4dd3-a679-a29c4ad73d3c" />
**After:**
<img width="275" alt="Screen Shot 2024-12-17 at 10 28 35 pm" src="https://github.com/user-attachments/assets/2ae70164-0ba0-4209-85ad-6e86af5a1d78" />


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 10.13.6
- **FreeTube version:** ff15d83bc1ce9c3484d47b74e75a3ee66d926494

## Additional context
<!-- Add any other context about the pull request here. -->
