### PR TITLE
Fix: search history text overflows if search term is long

### DIFF
--- a/src/renderer/components/ft-input/ft-input.css
+++ b/src/renderer/components/ft-input/ft-input.css
@@ -210,6 +210,18 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   padding-inline: 15px;
 }
 
+.optionWrapper {
+  display: flex;
+  align-items: center;
+  inline-size: 80%;
+}
+
+.optionWrapper span {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .searchResultIcon {
   opacity: 0.6;
   padding-inline-end: 10px;

--- a/src/renderer/components/ft-input/ft-input.vue
+++ b/src/renderer/components/ft-input/ft-input.vue
@@ -84,7 +84,7 @@
           @mouseenter="searchState.selectedOption = index"
           @mouseleave="searchState.selectedOption = -1; removeButtonSelectedIndex = -1"
         >
-          <div>
+          <div class="optionWrapper">
             <font-awesome-icon
               v-if="dataListProperties[index]?.iconName"
               :icon="['fas', dataListProperties[index].iconName]"


### PR DESCRIPTION
# Fix search history text overflows if search term is long

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6727 

## Description
Truncates text that exceeds the length of the search history input