### PR TITLE
Fix: increased color contrast for uploader comments in Catppuccin Moc…

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -291,7 +291,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
   --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --secondary-card-bg-color: #4c4c76;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6597

## Description
This pull request improves the color contrast of the uploader's username in the Catppuccin Mocha theme to meet accessibility standards. The contrast for the username's highlight around comments from the uploader was previously too low. Now, it adheres to a higher contrast ratio, ensuring better readability and accessibility for users.

The fix modifies the CSS for the `Catppuccin Mocha` theme to make the uploader's comment more distinguishable, by adjusting the relevant colors used in the theme.

## Screenshots
**Before**: (Screenshot showing the low contrast issue)
![Image 19-01-2025 à 19 02](https://github.com/user-attachments/assets/8aefc561-cdbc-46a9-bd4b-493546a08476)

**After**: (Screenshot showing the improved contrast)
![Image 19-01-2025 à 19 22 (1)](https://github.com/user-attachments/assets/7adfa15c-19e6-4ef2-a4dc-051ddb9b88ef)

## Testing
- The changes were tested locally by running the FreeTube application and setting the theme to Catppuccin Mocha.
- I verified that the color contrast of the uploader's name was improved across different environments.
- There are no remaining ramifications or errors related to this fix.

## Desktop
- **OS:** macOS 11 (Big Sur)
- **OS Version:** 11.5.1
- **FreeTube version:** 0.22.1

## Additional context
- This fix was made in accordance with accessibility standards to ensure the readability of the uploader's name in the comments section for users with visual impairments.
