### PR TITLE
Build name convention standardization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,91 +117,91 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_x64
+        name: freetube-${{ steps.versionNumber.outputs.result }}-linux-x64-portable.zip
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.zip
 
     - name: Upload Linux .7z x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_x64.7z
+        name: freetube-${{ steps.versionNumber.outputs.result }}-linux-x64-portable.7z
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.7z
 
     - name: Upload Linux .zip ARMv7l Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_armv7l
+        name: freetube-${{ steps.versionNumber.outputs.result }}-linux-armv7l-portable.zip
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.zip
 
     - name: Upload Linux .7z ARMv7l Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_armv7l.7z
+        name: freetube-${{ steps.versionNumber.outputs.result }}-linux-armv7l-portable.7z
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.7z
 
     - name: Upload Linux .zip ARM64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_arm64
+        name: freetube-${{ steps.versionNumber.outputs.result }}-linux-arm64-portable.zip
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.zip
 
     - name: Upload Linux .7z ARM64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_linux_portable_arm64.7z
+        name: freetube-${{ steps.versionNumber.outputs.result }}-linux-arm64-portable.7z
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.7z
 
     - name: Upload .deb x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_amd64.deb
+        name: freetube-${{ steps.versionNumber.outputs.result }}-amd64.deb
         path: build/freetube_${{ steps.versionNumber.outputs.result }}_amd64.deb
 
     - name: Upload .deb ARMv7l Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_armv7l.deb
+        name: freetube-${{ steps.versionNumber.outputs.result }}-armv7l.deb
         path: build/freetube_${{ steps.versionNumber.outputs.result }}_armv7l.deb
 
     - name: Upload .deb ARM64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_arm64.deb
+        name: freetube-${{ steps.versionNumber.outputs.result }}-arm64.deb
         path: build/freetube_${{ steps.versionNumber.outputs.result }}_arm64.deb
 
     - name: Upload AppImage x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_amd64.AppImage
+        name: freetube-${{ steps.versionNumber.outputs.result }}-amd64.AppImage
         path: build/FreeTube-${{ steps.versionNumber.outputs.result }}.AppImage
 
     - name: Upload AppImage ARMv7l Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_armv7l.AppImage
+        name: freetube-${{ steps.versionNumber.outputs.result }}-armv7l.AppImage
         path: build/FreeTube-${{ steps.versionNumber.outputs.result }}-armv7l.AppImage
 
     - name: Upload AppImage ARM64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_arm64.AppImage
+        name: freetube-${{ steps.versionNumber.outputs.result }}-arm64.AppImage
         path: build/FreeTube-${{ steps.versionNumber.outputs.result }}-arm64.AppImage
 
     - name: Upload .rpm x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_amd64.rpm
+        name: freetube-${{ steps.versionNumber.outputs.result }}-amd64.rpm
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.x86_64.rpm
 
     # rpm are not built for armv7l
@@ -210,42 +210,42 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_arm64.rpm
+        name: freetube-${{ steps.versionNumber.outputs.result }}-arm64.rpm
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.aarch64.rpm
 
     - name: Upload Alpine .apk x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_alpine_amd64.apk
+        name: freetube-${{ steps.versionNumber.outputs.result }}-alpine-amd64.apk
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.apk
 
     - name: Upload Alpine .apk ARMv7l Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_alpine_armv7l.apk
+        name: freetube-${{ steps.versionNumber.outputs.result }}-alpine-armv7l.apk
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.apk
 
     - name: Upload Alpine .apk ARM64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_alpine_arm64.apk
+        name: freetube-${{ steps.versionNumber.outputs.result }}-alpine-arm64.apk
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.apk
 
     - name: Upload Pacman .pacman x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
-        name: freetube_${{ steps.versionNumber.outputs.result }}_amd64.pacman
+        name: freetube-${{ steps.versionNumber.outputs.result }}-amd64.pacman
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.pacman
 
     # - name: Upload Web Build
       # uses: actions/upload-artifact@v4
       # if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       # with:
