### PR TITLE
Fix #4924 : Hide Search Bar and Filter in "Add to Playlist" When Playlists Are Less Than Two

### DIFF
--- a/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.vue
+++ b/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.vue
@@ -11,6 +11,7 @@
       }) }}
     </p>
     <div
+      v-if="allPlaylists.length > 2"
       class="searchInputsRow"
     >
       <ft-input
@@ -24,6 +25,7 @@
       />
     </div>
     <div
+      v-if="allPlaylists.length > 2"
       class="optionsRow"
     >
       <div

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -17,7 +17,7 @@
         {{ $t("History.History") }}
       </h2>
       <ft-input
-        v-show="fullData.length > 0"
+        v-show="fullData.length > 2"
         ref="searchBar"
         :placeholder="$t('History.Search bar placeholder')"
         :show-clear-text-button="true"
@@ -30,7 +30,7 @@
         class="optionsRow"
       >
         <ft-toggle-switch
-          v-if="fullData.length > 1"
+          v-if="fullData.length > 2"
           :label="$t('History.Case Sensitive Search')"
           :compact="true"
           :default-value="doCaseSensitiveSearch"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -10,7 +10,7 @@
         {{ $t('Channels.Title') }}
       </h2>
       <ft-input
-        v-show="subscribedChannels.length > 0"
+        v-show="subscribedChannels.length > 2"
         ref="searchBarChannels"
         :placeholder="$t('Channels.Search bar placeholder')"
         :value="query"

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -25,7 +25,7 @@
           @click="createNewPlaylist"
         />
         <div
-          v-if="fullData.length > 1"
+          v-if="fullData.length > 2"
           class="searchInputsRow"
         >
           <ft-input
@@ -40,6 +40,7 @@
           />
         </div>
         <div
+          v-if="fullData.length > 2"
           class="optionsRow"
         >
           <ft-toggle-switch


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #4924

## Description
I have checked whether the playlist length is greater than two before displaying the search bar and search filter in the "Add to Playlist" section. This ensures that these elements will only appear when there are more than two playlists, improving UI clarity and user experience.  

Additionally, I have applied the same fix to the Channel List, History, and  Add Video to Playlist pages. Now, the search bar and sorting options will only appear when there is more than one channel, video, or playlist, keeping the interface clean and consistent across different sections.

## Screenshots 

## Add Video to Playlist before

![Screenshot 2025-03-23 191555](https://github.com/user-attachments/assets/9de08901-8e57-4b82-9bb6-9142ca4472f9)

## Add Video to Playlist after

![Screenshot 2025-03-23 193458](https://github.com/user-attachments/assets/d771eff0-99bd-4458-bf42-a24a251e517f)

### Playlist Before 

![Screenshot 2025-03-22 132141](https://github.com/user-attachments/assets/b61a19e1-a3f8-4ac8-87fa-44ea73b22f60)

### Playlist After

![Screenshot 2025-03-22 131920](https://github.com/user-attachments/assets/beb3e559-a583-4b9e-96da-ec2a4b8ac146)

###  Channels Before

![Screenshot 2025-03-22 160107](https://github.com/user-attachments/assets/d4ffe091-e371-40f5-8f01-39a6c0d7f08b)

###  Channels After

![Screenshot 2025-03-22 160126](https://github.com/user-attachments/assets/930ef57c-33c7-4079-810f-199db657aaf1)

### History Before

![Screenshot 2025-03-22 154706](https://github.com/user-attachments/assets/3e9f38ad-f69d-4d0b-9450-ca50c7fdfbe3)

### History After

![Screenshot 2025-03-22 154631](https://github.com/user-attachments/assets/a7f06b50-b555-403b-9289-214f3bc77c9a)

## Desktop
- **OS:** Windows 11  
- **OS Version:** 24H2 (OS Build 26100.3476)  
- **FreeTube version:** 0.23.2  

## Additional context
This update prevents unnecessary UI elements from appearing when there are fewer than two playlists, channels, or videos. It ensures that the search bar and sorting options are only visible when relevant, making the interface cleaner and more intuitive across the Add to Playlist, Add Video to Playlist, Channel List, and History pages.
