### PR TITLE
Prevent the seek bar thumbnail preview blocking clicks

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -44,6 +44,11 @@
   flex-direction: column-reverse;
 }
 
+/* Ensure that the thumbnail preview doesn't block clicks (e.g. click to pause) */
+:deep(#shaka-player-ui-thumbnail-container) {
+  pointer-events: none;
+}
+
 /*
   Apply the active FreeTube base theme to shaka-player's menus.
   Usually we go for classes and not element names,


### PR DESCRIPTION
# Prevent the seek bar thumbnail preview blocking clicks

## Pull Request Type

- [x] Bugfix

## Related issue

closes #5965

## Description

This pull request disables the seek bar thumbnail container receiving pointer/mouse events, that way the thumbnail container will pass through any clicks, instead of blocking them.

## Testing

This isn't easy to reproduce and requires a bunch of trial and error. You can try moving the mouse from the seek bar to the thumbnail preview quickly and then click as soon as possible, if the video pauses/resumes instead of nothing happening, this bug fix works.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 0464d90e307d0d3d88c396ca869d93b22ad4bb82