### PR TITLE
Fix Very long words in video title in recommended videos next to video player break css

### DIFF
--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -240,6 +240,7 @@ $watched-transition-duration: 0.5s;
       grid-area: title;
       text-decoration: none;
       word-wrap: break-word;
+      overflow-wrap: anywhere;
 
       @include low-contrast-when-watched(var(--primary-text-color));
 


### PR DESCRIPTION
# Fix Very long words in video title in recommended videos next to video player break css 

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6725 

## Description
Long strings of video titles (connected by underscores or dashes) were not being wrapped correctly.