### PR TITLE
Bump youtubei.js from 13.0.0 to 13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-observe-visibility": "^1.0.0",
     "vue-router": "^3.6.5",
     "vuex": "^3.6.2",
-    "youtubei.js": "^13.0.0"
+    "youtubei.js": "^13.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "freetube",
   "productName": "FreeTube",
   "description": "A private YouTube client",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "license": "AGPL-3.0-or-later",
   "main": "./dist/main.js",
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5949,10 +5949,10 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jintr@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/jintr/-/jintr-3.2.0.tgz#38bfc2311c7ed4412ebe0bfc5c2e700f8f433921"
-  integrity sha512-psD1yf05kMKDNsUdW1l5YhO59pHScQ6OIHHb8W5SKSM2dCOFPsqolmIuSHgVA8+3Dc47NJR181CXZ4alCAPTkA==
+jintr@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jintr/-/jintr-3.2.1.tgz#ea6719485c9ff5f14ca7f9131990040d4fdfe1be"
+  integrity sha512-yjKUBuwTTg4nc4izMysxuIk0BKh45hnbc1KnXE6LxagIGZn5od+I2elpuRY9IIm3EiKiUZxhxV89a0iX+xoEZg==
   dependencies:
     acorn "^8.8.0"
 
@@ -9722,12 +9722,12 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-youtubei.js@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-13.0.0.tgz#f036bc6f5cb9ef8bd73da7e1079a2b70776bb2f7"
-  integrity sha512-b1QkN9bfgphK+5tI4qteSK54kNxmPhoedvMw0jl4uSn+L8gbDbJ4z52amNuYNcOdp4X/SI3JuUb+f5V0DPJ8Vw==
+youtubei.js@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/youtubei.js/-/youtubei.js-13.1.0.tgz#1e15da01e58c782ab6fb7cc9191a1c99f821c57f"
+  integrity sha512-uL4TyojAYET0c5NGFD7+ScCod/k8Pc/B+D5tLrunFcz1GaBjRMOGRPcNGaRmnhwisegU7ibtw0iUxCN+BZ0ang==
   dependencies:
     "@bufbuild/protobuf" "^2.0.0"
-    jintr "^3.2.0"
+    jintr "^3.2.1"
     tslib "^2.5.0"
     undici "^5.19.1"


### PR DESCRIPTION
# Bump youtubei.js from 13.0.0 to 13.1.0

See https://github.com/FreeTubeApp/FreeTube/pull/6867
Also bumps version number

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix