### PR TITLE
Set `process.platform` at build time

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -40,6 +40,7 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
+      'process.platform': `'${process.platform}'`,
       'process.env.IS_ELECTRON_MAIN': true
     })
   ],

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -122,6 +122,7 @@ const config = {
   plugins: [
     processLocalesPlugin,
     new webpack.DefinePlugin({
+      'process.platform': `'${process.platform}'`,
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': true,

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -118,6 +118,7 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
+      'process.platform': 'undefined',
       'process.env.IS_ELECTRON': false,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': false,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1738,6 +1738,24 @@ function runApp() {
     const hidePlaylists = (await sidenavSettings.hidePlaylists)?.value
 
     const template = [
+      ...process.platform === 'darwin'
+        ? [
+            {
+              label: app.getName(),
+              submenu: [
+                { role: 'about' },
+                { type: 'separator' },
+                { role: 'services' },
+                { type: 'separator' },
+                { role: 'hide' },
+                { role: 'hideothers' },
+                { role: 'unhide' },
+                { type: 'separator' },
+                { role: 'quit' }
+              ]
+            }
+          ]
+        : [],
       {
         label: 'File',
         submenu: [
@@ -1945,31 +1963,15 @@ function runApp() {
           { role: 'minimize' },
           { role: 'close' }
         ]
-      }
+      },
+      ...process.platform === 'darwin'
+        ? [
+            { role: 'window' },
+            { role: 'help' },
+            { role: 'services' }
+          ]
+        : []
     ]
-
-    if (process.platform === 'darwin') {
-      template.unshift({
-        label: app.getName(),
-        submenu: [
-          { role: 'about' },
-          { type: 'separator' },
-          { role: 'services' },
-          { type: 'separator' },
-          { role: 'hide' },
-          { role: 'hideothers' },
-          { role: 'unhide' },
-          { type: 'separator' },
-          { role: 'quit' }
-        ]
-      })
-
-      template.push(
-        { role: 'window' },
-        { role: 'help' },
-        { role: 'services' }
-      )
-    }
 
     const menu = Menu.buildFromTemplate(template)
     Menu.setApplicationMenu(menu)

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -198,18 +198,19 @@ export default defineComponent({
         this.$t('Settings.General Settings.Thumbnail Preference.Default'),
         this.$t('Settings.Player Settings.Default Viewing Mode.Theater'),
         this.$t('Video.Player.Full Window'),
+
+        ...process.env.IS_ELECTRON
+          ? [
+              this.$t('Settings.Player Settings.Default Viewing Mode.Full Screen'),
+              this.$t('Settings.Player Settings.Default Viewing Mode.Picture in Picture')
+            ]
+          : []
       ]
 
-      if (process.env.IS_ELECTRON) {
+      if (process.env.IS_ELECTRON && this.externalPlayer !== '') {
         viewingModeNames.push(
-          this.$t('Settings.Player Settings.Default Viewing Mode.Full Screen'),
-          this.$t('Settings.Player Settings.Default Viewing Mode.Picture in Picture')
+          this.$t('Settings.Player Settings.Default Viewing Mode.External Player', { externalPlayerName: this.externalPlayer })
         )
-        if (this.externalPlayer !== '') {
-          viewingModeNames.push(
-            this.$t('Settings.Player Settings.Default Viewing Mode.External Player', { externalPlayerName: this.externalPlayer })
-          )
-        }
       }
 
       return viewingModeNames
@@ -219,15 +220,15 @@ export default defineComponent({
       const viewingModeValues = [
         'default',
         'theatre',
-        'fullwindow'
+        'fullwindow',
+
+        ...process.env.IS_ELECTRON
+          ? ['fullscreen', 'pip']
+          : []
       ]
 
-      if (process.env.IS_ELECTRON) {
-        viewingModeValues.push('fullscreen', 'pip')
-
-        if (this.externalPlayer !== '') {
-          viewingModeValues.push('external_player')
-        }
+      if (process.env.IS_ELECTRON && this.externalPlayer !== '') {
+        viewingModeValues.push('external_player')
       }
 
       return viewingModeValues

--- a/src/renderer/components/top-nav/top-nav.js
+++ b/src/renderer/components/top-nav/top-nav.js
@@ -100,10 +100,14 @@ export default defineComponent({
     },
 
     forwardText: function () {
-      const shortcuts = [KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD]
-      if (process.platform === 'darwin') {
-        shortcuts.push(KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD_ALT_MAC)
-      }
+      const shortcuts = process.platform === 'darwin'
+        ? [
+            KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD,
+            KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD_ALT_MAC
+          ]
+        : [
+            KeyboardShortcuts.APP.GENERAL.HISTORY_FORWARD
+          ]
 
       return localizeAndAddKeyboardShortcutToActionTitle(
         this.$t('Forward'),
@@ -112,10 +116,14 @@ export default defineComponent({
     },
 
     backwardText: function () {
-      const shortcuts = [KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD]
-      if (process.platform === 'darwin') {
-        shortcuts.push(KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD_ALT_MAC)
-      }
+      const shortcuts = process.platform === 'darwin'
+        ? [
+            KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD,
+            KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD_ALT_MAC
+          ]
+        : [
+            KeyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD
+          ]
 
       return localizeAndAddKeyboardShortcutToActionTitle(
         this.$t('Back'),


### PR DESCRIPTION
# Set `process.platform` at build time

## Pull Request Type

- [x] Performance improvement

## Description

For a while now I've been wondering what the best approach would be for detecting the OS that FreeTube is running on for OS specific functionality like keyboard shortcuts when we disable `nodeIntegration`. Currently we use Node.js' `process.platform` property. Originally I was planning to try and detect it with [`navigator.platform`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform) and [`navigator.userAgentData`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData) like shaka-player does, but then after looking at native code in a different project I remembed that compile to native languages do the OS specific stuff at build time and there is no reason why we can't do the same, we already have various other build flags.

The webpack config for the renderer and main files use the `process.platform` value of the machine that the build is running on and the web config uses `undefined` which is the same as the current behaviour as the `process` polyfill doesn't support the `platform` property. This shouldn't cause any problems as the `_scripts/build.js` script that calls electron-builder for the production builds already uses the OS of the machine it is running on and during development we launch electron on the same machine that webpack is running on so it won't cause issues there either. The only case it could cause problems is if someone were to run `yarn run pack` on one machine, copy the output to another machine running a different OS and run `yarn run build-release` there, but nobody should be doing that.

We can't get rid of the `process` polyfill just yet as the util polyfill that the web version of `nedb` uses, uses the `process` global, I am working on a modernised fork of nedb that should resolve that though (switch to ESM, remove the callback APIs and deprecated functionality, the idea is that we will only have to change the package name in the package.json file in FreeTube without needing any code changes).

All numbers are in bytes. For the platform specific after numbers, I hardcoded the `process.platform` to specific platforms in the webpack config and ran `yarn run clean && yarn run pack`.

| | Windows | macOS | Linux |
| --- | --- | --- | --- |
| `main.js` before | 118813 | 118813 | 118813 |
| `main.js` after | 117235 (-1578) | 118394 (-419) | 117204 (-1609) |
| `renderer.js` before | 2604678 | 2604678 | 2604678 |
| `renderer.js` after | 2603626 (-1052) | 2603464 (-1214) | 2603545 (-1133) |

## Testing

`yarn run dev` and check that platform specific things like keyboard shortcuts still work.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 83d99dd72d4010a35bbaa5037116ac3f3e238f3e