### PR TITLE
Change CREATE_NEW_WINDOW IPC call to accept a path and query

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -631,6 +631,8 @@ function runApp() {
     }
   }
 
+  const ROOT_APP_URL = process.env.NODE_ENV === 'development' ? 'http://localhost:9080' : 'app://bundle/index.html'
+
   async function createWindow(
     {
       replaceMainWindow = true,
@@ -774,18 +776,10 @@ function runApp() {
     }
 
     // load root file/url
-    if (process.env.NODE_ENV === 'development') {
-      let devStartupURL = 'http://localhost:9080'
-      if (windowStartupUrl != null) {
-        devStartupURL = windowStartupUrl
-      }
-      newWindow.loadURL(devStartupURL)
+    if (windowStartupUrl != null) {
+      newWindow.loadURL(windowStartupUrl)
     } else {
-      if (windowStartupUrl != null) {
-        newWindow.loadURL(windowStartupUrl)
-      } else {
-        newWindow.loadURL('app://bundle/index.html')
-      }
+      newWindow.loadURL(ROOT_APP_URL)
     }
 
     if (typeof searchQueryText === 'string' && searchQueryText.length > 0) {
@@ -1011,12 +1005,39 @@ function runApp() {
     return powerSaveBlocker.start('prevent-display-sleep')
   })
 
-  ipcMain.on(IpcChannels.CREATE_NEW_WINDOW, (_e, { windowStartupUrl = null, searchQueryText = null } = { }) => {
+  ipcMain.on(IpcChannels.CREATE_NEW_WINDOW, (event, path, query, searchQueryText) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
+    if (path == null && query == null && searchQueryText == null) {
+      createWindow({ replaceMainWindow: false, showWindowNow: true })
+      return
+    }
+
+    if (
+      typeof path !== 'string' ||
+      (typeof query !== 'object' && query != null) ||
+      (typeof searchQueryText !== 'string' && searchQueryText != null)
+    ) {
+      return
+    }
+
+    if (path.charAt(0) !== '/') {
+      path = `/${path}`
+    }
+
+    let windowStartupUrl = `${ROOT_APP_URL}#${path}`
+
+    if (query) {
+      windowStartupUrl += '?' + new URLSearchParams(query).toString()
+    }
+
     createWindow({
       replaceMainWindow: false,
       showWindowNow: true,
-      windowStartupUrl: windowStartupUrl,
-      searchQueryText: searchQueryText
+      windowStartupUrl,
+      searchQueryText
     })
   })
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -232,18 +232,11 @@ export async function openExternalLink(url) {
  * @param {object} params.query the query params to use (optional)
  * @param {string} params.searchQueryText the text to show in the search bar in the new window (optional)
  */
-export function openInternalPath({ path, query = {}, doCreateNewWindow, searchQueryText = null }) {
+export function openInternalPath({ path, query = undefined, doCreateNewWindow, searchQueryText = null }) {
   if (process.env.IS_ELECTRON && doCreateNewWindow) {
     const { ipcRenderer } = require('electron')
 
-    // Combine current document path and new "hash" as new window startup URL
-    const newWindowStartupURL = new URL(window.location.href)
-    newWindowStartupURL.hash = `${path}?${(new URLSearchParams(query)).toString()}`
-
-    ipcRenderer.send(IpcChannels.CREATE_NEW_WINDOW, {
-      windowStartupUrl: newWindowStartupURL.toString(),
-      searchQueryText
-    })
+    ipcRenderer.send(IpcChannels.CREATE_NEW_WINDOW, path, query, searchQueryText)
   } else {
     router.push({
       path,


### PR DESCRIPTION
# Change CREATE_NEW_WINDOW IPC call to accept a path and query

## Pull Request Type

- [x] Security improvement

## Description

Currently the `CREATE_NEW_WINDOW` IPC call accepts a URL and performs no validation on it, which means it can be used to open new windows to arbitrary URLs. This pull request locks it down by making it accept a path and query parameters instead, so that it can only be used to create windows with in-app URLs and adds some parameter validation.

## Testing

- Please check that the new window button in the top bar still works (calls `CREATE_NEW_WINDOW` with no parameters)
- Please test opening various queries in new windows from the search bar (SHIFT+ENTER or SHIFT+click on the search button)
  - https://youtu.be/jNQXAC9IVRw (just path)
  - https://youtu.be/jNQXAC9IVRw?t=10 (path and query)
  - `test` (path, query and searchQueryText) -> the search query text should appear in the search bar in the new window

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 7ad5873bec7754e757c9d2ddf0ece3f6df8ad337