### PR TITLE
A few minor performance improvements

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,6 +96,9 @@ export default [
       'unicorn/prefer-keyboard-event-key': 'error',
       'unicorn/prefer-regexp-test': 'error',
       'unicorn/prefer-string-replace-all': 'error',
+      'unicorn/prefer-optional-catch-binding': 'error',
+      'unicorn/prefer-date-now': 'error',
+      'unicorn/prefer-array-index-of': 'error',
       '@intlify/vue-i18n/no-dynamic-keys': 'error',
       '@intlify/vue-i18n/no-duplicate-keys-in-locale': 'error',
 
@@ -222,6 +225,9 @@ export default [
       'no-console': 'off',
       'n/no-path-concat': 'off',
       'unicorn/better-regex': 'error',
+      'unicorn/prefer-optional-catch-binding': 'error',
+      'unicorn/prefer-date-now': 'error',
+      'unicorn/prefer-array-index-of': 'error',
     }
   },
   {
@@ -242,6 +248,9 @@ export default [
       '@stylistic/comma-dangle': ['error', 'only-multiline'],
       'n/no-path-concat': 'off',
       'unicorn/better-regex': 'error',
+      'unicorn/prefer-optional-catch-binding': 'error',
+      'unicorn/prefer-date-now': 'error',
+      'unicorn/prefer-array-index-of': 'error',
     }
   }
 ]

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -752,7 +752,7 @@ export default defineComponent({
         viewCount: this.viewCount,
         lengthSeconds: this.data.lengthSeconds,
         watchProgress: 0,
-        timeWatched: new Date().getTime(),
+        timeWatched: Date.now(),
         isLive: false,
         type: 'video'
       }

--- a/src/renderer/components/ft-prompt/ft-prompt.js
+++ b/src/renderer/components/ft-prompt/ft-prompt.js
@@ -120,9 +120,7 @@ export default defineComponent({
       }
     },
     arrowKeys: function(e) {
-      const currentIndex = this.promptButtons.findIndex((cur) => {
-        return cur === e.target
-      })
+      const currentIndex = this.promptButtons.indexOf(e.target)
 
       // Only react if a button was focused when the arrow key was pressed
       if (currentIndex === -1) {
@@ -132,7 +130,7 @@ export default defineComponent({
       e.preventDefault()
 
       const direction = (e.key === 'ArrowLeft') ? -1 : 1
-      this.focusItem(parseInt(currentIndex) + direction)
+      this.focusItem(currentIndex + direction)
     },
 
     ...mapActions([

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -939,7 +939,7 @@ function setMultiplePublishedTimestamps(videos) {
  */
 function setPublishedTimestamp(video) {
   if (video.liveNow) {
-    video.published = new Date().getTime()
+    video.published = Date.now()
   } else if (video.isUpcoming) {
     video.published = video.premiereTimestamp * 1000
   } else if (typeof video.published === 'number') {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -92,7 +92,7 @@ export async function parseYouTubeRSSFeed(rssString, channelId) {
       name: channelName,
       videos: await Promise.all(promises)
     }
-  } catch (e) {
+  } catch {
     return {
       videos: []
     }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -614,7 +614,7 @@ export function getVideoParamsFromUrl(url) {
   const paramsObject = { videoId: null, timestamp: null, playlistId: null }
   try {
     urlObject = new URL(url)
-  } catch (e) {
+  } catch {
     return paramsObject
   }
 
@@ -756,7 +756,7 @@ export function getRelativeTimeFromDate(date, hideSeconds = false, useThirtyDayM
     return ''
   }
 
-  const now = new Date().getTime()
+  const now = Date.now()
   // Convert from ms to second
   // For easier code interpretation the value is made to be positive
   let timeDiffFromNow = ((now - date) / 1000)

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -93,7 +93,7 @@ const actions = {
     payload.lastUpdatedAt = Date.now()
     // Ensure all videos has required attributes
 
-    const currentTime = new Date().getTime()
+    const currentTime = Date.now()
 
     if (Array.isArray(payload.videos)) {
       payload.videos.forEach(videoData => {
@@ -173,7 +173,7 @@ const actions = {
     try {
       const { _id, videoData } = payload
       if (videoData.timeAdded == null) {
-        videoData.timeAdded = new Date().getTime()
+        videoData.timeAdded = Date.now()
       }
       if (videoData.playlistItemId == null) {
         videoData.playlistItemId = generateRandomUniqueId()
@@ -195,7 +195,7 @@ const actions = {
     try {
       const { _id, videos } = payload
 
-      const currentTime = new Date().getTime()
+      const currentTime = Date.now()
 
       const newVideoObjects = videos.map((video) => {
         // Create a new object to prevent changing existing values outside
@@ -241,7 +241,7 @@ const actions = {
         })
       } else {
         const dateNow = Date.now()
-        const currentTime = new Date().getTime()
+        const currentTime = Date.now()
 
         payload.forEach((playlist) => {
           let anythingUpdated = false

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1058,7 +1058,7 @@ export default defineComponent({
         viewCount: this.videoViewCount,
         lengthSeconds: this.videoLengthSeconds,
         watchProgress: watchProgress,
-        timeWatched: new Date().getTime(),
+        timeWatched: Date.now(),
         isLive: false,
         type: 'video',
       }


### PR DESCRIPTION
# A few minor performance improvements

## Pull Request Type

- [x] Performance improvements

## Description

This pull request contains a few minor performance improvements and adds eslint rules from eslint-plugin-unicorn to enforce them. Such as:
- Use `Date.now()` instead of `new Date().getTime()` to avoid creating unnecessary `Date` objects
- Use `Array#indexOf()` instead of `Array#findIndex()` when possible to avoid creating the extra function and the extra function calls.
- Don't declare a variable for the error object in `try-catch` when we don't need the error object.

I also got rid of an unnecessary `parseInt` call in `ft-prompt` as it is called on the result of an `Array#indexOf()` call, which always returns numbers, so there is no need to convert it to a string and then back to a number.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 66936543244d4b1847152700ddcf3c55cbe7c723