### PR TITLE
Fix Flatpak Script to Work again and remove Upload ID secret

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -19,17 +19,16 @@ jobs:
       with:
         repository: flathub/io.freetubeapp.FreeTube
         token: ${{ secrets.FLATHUB_TOKEN }}
-    - name: GitHub API exec action
+    - name: Get Repo Release List
       uses: moustacheful/github-api-exec-action@v0
-      id: api_results
+      id: list_results
       with:
         # Command to execute, (e.g: `pulls.create`), see https://octokit.github.io/rest.js/ for available commands
-        command: repos.getRelease
+        command: repos.listReleases
         payload: >
             {
               "owner": "FreeTubeApp",
-              "repo": "FreeTube",
-              "release_id": ${{ secrets.UPLOAD_ID }}
+              "repo": "FreeTube"
             }
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +38,7 @@ jobs:
       uses: bluwy/substitute-string-action@v3
       id: sub
       with:
-        _input-text: ${{ fromJson(steps.api_results.outputs.result).tag_name }}
+        _input-text: ${{ fromJson(steps.list_results.outputs.result)[0].tag_name }}
         -beta: ''
         v: ''
     - name: Create Release Branch
@@ -97,7 +96,7 @@ jobs:
         # The Command which should be run
         cmd: yq -i '.modules[0].sources[1].sha256 = "${{ env.HASH_ARM64 }}"' io.freetubeapp.FreeTube.yml
     - name: Add Patch Notes to XML File
-      run: xmlstarlet ed -L -i /application/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
+      run: xmlstarlet ed -L -i /component/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
     - name: Remove Release Files
       run: |
         rm freetube-${{ steps.sub.outputs.result }}-linux-x64-portable.zip
@@ -108,7 +107,6 @@ jobs:
         # Optional but recommended
         # Defaults to "Apply automatic changes"
         commit_message: Update files for v${{ steps.sub.outputs.result }}
-        token: ${{ secrets.FLATHUB_TOKEN }}
 
         # Optional options appended to `git-commit`
         # See https://git-scm.com/docs/git-commit for a list of available options


### PR DESCRIPTION
# Fix Flatpak Script to Work again and remove Upload ID secret

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
This updates the Flatpak build script to fix an issue where a file wasn't being updated properly and also updates the script to no longer need the upload_id secret.

## Testing

I created a fork and tested the changes on a separate repo. Everything worked as intended.
