### PR TITLE
Add null-check for RichShelf playlist url

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -925,7 +925,7 @@ export function parseChannelHomeTab(homeTab) {
           title: shelf.title?.text,
           content: shelf.contents.map(e => parseListItem(e.content)),
           subtitle: shelf.subtitle?.text,
-          playlistId: shelf.endpoint?.metadata.url.includes('/playlist') ? shelf.endpoint?.metadata.url.replace('/playlist?list=', '') : null
+          playlistId: shelf.endpoint?.metadata.url?.includes('/playlist') ? shelf.endpoint?.metadata.url.replace('/playlist?list=', '') : null
         })
       }
     }


### PR DESCRIPTION
# Add null-check for RichShelf playlist url

## Pull Request Type
- [x] Bugfix

## Description
This is causing error on the music channel since it is missing the url property.

## Testing 
- can't test right now since music channel is currently empty due to a bug (addressed here:  https://github.com/LuanRT/YouTube.js/pull/891 )

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 41
- **FreeTube version:** latest nightly
