### PR TITLE
Request the single instance lock as soon as possible

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -340,6 +340,17 @@ class SubscriptionCache {
   }
 }
 
+function loadDatastores() {
+  return Promise.allSettled([
+    db.settings.loadDatabaseAsync(),
+    db.history.loadDatabaseAsync(),
+    db.profiles.loadDatabaseAsync(),
+    db.playlists.loadDatabaseAsync(),
+    db.searchHistory.loadDatabaseAsync(),
+    db.subscriptionCache.loadDatabaseAsync(),
+  ])
+}
+
 function compactAllDatastores() {
   return Promise.allSettled([
     db.settings.compactDatafileAsync(),
@@ -359,5 +370,6 @@ export {
   SearchHistory as searchHistory,
   SubscriptionCache as subscriptionCache,
 
+  loadDatastores,
   compactAllDatastores,
 }

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -22,9 +22,9 @@ if (process.env.IS_ELECTRON_MAIN) {
   dbPath = (dbName) => `${dbName}.db`
 }
 
-export const settings = new Datastore({ filename: dbPath('settings'), autoload: true })
-export const profiles = new Datastore({ filename: dbPath('profiles'), autoload: true })
-export const playlists = new Datastore({ filename: dbPath('playlists'), autoload: true })
-export const history = new Datastore({ filename: dbPath('history'), autoload: true })
-export const searchHistory = new Datastore({ filename: dbPath('search-history'), autoload: true })
-export const subscriptionCache = new Datastore({ filename: dbPath('subscription-cache'), autoload: true })
+export const settings = new Datastore({ filename: dbPath('settings'), autoload: !process.env.IS_ELECTRON_MAIN })
+export const profiles = new Datastore({ filename: dbPath('profiles'), autoload: !process.env.IS_ELECTRON_MAIN })
+export const playlists = new Datastore({ filename: dbPath('playlists'), autoload: !process.env.IS_ELECTRON_MAIN })
+export const history = new Datastore({ filename: dbPath('history'), autoload: !process.env.IS_ELECTRON_MAIN })
+export const searchHistory = new Datastore({ filename: dbPath('search-history'), autoload: !process.env.IS_ELECTRON_MAIN })
+export const subscriptionCache = new Datastore({ filename: dbPath('subscription-cache'), autoload: !process.env.IS_ELECTRON_MAIN })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -34,7 +34,14 @@ if (process.argv.includes('--version')) {
   printHelp()
   app.exit()
 } else {
-  runApp()
+  // Only allow single instance of the application
+  // Exit if we didn't get the lock, because another instance already has it
+  if (process.env.NODE_ENV !== 'development' && !app.requestSingleInstanceLock()) {
+    app.exit()
+  } else {
+    baseHandlers.loadDatastores()
+    runApp()
+  }
 }
 
 function printHelp() {
@@ -254,12 +261,6 @@ function runApp() {
   }
 
   if (process.env.NODE_ENV !== 'development') {
-    // Only allow single instance of the application
-    const gotTheLock = app.requestSingleInstanceLock()
-    if (!gotTheLock) {
-      app.quit()
-    }
-
     app.on('second-instance', (_, commandLine, __) => {
       // Someone tried to run a second instance
       if (typeof commandLine !== 'undefined') {


### PR DESCRIPTION
# Request the single instance lock as soon as possible

## Pull Request Type

- [x] Other
- [x] Performance improvement

## Description

In release builds we use Electron's single instance lock mechanism to ensure that only one instance of FreeTube is running. At the moment we call the `requestSingleInstance()` function after we have already done various other startup tasks and started loading the databases. This pull request moves that call as early on as possible and only starts loading the databases when we have the lock, so that we don't start loading them in a process that we are about to quit. Outside of Electron we still let nedb load the databases automatically.

## Testing

Please test that FreeTube launches correctly and loads your data in dev mode, we don't have the single instance lock mechanism enabled in dev, as we need to be able to relaunch it when the main.js file has been edited.

For actually testing the single instance lock I have also created a build for this branch: https://github.com/absidue/FreeTube/actions/runs/13145941043
Please test that opening a FreeTube window works correctly and then try launching a second instance through the command line, it should focus the original window instead.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 9de03bf412d24e207a6368e538bebdfc31150506