### PR TITLE
Fix being able to have duplicate keyword search history due to spaces

### DIFF
--- a/src/renderer/views/SearchPage/SearchPage.js
+++ b/src/renderer/views/SearchPage/SearchPage.js
@@ -54,10 +54,14 @@ export default defineComponent({
     rememberSearchHistory: function () {
       return this.$store.getters.getRememberSearchHistory
     },
+
+    processedQuery: function () {
+      return this.query.trim()
+    },
   },
   watch: {
     $route () {
-      const query = this.$route.params.query
+      const query = this.$route.params.query.trim()
       let features = this.$route.query.features
       // if page gets refreshed and there's only one feature then it will be a string
       if (typeof features === 'string') {
@@ -79,13 +83,13 @@ export default defineComponent({
 
       this.query = query
 
-      this.setAppTitle(`${this.query} - ${packageDetails.productName}`)
+      this.setAppTitle(`${this.processedQuery} - ${packageDetails.productName}`)
       this.checkSearchCache(payload)
     }
   },
   mounted: function () {
     this.query = this.$route.params.query
-    this.setAppTitle(`${this.query} - ${packageDetails.productName}`)
+    this.setAppTitle(`${this.processedQuery} - ${packageDetails.productName}`)
 
     let features = this.$route.query.features
     // if page gets refreshed and there's only one feature then it will be a string
@@ -102,7 +106,7 @@ export default defineComponent({
     }
 
     const payload = {
-      query: this.query,
+      query: this.processedQuery,
       options: {},
       searchSettings: this.searchSettings
     }
@@ -112,7 +116,7 @@ export default defineComponent({
   methods: {
     updateSearchHistoryEntry: function () {
       const persistentSearchHistoryPayload = {
-        _id: this.query,
+        _id: this.processedQuery,
         lastUpdatedAt: Date.now()
       }
 
@@ -285,7 +289,7 @@ export default defineComponent({
 
     nextPage: function () {
       const payload = {
-        query: this.query,
+        query: this.processedQuery,
         searchSettings: this.searchSettings,
         options: {
           nextPageRef: this.nextPageRef


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Saw some duplicate keyword search history entries after searching something via copy & paste (sometimes with surrounding spaces)
This PR trims all spaces around input keyword used in search & keyword search history (but keeping spaces in user inputs

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Enable keyword search history (Privacy -> Remember Search History?
- Clear/Delete related/all keyword search history entries
- Search "LTT " (trailing space)
- Search "LTT" (no space)
- Confirms it won't re-search on 2nd search (no loading animation)
- Confirms only "LTT" (no space) saved in keyword search history

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
