### PR TITLE
Add total duration display to playlists

### DIFF
--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -243,6 +243,15 @@ export default defineComponent({
     sortBySelectValues() {
       return this.sortByValues
     },
+    totalPlaylistDuration() {
+      if (!this.playlistItems || this.playlistItems.length === 0) {
+        return '0h 0m 0s'
+      }
+      const totalSeconds = this.playlistItems.reduce((acc, video) => {
+        return acc + (video.lengthSeconds || 0)
+      }, 0)
+      return this.formatDuration(totalSeconds)
+    },
   },
   watch: {
     $route() {
@@ -677,6 +686,13 @@ export default defineComponent({
 
         throw failure
       }
+    },
+    formatDuration(totalSeconds) {
+      const hours = Math.floor(totalSeconds / 3600)
+      const minutes = Math.floor((totalSeconds % 3600) / 60)
+      const seconds = totalSeconds % 60
+
+      return `${hours}h ${minutes}m ${seconds}s`
     },
 
     getIconForSortPreference: (s) => getIconForSortPreference(s),

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -244,9 +244,6 @@ export default defineComponent({
       return this.sortByValues
     },
     totalPlaylistDuration() {
-      if (!this.playlistItems || this.playlistItems.length === 0) {
-        return '0h 0m 0s'
-      }
       const totalSeconds = this.playlistItems.reduce((acc, video) => {
         return acc + (video.lengthSeconds || 0)
       }, 0)
@@ -687,12 +684,15 @@ export default defineComponent({
         throw failure
       }
     },
-    formatDuration(totalSeconds) {
-      const hours = Math.floor(totalSeconds / 3600)
-      const minutes = Math.floor((totalSeconds % 3600) / 60)
-      const seconds = totalSeconds % 60
 
-      return `${hours}h ${minutes}m ${seconds}s`
+    formatDuration(totalSeconds, locale = 'en') {
+      const duration = {
+        hours: Math.floor(totalSeconds / 3600),
+        minutes: Math.floor((totalSeconds % 3600) / 60),
+        seconds: totalSeconds % 60,
+      }
+
+      return new Intl.DurationFormat(locale, { style: 'short' }).format(duration)
     },
 
     getIconForSortPreference: (s) => getIconForSortPreference(s),

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -19,6 +19,27 @@
   }
 }
 
+.playlistDurationContainer {
+  position: sticky;
+  margin-block: -20px 16px;
+  inset-block-start: calc(var(--top-bar-push-down-adjustment-default) + var(--top-bar-push-down-adjustment-edit-mode) + var(--top-bar-push-down-adjustment-no-description) + var(--top-bar-push-down-adjustment-one-or-fewer));
+  padding-block: 8px;
+  margin-inline: auto;
+  padding-inline: 16px;
+  box-sizing: content-box;
+  inline-size: 85%;
+  background-color: var(--card-bg-color);
+  box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
+  z-index: 3;
+  text-align: center;
+}
+
+.totalDuration {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--primary-text-color);
+}
+
 .routerView {
   display: flex;
 
@@ -67,26 +88,47 @@
   }
 
   &.list {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+
+    .playlistInfoWrapper {
+      display: flex;
+      flex-direction: column;
+      inline-size: 30%;
+    }
+
     .playlistInfoContainer {
       background-color: var(--card-bg-color);
-      block-size: calc(100vh - 132px);
-      inline-size: 30%;
+      block-size: calc(100vh - 177px);
       inset-block-start: 96px;
-      margin-inline-end: 1em;
       position: sticky;
+      inline-size: 100%;
+    }
 
-      .playlistInfo {
-        padding: 10px;
-      }
+    .playlistDurationContainer {
+      inline-size: 96%;
+      margin-block-start: 6px;
+      text-align: center;
+      padding: 7px;
+      background-color: var(--card-bg-color);
+      box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
+      z-index: 2;
+      position: sticky;
     }
 
     .playlistItemsCard {
-      inline-size: 60%;
+      inline-size: 65%;
       padding: 10px;
+    }
+
+    .totalDuration {
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: var(--primary-text-color);
     }
   }
 }
-
 
 .playlistItem {
   display: grid;
@@ -157,26 +199,4 @@
 
 .message {
   color: var(--tertiary-text-color);
-}
-
-.playlistDurationContainer {
-  position: sticky;
-  margin-block: -35px 16px;
-  inset-block-start: calc(var(--top-bar-push-down-adjustment-default) + var(--top-bar-push-down-adjustment-edit-mode) + var(--top-bar-push-down-adjustment-no-description) + var(--top-bar-push-down-adjustment-one-or-fewer));
-  padding-block: 8px;
-  margin-inline: auto;
-  padding-inline: 16px;
-  box-sizing: content-box;
-  inline-size: 85%;
-  background-color: var(--card-bg-color);
-  box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
-  z-index: 3;
-  border-radius: 8px;
-  text-align: center;
-}
-
-.totalDuration {
-  font-size: 1.1rem;
-  font-weight: 500;
-  color: var(--primary-text-color);
 }

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -158,3 +158,25 @@
 .message {
   color: var(--tertiary-text-color);
 }
+
+.playlistDurationContainer {
+  position: sticky;
+  margin-block: -35px 16px;
+  inset-block-start: calc(var(--top-bar-push-down-adjustment-default) + var(--top-bar-push-down-adjustment-edit-mode) + var(--top-bar-push-down-adjustment-no-description) + var(--top-bar-push-down-adjustment-one-or-fewer));
+  padding-block: 8px;
+  margin-inline: auto;
+  padding-inline: 16px;
+  box-sizing: content-box;
+  inline-size: 85%;
+  background-color: var(--card-bg-color);
+  box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
+  z-index: 3;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.totalDuration {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--primary-text-color);
+}

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -42,7 +42,14 @@
         @prompt-close="promptOpen = false"
       />
     </div>
-
+    <div
+      v-if="playlistItems.length > 0"
+      class="playlistDurationContainer"
+    >
+      <p class="totalDuration">
+        {{ $t('User Playlists.TotalTimePlaylist', { duration: totalPlaylistDuration }) }}
+      </p>
+    </div>
     <ft-card
       v-if="!isLoading"
       class="playlistItemsCard"

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -7,48 +7,50 @@
       v-if="isLoading"
       :fullscreen="true"
     />
-    <div
-      v-if="!isLoading"
-      class="playlistInfoContainer"
-      :class="{
-        promptOpen,
-      }"
-    >
-      <playlist-info
-        :id="playlistId"
-        :first-video-id="firstVideoId"
-        :first-video-playlist-item-id="firstVideoPlaylistItemId"
-        :playlist-thumbnail="playlistThumbnail"
-        :title="playlistTitle"
-        :channel-name="channelName"
-        :channel-thumbnail="channelThumbnail"
-        :channel-id="channelId"
-        :last-updated="lastUpdated"
-        :description="playlistDescription"
-        :video-count="videoCount"
-        :videos="playlistItems"
-        :view-count="viewCount"
-        :info-source="infoSource"
-        :more-video-data-available="moreVideoDataAvailable"
-        :search-video-mode-allowed="isUserPlaylistRequested && videoCount > 1"
-        :search-video-mode-enabled="playlistInVideoSearchMode"
-        :search-query-text="searchQueryTextRequested"
-        :theme="listType === 'list' ? 'base' : 'top-bar'"
-        class="playlistInfo"
-        @enter-edit-mode="playlistInEditMode = true"
-        @exit-edit-mode="playlistInEditMode = false"
-        @search-video-query-change="(v) => handleVideoSearchQueryChange(v)"
-        @prompt-open="promptOpen = true"
-        @prompt-close="promptOpen = false"
-      />
-    </div>
-    <div
-      v-if="playlistItems.length > 0"
-      class="playlistDurationContainer"
-    >
-      <p class="totalDuration">
-        {{ $t('User Playlists.TotalTimePlaylist', { duration: totalPlaylistDuration }) }}
-      </p>
+    <div class="playlistInfoWrapper">
+      <div
+        v-if="!isLoading"
+        class="playlistInfoContainer"
+        :class="{
+          promptOpen,
+        }"
+      >
+        <playlist-info
+          :id="playlistId"
+          :first-video-id="firstVideoId"
+          :first-video-playlist-item-id="firstVideoPlaylistItemId"
+          :playlist-thumbnail="playlistThumbnail"
+          :title="playlistTitle"
+          :channel-name="channelName"
+          :channel-thumbnail="channelThumbnail"
+          :channel-id="channelId"
+          :last-updated="lastUpdated"
+          :description="playlistDescription"
+          :video-count="videoCount"
+          :videos="playlistItems"
+          :view-count="viewCount"
+          :info-source="infoSource"
+          :more-video-data-available="moreVideoDataAvailable"
+          :search-video-mode-allowed="isUserPlaylistRequested && videoCount > 1"
+          :search-video-mode-enabled="playlistInVideoSearchMode"
+          :search-query-text="searchQueryTextRequested"
+          :theme="listType === 'list' ? 'base' : 'top-bar'"
+          class="playlistInfo"
+          @enter-edit-mode="playlistInEditMode = true"
+          @exit-edit-mode="playlistInEditMode = false"
+          @search-video-query-change="(v) => handleVideoSearchQueryChange(v)"
+          @prompt-open="promptOpen = true"
+          @prompt-close="promptOpen = false"
+        />
+      </div>
+      <div
+        v-if="playlistItems.length > 0"
+        class="playlistDurationContainer"
+      >
+        <p class="totalDuration">
+          {{ $t('User Playlists.TotalTimePlaylist', { duration: totalPlaylistDuration }) }}
+        </p>
+      </div>
     </div>
     <ft-card
       v-if="!isLoading"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -195,6 +195,8 @@ User Playlists:
   Cannot delete the quick bookmark target playlist.: Cannot delete the quick bookmark target playlist.
   Are you sure you want to delete this playlist? This cannot be undone: Are you sure you want to delete this playlist? This cannot be undone.
 
+  TotalTimePlaylist: "Total time: {duration}"
+
   Sort By:
     NameAscending: 'A-Z'
     NameDescending: 'Z-A'


### PR DESCRIPTION
# Title
Add total duration display to playlists
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6152 
## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This pull request adds the total playlist duration display to the playlist info container.

Changes made:
- Implemented a feature to show the total duration of the playlist.
- Ensured the visual style integrates seamlessly with the current UI.
## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
After : 
![totaltime2](https://github.com/user-attachments/assets/720ab712-d672-41c6-9c5e-950db0e2384b)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Approach:
- Verified the feature on different screen sizes using the toggle device bar.
Behavior Confirmed:
- The total duration appears correctly and adapts visually to the playlist info container.
## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11
- **OS Version:** 23H2
- **FreeTube version:** 0.22.1
