### PR TITLE
CLI re-use existing window even if freetube window is in the background (podcast usage)

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -50,9 +50,9 @@ function printHelp() {
   console.log(`\
 usage: ${process.argv0} [options...] [url]
 Options:
-  --help, -h           show this message, then exit
-  --version            print the current version, then exit
-  --new-window         reuse an existing instance if possible`)
+  help, -h           show this message, then exit
+  version            print the current version, then exit
+  new-window         reuse an existing instance if possible`)
 }
 
 function runApp() {
@@ -227,7 +227,7 @@ function runApp() {
 
   // disable electron warning
   process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true'
-  const isDebug = process.argv.includes('--debug')
+  const isDebug = process.argv.includes('debug')
 
   let mainWindow
   let startupUrl
@@ -278,12 +278,11 @@ function runApp() {
             // Just focus the main window (instead of starting a new instance)
             if (mainWindow.isMinimized()) mainWindow.restore()
             mainWindow.focus()
-
-            // Ensure the window is brought to the foreground (podcast use case)
-            mainWindow.show()
-            mainWindow.focus()
+            
             // On macOS, bring the application to the foreground (podcast use case)
             if (process.platform === 'darwin') {
+              mainWindow.show()
+              mainWindow.focus()
               app.focus({ steal: true })
             }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -279,6 +279,14 @@ function runApp() {
             if (mainWindow.isMinimized()) mainWindow.restore()
             mainWindow.focus()
 
+            // Ensure the window is brought to the foreground (podcast use case)
+            mainWindow.show()
+            mainWindow.focus()
+            // On macOS, bring the application to the foreground (podcast use case)
+            if (process.platform === 'darwin') {
+              app.focus({ steal: true })
+            }
+
             if (url) mainWindow.webContents.send(IpcChannels.OPEN_URL, url)
           }
         } else {


### PR DESCRIPTION


# FreeTube CLI when main window is in the foreground

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When invoking the CLI with a new URL, if the current FreeTube window is in the background (out of focus), a new window is created...
This pull request bring the window in the foreground which fix the problem.

The main use-case is when you are on a youtube podcast for which you generally don't have the freetube window in the foreground or as picture-in-picture.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Desktop
<!-- Please complete the following information-->
- **OS:** ALL
- **OS Version:** ALL
- **FreeTube version:** ALL

## Additional context
<!-- Add any other context about the pull request here. -->
