### PR TITLE
Feature/add Windows Taskbar jumplist task 'New Window'

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -225,6 +225,22 @@ function runApp() {
     }
   })
 
+   // If in windows, add Windows Jump List task 'New Window'
+   if (process.platform === 'win32') {
+     const iconPath = path.join(path.dirname(app.getPath('exe')), 'freetube.exe');
+ 
+     app.setUserTasks([
+       {
+         program: process.execPath,
+         arguments: '--new-window',
+         iconPath: `${iconPath},0`,
+         iconIndex: 0,
+         title: 'New Window',
+         description: 'Create a new window'
+       },
+     ])
+   }
+
   // disable electron warning
   process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true'
   const isDebug = process.argv.includes('--debug')

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -225,22 +225,21 @@ function runApp() {
     }
   })
 
-   // If in windows, add Windows Jump List task 'New Window'
-   if (process.platform === 'win32') {
-     const iconPath = path.join(path.dirname(app.getPath('exe')), 'freetube.exe');
- 
-     app.setUserTasks([
-       {
-         program: process.execPath,
-         arguments: '--new-window',
-         iconPath: `${iconPath},0`,
-         iconIndex: 0,
-         title: 'New Window',
-         description: 'Create a new window'
-       },
-     ])
-   }
-
+  // If in windows, add Windows Jump List task 'New Window'
+  if (process.platform === 'win32') {
+    app.setJumpList([{
+      type: 'tasks',
+      items: [{
+        type: 'task',
+        program: process.execPath,
+        args: '--new-window',
+        title: 'New Window',
+        description: 'Create a new window',
+        iconPath: process.execPath,
+        iconIndex: 0
+      }]
+    }])
+  }
   // disable electron warning
   process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true'
   const isDebug = process.argv.includes('--debug')


### PR DESCRIPTION
# Title

[Windows: Open New Window from Taskbar Jumplist](https://github.com/FreeTubeApp/FreeTube/commit/a8916e595a0e08d79b3c1b771964e6c2acf9186a)

## Pull Request Type
- [ ] Feature Implementation

## Description

Windows users now have the option to right click and open a new window from the taskbar. If Windows O/S is detected, this feature adds a 'New Window' option to the taskbar context menu. This enhancement aims to simplify the process of opening multiple instances of an application, aligning with user preferences for more intuitive taskbar functionality.

## Screenshots

![2GLSh4sVDc](https://github.com/user-attachments/assets/a07e5b60-eab2-4283-8323-bcdea94d8e04)

## Testing 

Built & tested, working fine.

## Desktop

Windows 11
26100
23.2 latest dev

## Additional context

This feature is particularly useful for users who frequently need multiple instances of the same application open simultaneously. It streamlines workflow mimicking browser taskbar functionality by eliminating the need for additional clicks or keyboard shortcuts to achieve this functionality. The implementation is designed to be user-friendly and accessible directly from the taskbar, enhancing overall productivity and user experience on Windows systems.