### PR TITLE
Add missing release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,28 @@ jobs:
         asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage
         asset_content_type: application/vnd.appimage
 
+    - name: Upload AppImage ARMv7l Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.AppImage
+        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-armv7l.AppImage
+        asset_content_type: application/vnd.appimage
+
+    - name: Upload AppImage ARM64 Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage
+        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage
+        asset_content_type: application/vnd.appimage
+
     - name: Upload Linux .zip x64 Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
@@ -371,3 +393,47 @@ jobs:
         asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-mac-arm64.7z
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-mac.7z
         asset_content_type: application/x-7z-compressed
+
+    - name: Upload Alpine .apk x64 Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-alpine-amd64.apk
+        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.apk
+        asset_content_type: application/octet-stream
+
+    - name: Upload Alpine .apk ARMv7l Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-alpine-armv7l.apk
+        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.apk
+        asset_content_type: application/octet-stream
+
+    - name: Upload Alpine .apk ARM64 Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-alpine-arm64.apk
+        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.apk
+        asset_content_type: application/octet-stream
+
+    - name: Upload Pacman .pacman x64 Release
+      uses: actions/upload-release-asset@v1
+      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-amd64.pacman
+        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.pacman
+        asset_content_type: application/x-zstd-compressed-tar


### PR DESCRIPTION
# Add missing release builds

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/6157

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR adds the following release builds:
- AppImage ARMv7l
- AppImage ARM64
- Alpine .apk x64
- Alpine .apk ARMv7l
- Alpine .apk ARM64
- Pacman .pacman x64

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
As this is a release workflow im not sure how to properly test it. This should just work out of the box. Almost everything could be taken over from the nightly build workflow. The only thing im worried about is the `asset_content_type` for the Pacman build, that was the only real thing i had to figure out as there were varying answers online.

## Additional context
<!-- Add any other context about the pull request here. -->
This journey is only part one of many PR's (well i hope not too many) to come on this subject and has been triggered by @PikachuEXE PR. I noticed that we had more nightly builds than release builds so i went on a quest to provide these missing builds to users so they wouldnt need to use the nightly builds.
