### PR TITLE
Move saving screenshots to the default folder to an IPC call

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -48,6 +48,8 @@ const IpcChannels = {
   SET_INVIDIOUS_AUTHORIZATION: 'set-invidious-authorization',
 
   GENERATE_PO_TOKEN: 'generate-po-token',
+
+  WRITE_SCREENSHOT: 'write-screenshot',
 }
 
 const DBActions = {

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -77,6 +77,10 @@ class Settings {
     }
   }
 
+  static _findScreenshotFolderPath() {
+    return db.settings.findOneAsync({ _id: 'screenshotFolderPath' })
+  }
+
   static _updateBounds(value) {
     return db.settings.updateAsync({ _id: 'bounds' }, { _id: 'bounds', value }, { upsert: true })
   }


### PR DESCRIPTION
# Move saving screenshots to the default folder to an IPC call

## Pull Request Type

- [x] Refactor
- [x] Security improvement

## Description

Currently the code for saving video screenshots to the default save location uses the Node.js `path` and `fs/promises` modules in the renderer processes. While it does work, it is one of the reasons that we currently have to have `nodeIntegration` turned on in our renderer processes. This pull request moves it to an IPC call, which allows us to add a few security measures like making sure that IPC call can only write inside the users configured folder and gets us one step closer to turning off `nodeIntegration`.

Just a reminder why having `nodeIntegration` turned on in the renderer is a bad idea. Having that turned on means that you can use any Node.js and Electron APIs in there, which is not ideal considering that we load data, including HTML, from third party sources and have the devtools enabled.

P.S. I would recommend turning on the "Hide Whitespace" setting when reviewing this pull request.

## Testing

1. Check that prompting for the save location still works when "Ask for Save Folder" is enabled.
    1. Turn on the "Ask for Save Folder" setting.
    2. Take a screenshot.
    3. Check that it saved it to your chosen location.
2. Check that saving to the selected default save location works.
    1. Turn off the "Ask for Save Folder" setting.
    2. Choose a default save folder.
    3. Take a screenshot.
    4. Check that it saved it to the folder that you had previously selected.
3. Check that saving to the default save location works when the user hasn't set it yet.
    1. Close FreeTube
    2. Go to the data location (https://docs.freetubeapp.io/usage/data-location/) but open the `Electron` folder instead of the `FreeTube` one.
    3. Remove the `screenshotFolderPath` line from the `settings.db file`.
    4. Run FreeTube again with `yarn dev`.
    5. Take a screenshot.
    6. Check that the screenshot was saved to a FreeTube folder inside the pictures folder in your user profile.

## Desktop

- **OS:** Windows
- **OS Version:** 10 
- **FreeTube version:** 89d72962c8c31677b66cbc5177ba3bccc867e73a