### PR TITLE
Fix search not working on mobile because of undefined ref

### DIFF
--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -217,7 +217,7 @@ export default defineComponent({
       const doCreateNewWindow = event && event.shiftKey
 
       if (window.innerWidth <= MOBILE_WIDTH_THRESHOLD) {
-        this.$refs.searchInput.blur()
+        this.$refs.searchContainer.blur()
         this.showSearchContainer = false
       } else {
         this.$refs.searchInput.blur()

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -217,7 +217,7 @@ export default defineComponent({
       const doCreateNewWindow = event && event.shiftKey
 
       if (window.innerWidth <= MOBILE_WIDTH_THRESHOLD) {
-        this.$refs.searchContainer.blur()
+        this.$refs.searchInput.blur()
         this.showSearchContainer = false
       } else {
         this.$refs.searchInput.blur()

--- a/src/renderer/components/top-nav/top-nav.vue
+++ b/src/renderer/components/top-nav/top-nav.vue
@@ -45,6 +45,7 @@
       />
       <font-awesome-icon
         v-if="!hideSearchBar"
+        ref="searchContainer"
         class="navSearchIcon navIcon"
         :icon="['fas', 'search']"
         role="button"


### PR DESCRIPTION
# Fix search not working on mobile because of undefined ref

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other


## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I noticed that there was an error happening on mobile when trying to search. 
`vue.runtime.esm.js:3106 TypeError: Cannot read properties of undefined (reading 'blur')`
The line that traces back to is here:
https://github.com/FreeTubeApp/FreeTube/blob/bfa22f49b664ea45acb6601a7060fa208e235548/src/renderer/components/top-nav/top-nav.js#L220

Looking into the component's template, I couldn't find a ref that matched it. Looking at the history, it looks like at one point the ref was on this element with the `searchContainer` class.

https://github.com/FreeTubeApp/FreeTube/commit/8e72e7fe5f58502a3692887b00a1d3e200c88ac0#diff-07257d469f27c18e3d2c97c8c867fe787ee304ee7fbb6a3daffb80600a8183f9R71

This PR adds back this `ref="searchContainer"` to prevent that error and fix the search on mobile.

## Testing <!-- for code that is not small enough to be easily understandable -->
1. Shrink the window down to small enough that the search bar is hidden
2. Attempt to search

## Desktop
<!-- Please complete the following information-->
- **OS:** LMDE
- **OS Version:** 6
- **FreeTube version:** bfa22f49b664ea45acb6601a7060fa208e235548

## Additional context
i definitely have fixed this in my fork by just adding a null check, but looking into it, this seems like the true fix.
