### PR TITLE
fix:(watch.vue) Add refresh functionality  to  live stream starting soon msg

### DIFF
--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -83,10 +83,18 @@
               </span>
             </p>
             <p
-              v-else
-              class="premiereText"
-            >
-              {{ $t("Video.Starting soon, please refresh the page to check again") }}
+             v-else
+             class="premiereText"
+             @click="refreshPage"
+             style="cursor: pointer;"
+           >
+             {{ $t("Video.Starting soon, please refresh the page to check again") }}
+             <font-awesome-icon
+               :icon="['fas', 'sync']"
+               class="refreshIcon"
+               @click.stop="refreshPage"
+               style="margin-left: 8px; cursor: pointer;"
+             />
             </p>
           </div>
           <div
@@ -223,5 +231,12 @@
   </div>
 </template>
 
-<script src="./Watch.js" />
+<script
+methods: {
+  refreshPage() {
+    window.location.reload();
+  }
+}
+src="./Watch.js"
+/>
 <style scoped src="./Watch.scss" lang="scss" />


### PR DESCRIPTION
# Add refresh functionality and icon to  live stream starting soon message

## Pull Request Type

- [X] Bugfix



## Description
adds the ability for user to click the "Video.Starting soon, please refresh the page to check again" and refresh the page. 
also adds small  refresh icon at the end of the text 

## Screenshots <!-- If appropriate -->
N/A

## Testing <!-- for code that is not small enough to be easily understandable -->
very small change to make text clickable and adding refresh method.

## Desktop
<!-- Please complete the following information-->
- Linux Mint Cinnamon
-  22.1
- v0.23.2 Beta

## Additional context
Just a small quick change i got motivated to try  after i was waiting for the WAN show  and I had to click out and click back in to the live stream a few times to refresh and get the live stream to start (Ctrl + r wasnt working for me).  So I thought i could quickly add this small quality of life improvement. 

If this is a fix you all like i might go in and  add contextual refreshes like this  other places. ive noticed that when some components error out like live stream chat theres no way to refresh without refreshing the whole page which can make you lose your place in a live stream. 

Absolutely Love the app by the way thank you dev team for all the awesome work. 