### PR TITLE
Use Date.now() and Date.parse() when a millisecond value is needed

### DIFF
--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -106,7 +106,6 @@ export async function parseYouTubeRSSFeed(rssString, channelId) {
  */
 async function parseRSSEntry(entry, channelId, channelName) {
   // doesn't need to be asynchronous, but doing it allows us to do the relatively slow DOM querying in parallel
-  const published = new Date(entry.querySelector('published').textContent)
 
   return {
     authorId: channelId,
@@ -114,7 +113,7 @@ async function parseRSSEntry(entry, channelId, channelName) {
     // querySelector doesn't support xml namespaces so we have to use getElementsByTagName here
     videoId: entry.getElementsByTagName('yt:videoId')[0].textContent,
     title: entry.querySelector('title').textContent,
-    published: published.getTime(),
+    published: Date.parse(entry.querySelector('published').textContent),
     viewCount: entry.getElementsByTagName('media:statistics')[0]?.getAttribute('views') || null,
     type: 'video',
     lengthSeconds: '0:00',

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -56,16 +56,16 @@ export function getIconForSortPreference(sortPreference) {
  * @param {Date|undefined} premiereDate
  */
 export function calculatePublishedDate(publishedText, isLive = false, isUpcoming = false, premiereDate = undefined) {
-  const date = new Date()
+  const now = Date.now()
 
   if (isLive) {
-    return date.getTime()
+    return now
   } else if (isUpcoming) {
     if (premiereDate) {
       return premiereDate.getTime()
     } else {
       // should never happen but just to be sure that we always return a number
-      return date.getTime()
+      return now
     }
   }
 
@@ -97,7 +97,7 @@ export function calculatePublishedDate(publishedText, isLive = false, isUpcoming
     timeSpan = timeAmount * 31556952000
   }
 
-  return date.getTime() - timeSpan
+  return now - timeSpan
 }
 
 /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -397,10 +397,10 @@ export default defineComponent({
 
         if (result.page[0].microformat?.publish_date) {
           // `result.page[0].microformat.publish_date` example value: `2023-08-12T08:59:59-07:00`
-          this.videoPublished = new Date(result.page[0].microformat.publish_date).getTime()
+          this.videoPublished = Date.parse(result.page[0].microformat.publish_date)
         } else {
           // text date Jan 1, 2000, not as accurate but better than nothing
-          this.videoPublished = new Date(result.primary_info.published).getTime()
+          this.videoPublished = Date.parse(result.primary_info.published)
         }
 
         if (result.secondary_info?.description.runs) {


### PR DESCRIPTION
# Use Date.now() and Date.parse() when a millisecond value is needed

## Pull Request Type

- [x] Performance improvement

## Description

At the moment when we need to parse a date but get the millisecond value from it we call the `Date()` constructor and then call `.getTime()` on it, in this pull request we instead use `Date.parse()` which uses the same string date parsing algorithm as the `Date()` constructor but directly produces a number of milliseconds. I also fixed another instance of using the `Date()` constructor without any arguments and then calling `.getTime()` on it, which wasn't caught by the linter (presumably because it was split up and `.getTime()` was called multiple times).

## Testing
1. Refresh your subscriptions with RSS enabled and check that the published dates show up.
2. Visit any page that has lists of videos with the local API and check that the published dates show up (e.g. search, trending, channel pages).
3. Open a video and check that the published date shows up in the video info section.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d4ad95bf70a45738281f66abbbf21907c7e5b073