### PR TITLE
fix: improve uploader highlight contrast for Catppuccin Mocha

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -290,7 +290,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
   --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --secondary-card-bg-color: #640473;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION

Improved Color Contrast for Uploader Comments in Catppuccin Mocha Theme
Pull Request Type
Bugfix
Feature Implementation
Documentation
Other
Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/6597

Description
This pull request changes the color styling of the theme catppuccinMocha at :
CSS properties : card-bg-color and secondary-card-bg-color for .catppuccinMocha
from --card-bg-color: #181825 to -> --card-bg-color: #091f14
from --secondary-card-bg-color: #1e1e2e to -> --secondary-card-bg-color: #acc8e5
This change ensures a correct contrast ratio.
scrrenshots:
before:
![Screenshot 2025-03-19 215720](https://github.com/user-attachments/assets/7e170098-8cd8-43f9-b97a-dd27fcfb0904)


after:
![Screenshot 2025-03-19 215558](https://github.com/user-attachments/assets/dddb5859-4d65-419c-b450-7c0648539bfe)

Testing
The code is straightforward, and no additional testing was required.

Desktop
OS: Windows 11 pro
OS Version: 10.0.26100
FreeTube version: 0.23.2
if there anything missing tell me