### PR TITLE
Add Creative Commons License to Description of Videos

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -114,6 +114,10 @@ export default defineComponent({
     isUnlisted: {
       type: Boolean,
       required: false
+    },
+    license: {
+      type: String,
+      default: null,
     }
   },
   emits: ['change-format', 'pause-player', 'set-info-area-sticky', 'scroll-to-info-area'],

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -141,6 +141,12 @@
         />
       </div>
     </div>
+    <div
+      v-if="license"
+      class="license"
+    >
+      {{ license }}
+    </div>
   </ft-card>
 </template>
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -82,6 +82,7 @@ export default defineComponent({
       isUpcoming: false,
       isPostLiveDvr: false,
       isUnlisted: false,
+      license: null,
       upcomingTimestamp: null,
       upcomingTimeLeft: null,
       /** @type {'dash' | 'audio' | 'legacy'} */
@@ -408,6 +409,7 @@ export default defineComponent({
         // extract localised title first and fall back to the not localised one
         this.videoTitle = result.primary_info?.title.text ?? result.basic_info.title
         this.videoViewCount = result.basic_info.view_count ?? (result.primary_info.view_count ? extractNumberFromString(result.primary_info.view_count.text) : null)
+        this.license = result.secondary_info.metadata.rows.matchCondition(element => element.title.text === 'License')?.contents[0].text
 
         this.channelId = result.basic_info.channel_id ?? result.secondary_info.owner?.author.id
         this.channelName = result.basic_info.author ?? result.secondary_info.owner?.author.name

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -150,6 +150,7 @@
         :in-user-playlist="!!selectedUserPlaylist"
         class="watchVideo"
         :class="{ theatreWatchVideo: useTheatreMode }"
+        :license="license"
         @change-format="handleFormatChange"
         @pause-player="pausePlayer"
         @set-info-area-sticky="infoAreaSticky = $event"


### PR DESCRIPTION
# Title

Add Creative Commons License to Description of Videos

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Resolve #6600

## Description

Add creative common license text to the video description if the video is licensed under creative commons. 

## Screenshots <!-- If appropriate -->

![image](https://github.com/user-attachments/assets/2e189657-60ae-457e-8f4e-5cdcd0febbf0)