### PR TITLE
Fix second to last tooltip overflowing due to our wide player controls

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -296,6 +296,17 @@
   :deep(.shaka-tooltips-on button:hover::after) {
     margin-bottom: 8px;
   }
+
+  /*
+    similar to the styling that shaka-player applies with last-child
+    needed as we have made the controls a lot wider than they were intended to be :/
+   */
+  :deep(.shaka-tooltips-on button:nth-last-child(2):active::after),
+  :deep(.shaka-tooltips-on button:nth-last-child(2):focus-visible::after),
+  :deep(.shaka-tooltips-on button:nth-last-child(2):hover::after) {
+    left: 32px;
+    transform: translateX(-80%);
+  }
 }
 
 @media only screen and (width <=1350px) {


### PR DESCRIPTION
# Fix second to last tooltip overflowing due to our wide player controls

## Pull Request Type

- [x] Bugfix

## Related issue

- #6007
- closes #6331
- closes #6336

## Description

Fixes the second to last player tooltip overflowing.

## Screenshots

![tooltip](https://github.com/user-attachments/assets/d1ba4fba-e5d7-4d54-a6c4-fad15ad6fe8b)

## Testing

Open a video and decide if it looks better.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** eec8c7fbcfa80451f3753111a344e4f269a63bf8