### PR TITLE
Fix: Settings tooltips cut off at the bottom

### DIFF
--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -6,6 +6,10 @@
   }
 }
 
+.settingsSection:not(.hideOnMobile) {
+  margin-block-end: inherit;
+}
+
 .sectionHeader {
   cursor: pointer;
   display: block;

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -63,7 +63,7 @@
 
   .settingsSections {
     overflow-y: hidden;
-    margin-block-end: 80px;
+    margin-block-end: 160px;
   }
 
   .hideOnMobile {


### PR DESCRIPTION
# Fix: Settings tooltips cut off at the bottom

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6704 

## Description
Adds a larger margin to the bottom of setting sections when in mobile view

## Testing <!-- for code that is not small enough to be easily understandable -->
Resize the window while in Settings view and hover over an affected tooltip

## Screenshots
Before
![2025-02-02_17-06-28](https://github.com/user-attachments/assets/17ac41f8-fb53-449e-99c5-e8651d7d1db5)

After
![2025-02-02_17-05-09](https://github.com/user-attachments/assets/31b93660-6803-4365-a669-9ce26e7e3c92)
