### PR TITLE
Apply proxy settings to the PO token web views

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -289,6 +289,8 @@ function runApp() {
     })
   }
 
+  let proxyUrl
+
   app.on('ready', async (_, __) => {
     if (process.env.NODE_ENV === 'production') {
       protocol.handle('app', async (request) => {
@@ -402,8 +404,10 @@ function runApp() {
     }
 
     if (useProxy) {
+      proxyUrl = `${proxyProtocol}://${proxyHostname}:${proxyPort}`
+
       session.defaultSession.setProxy({
-        proxyRules: `${proxyProtocol}://${proxyHostname}:${proxyPort}`
+        proxyRules: proxyUrl
       })
     }
 
@@ -898,18 +902,20 @@ function runApp() {
   })
 
   ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (_, visitorData) => {
-    return generatePoToken(visitorData)
+    return generatePoToken(visitorData, proxyUrl)
   })
 
   ipcMain.on(IpcChannels.ENABLE_PROXY, (_, url) => {
     session.defaultSession.setProxy({
       proxyRules: url
     })
+    proxyUrl = url
     session.defaultSession.closeAllConnections()
   })
 
   ipcMain.on(IpcChannels.DISABLE_PROXY, () => {
     session.defaultSession.setProxy({})
+    proxyUrl = undefined
     session.defaultSession.closeAllConnections()
   })
 

--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -10,9 +10,10 @@ import { join } from 'path'
  * as the BotGuard stuff accesses the global `document` and `window` objects and also requires making some requests.
  * So we definitely don't want it running in the same places as the rest of the FreeTube code with the user data.
  * @param {string} visitorData
+ * @param {string|undefined} proxyUrl
  * @returns {Promise<string>}
  */
-export async function generatePoToken(visitorData) {
+export async function generatePoToken(visitorData, proxyUrl) {
   const sessionUuid = crypto.randomUUID()
 
   const theSession = session.fromPartition(`potoken-${sessionUuid}`, { cache: false })
@@ -27,6 +28,12 @@ export async function generatePoToken(visitorData) {
       .filter(part => !part.includes('Electron'))
       .join(' ')
   )
+
+  if (proxyUrl) {
+    await theSession.setProxy({
+      proxyRules: proxyUrl
+    })
+  }
 
   const webContentsView = new WebContentsView({
     webPreferences: {


### PR DESCRIPTION
# Apply proxy settings to the PO token web views

## Pull Request Type

- [x] Bugfix

## Related issue
- closes #6722 

## Description
Currently we don't apply the user's configured proxy settings to the separate sessions that we use for the PO token web views. This pull request corrects that. To not impact video loading performance too much I decided to cache the proxy URL in a variable, that way we don't have to make multiple calls to nedb each time a video is opened.

## Testing

Set a proxy in FreeTube's proxy settings and check that it works and doesn't cause any new problems.

I used the Charles Proxy app to test this, if you want to do the same you'll need to add this snippet to the `src/main/index.js` file so that the SSL spoofing works:

```js
app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
  event.preventDefault()
  // eslint-disable-next-line n/no-callback-literal
  callback(true)
})
```

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** ce3842924b06bac1199a569b4a1251a195946772