### PR TITLE
Filter our members-only section on channel home pages

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -888,12 +888,18 @@ export function parseChannelHomeTab(homeTab) {
       if (itemSection.contents.at(0).type === 'Shelf') {
         /** @type {import('youtubei.js').YTNodes.Shelf} */
         const shelf = itemSection.contents.at(0)
-        shelves.push({
-          title: shelf.title.text,
-          content: shelf.content.items.map(parseListItem).filter(_ => _),
-          playlistId: shelf.play_all_button?.endpoint.payload.playlistId,
-          subtitle: shelf.subtitle?.text
-        })
+
+        const playlistId = shelf.play_all_button?.endpoint.payload.playlistId
+
+        // filter out the members-only video section as none of the videos in that section are playable as they require a paid channel membership
+        if (!playlistId || !playlistId.startsWith('UUMO')) {
+          shelves.push({
+            title: shelf.title.text,
+            content: shelf.content.items.map(parseListItem).filter(_ => _),
+            playlistId,
+            subtitle: shelf.subtitle?.text
+          })
+        }
       } else if (itemSection.contents.at(0).type === 'ReelShelf') {
         /** @type {import('youtubei.js').YTNodes.ReelShelf} */
         const shelf = itemSection.contents.at(0)


### PR DESCRIPTION
# Filter our members-only section on channel home pages

## Pull Request Type

- [x] Other

## Related issue


## Description

On channels that support paid memberships YouTube displays a members-only videos section on the home tab based on the auto-generated channel members-only playlist. As none of the videos in that section can be played in FreeTube I think it makes sense to hide it. As YouTube doesn't show those videos in search results or on the videos channel tab, the channel home tab is the most likely place for people to discover them (unless the video is explicitly mentioned in a public community post).

On YouTube itself it makes sense to show that section as logged in users just need to sign up for the channel membership and can view the videos but as we don't support logging in with a YouTube account in FreeTube and don't plan to either, I don't think it makes sense to make it easier for the user to find videos that they can't play.

## Screenshots
### Before
![before](https://github.com/user-attachments/assets/60b9c407-5322-4904-a29e-87d51a5ed1b2)

### After
![after](https://github.com/user-attachments/assets/3337f34c-208e-4583-b983-86f8eb93c454)

## Testing

Visit https://youtube.com/@LinusTechTips and check that the member-only section is hidden.

## Desktop

- **OS:**
- **OS Version:**
- **FreeTube version:**