### PR TITLE
Fix Color Contrast for Catppuccin Mocha card background

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -275,7 +275,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
   --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --secondary-card-bg-color: #6c7086;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION
# Fix Color Contrast for Catppuccin Mocha card background

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6597 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I wanted to improve the color contrast for the background around the video uploader's name on an uploader's comment. Strong color contrasts are important for accessibility.

This PR improves the color contrast from 1.07:1 to 3.59:1 ([link to contrast checker](https://webaim.org/resources/contrastchecker/?fcolor=6C7086&bcolor=181825)) while still staying within the Catppuccin Mocha color palette ("Overlay 0").

I considered this color a decent middleground between background contrast and text contrast. The text vs. secondary-card-bg contrast is still a clearly differentiated [3.37:1](https://webaim.org/resources/contrastchecker/?fcolor=CDD6F4&bcolor=6C7086).

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Before:
![old](https://github.com/user-attachments/assets/1d3c1204-1ba5-44cf-995d-31e21d6f146b)

After:
![new](https://github.com/user-attachments/assets/24937867-8211-4d32-ae86-33a1b768844f)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- This was tested by changing the CSS code on a local FreeTube instance
- No ramifications (other themes remain unchanged)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** v0.23.1 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
This satisfies the [WCAG recommendation](https://www.w3.org/WAI/WCAG21/Techniques/general/G183.html) of at least 3:1.