### PR TITLE
Update themes.css

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -289,8 +289,8 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --title-color: var(--accent-color);
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
-  --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+ --card-bg-color: #091f14;
+  --secondary-card-bg-color: #acc8e5;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION
Improved Color Contrast for Uploader Comments in Catppuccin Mocha Theme
Pull Request Type
 Bugfix
 Feature Implementation
 Documentation
 Other
Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/6597

Description
This pull request changes the color styling of the theme catppuccinMocha at :
CSS properties : card-bg-color and secondary-card-bg-color for .catppuccinMocha
from --card-bg-color: #181825 to -> --card-bg-color: #091f14
from --secondary-card-bg-color: #1e1e2e to -> --secondary-card-bg-color: #acc8e5
This change ensures a correct contrast ratio.
scrrenshots:
before:
![Screenshot 2025-03-19 161733](https://github.com/user-attachments/assets/9511b01a-0f47-4bb4-9644-2fda1b7f7a24)
after:
![Screenshot 2025-03-19 161412](https://github.com/user-attachments/assets/83d1b45f-d50c-42ef-9ad8-33bb9c1f2c25)
Testing
The code is straightforward, and no additional testing was required.

Desktop
OS: Windows 11 pro 
OS Version: 10.0.26100 
FreeTube version: 0.23.2