### PR TITLE
solving issue of Video with no views say NaN views

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -582,12 +582,9 @@ export async function getSystemLocale() {
 }
 
 export function extractNumberFromString(str) {
-  if (typeof str === 'string') {
-    return parseInt(str.replaceAll(/\D+/g, ''))
-  } else {
-    return NaN
-  }
+  return typeof str === 'string' ? parseInt(str.replace(/\D/g, ''), 10) || 0 : NaN;
 }
+
 
 export function showExternalPlayerUnsupportedActionToast(externalPlayer, action) {
   const message = i18n.t('Video.External Player.UnsupportedActionTemplate', { externalPlayer, action })


### PR DESCRIPTION
## Pull Request Type

- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other
## related issue

Resolve #6568

## Description
the issue of showing NaN Views is solved and Videos with NaN views becomes videos with 0 views


## Screenshots <!-- If appropriate -->
before : 
![firstone](https://github.com/user-attachments/assets/120ba67b-293b-4530-8aed-b501606d59ce)

after : 
![secondone](https://github.com/user-attachments/assets/47d8bc13-97a6-4d55-b4b5-d1c389789814)



## Desktop
<!-- Please complete the following information-->
- **OS:*windows 10 pro*
- **OS Version:*22H2*
- **FreeTube version:*0.23.2*

