### PR TITLE
Fix `ft-share-button` when the window width is below `900`

### DIFF
--- a/src/renderer/components/ft-icon-button/ft-icon-button.js
+++ b/src/renderer/components/ft-icon-button/ft-icon-button.js
@@ -153,7 +153,7 @@ export default defineComponent({
     },
 
     handleDropdownFocusOut: function () {
-      if (this.dropdownShown && !this.$refs.ftIconButton.matches(':focus-within')) {
+      if (!this.useModal && this.dropdownShown && !this.$refs.ftIconButton.matches(':focus-within')) {
         this.dropdownShown = false
       }
     },


### PR DESCRIPTION
# Fix `ft-share-button` when the window width is below `900`

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The `ft-share-button` doesn't show its prompt properly when the window width is below `900`. The `handleDropdownFocusOut` function is called when the prompt is shown causing it to immediately hide. The result is that it seems like the ft-share-button doesn't work on mobile. This PR addresses this by adding a check to the `handleDropdownFocusOut` function to not hide the dropdown if `useModal` is `true`.

## Screenshots <!-- If appropriate -->
|before|after|
|--|--|
|![before](https://github.com/user-attachments/assets/c0396b69-a6e4-4d94-bd02-d7289764e102)|![after](https://github.com/user-attachments/assets/329c68ee-aef5-4d9c-83f6-3a99f37fd2a4)|


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Find a video (or channel)
2. Reduce window width to below `900`
3. Click the share icon
4. Make sure the share prompt opens
