### PR TITLE
Fixes #6330: Commented out overflow-x: hidden to resolve scrollbar issue

### DIFF
--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -5,7 +5,7 @@
 
 .settingsSections,
 .switchRow {
-  overflow-x: hidden;
+  /* overflow-x: hidden; */
   max-inline-size: 90%;
 }
 


### PR DESCRIPTION
# Title

Fix unnecessary vertical scrollbar in settings page

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6330 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This pull request fixes an issue where an unnecessary vertical scrollbar appeared in the settings page for certain languages (e.g., German, Turkish).

Changes made:
- Commented out the overflow-x: hidden property in .settingsSections and .switchRow within the Settings.css file.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before :
![20250121_CAP_Bug](https://github.com/user-attachments/assets/b7184375-3b80-4dcf-87d4-2b3617e872cd)

After : 
![20250121_CAP_BugFix](https://github.com/user-attachments/assets/d4242c5e-55dd-4fa9-9320-5fcef0d4aef6)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Approach:
- Tested across multiple languages that previously showed the issue (German, Polish, Turkish).
- Used the toggle device bar to simulate different screen sizes and validate responsive behavior.

Behavior Confirmed:
- The scrollbar no longer appears unnecessarily.
- No new horizontal scrollbars were introduced as a side effect.

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11
- **OS Version:** 23H2
- **FreeTube version:** 0.22.1

## Additional context
<!-- Add any other context about the pull request here. -->
- Left the commented code in place to make reactivation easier, if needed in the future.