### PR TITLE
Fix: Incorrect 'Enter' behaviour when using IME input

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -273,7 +273,7 @@ export default defineComponent({
      */
     handleKeyDown: function (event) {
       // Update Input box value if enter key was pressed and option selected
-      if (event.key === 'Enter') {
+      if (event.key === 'Enter' && !event.isComposing) {
         if (this.removeButtonSelectedIndex !== -1) {
           this.handleRemoveClick(this.removeButtonSelectedIndex)
         } else if (this.searchState.selectedOption !== -1) {


### PR DESCRIPTION
# Fix incorrect 'Enter' behaviour when using IME input

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6798

## Description
Checks if the user is in the middle of IME input before ft-input accepts its usual 'Enter' behaviour. 

## Desktop
- **OS:** macOS 
- **OS Version:** Sequoia 15.2
- **FreeTube version:** v0.23.1
