### PR TITLE
updated routerView to fix breaking of about page on smaller screens

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -11,6 +11,7 @@
 }
 
 .routerView {
+  inline-size:85%;
   flex: 1 1 0%;
   margin-block: 18px;
   margin-inline: 10px;


### PR DESCRIPTION
# Title

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #7000

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Changes inline size of rooterView to make it not break on smaller screen (680-848px)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
tested by viewing the about page on different widths

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** Windows 11
- **FreeTube version:** Release 0.23.2 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
