### PR TITLE
Added the loop playback default function

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1141,6 +1141,7 @@ export default defineComponent({
       if ('mediaSession' in navigator) {
         navigator.mediaSession.playbackState = 'playing'
       }
+      video.value.loop = store.getters.getLoopPlayback
     }
 
     function handlePause() {
@@ -1152,6 +1153,15 @@ export default defineComponent({
     }
 
     function handleEnded() {
+      if (!store.getters.getLoopPlayback) {
+        stopPowerSaveBlocker()
+
+        if ('mediaSession' in navigator) {
+          navigator.mediaSession.playbackState = 'none'
+        }
+
+        emit('ended')
+      }
       stopPowerSaveBlocker()
 
       if ('mediaSession' in navigator) {
@@ -1583,6 +1593,11 @@ export default defineComponent({
 
         // for manual changes e.g. in quality selector
         player.removeEventListener('variantchanged', updateQualityStats)
+      }
+    })
+    watch(() => store.getters.getLoopPlayback, (newValue) => {
+      if (video.value) {
+        video.value.loop = newValue
       }
     })
 

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -22,8 +22,7 @@ export default defineComponent({
     'ft-input': FtInput,
     'ft-tooltip': FtTooltip
   },
-  data:
-  function () {
+  data: function () {
     return {
       usingElectron: process.env.IS_ELECTRON,
       formatValues: [
@@ -64,9 +63,6 @@ export default defineComponent({
     }
   },
   computed: {
-    playNextVideo: function () {
-      return this.$store.getters.getPlayNextVideo
-    },
     backendPreference: function () {
       return this.$store.getters.getBackendPreference
     },
@@ -81,6 +77,10 @@ export default defineComponent({
 
     autoplayPlaylists: function () {
       return this.$store.getters.getAutoplayPlaylists
+    },
+
+    playNextVideo: function () {
+      return this.$store.getters.getPlayNextVideo
     },
 
     enableSubtitlesByDefault: function () {
@@ -261,8 +261,7 @@ export default defineComponent({
 
     hideComments: function () {
       return this.$store.getters.getHideComments
-    }
-
+    },
   },
   watch: {
     screenshotFolder: function() {
@@ -304,7 +303,7 @@ export default defineComponent({
     },
 
     chooseScreenshotFolder: async function() {
-    // only use with electron
+      // only use with electron
       if (process.env.IS_ELECTRON) {
         const { ipcRenderer } = require('electron')
         ipcRenderer.send(IpcChannels.CHOOSE_DEFAULT_FOLDER, DefaultFolderKind.SCREENSHOTS)

--- a/src/renderer/components/player-settings/player-settings.js
+++ b/src/renderer/components/player-settings/player-settings.js
@@ -22,7 +22,8 @@ export default defineComponent({
     'ft-input': FtInput,
     'ft-tooltip': FtTooltip
   },
-  data: function () {
+  data:
+  function () {
     return {
       usingElectron: process.env.IS_ELECTRON,
       formatValues: [
@@ -63,6 +64,9 @@ export default defineComponent({
     }
   },
   computed: {
+    playNextVideo: function () {
+      return this.$store.getters.getPlayNextVideo
+    },
     backendPreference: function () {
       return this.$store.getters.getBackendPreference
     },
@@ -77,10 +81,6 @@ export default defineComponent({
 
     autoplayPlaylists: function () {
       return this.$store.getters.getAutoplayPlaylists
-    },
-
-    playNextVideo: function () {
-      return this.$store.getters.getPlayNextVideo
     },
 
     enableSubtitlesByDefault: function () {
@@ -167,6 +167,9 @@ export default defineComponent({
 
     videoPlaybackRateInterval: function () {
       return this.$store.getters.getVideoPlaybackRateInterval
+    },
+    loopPlayback: function () {
+      return this.$store.getters.getLoopPlayback
     },
 
     formatNames: function () {
@@ -258,7 +261,8 @@ export default defineComponent({
 
     hideComments: function () {
       return this.$store.getters.getHideComments
-    },
+    }
+
   },
   watch: {
     screenshotFolder: function() {
@@ -270,6 +274,9 @@ export default defineComponent({
     this.getScreenshotFilenameExample(this.screenshotFilenamePattern)
   },
   methods: {
+    toggleLoopPlayback: function () {
+      this.updateLoopPlayback(!this.loopPlayback)
+    },
     handleUpdateScreenshotFormat: async function(format) {
       await this.updateScreenshotFormat(format)
       this.getScreenshotFilenameExample(this.screenshotFilenamePattern)
@@ -297,7 +304,7 @@ export default defineComponent({
     },
 
     chooseScreenshotFolder: async function() {
-      // only use with electron
+    // only use with electron
       if (process.env.IS_ELECTRON) {
         const { ipcRenderer } = require('electron')
         ipcRenderer.send(IpcChannels.CHOOSE_DEFAULT_FOLDER, DefaultFolderKind.SCREENSHOTS)
@@ -357,6 +364,7 @@ export default defineComponent({
       'updateScreenshotQuality',
       'updateScreenshotAskPath',
       'updateScreenshotFilenamePattern',
+      'updateLoopPlayback',
       'parseScreenshotCustomFileName',
     ])
   }

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -41,7 +41,7 @@
           @change="updateVideoSkipMouseScroll"
         />
         <ft-toggle-switch
-          :label="$t('Enable Loop by default')"
+          :label="$t('Settings.Player Settings.Enable Loop by default')"
           :compact="true"
           :default-value="loopPlayback"
           @change="updateLoopPlayback"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -46,12 +46,6 @@
           :tooltip="$t('Tooltips.Player Settings.Skip by Scrolling Over Video Player')"
           @change="updateVideoSkipMouseScroll"
         />
-        <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Enable Loop by Default')"
-          :compact="true"
-          :default-value="loopPlayback"
-          @change="updateLoopPlayback"
-        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -19,7 +19,7 @@
           @change="updateEnableSubtitlesByDefault"
         />
         <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Enable Loop by default')"
+          :label="$t('Settings.Player Settings.Enable Loop by Default')"
           :compact="true"
           :default-value="loopPlayback"
           @change="updateLoopPlayback"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -41,7 +41,7 @@
           @change="updateVideoSkipMouseScroll"
         />
         <ft-toggle-switch
-          :label="$t('Settings.Player Settings.Enable Loop by default')"
+          :label="$t('Settings.Player Settings.Enable Loop by Default')"
           :compact="true"
           :default-value="loopPlayback"
           @change="updateLoopPlayback"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -19,6 +19,12 @@
           @change="updateEnableSubtitlesByDefault"
         />
         <ft-toggle-switch
+          :label="$t('Settings.Player Settings.Enable Loop by default')"
+          :compact="true"
+          :default-value="loopPlayback"
+          @change="updateLoopPlayback"
+        />
+        <ft-toggle-switch
           :label="$t('Settings.Player Settings.Scroll Volume Over Video Player')"
           :compact="true"
           :disabled="videoSkipMouseScroll"

--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -40,6 +40,12 @@
           :tooltip="$t('Tooltips.Player Settings.Skip by Scrolling Over Video Player')"
           @change="updateVideoSkipMouseScroll"
         />
+        <ft-toggle-switch
+          :label="$t('Enable Loop by default')"
+          :compact="true"
+          :default-value="loopPlayback"
+          @change="updateLoopPlayback"
+        />
       </div>
       <div class="switchColumn">
         <ft-toggle-switch

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -306,6 +306,7 @@ const state = {
   defaultInvidiousInstance: '',
   defaultVolume: 1,
   uiScale: 100,
+  loopPlayback: false
 }
 
 const sideEffectHandlers = {
@@ -404,11 +405,9 @@ const sideEffectHandlers = {
 
 const settingsWithSideEffects = Object.keys(sideEffectHandlers)
 
-const customState = {
-}
+const customState = {}
 
-const customGetters = {
-}
+const customGetters = {}
 
 const customMutations = {}
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -405,9 +405,11 @@ const sideEffectHandlers = {
 
 const settingsWithSideEffects = Object.keys(sideEffectHandlers)
 
-const customState = {}
+const customState = {
+}
 
-const customGetters = {}
+const customGetters = {
+}
 
 const customMutations = {}
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -449,6 +449,7 @@ Settings:
     Scroll Volume Over Video Player: Scroll Volume Over Video Player
     Scroll Playback Rate Over Video Player: Scroll Playback Rate Over Video Player
     Skip by Scrolling Over Video Player: Skip by Scrolling Over Video Player
+    Enable Loop by default: Enable Loop by default
     Display Play Button In Video Player: Display Play Button In Video Player
     Enter Fullscreen on Display Rotate: Enter Fullscreen on Display Rotate
     Next Video Interval: Autoplay Countdown Timer

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -449,7 +449,7 @@ Settings:
     Scroll Volume Over Video Player: Scroll Volume Over Video Player
     Scroll Playback Rate Over Video Player: Scroll Playback Rate Over Video Player
     Skip by Scrolling Over Video Player: Skip by Scrolling Over Video Player
-    Enable Loop by default: Enable Loop by default
+    Enable Loop by Default: Enable Loop by Default
     Display Play Button In Video Player: Display Play Button In Video Player
     Enter Fullscreen on Display Rotate: Enter Fullscreen on Display Rotate
     Next Video Interval: Autoplay Countdown Timer


### PR DESCRIPTION
# Add playback loop default option

## Pull Request Type

- [x]  Feature Implementation
- [ ]  Bugfix
- [ ]  Documentation
- [ ]  Other

## Related Issue
Closes [#7009](https://github.com/FreeTubeApp/FreeTube/issues/7009)

## Description
This pull request adds **a default playback loop option** to FreeTube. With this feature, users can **enable looping for videos automatically**, improving the playback experience for those who frequently use the loop functionality.

Changes include:

- Adding a new setting for enabling/disabling the default loop option.
- Modifying the player settings component to support this feature.
- Ensuring the setting persists between sessions.

## Screenshots
A screen recording has been provided instead of screenshots.

https://github.com/user-attachments/assets/f9dae35f-9c15-4381-aadd-01a2e4f95e22



## Testing
The code is straightforward, and no additional testing was required.

## Desktop
**OS**: Windows 10 Professionnel
**OS Version**: 22H2
**FreeTube Version**: 0.23.2

## Additional Context
This feature enhances the user's ability to control playback behavior, making looping more accessible without requiring manual toggling for each video.

