### PR TITLE
Fix: Remove unnecessary overflow

### DIFF
--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -5,7 +5,7 @@
 
 .settingsSections,
 .switchRow {
-  overflow-x: hidden;
+  
   max-inline-size: 90%;
 }
 


### PR DESCRIPTION
Title:
Fix: Remove unnecessary overflow: hidden to resolve scrollbar issue in Turkish/German settings

Description:
In settings.css, I removed the overflow: hidden property. This change fixes the issue where an unwanted extra scrollbar appears when the language is set to Turkish or German.
screenshots :
before:
![Screenshot 2025-03-19 224606](https://github.com/user-attachments/assets/7df5dd44-bfa5-491c-9355-8534e4464e67)
after:
![Screenshot 2025-03-19 224557](https://github.com/user-attachments/assets/0defc0a4-d808-41d0-a425-614638bbce00)


After removing overflow: hidden, the layout behaves as expected and no additional scrollbar shows up in these languages. thank you