### PR TITLE
Disable spell checker on the `ft-input` Component

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -55,10 +55,6 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    spellcheck: {
-      type: Boolean,
-      default: true
-    },
     dataList: {
       type: Array,
       default: () => { return [] }

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -50,7 +50,7 @@
         :type="inputType"
         :placeholder="placeholder"
         :disabled="disabled"
-        :spellcheck="spellcheck"
+        :spellcheck="false"
         :aria-label="!showLabel ? placeholder : null"
         @input="e => handleInput(e.target.value)"
         @focus="handleFocus"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -235,7 +235,6 @@
           class="screenshotFilenamePatternInput"
           placeholder=""
           :value="screenshotFilenamePattern"
-          :spellcheck="false"
           :show-action-button="false"
           :show-label="false"
           @input="handleScreenshotFilenamePatternChanged"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -94,7 +94,6 @@
           :is-search="true"
           :data-list="activeDataList"
           :data-list-properties="activeDataListProperties"
-          :spellcheck="false"
           :show-clear-text-button="true"
           :show-data-when-empty="true"
           @input="getSearchSuggestionsDebounce"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -9,7 +9,6 @@
         :value="query"
         :show-clear-text-button="true"
         :show-action-button="false"
-        :spellcheck="false"
         :maxlength="255"
         @input="(input) => handleQueryChange(input)"
         @clear="() => handleQueryChange('')"


### PR DESCRIPTION
# Title

Disable spell checker in the `ft-input` component

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Resolve #6548

## Description

This disables the spell checker on the `ft-input` component so that we don't get any spell checks on the search elements. 

## Screenshots <!-- If appropriate -->

![image](https://github.com/user-attachments/assets/9ff8f3d5-7e79-461a-9619-f517e662a58f)