### PR TITLE
Remove authorId and author from the required properties for copying playlists

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -327,8 +327,6 @@ const actions = {
       const requiredVideoKeys = [
         'videoId',
         'title',
-        'author',
-        'authorId',
         'lengthSeconds',
 
         // `timeAdded` should be generated when videos are added


### PR DESCRIPTION
# Remove authorId and author from the required properties for copying playlists

## Pull Request Type

- [x] Bugfix

## Related issue

closes #7023

## Description

Shorts only playlists don't have any uploader information, so the playlist copy validation code complains about the `author` and `authorId` properties being missing. This pull request removes those two properties from the required keys allowing those playlists to be copied.

## Testing

1. Open https://youtube.com/playlist?list=PLnN2bBxGARv7fRxsCcWaxvGE6sn5Ypp1H
2. Try to copy the playlist
3. There should be no validation error in the devtools console.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** f31f8a214e41d311e38379c80c73ec6f097c2dd9