### PR TITLE
Make Cmd left/right go back/forward

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -127,6 +127,8 @@ const KeyboardShortcuts = {
       SHOW_SHORTCUTS: 'shift+?',
       HISTORY_BACKWARD: 'alt+arrowleft',
       HISTORY_FORWARD: 'alt+arrowright',
+      HISTORY_BACKWARD_ALT_MAC: 'cmd+arrowleft',
+      HISTORY_FORWARD_ALT_MAC: 'cmd+arrowright',
       FULLSCREEN: 'f11',
       NAVIGATE_TO_SETTINGS: 'ctrl+,',
       NAVIGATE_TO_HISTORY: 'ctrl+H',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1702,6 +1702,20 @@ function runApp() {
             },
             type: 'normal',
           },
+          ...(process.platform === 'darwin'
+            ? [
+                {
+                  label: 'Back',
+                  accelerator: 'Cmd+Left',
+                  click: (_menuItem, browserWindow, _event) => {
+                    if (browserWindow == null) { return }
+
+                    browserWindow.webContents.navigationHistory.goBack()
+                  },
+                  visible: false,
+                },
+              ]
+            : []),
           {
             label: 'Forward',
             accelerator: 'Alt+Right',
@@ -1712,6 +1726,20 @@ function runApp() {
             },
             type: 'normal',
           },
+          ...(process.platform === 'darwin'
+            ? [
+                {
+                  label: 'Forward',
+                  accelerator: 'Cmd+Right',
+                  click: (_menuItem, browserWindow, _event) => {
+                    if (browserWindow == null) { return }
+
+                    browserWindow.webContents.navigationHistory.goForward()
+                  },
+                  visible: false,
+                },
+              ]
+            : []),
         ]
       },
       {

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -115,6 +115,14 @@ const localizedShortcutNameDictionary = computed(() => {
     ['SHOW_SHORTCUTS', t('KeyboardShortcutPrompt.Show Keyboard Shortcuts')],
     ['HISTORY_BACKWARD', t('KeyboardShortcutPrompt.History Backward')],
     ['HISTORY_FORWARD', t('KeyboardShortcutPrompt.History Forward')],
+    ...(
+      isMac
+        ? [
+            ['HISTORY_BACKWARD_ALT_MAC', t('KeyboardShortcutPrompt.History Backward (Mac only)')],
+            ['HISTORY_FORWARD_ALT_MAC', t('KeyboardShortcutPrompt.History Forward (Mac only)')],
+          ]
+        : []
+    ),
     ['FULLSCREEN', t('KeyboardShortcutPrompt.Fullscreen')],
     ['NAVIGATE_TO_SETTINGS', t('KeyboardShortcutPrompt.Navigate to Settings')],
     (

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -101,16 +101,26 @@ export default defineComponent({
     },
 
     forwardText: function () {
+      const shortcuts = [KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD]
+      if (process.platform === 'darwin') {
+        shortcuts.push(KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD_ALT_MAC)
+      }
+
       return localizeAndAddKeyboardShortcutToActionTitle(
         this.$t('Forward'),
-        KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD
+        shortcuts,
       ) + this.navigationHistoryAddendum
     },
 
     backwardText: function () {
+      const shortcuts = [KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD]
+      if (process.platform === 'darwin') {
+        shortcuts.push(KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD_ALT_MAC)
+      }
+
       return localizeAndAddKeyboardShortcutToActionTitle(
         this.$t('Back'),
-        KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD
+        shortcuts,
       ) + this.navigationHistoryAddendum
     },
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1021,10 +1021,14 @@ export function addKeyboardShortcutToActionTitle(actionTitle, shortcut) {
 
 /**
  * @param {string} localizedActionTitle
- * @param {string} unlocalizedShortcut
+ * @param {string|string[]} sometimesManyUnlocalizedShortcuts
  * @returns {string} the localized action title with keyboard shortcut
  */
-export function localizeAndAddKeyboardShortcutToActionTitle(localizedActionTitle, unlocalizedShortcut) {
-  const localizedShortcut = getLocalizedShortcut(unlocalizedShortcut)
-  return addKeyboardShortcutToActionTitle(localizedActionTitle, localizedShortcut)
+export function localizeAndAddKeyboardShortcutToActionTitle(localizedActionTitle, sometimesManyUnlocalizedShortcuts) {
+  let unlocalizedShortcuts = sometimesManyUnlocalizedShortcuts
+  if (!Array.isArray(sometimesManyUnlocalizedShortcuts)) {
+    unlocalizedShortcuts = [unlocalizedShortcuts]
+  }
+  const localizedShortcuts = unlocalizedShortcuts.map((s) => getLocalizedShortcut(s))
+  return addKeyboardShortcutToActionTitle(localizedActionTitle, localizedShortcuts.join('/'))
 }

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1146,6 +1146,8 @@ KeyboardShortcutPrompt:
   Show Keyboard Shortcuts: Show keyboard shortcuts
   History Backward: Go back one page
   History Forward: Go forward one page
+  History Backward (Mac only): Go back one page (Mac only)
+  History Forward (Mac only): Go forward one page (Mac only)
   New Window: Create a new window
   Navigate to Settings: Navigate to the Settings page
   Navigate to History: Navigate to the History page


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/5966

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
For **MacOS only**, make Cmd left/right as an additional keyboard shortcut to go back/forward in history

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![image](https://github.com/user-attachments/assets/8123843b-bcf3-4724-b5ff-07eb6bb798c4)
![image](https://github.com/user-attachments/assets/6a6efbee-9155-4d1f-85e1-f25ed5374748)


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Ensure existing back/forward shortcuts working (All OS) (Alt Left/Right)
- Ensure **new** back/forward shortcuts working (macOS only) (Cmd Left/Right)
- Ensure tooltip on back/forward buttons unchanged (non macOS only)
- Ensure tooltip on back/forward buttons updated (macOS only)
- Open keyboard modal, ensure shortcuts unchanged (non macOS only)
- Open keyboard modal, ensure shortcut list updated (MacOS only)

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
