### PR TITLE
Allow legacy formats to be used even when dash and audio-only are unavailable

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -65,7 +65,7 @@ export default defineComponent({
     },
     manifestSrc: {
       type: String,
-      required: true
+      default: null
     },
     manifestMimeType: {
       type: String,

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -272,7 +272,12 @@ export async function getLocalVideoInfo(id) {
 
   if (info.streaming_data) {
     decipherFormats(info.streaming_data.formats, webInnertube.session.player)
-    decipherFormats(info.streaming_data.adaptive_formats, webInnertube.session.player)
+
+    const firstFormat = info.streaming_data.adaptive_formats[0]
+
+    if (firstFormat.url || firstFormat.signature_cipher || firstFormat.cipher) {
+      decipherFormats(info.streaming_data.adaptive_formats, webInnertube.session.player)
+    }
 
     if (info.streaming_data.dash_manifest_url) {
       let url = info.streaming_data.dash_manifest_url

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -695,25 +695,29 @@ export default defineComponent({
             /** @type {import('../../helpers/api/local').LocalFormat[]} */
             const formats = [...result.streaming_data.formats, ...result.streaming_data.adaptive_formats]
 
-            const downloadLinks = formats.map((format) => {
-              const qualityLabel = format.quality_label ?? format.bitrate
-              const fps = format.fps ? `${format.fps}fps` : 'kbps'
-              const type = format.mime_type.split(';')[0]
-              let label = `${qualityLabel} ${fps} - ${type}`
+            const downloadLinks = []
 
-              if (format.has_audio !== format.has_video) {
-                if (format.has_video) {
-                  label += ` ${this.$t('Video.video only')}`
-                } else {
-                  label += ` ${this.$t('Video.audio only')}`
+            for (const format of formats) {
+              if (format.freeTubeUrl) {
+                const qualityLabel = format.quality_label ?? format.bitrate
+                const fps = format.fps ? `${format.fps}fps` : 'kbps'
+                const type = format.mime_type.split(';')[0]
+                let label = `${qualityLabel} ${fps} - ${type}`
+
+                if (format.has_audio !== format.has_video) {
+                  if (format.has_video) {
+                    label += ` ${this.$t('Video.video only')}`
+                  } else {
+                    label += ` ${this.$t('Video.audio only')}`
+                  }
                 }
-              }
 
-              return {
-                url: format.freeTubeUrl,
-                label: label
+                downloadLinks.push({
+                  url: format.freeTubeUrl,
+                  label: label
+                })
               }
-            })
+            }
 
             if (result.captions) {
               const captionTracks = result.captions?.caption_tracks?.map((caption) => {
@@ -779,7 +783,7 @@ export default defineComponent({
             return
           }
 
-          if (result.streaming_data?.adaptive_formats.length > 0) {
+          if (result.streaming_data?.adaptive_formats.length > 0 && result.streaming_data.adaptive_formats[0].freeTubeUrl) {
             this.vrProjection = result.streaming_data.adaptive_formats
               .find(format => {
                 return format.has_video &&


### PR DESCRIPTION
# Allow legacy formats to be used even when dash and audio-only are unavailable

## Pull Request Type

- [x] Bugfix
- [x] Feature Implementation

## Description

Currently when FreeTube receives a SABR-only response from YouTube we get a `No valid URL to decipher` error from the local API and then try falling back to the Invidious API which will fail unless the user is running their own Invidious instance and has configured it in the FreeTube settings. As the legacy format 360p stream is still available in those responses, this pull request makes sure that it can still be used even when the URLs are missing for the DASH streams.

While the goal is still to add SABR support to FreeTube, this allows people to still watch videos in the mean time, even if it is at a low quality.

## Testing

You can replicate a SABR-only response by adding `info.streaming_data.adaptive_formats.forEach(f => { f.url = undefined })` just inside the `if (info.streaming_data) {` line in `src/renderer/helpers/api/local.js`.

Check that the legacy formats get selected automatically, you can't switch to DASH or audio-only and the downloads menu only lists the subtitles and the legacy format stream.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 36d533a8c00897d5e190bb862dcb5217f5ee2ce1