### PR TITLE
Local API: Improve audio quality by sorting streams, highest bitrate first

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -270,6 +270,7 @@ export async function getLocalVideoInfo(id) {
   }
 
   if (info.streaming_data) {
+    sortStreams(info.streaming_data)
     decipherFormats(info.streaming_data.formats, webInnertube.session.player)
     decipherFormats(info.streaming_data.adaptive_formats, webInnertube.session.player)
 
@@ -287,6 +288,16 @@ export async function getLocalVideoInfo(id) {
   }
 
   return info
+}
+
+/**
+ * Sort the video's streams so that higher bitrate streams appear first.
+ * Workaround to make the player always select high-quality audio.
+ * @param {import('youtubei.js').APIResponseTypes.IStreamingData} data
+ */
+function sortStreams(data) {
+  data.formats.sort((a, b) => b.bitrate - a.bitrate)
+  data.adaptive_formats.sort((a, b) => b.bitrate - a.bitrate)
 }
 
 /**


### PR DESCRIPTION
# Local API: Improve audio quality by sorting streams, highest bitrate first

## Pull Request Type
- [x] Bugfix

## Related issue
#6138

## Description
The player seems to select the first audio stream it sees (I do not know its precise behavior). YouTube often puts a 40-50kbps audio stream first in the format list, which means FreeTube selects it and gives low quality audio.

Higher bitrate streams consistently coming first due to sorting means the player selects a high-quality audio stream, rather than potentially a very low-quality one. See #6138 for more info.

## Testing
Try watching videos with/without this patch, e.g. https://youtu.be/G4qVG_FL4_s

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0.23.1

## Additional context
This doesn't break the quality selector.

I didn't touch the Invidious API because there were no working instances, can't test.