### PR TITLE
Move screenshot fallback path handling to the main process

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,6 @@ const IpcChannels = {
   DISABLE_PROXY: 'disable-proxy',
   OPEN_EXTERNAL_LINK: 'open-external-link',
   GET_SYSTEM_LOCALE: 'get-system-locale',
-  GET_PICTURES_PATH: 'get-pictures-path',
   GET_NAVIGATION_HISTORY: 'get-navigation-history',
   SHOW_SAVE_DIALOG: 'show-save-dialog',
   STOP_POWER_SAVE_BLOCKER: 'stop-power-save-blocker',
@@ -48,6 +47,7 @@ const IpcChannels = {
 
   GENERATE_PO_TOKEN: 'generate-po-token',
 
+  GET_SCREENSHOT_FALLBACK_FOLDER: 'get-screenshot-fallback-folder',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   WRITE_SCREENSHOT: 'write-screenshot',
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -986,10 +986,6 @@ function runApp() {
     return app.getSystemLocale()
   })
 
-  ipcMain.handle(IpcChannels.GET_PICTURES_PATH, () => {
-    return app.getPath('pictures')
-  })
-
   // Allows programmatic toggling of fullscreen without accompanying user interaction.
   // See: https://developer.mozilla.org/en-US/docs/Web/Security/User_activation#transient_activation
   ipcMain.on(IpcChannels.REQUEST_FULLSCREEN, ({ sender }) => {
@@ -1015,6 +1011,14 @@ function runApp() {
       return window.webContents.id === sender.id
     })
   }
+
+  ipcMain.handle(IpcChannels.GET_SCREENSHOT_FALLBACK_FOLDER, (event) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
+    return path.join(app.getPath('pictures'), 'Freetube')
+  })
 
   ipcMain.on(IpcChannels.CHOOSE_DEFAULT_FOLDER, async (event, kind) => {
     if (!isFreeTubeUrl(event.senderFrame.url) || (kind !== DefaultFolderKind.DOWNLOADS && kind !== DefaultFolderKind.SCREENSHOTS)) {

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -9,8 +9,6 @@ import FtButton from '../ft-button/ft-button.vue'
 import FtInput from '../ft-input/ft-input.vue'
 import FtTooltip from '../ft-tooltip/ft-tooltip.vue'
 import { DefaultFolderKind, IpcChannels } from '../../../constants'
-import path from 'path'
-import { getPicturesPath } from '../../helpers/utils'
 
 export default defineComponent({
   name: 'PlayerSettings',
@@ -279,7 +277,8 @@ export default defineComponent({
 
     getScreenshotEmptyFolderPlaceholder: async function() {
       if (process.env.IS_ELECTRON) {
-        return path.join(await getPicturesPath(), 'Freetube')
+        const { ipcRenderer } = require('electron')
+        return await ipcRenderer.invoke(IpcChannels.GET_SCREENSHOT_FALLBACK_FOLDER)
       } else {
         return ''
       }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -581,15 +581,6 @@ export async function getSystemLocale() {
   return locale || 'en-US'
 }
 
-export async function getPicturesPath() {
-  if (process.env.IS_ELECTRON) {
-    const { ipcRenderer } = require('electron')
-    return await ipcRenderer.invoke(IpcChannels.GET_PICTURES_PATH)
-  } else {
-    return null
-  }
-}
-
 export function extractNumberFromString(str) {
   if (typeof str === 'string') {
     return parseInt(str.replaceAll(/\D+/g, ''))


### PR DESCRIPTION
# Move screenshot fallback path handling to the main process

## Pull Request Type

- [x] Other

## Description

This pull request moves the screenshot fallback path handling into the main process, that allows us to remove a use of a Node.js API in the renderer process. After this pull request the only remaining Node.js API uses in the renderer process is the video/audio/subtitle download logic.

## Testing

1. In the dev data location (Electron folder instead of the FreeTube one), check that `screenshotFolderPath` doesn't exist in the `settings.db` file, if it does remove that line.
2. Start FreeTube
3. Open the player settings
4. Make sure taking screenshots is enable and ask for path is disabled.
5. Check that it shows the correct path (should be the pictures folder in your user profile + Freetube).

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 68ec1e12bbdfa6b37122f9513ae1a5fc05ddb3e2