### PR TITLE
fix: prevent prompt scrolling propagation

### DIFF
--- a/src/renderer/components/FtPrompt/FtPrompt.css
+++ b/src/renderer/components/FtPrompt/FtPrompt.css
@@ -17,6 +17,7 @@
 
 .promptCard {
   overflow-y: scroll;
+  overscroll-behavior-y: contain;
   max-block-size: 95%;
 }
 


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6695

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This change adds `overscroll-behavior-y: contain;` to the `.promptCard` class.  This prevents the scroll from the Prompt component from propagating to the underlying content, improving the user experience.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
