### PR TITLE
Hide Electron-only UI scale setting outside of Electron

### DIFF
--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -39,18 +39,20 @@
         />
       </div>
     </div>
-    <FtFlexBox>
-      <FtSlider
-        :label="$t('Settings.Theme Settings.UI Scale')"
-        :default-value="uiScale"
-        :min-value="50"
-        :max-value="300"
-        :step="5"
-        value-extension="%"
-        @change="updateUiScale(parseInt($event))"
-      />
-    </FtFlexBox>
-    <br>
+    <template v-if="usingElectron">
+      <FtFlexBox>
+        <FtSlider
+          :label="$t('Settings.Theme Settings.UI Scale')"
+          :default-value="uiScale"
+          :min-value="50"
+          :max-value="300"
+          :step="5"
+          value-extension="%"
+          @change="updateUiScale"
+        />
+      </FtFlexBox>
+      <br>
+    </template>
     <FtFlexBox>
       <FtSelect
         :placeholder="$t('Settings.Theme Settings.Base Theme.Base Theme')"


### PR DESCRIPTION
# Hide Electron-only UI scale setting outside of Electron

## Pull Request Type

- [x] Bugfix

## Related issue

- https://github.com/MarmadileManteater/FreeTubeAndroid/issues/460

## Description

FreeTube's UI scale setting only works in Electron as it sets the zoom level of the window through an Electron API, so we should hide it outside of Electron (e.g. FreeTubeAndroid). I also remove the unnecessary call to parseInt, as the value in `ft-slider`'s change emit is already a number.

https://github.com/FreeTubeApp/FreeTube/blob/b01abad5c35097d80a2088e66ababbc8f14bc76a/src/renderer/store/modules/settings.js#L411-L420

## Testing
1. `yarn dev`
2. Check that the setting still shows up
3. `yarn dev:web`
4. Check that the setting is hidden

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b01abad5c35097d80a2088e66ababbc8f14bc76a