### PR TITLE
catppuccinMocha card bg color change

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -289,8 +289,8 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --title-color: var(--accent-color);
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
-  --card-bg-color: #112a46;
-  --secondary-card-bg-color: #acc8e5;
+  --card-bg-color: #181825;
+  --secondary-card-bg-color: #5f5fc9;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -289,8 +289,8 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --title-color: var(--accent-color);
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
-  --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --card-bg-color: #112a46;
+  --secondary-card-bg-color: #acc8e5;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION
# Improved Color Contrast for Uploader Comments in Catppuccin Mocha Theme

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6597

## Description
This pull request changes the color styling of the theme catppuccinMocha at : 
CSS properties : card-bg-color and secondary-card-bg-color for .catppuccinMocha
from --card-bg-color: #181825 to ->   --card-bg-color: #112a46
from --secondary-card-bg-color: #1e1e2e to -> --secondary-card-bg-color: #acc8e5 
This change ensures a correct contrast ratio.
## Screenshots
before : 
<img width="959" alt="aCapture d'écran 2025-03-19 142812" src="https://github.com/user-attachments/assets/879be2d9-d57b-4544-b2d0-3ce7962cc8a4" />
after : 
![Capture d'écran 2025-03-19 141300](https://github.com/user-attachments/assets/c535137c-e4f9-4f16-842a-d3fef053bce5)

## Testing 
The code is straightforward, and no additional testing was required.

## Desktop
<!-- Please complete the following information-->
- **OS: Windows 11**
- **OS Version: 23H2**
- **FreeTube version: 0.23.2**

## Additional context
-----