### PR TITLE
Move the choose default folder logic to the main process

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,6 @@ const IpcChannels = {
   GET_SYSTEM_LOCALE: 'get-system-locale',
   GET_PICTURES_PATH: 'get-pictures-path',
   GET_NAVIGATION_HISTORY: 'get-navigation-history',
-  SHOW_OPEN_DIALOG: 'show-open-dialog',
   SHOW_SAVE_DIALOG: 'show-save-dialog',
   STOP_POWER_SAVE_BLOCKER: 'stop-power-save-blocker',
   START_POWER_SAVE_BLOCKER: 'start-power-save-blocker',
@@ -49,6 +48,7 @@ const IpcChannels = {
 
   GENERATE_PO_TOKEN: 'generate-po-token',
 
+  CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   WRITE_SCREENSHOT: 'write-screenshot',
 }
 
@@ -124,6 +124,11 @@ const SyncEvents = {
     UPDATE_SHORTS_WITH_CHANNEL_PAGE_SHORTS_BY_CHANNEL: 'sync-subscriptions-update-shorts-with-channel-page-shorts-by-channel',
     UPDATE_COMMUNITY_POSTS_BY_CHANNEL: 'sync-subscriptions-update-community-posts-by-channel',
   },
+}
+
+const DefaultFolderKind = {
+  DOWNLOADS: 0,
+  SCREENSHOTS: 1
 }
 
 /*
@@ -216,6 +221,7 @@ export {
   IpcChannels,
   DBActions,
   SyncEvents,
+  DefaultFolderKind,
   KeyboardShortcuts,
   MAIN_PROFILE_ID,
   MOBILE_WIDTH_THRESHOLD,

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -59,12 +59,8 @@ class Settings {
     })
   }
 
-  static _findBounds() {
-    return db.settings.findOneAsync({ _id: 'bounds' })
-  }
-
-  static _findTheme() {
-    return db.settings.findOneAsync({ _id: 'baseTheme' })
+  static _findOne(_id) {
+    return db.settings.findOneAsync({ _id })
   }
 
   static _findSidenavSettings() {
@@ -75,10 +71,6 @@ class Settings {
       backendPreference: db.settings.findOneAsync({ _id: 'backendPreference' }),
       hidePlaylists: db.settings.findOneAsync({ _id: 'hidePlaylists' }),
     }
-  }
-
-  static _findScreenshotFolderPath() {
-    return db.settings.findOneAsync({ _id: 'screenshotFolderPath' })
   }
 
   static _updateBounds(value) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -12,6 +12,7 @@ import {
   SyncEvents,
   ABOUT_BITCOIN_ADDRESS,
   KeyboardShortcuts,
+  DefaultFolderKind,
 } from '../constants'
 import * as baseHandlers from '../datastores/handlers/base'
 import { extractExpiryTimestamp, ImageCache } from './ImageCache'
@@ -643,7 +644,7 @@ function runApp() {
       searchQueryText = null
     } = { }) {
     // Syncing new window background to theme choice.
-    const windowBackground = await baseHandlers.settings._findTheme().then((setting) => {
+    const windowBackground = await baseHandlers.settings._findOne('baseTheme').then((setting) => {
       if (!setting) {
         return nativeTheme.shouldUseDarkColors ? '#212121' : '#f1f1f1'
       }
@@ -745,7 +746,7 @@ function runApp() {
       height: 800
     })
 
-    const boundsDoc = await baseHandlers.settings._findBounds()
+    const boundsDoc = await baseHandlers.settings._findOne('bounds')
     if (typeof boundsDoc?.value === 'object') {
       const { maximized, fullScreen, ...bounds } = boundsDoc.value
       const windowVisible = screen.getAllDisplays().some(display => {
@@ -989,14 +990,6 @@ function runApp() {
     sender.executeJavaScript('document.querySelector("video.player").ui.getControls().togglePiP()', true)
   })
 
-  ipcMain.handle(IpcChannels.SHOW_OPEN_DIALOG, async ({ sender }, options) => {
-    const senderWindow = findSenderWindow(sender)
-    if (senderWindow) {
-      return await dialog.showOpenDialog(senderWindow, options)
-    }
-    return await dialog.showOpenDialog(options)
-  })
-
   ipcMain.handle(IpcChannels.SHOW_SAVE_DIALOG, async ({ sender }, options) => {
     const senderWindow = findSenderWindow(sender)
     if (senderWindow) {
@@ -1011,12 +1004,58 @@ function runApp() {
     })
   }
 
+  ipcMain.on(IpcChannels.CHOOSE_DEFAULT_FOLDER, async (event, kind) => {
+    if (!isFreeTubeUrl(event.senderFrame.url) || (kind !== DefaultFolderKind.DOWNLOADS && kind !== DefaultFolderKind.SCREENSHOTS)) {
+      return
+    }
+
+    const settingId = kind === DefaultFolderKind.DOWNLOADS ? 'downloadFolderPath' : 'screenshotFolderPath'
+
+    let currentPath = (await baseHandlers.settings._findOne(settingId))?.value
+
+    if (typeof currentPath !== 'string' || currentPath.length === 0) {
+      currentPath = app.getPath(kind === DefaultFolderKind.DOWNLOADS ? 'downloads' : 'pictures')
+    }
+
+    const dialogOptions = {
+      defaultPath: currentPath,
+      properties: ['openDirectory']
+    }
+
+    let result
+
+    const window = BrowserWindow.fromWebContents(event.sender)
+    if (window) {
+      result = await dialog.showOpenDialog(window, dialogOptions)
+    } else {
+      result = await dialog.showOpenDialog(dialogOptions)
+    }
+
+    if (result.canceled) {
+      return
+    }
+
+    await baseHandlers.settings.upsert(settingId, result.filePaths[0])
+
+    const syncPayload = {
+      event: SyncEvents.GENERAL.UPSERT,
+      data: {
+        _id: settingId,
+        value: result.filePaths[0]
+      }
+    }
+
+    BrowserWindow.getAllWindows().forEach((window) => {
+      window.webContents.send(IpcChannels.SYNC_SETTINGS, syncPayload)
+    })
+  })
+
   ipcMain.handle(IpcChannels.WRITE_SCREENSHOT, async (event, filename, arrayBuffer) => {
     if (!isFreeTubeUrl(event.senderFrame.url) || typeof filename !== 'string' || !(arrayBuffer instanceof ArrayBuffer)) {
       return
     }
 
-    const screenshotFolderPath = await baseHandlers.settings._findScreenshotFolderPath()
+    const screenshotFolderPath = await baseHandlers.settings._findOne('screenshotFolderPath')
 
     let directory
     if (screenshotFolderPath && screenshotFolderPath.value.length > 0) {
@@ -1172,6 +1211,12 @@ function runApp() {
           return await baseHandlers.settings.find()
 
         case DBActions.GENERAL.UPSERT:
+          // These two are only allowed to be changed by the CHOOSE_DEFAULT_FOLDER IPC action
+          // to avoid the "write to default folder" IPC calls being abused to write to arbitrary locations
+          if (data._id === 'downloadFolderPath' || data._id === 'screenshotFolderPath') {
+            return null
+          }
+
           await baseHandlers.settings.upsert(data._id, data.value)
           syncOtherWindows(
             IpcChannels.SYNC_SETTINGS,

--- a/src/renderer/components/download-settings/download-settings.js
+++ b/src/renderer/components/download-settings/download-settings.js
@@ -6,7 +6,7 @@ import FtSelect from '../ft-select/ft-select.vue'
 import FtButton from '../ft-button/ft-button.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import { mapActions } from 'vuex'
-import { IpcChannels } from '../../../constants'
+import { DefaultFolderKind, IpcChannels } from '../../../constants'
 
 export default defineComponent({
   name: 'DownloadSettings',
@@ -50,20 +50,11 @@ export default defineComponent({
     chooseDownloadingFolder: async function () {
       if (process.env.IS_ELECTRON) {
         const { ipcRenderer } = require('electron')
-
-        const folder = await ipcRenderer.invoke(
-          IpcChannels.SHOW_OPEN_DIALOG,
-          { properties: ['openDirectory'] }
-        )
-
-        if (folder.canceled) return
-
-        this.updateDownloadFolderPath(folder.filePaths[0])
+        ipcRenderer.send(IpcChannels.CHOOSE_DEFAULT_FOLDER, DefaultFolderKind.DOWNLOADS)
       }
     },
     ...mapActions([
       'updateDownloadAskPath',
-      'updateDownloadFolderPath',
       'updateDownloadBehavior'
     ])
   }

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -8,7 +8,7 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../ft-button/ft-button.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtTooltip from '../ft-tooltip/ft-tooltip.vue'
-import { IpcChannels } from '../../../constants'
+import { DefaultFolderKind, IpcChannels } from '../../../constants'
 import path from 'path'
 import { getPicturesPath } from '../../helpers/utils'
 
@@ -300,15 +300,7 @@ export default defineComponent({
       // only use with electron
       if (process.env.IS_ELECTRON) {
         const { ipcRenderer } = require('electron')
-        const folder = await ipcRenderer.invoke(
-          IpcChannels.SHOW_OPEN_DIALOG,
-          { properties: ['openDirectory'] }
-        )
-
-        if (!folder.canceled) {
-          await this.updateScreenshotFolderPath(folder.filePaths[0])
-          this.getScreenshotFolderPlaceholder()
-        }
+        ipcRenderer.send(IpcChannels.CHOOSE_DEFAULT_FOLDER, DefaultFolderKind.SCREENSHOTS)
       }
     },
 
@@ -364,7 +356,6 @@ export default defineComponent({
       'updateScreenshotFormat',
       'updateScreenshotQuality',
       'updateScreenshotAskPath',
-      'updateScreenshotFolderPath',
       'updateScreenshotFilenamePattern',
       'parseScreenshotCustomFileName',
     ])


### PR DESCRIPTION
# Move the choose default folder logic to the main process

## Pull Request Type

- [x] Security improvement

## Description

From a security perspective the current `SHOW_OPEN_DIALOG` IPC call has two destinct issues, firstly it just wraps the Electron dialog API, giving the renderer processes full control over what options to pass as it doesn't validate any of the options and secondly while yes the app code prompts the user for the folder and then saves the path to the settings, there is nothing stopping you from setting it to any path you want through the devtools, without prompting the user and then using the `WRITE_SCREENSHOT` IPC call to write to that location.

This pull request attempts to resolve both of those issues. It blocks modifications to the `downloadFolderPath` and `screenshotFolderPath` settings from the renderer process and also provides a single IPC call to handle prompting the user and saving the path to the settings. The new `CHOOSE_DEFAULT_FOLDER` IPC call only takes a single parameter which tells it whether it is prompting the user for the screenshots or downloads folder. That means that the `WRITE_SCREENSHOT` IPC call will only be able to write to the folder selected by the user in the folder chooser dialog.

Yes, I am aware that we still have Node integration turned on, so these changes don't make much of a difference just yet, but once we turn it off, the IPC calls will be the way to perform priviledge actions, so we want to lock them down as much as possible.

## Testing

Use the buttons in the screenshot and download settings to check that the folder chooser shows up and works correctly (e.g. try choosing a folder, try cancelling and check that it doesn't overwrite the existing value, etc).

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0464d90e307d0d3d88c396ca869d93b22ad4bb82