### PR TITLE
Add missing IPC constants

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -88,6 +88,7 @@ const SyncEvents = {
     CREATE: 'sync-create',
     UPSERT: 'sync-upsert',
     DELETE: 'sync-delete',
+    DELETE_MULTIPLE: 'sync-delete-multiple',
     DELETE_ALL: 'sync-delete-all'
   },
 
@@ -104,6 +105,7 @@ const SyncEvents = {
 
   PLAYLISTS: {
     UPSERT_VIDEO: 'sync-playlists-upsert-video',
+    UPSERT_VIDEOS: 'sync-playlists-upsert-videos',
     DELETE_VIDEO: 'sync-playlists-delete-video',
   },
 


### PR DESCRIPTION
# Add missing IPC constants

## Pull Request Type

- [x] Bugfix

## Description

This pull request adds two missing IPC constants `SyncEvents.GENERAL.DELETE_MULTIPLE` which is used by the subscription cache to remove the caches for unsubscribed channels and `SyncEvents.PLAYLISTS.UPSERT_VIDEOS`. I am not aware of any bug reports or problems directly caused by these issues, presumably it just used `undefined` instead and we got lucky that they didn't overlap.

As an added bonus this also reduces the size of the renderer.js file by 131 bytes. What?? "How did you add code but it got smaller??" To understand why you need to understand what terser (the JavaScript mimifier used by webpack) does with our constants.

When terser is able to statically determine that all accesses to the constants are read-only and static (no dynamic lookups, nothing that depends on them being wrapped in an object and no writes) it hoists them out of their objects into their own variables and rewrites to accesses to use those variables:

Simplified example:
```js
const TEST = {
  CONST1: {
   THE_VALUE: 'some-constant-value'
  }
}

console.log(TEST.CONST1.THE_VALUE)
console.log(TEST.CONST1.THE_VALUE)
```

```js
const a = 'some-constant-value'

console.log(a)
console.log(a)
```

But when we access a property that doesn't exist, terser bails out of the optimisation, it still hoists the `GENERAL` and `PLAYLISTS` properties into their own variables but their values stay as objects, because it can't safely say that the missing property won't be added later in some way (if you the developer specifically wrote an access for a property that doesn't currently exist on the object, you must know more information than what terser can see, so it bails out to avoid breaking things).

But why didn't it do it for the 'local' and 'invidious' constants that @ChunkyProgrammer was going to introduce in a PR a while back? I see two possible reasons, maybe it thought one of the accesses was dynamic so it would have been unsafe to hoist them or the number of references went over some internal threshold that made it think it would take too long to analyse and optimise.

## Testing

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 2e28c69b3f0d31298c41bac77262bbbe49ab2a1c