### PR TITLE
Fix comment sorting when sort by newest is the default

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -291,11 +291,10 @@ export async function getLocalVideoInfo(id) {
 
 /**
  * @param {string} id
- * @param {boolean | undefined} sortByNewest
  */
-export async function getLocalComments(id, sortByNewest = false) {
+export async function getLocalComments(id) {
   const innertube = await createInnertube()
-  return innertube.getComments(id, sortByNewest ? 'NEWEST_FIRST' : 'TOP_COMMENTS')
+  return innertube.getComments(id)
 }
 
 // I know `type & type` is typescript syntax and not valid jsdoc but I couldn't get @extends or @augments to work


### PR DESCRIPTION
# Fix comment sorting when sort by newest is the default

## Pull Request Type

- [x] Bugfix

## Related issue
- closes #6632 

## Description

On some videos the default sorting value is Newest First, at the moment we are unable to switch back to Top Comments on those videos. This pull request fixes that by matching YouTube's default sorting for each video and then using their provided parameter values for the sorting changes.

Thanks to @LuanRT for suggesting this fix.

Technical details on the problem:

The internal value for sorting by top comments is `0`, however due to the way that protobuf v3 works, when YouTube.js generates the protobuf with that value, the protobuf encoder drops the sorting field as `0` is considered the default value. This isn't a problem on videos where the default sorting is top comments because then we can do default (top comments) and newest first (explicitly requested with the value `1`), but when the default is newest first, our choices are default (newest first) and newest first (explicitly requested with the value `1`.

## Testing

Video with sort by Top Comments as the default: https://youtu.be/jNQXAC9IVRw
Video with sort by Newest First as the default: https://youtu.be/fn3KWM1kuAw

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** bfa22f49b664ea45acb6601a7060fa208e235548