### PR TITLE
Disable store strict mode, due to performance problems because of the amount of data in the store

### DIFF
--- a/src/renderer/store/index.js
+++ b/src/renderer/store/index.js
@@ -8,7 +8,11 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   modules,
-  strict: process.env.NODE_ENV !== 'production'
+
+  // Detects unsafe changes to the store state e.g. outside of mutations
+  // but we have to turn it off despite its usefulness as we have so much data in the store
+  // that it causes a noticable slow-down :(
+  strict: false
 
   // TODO: Enable when deploy
   // plugins: [createPersistedState()]

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -47,7 +47,7 @@ function profileSort(a, b) {
 }
 
 const actions = {
-  async grabAllProfiles({ rootState, commit }, defaultName = null) {
+  async grabAllProfiles({ rootState, commit, state }, defaultName = null) {
     let profiles
     try {
       profiles = await DBProfileHandlers.find()


### PR DESCRIPTION
# Disable store strict mode, due to performance problems because of the amount of data in the store

## Pull Request Type

- [x] Other - Refactor

## Related issue

https://github.com/FreeTubeApp/FreeTube/pull/6414#issuecomment-2564401808
https://github.com/FreeTubeApp/FreeTube/pull/6414#issuecomment-2559320728

## Description

Vuex's strict mode is intended to warn you about modifications to the store state outside of mutations as those are unsafe and can cause problems with the changes not getting tracked and propagated properly. However as it works by adding a deep watcher to the store, the performance impact it has is directly connected to the amount of data in the store and the amount of reads and writes that you do, unfortunately we have reached a point where we have so much data in the store (and are planning to keep adding more, with it being unlikely that we will scale back (removing features anyone?)), that it causes noticable slow downs.

This pull request disables those safety checks in vuex to get the performance back to an acceptable level but we just need to be more careful when writing code that interacts with the store, as we won't get "automated" warnings anymore about unsafe code.

I also fixed the `grabAllProfiles` action accessing the state in the wrong way.

## Testing

1. `yarn dev`
2. It should be faster

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 70b616a3917215033dfb6047a0566961e45d6f2d