### PR TITLE
Avoid logging an error when a player cache entry does not exist

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1092,7 +1092,12 @@ function runApp() {
 
       return contents.buffer
     } catch (e) {
-      console.error(e)
+      // Don't log the error if the file doesn't exist as we'll just fetch it from YouTube
+      // this usually happens when YouTube updates their player JavaScript
+      if (e.code !== 'ENOENT') {
+        console.error(e)
+      }
+
       return undefined
     }
   })


### PR DESCRIPTION
# Avoid logging an error when a player cache entry does not exist

## Pull Request Type

- [x] Bugfix

## Description

When a player cache entry doesn't exist, we currently log Node.js' `ENOENT` error, which just means "error no entry", which will occur every now and then, as the player IDs change when YouTube updates their player JavaScript. On various occasions users have seen these error messages and thought they meant that something was wrong, so lets not log them to avoid confusing users.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** ec3b15355ad81e3b270b80c92556e390c5143021