### PR TITLE
Fix video pausing when saving a screenshot to the default folder

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1593,7 +1593,7 @@ export default defineComponent({
       const filenameWithExtension = `${filename}.${format}`
 
       const wasPlaying = !video_.paused
-      if (wasPlaying) {
+      if ((!process.env.IS_ELECTRON || screenshotAskPath.value) && wasPlaying) {
         video_.pause()
       }
 
@@ -1630,7 +1630,7 @@ export default defineComponent({
       } finally {
         canvas.remove()
 
-        if (wasPlaying) {
+        if ((!process.env.IS_ELECTRON || screenshotAskPath.value) && wasPlaying) {
           video_.play()
         }
       }


### PR DESCRIPTION
# Fix video pausing when saving a screenshot to the default folder

## Pull Request Type

- [x] Bugfix

## Related issue

- closes #6720

## Description

In #6636 I unified the screenshot logic in the video player, but I forgot to account for the fact that pausing is only necessary when we prompt the user for where to save the screenshot so that they don't miss what is going on in the video while they are distracted by the prompt. As saving to the default folder requires no user interaction after triggering the screenshot, we don't have to pause the video.

## Testing

1. Make sure Ask for Save Folder is turned OFF in the screenshot settings
2. Start a video
3. While the video is playing take some screenshots
4. The video should continue playing while the screenshots are being taken

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b6b97fbf5b7b414ab67798f0bcfd464bdb0e7d11