### PR TITLE
Clean up unused template refs

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -109,7 +109,6 @@
       >
         <!-- <keep-alive> -->
         <RouterView
-          ref="router"
           class="routerView"
         />
         <!-- </keep-alive> -->

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -1,6 +1,5 @@
 <template>
   <FtFlexBox
-    ref="sideNav"
     class="sideNav"
     :class="[{closed: !isOpen}, applyHiddenLabels]"
     role="navigation"

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -786,10 +786,6 @@ export default defineComponent({
       this.addToPlaylistPromptCloseCallback = () => {
         // Run once only
         this.addToPlaylistPromptCloseCallback = null
-
-        // `thumbnailLink` is a `router-link`
-        // `focus()` can only be called on the actual element
-        this.$refs.addToPlaylistIcon?.$el?.focus()
       }
     },
 

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -46,7 +46,6 @@
       <span class="playlistIcons">
         <ft-icon-button
           v-if="showPlaylists"
-          ref="addToPlaylistIcon"
           :title="$t('User Playlists.Add to Playlist')"
           :icon="['fas', 'plus']"
           class="addToPlaylistIcon"

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -84,7 +84,6 @@
       <div
         v-if="!hideSearchBar"
         v-show="showSearchContainer"
-        ref="searchContainer"
         class="searchContainer"
       >
         <ft-input


### PR DESCRIPTION
# Clean up unused template refs

## Pull Request Type

- [x] Cleanup

## Description

This pull request removes some unused template refs. Three of the removed refs were completely unused, the forth one was being used to focus the icon button when the add to playlist prompt closes, but as the FtPrompt already takes care of that for us we can remove it too.

https://github.com/FreeTubeApp/FreeTube/blob/d35174ed53a1b7b931124d811a92adf6d35185ea/src/renderer/components/FtPrompt/FtPrompt.vue#L110-L125

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d35174ed53a1b7b931124d811a92adf6d35185ea