### PR TITLE
Shrink mime-db even further

### DIFF
--- a/_scripts/mime-db-shrinking-loader.js
+++ b/_scripts/mime-db-shrinking-loader.js
@@ -8,18 +8,15 @@
 module.exports = function (source) {
   const original = JSON.parse(source)
 
-  const reduced = {}
+  // Only the extensions field is needed, see: https://github.com/kevva/ext-list/blob/v2.2.2/index.js
 
-  for (const mimeType of Object.keys(original)) {
-    if (mimeType.startsWith('image/') && original[mimeType].extensions &&
-      (!mimeType.startsWith('image/x-') || mimeType === 'image/x-icon' || mimeType === 'image/x-ms-bmp') &&
-      (!mimeType.startsWith('image/vnd.') || mimeType === 'image/vnd.microsoft.icon')) {
-      // Only the extensions field is needed, see: https://github.com/kevva/ext-list/blob/v2.2.2/index.js
-      reduced[mimeType] = {
-        extensions: original[mimeType].extensions
-      }
-    }
-  }
-
-  return JSON.stringify(reduced)
+  return JSON.stringify({
+    'image/apng': { extensions: original['image/apng'].extensions },
+    'image/avif': { extensions: original['image/avif'].extensions },
+    'image/gif': { extensions: original['image/gif'].extensions },
+    'image/jpeg': { extensions: original['image/jpeg'].extensions },
+    'image/png': { extensions: original['image/png'].extensions },
+    'image/svg+xml': { extensions: original['image/svg+xml'].extensions },
+    'image/webp': { extensions: original['image/webp'].extensions }
+  })
 }


### PR DESCRIPTION
# Shrink mime-db even further

## Pull Request Type

- [x] Performance improvement

## Related issue

- Pull request that added the mime-db-shrinking-loader: #5148

## Description

When I orginally added the `mime-db-shrinking-loader` I restricted it to only include image mimetypes and only if they weren't vendor specific `x-` or `vnd.`. However I've since realised that there is only a small set of mimetypes that are actually going to be used for images that are displayed in FreeTube, so we can just hardcode that list instead of including loads that we know we'll never need.

## Screenshots
Before:
![before](https://github.com/user-attachments/assets/005fa5b5-6218-4065-9fd4-31148915a5ae)

After:
![after](https://github.com/user-attachments/assets/d70daf1d-850e-4741-bd07-3e26a26d647d)

## Testing

1. Right click on an image (e.g. a video or channel thumbnail)
2. Click `Save Image As`
3. Check that the image was saved correctly.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** edef122d4df920ee80e481bf1ba87961006c54d2