### PR TITLE
Improve audio quality by selecting highest audio bitrate

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1292,7 +1292,9 @@ export default defineComponent({
 
         chosenVariant = findMostSimilarAudioBandwidth(matches, audioBandwidth)
       } else {
-        chosenVariant = matches[0]
+        chosenVariant = matches.reduce((prev, current) => {
+          return (current.audioBandwidth > prev.audioBandwidth) ? current : prev
+        }, matches[0])
       }
 
       player.selectVariantTrack(chosenVariant)


### PR DESCRIPTION
# Improve audio quality by selecting stream with highest audio bitrate

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
#6138 

## Description
Select the stream with the highest audio bitrate. Improves the issue where FreeTube usually uses the lowest quality audio available, but does not fix it. This patch seems to work as long as you do not select a quality while watching a video. Selecting a quality (e.g. 1080p) specifically while watching a video will usually give you bad audio. See #6138 for more info. I don't know how to fix this issue in the general case, but at least this improves things.

## Testing <!-- for code that is not small enough to be easily understandable -->
Try watching videos with/without this patch, e.g. https://youtu.be/G4qVG_FL4_s

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.22.1 (1c3728ec699777c16b565b022753a255b1e5cc34 + this patch)