### PR TITLE
Fix: Utilize empty space for playlist queue when Hide Recommended Videos is enabled

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -14,6 +14,7 @@
   flex: 1 1 0%;
   margin-block: 18px;
   margin-inline: 10px;
+  block-size: 90vh;
 }
 
 .banner {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -16,6 +16,10 @@
   inset-block-end: 15px;
 }
 
+.playlistArea {
+  block-size: inherit;
+}
+
 .playlistIndex {
   position: relative;
   inset-block-end: 15px;
@@ -85,7 +89,14 @@
 
 .playlistItems {
   overflow-y: auto;
+}
+
+.playlistItemsVideos {
   block-size: 360px;
+}
+
+.playlistItemsNoVideos {
+  block-size: 85%;
 }
 
 .playlistItem {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.css
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.css
@@ -91,12 +91,14 @@
   overflow-y: auto;
 }
 
-.playlistItemsVideos {
-  block-size: 360px;
-}
-
 .playlistItemsNoVideos {
   block-size: 85%;
+}
+
+@media only screen and (width <= 1350px) {
+  .playlistItemsNoVideos {
+    block-size: 360px;
+  }
 }
 
 .playlistItem {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -142,6 +142,9 @@ export default defineComponent({
     sortOrder: function () {
       return this.isUserPlaylist ? this.userPlaylistSortOrder : SORT_BY_VALUES.Custom
     },
+    hideRecommendedVideos: function () {
+      return this.$store.getters.getHideRecommendedVideos
+    },
   },
   watch: {
     userPlaylistsReady: function() {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
@@ -5,6 +5,7 @@
     />
     <div
       v-else
+      class="playlistArea"
     >
       <h3
         class="playlistTitle"
@@ -110,6 +111,10 @@
         v-if="!isLoading"
         ref="playlistItems"
         class="playlistItems"
+        :class=" {
+          playlistItemsVideos: !hideRecommendedVideos,
+          playlistItemsNoVideos : hideRecommendedVideos
+        } "
       >
         <ft-list-video-numbered
           v-for="(item, index) in playlistItems"

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -137,6 +137,7 @@
   }
 
   .sidebarArea {
+    block-size: 90%;
     grid-area: sidebar;
 
     @media only screen and (width >= 1051px) {
@@ -168,6 +169,10 @@
     @media (width <= 768px) {
       block-size: auto;
     }
+  }
+
+  .watchVideoPlaylistNoCard {
+    block-size: 100%;
   }
 
   .watchVideoRecommendations,

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -137,7 +137,7 @@
   }
 
   .sidebarArea {
-    block-size: 90%;
+    block-size: 95%;
     grid-area: sidebar;
 
     @media only screen and (width >= 1051px) {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -206,7 +206,10 @@
         :video-id="videoId"
         :playlist-item-id="playlistItemId"
         class="watchVideoSideBar watchVideoPlaylist"
-        :class="{ theatrePlaylist: useTheatreMode }"
+        :class="{
+          theatrePlaylist: useTheatreMode,
+          watchVideoPlaylistNoCard: hideRecommendedVideos
+        }"
         @pause-player="pausePlayer"
       />
       <watch-video-recommendations


### PR DESCRIPTION
# Fix: Utilize empty space for playlist queue when Hide Recommended Videos is enabled

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #6925 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Playlist area is expanded the entire height of the sidebar when recommended videos are disabled and viewport is wide enough.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before:
![2025-02-28_18-19-34](https://github.com/user-attachments/assets/59bdf65e-dca1-4987-a853-865b7362bd42)

After:
![2025-02-28_18-09-05](https://github.com/user-attachments/assets/cf3ede60-fb0f-4aa7-b05d-44974b69e0c2)

## Additional context
<!-- Add any other context about the pull request here. -->
Unsure if modifying the main viewport height or using `@media` selectors is the best way to go about this, but it's what I came up with and seems okay when tested with different viewport sizes.