### PR TITLE
Remove buggy VA-API on Linux flag

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -209,14 +209,6 @@ function runApp() {
   let mainWindow
   let startupUrl
 
-  if (process.platform === 'linux') {
-    // Enable hardware acceleration via VA-API with OpenGL if no other feature flags are found
-    // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/vaapi.md
-    if (!app.commandLine.hasSwitch('enable-features')) {
-      app.commandLine.appendSwitch('enable-features', 'VaapiVideoDecodeLinuxGL')
-    }
-  }
-
   const userDataPath = app.getPath('userData')
 
   // command line switches need to be added before the app ready event first


### PR DESCRIPTION
# Remove buggy VA-API on Linux flag

## Pull Request Type

- [x] Bugfix

## Related issue

- closes #5975
- closes #6274
- #6457

## Description

We added the VA-API flag to enable hardware acceleration on more Linux devices, however as it is causing the video player to crash for quite a few users and broken video output for others, the feature is clearly not ready to be enabled by default in FreeTube. Users that have a setup that supports VA-API and it doesn't cause FreeTube to break can still manually pass this flag on the command line when running FreeTube.

We can reconsider re-adding it in the future when it is more stable, although when Chromium considers it stable enough, they will probably enable it by default anyway.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b01abad5c35097d80a2088e66ababbc8f14bc76a