### PR TITLE
Move 'Subscriptions' section below 'About' section in the left sections sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,5 +121,6 @@
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.0",
     "yaml-eslint-parser": "^1.3.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -9,29 +9,6 @@
       :class="applyHiddenLabels"
     >
       <router-link
-        class="navOption topNavOption mobileShow "
-        role="button"
-        to="/subscriptions"
-        :title="$t('Subscriptions.Subscriptions')"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FontAwesomeIcon
-            :icon="['fas', 'rss']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-            fixed-width
-          />
-        </div>
-        <p
-          v-if="!hideText"
-          class="navLabel"
-        >
-          {{ $t("Subscriptions.Subscriptions") }}
-        </p>
-      </router-link>
-      <router-link
         class="navOption mobileHidden"
         role="button"
         to="/subscribedchannels"
@@ -195,6 +172,27 @@
           class="navLabel"
         >
           {{ $t("About.About") }}
+        </p>
+      </router-link>
+      <router-link
+        class="navOption topNavOption mobileShow"
+        role="button"
+        to="/subscriptions"
+        :title="$t('Subscriptions.Subscriptions')"
+      >
+        <div class="thumbnailContainer">
+          <FontAwesomeIcon
+            :icon="['fas', 'rss']"
+            class="navIcon"
+            :class="applyNavIconExpand"
+            fixed-width
+          />
+        </div>
+        <p
+          v-if="!hideText"
+          class="navLabel"
+        >
+          {{ $t("Subscriptions.Subscriptions") }}
         </p>
       </router-link>
       <hr>

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.css
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.css
@@ -1,6 +1,6 @@
 .card {
   inline-size: 85%;
-  margin-block: 0 60px;
+  margin-block: 60px;
   margin-inline: auto;
 }
 


### PR DESCRIPTION
Type of the issue: Other

 Hello, I moved 'Subscriptions' section below 'About' in the left sections sidebar since it should be located just above the channels that the user subscribed to, not at the top of the bar. I didn't find an issue mentionning that problem, but i still estimated that this change was good.

Freetube version: 0.23.2
OS: Windows 11

)
Here you can find attached two screenshots: one before the change, and one after. 
![Capture d’écran 2025-03-13 010400](https://github.com/user-attachments/assets/9d7af315-210f-469d-9feb-452fc7051bed)

![Capture d’écran 2025-03-13 030720](https://github.com/user-attachments/assets/0d468903-c2b4-4eb4-8231-8b36c1e4a8a1)
