### PR TITLE
Detect and properly error on DRM protected videos

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -376,7 +376,7 @@ export default defineComponent({
 
         // extract localised title first and fall back to the not localised one
         this.videoTitle = result.primary_info?.title.text ?? result.basic_info.title
-        this.videoViewCount = result.basic_info.view_count ?? extractNumberFromString(result.primary_info.view_count.text)
+        this.videoViewCount = result.basic_info.view_count ?? (result.primary_info.view_count ? extractNumberFromString(result.primary_info.view_count.text) : 0)
 
         this.channelId = result.basic_info.channel_id ?? result.secondary_info.owner?.author.id
         this.channelName = result.basic_info.author ?? result.secondary_info.owner?.author.name
@@ -509,7 +509,9 @@ export default defineComponent({
         // The apostrophe is intentionally that one (char code 8217), because that is the one YouTube uses
         const BOT_MESSAGE = 'Sign in to confirm you’re not a bot'
 
-        if (playabilityStatus.status === 'UNPLAYABLE' || playabilityStatus.status === 'LOGIN_REQUIRED') {
+        const isDrmProtected = result.streaming_data?.adaptive_formats.some(format => format.drm_families || format.drm_track_type)
+
+        if (playabilityStatus.status === 'UNPLAYABLE' || playabilityStatus.status === 'LOGIN_REQUIRED' || isDrmProtected) {
           if (playabilityStatus.error_screen?.offer_id === 'sponsors_only_video') {
             // Members-only videos can only be watched while logged into a Google account that is a paid channel member
             // so there is no point trying any other backends as it will always fail
@@ -522,6 +524,13 @@ export default defineComponent({
             // Age-restricted videos can only be watched while logged into a Google account that is age-verified
             // so there is no point trying any other backends as it will always fail
             this.errorMessage = this.$t('Video.AgeRestricted')
+            this.isLoading = false
+            this.updateTitle()
+            return
+          } else if (isDrmProtected) {
+            // DRM protected videos (e.g. movies) cannot be played in FreeTube,
+            // as they require the proprietary and closed source Wideview CDM which is understandably not included in standard Electron builds
+            this.errorMessage = this.$t('Video.DRMProtected')
             this.isLoading = false
             this.updateTitle()
             return

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -806,6 +806,7 @@ Video:
   IP block: 'YouTube has blocked your IP address from watching videos. Please try switching to a different VPN or proxy.'
   MembersOnly: Members-only videos cannot be watched with FreeTube as they require Google login and paid membership to the uploader's channel.
   AgeRestricted: Age-restricted videos cannot be watched with FreeTube as they require Google login and using an age-verified YouTube account.
+  DRMProtected: DRM protected videos cannot be played in FreeTube, as they require proprietary, closed source components. If you want to watch this video please watch it on the official YouTube website in a DRM enabled web browser.
   More Options: More Options
   Mark As Watched: Mark As Watched
   Remove From History: Remove From History


### PR DESCRIPTION
# Detect and properly error on DRM protected videos

## Pull Request Type

- [x] Bugfix

## Related issue

- closes #6346

## Description

DRM protected videos cannot be played in FreeTube as that requires the proprietary, closed source Widevine CDM and a VPM signed build of Electron, both things which are understandably not included in the standard open source Electron builds. This pull request adds support for FreeTube to detect such videos and show a user friendly message (instead it attempting and failing to play the DRM protected content).

Unfortunately the movie trailers are unlisted videos, so we can't just find the trailer some other way if it isn't included in the API response like they are for movies that are not free with ads.

## Screenshots

![screenshot-drm-message](https://github.com/user-attachments/assets/8abc74aa-4509-468b-9c07-112c75aedfcf)

## Testing

1. Find a free with ads movie (e.g. https://youtu.be/3fE5uTeBGUM in the US, provided in the linked issue)
2. Visit the page on the local API, you should see the same message as in the screenshot

## Desktop

- **OS:**
- **OS Version:**
- **FreeTube version:**