-        # name: freetube_${{ steps.versionNumber.outputs.result }}_static_web
+        # name: freetube-${{ steps.versionNumber.outputs.result }}-static-web
         # path: dist/web
 
     - name: Upload Windows x64 .exe Artifact
@@ -266,7 +266,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
       with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-win-x64-portable
+        name: freetube-${{ steps.versionNumber.outputs.result }}-win-x64-portable.zip
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-win.zip
 
     - name: Upload Windows x64 .7z Artifact
@@ -280,7 +280,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-win-arm64-portable
+        name: freetube-${{ steps.versionNumber.outputs.result }}-win-arm64-portable.zip
         path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64-win.zip
 
     - name: Upload Windows arm64 .7z Artifact
@@ -294,14 +294,14 @@ jobs:
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
       with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-portable-x64.exe
+        name: freetube-${{ steps.versionNumber.outputs.result }}-win-x64-portable.exe
         path: build/freetube ${{ steps.versionNumber.outputs.result }}.exe
 
     - name: Upload Windows arm64 Portable Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-portable-arm64.exe
+        name: freetube-${{ steps.versionNumber.outputs.result }}-win-arm64-portable.exe
         path: build/freetube ${{ steps.versionNumber.outputs.result }}.exe
 
     - name: Upload Mac x64 .dmg Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_amd64.AppImage
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-amd64.AppImage
         asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage
         asset_content_type: application/vnd.appimage
 
@@ -102,7 +102,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-portable-x64.zip
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-x64-portable.zip
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.zip
         asset_content_type: application/zip
 
@@ -113,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-portable-x64.7z
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-x64-portable.7z
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.7z
         asset_content_type: application/x-7z-compressed
 
@@ -124,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-portable-armv7l.zip
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-armv7l-portable.zip
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.zip
         asset_content_type: application/zip
 
@@ -135,7 +135,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-portable-armv7l.7z
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-armv7l-portable.7z
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.7z
         asset_content_type: application/x-7z-compressed
 
@@ -146,7 +146,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-portable-arm64.zip
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-arm64-portable.zip
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.zip
         asset_content_type: application/zip
 
@@ -157,7 +157,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-portable-arm64.7z
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-linux-arm64-portable.7z
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.7z
         asset_content_type: application/x-7z-compressed
 
@@ -168,7 +168,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_amd64.deb
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-amd64.deb
         asset_path: build/freetube_${{ steps.getPackageInfo.outputs.version }}_amd64.deb
         asset_content_type: application/vnd.debian.binary-package
 
@@ -179,7 +179,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_armv7l.deb
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.deb
         asset_path: build/freetube_${{ steps.getPackageInfo.outputs.version }}_armv7l.deb
         asset_content_type: application/vnd.debian.binary-package
 
@@ -190,7 +190,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_arm64.deb
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.deb
         asset_path: build/freetube_${{ steps.getPackageInfo.outputs.version }}_arm64.deb
         asset_content_type: application/vnd.debian.binary-package
 
@@ -201,7 +201,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_amd64.rpm
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-amd64.rpm
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.x86_64.rpm
         asset_content_type: application/x-rpm
 
@@ -214,7 +214,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ secrets.UPLOAD_ID }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_arm64.rpm
+        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.rpm
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.aarch64.rpm
         asset_content_type: application/x-rpm
 


### PR DESCRIPTION
# Build name convention standardization

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/6415

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR changes the following:
-  We were using a mix match of hyphens and underscores so this changes all builds to use hyphens instead of underscores. Why hyphens? Most release builds were using hyphens and for nightly builds it was about 50/50 so i opted for hyphens as most normal users (the ones that use release builds) are used to seeing hyphens.
- Some build names didnt include the .zip extension so i added them
- if file name contains portable then the following structure is used, platform-architecture-portable. There was a mix of this structure and platform-portable-architecture being used.


## Additional context
<!-- Add any other context about the pull request here. -->
I will create a PR for our website that will pull the now adjusted release builds. That PR will be drafted as it should be merged right before release.

This is part 2 of making changes in these workflow. 
Upcoming parts:
- Part 3: Group all builds based on platform
- Part 4: Investigate if all builds have .zip and .7z equivalents