### PR TITLE
Fix search suggestions error for long search queries

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -63,13 +63,14 @@ async function createInnertube({ withPlayer = false, location = undefined, safet
   })
 }
 
+/** @type {Innertube | null} */
 let searchSuggestionsSession = null
 
 export async function getLocalSearchSuggestions(query) {
+  // The search suggestions endpoint does not like search queries larger than SEARCH_CHAR_LIMIT
+  // so return an empty array instead
   if (query.length > SEARCH_CHAR_LIMIT) {
-    // There's an event handler on the search input so avoid displaying an exception
-    console.error(`Query is over ${SEARCH_CHAR_LIMIT} characters`)
-    return
+    return []
   }
 
   // reuse innertube instance to keep the search suggestions snappy


### PR DESCRIPTION
# Fix search suggestions error for long search queries

## Pull Request Type

- [x] Bugfix

## Description

When a long search query was entered into the search box we were catching it before sending it to YouTube's search suggestions endpoit to avoid YouTube erroring but because we were returning `undefined` as the result, it was causing errors as the calling code expected an array. This pull request fixes that by returning an empty array in that case. I also got rid of the unnecessary long about the query being too long, in my mind there is no point logging an error for something that isn't actually an error, especially because the user wouldn't even see it.

## Screenshots

![error-messages](https://github.com/user-attachments/assets/473c4a71-119d-417a-98d9-1de635ac2425)

## Testing

1. Make sure sure you are using the local API.
2. Enter a search query that is longer than 100 characters into the search box e.g. `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`.
3. No errors should appear in the dev tools console.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** feba04a40fe50e981ca56a3b4c4b5e540ed7d3aa