### PR TITLE
IV: fix loading community tab

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -127,16 +127,24 @@ export async function invidiousGetChannelId(url) {
  *  description: string,
  *  descriptionHtml: string,
  *  allowedRegions: string[],
- *  tabs: ('home' | 'videos' | 'shorts' | 'streams' | 'podcasts' | 'releases' | 'playlists' | 'community')[],
+ *  tabs: ('home' | 'videos' | 'shorts' | 'live' | 'podcasts' | 'releases' | 'playlists' | 'community')[],
  *  latestVideos: InvidiousVideoType[],
  *  relatedChannels: InvidiousChannelObject[]
  * }>}
  */
 export async function invidiousGetChannelInfo(channelId) {
-  return await invidiousAPICall({
+  const channelInfo = await invidiousAPICall({
     resource: 'channels',
     id: channelId,
   })
+
+  channelInfo.tabs = channelInfo.tabs.map(tab => {
+    if (tab === 'streams') return 'live'
+    if (tab === 'posts') return 'community'
+    return tab
+  })
+
+  return channelInfo
 }
 
 /**

--- a/src/renderer/views/Channel/Channel.js
+++ b/src/renderer/views/Channel/Channel.js
@@ -1093,15 +1093,8 @@ export default defineComponent({
         // some channels only have a few tabs
         // here are all possible values: home, videos, shorts, streams, playlists, community, channels, about
 
-        const tabs = response.tabs.map(tab => {
-          if (tab === 'streams') {
-            return 'live'
-          }
-          return tab
-        })
-
         this.channelTabs = this.supportedChannelTabs.filter(tab => {
-          return tabs.includes(tab) && tab !== 'home'
+          return response.tabs.includes(tab) && tab !== 'home'
         })
 
         this.currentTab = this.currentOrFirstTab(this.$route.params.currentTab)
@@ -1114,7 +1107,7 @@ export default defineComponent({
           this.channelInvidiousShorts()
         }
 
-        if (!this.hideLiveStreams && response.tabs.includes('streams')) {
+        if (!this.hideLiveStreams && response.tabs.includes('live')) {
           this.channelInvidiousLive()
         }
 


### PR DESCRIPTION
# IV: fix loading community tab

## Pull Request Type
- [x] Bugfix

## Description
The community tab was renamed to `posts`

## Testing 
These are the steps I did to test this. It might be a bit overkill but there are no public instances with api enabled
### Invidious Setup for FreeTube development
- install podman or docker if not already installed (I recommend using either podman desktop or docker desktop but you should be able to use CLI as well)
- checkout latest changes from the invidious repo
- modify the `hmac_key` in the docker-compose.yml file (you can set it to anything for development purposes just as long as it's not `CHANGE_ME!!`)
- run `podman compose up -d` or ` docker compose up -d`
### FreeTube setup
- set `Current Invidious Instance` in FreeTube to http://localhost:3000
- go to a channel with community posts (ex: https://www.youtube.com/channel/UCX6OQ3DkcsbYNE6H8uQQuVA) and verify that the tests are working as expected
### cleanup Invidious
- I use Podman desktop to stop as well as delete containers since it's easier for me than using the CLI (you can also use Docker Desktop to do the same).

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 41 kde
- **FreeTube version:** latest nightly

