### PR TITLE
Fix comments with long single words that break boundaries of single column player view

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -1,6 +1,10 @@
 .card {
   padding-block: 0;
   padding-inline: 16px;
+  max-inline-size: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  min-inline-size: 0;
 }
 
 .getCommentsTitle,
@@ -40,6 +44,10 @@
 
 .comment {
   padding: 15px;
+  overflow-wrap: break-word;
+  inline-size: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .hideComments {
@@ -96,7 +104,10 @@
   font-size: 14px;
   margin-block-start: -10px;
   margin-inline-start: 70px;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  max-inline-size: calc(100% - 70px);
+  hyphens: auto;
 }
 
 .commentPinned {
@@ -193,4 +204,21 @@
   text-decoration: underline;
   cursor: pointer;
   color: var(--title-color);
+}
+
+.commentReplies .commentText {
+  max-inline-size: calc(100% - 70px);
+}
+
+@media only screen and (width <= 500px) {
+  .commentText {
+    max-inline-size: calc(100% - 75px);
+  }
+}
+
+@media only screen and (width <= 350px) {
+  .commentText {
+    max-inline-size: calc(100% - 80px);
+    margin-inline-start: 65px;
+  }
 }

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
@@ -57,6 +57,11 @@
 .postText {
   overflow-wrap: anywhere;
   white-space: pre-wrap;
+  word-break: normal;
+  min-inline-size: 0;
+  max-inline-size: 100%;
+  box-sizing: border-box;
+  hyphens: auto;
 }
 
 .commentsLink {
@@ -110,7 +115,8 @@
   .playlistText {
     margin-inline-start: 10px;
     inline-size: 50%;
-    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
 
     .playlistAuthor {
       font-size: small;

--- a/src/renderer/components/ft-card/ft-card.css
+++ b/src/renderer/components/ft-card/ft-card.css
@@ -4,4 +4,10 @@
   padding-block: 3px 16px;
   padding-inline: 16px;
   box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  max-inline-size: 100%;
+  overflow: hidden;
+  box-sizing: border-box;
+  min-inline-size: 0;
 }

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.css
@@ -173,11 +173,6 @@
   inset-block-start: 0;
 }
 
-.superChatMessage .chatMessage {
-  color: var(--text-with-main-color);
-  margin-inline-start: 20px;
-}
-
 .liveChatComments {
   inline-size: 100%;
   overflow-y: auto;
@@ -186,7 +181,23 @@
 .chatContent {
   margin-block: 5px 2px;
   font-size: 12px;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  box-sizing: border-box;
+  hyphens: auto;
+}
+
+.chatMessage {
+  overflow-wrap: anywhere;
+  word-break: normal;
+  hyphens: auto;
+}
+
+.superChatMessage .chatMessage {
+  color: var(--text-with-main-color);
+  margin-inline-start: 20px;
 }
 
 .member {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -129,6 +129,9 @@
     grid-column: 1;
     margin-block: 0 16px;
     margin-inline: 0;
+    min-inline-size: 0;
+    inline-size: 100%;
+    overflow-wrap: break-word;
   }
 
   .infoArea {
@@ -193,6 +196,12 @@
 
   @media only screen and (width <= 1050px) {
     @include single-column-template;
+
+    .watchVideo {
+      inline-size: 100%;
+      box-sizing: border-box;
+      min-inline-size: 0;
+    }
   }
 
   @media only screen and (width >= 1051px) {


### PR DESCRIPTION
Fix comments with long single words that break boundaries of single column player view

## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #7039

## Description

In the issue link, you can see the problem arises when the single word is extremely long it broke UI layout in narrow windows..

Currently we use break-word in css meaning the line will only change after the word ends. therefore, to fix the issue and not ruining user experience with (word-break: break-all) I have used a hybrid method: which only breaks extremely long single words.

1. Added Container Constraints:
- Added `min-inline-size: 0` to allow containers to properly shrink.
- Applied `overflow: hidden` to prevent content from spilling outside.

2. Implemented Smart Word Breaking:
- Used `overflow-wrap: anywhere` to handle extremely long words.
- Set `word-break: normal` to maintain natural breaks for regular text.
- Added `hyphens: auto` to improve readability at break points.

 3. Applied to Key Components:
- Comments in `CommentSection.css`
- Messages in `watch-video-live-chat.css`
- Posts in `FtCommunityPost.scss`
- Playlist text in community posts

 4. Fixed CSS Standards:
- Replaced standard properties with logical properties for RTL support.
- Removed redundant properties for cleaner code.

Result:
Text now wraps appropriately in all scenarios:
- Normal words break at natural points.
- Extremely long words break as needed without breaking layout.
- UI remains intact at all screen sizes.

---


## Screenshots 
**1st**
![image](https://github.com/user-attachments/assets/62d0cf13-2985-4007-85f3-5cca9956d927)

This Youtube video contains a comment which has a extremely long word

Left side: broken UI
Right side: Updated which breaks the extremely long word without breaking other normal words

**2nd**

Resizing makes the comments unreadable:

![image](https://github.com/user-attachments/assets/083cc1ef-e487-4d42-acfe-7760ed75e888)

Left side: Unreadable code 
Right side: Fixed perfection 


## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? --> Yes the pull request has be tested.


 I have extensively tested this for 30+ videos on my Windows 11 laptop, the changes are drastic and effective. UI is working properly and it fixes the current issue


Are there any ramifications remaining? No, There is no new bugs or problems and "all" the issues have been resolved properly

## Desktop
<!-- Please complete the following information-->
- **Windows 11**
- **Version 24H2 (OS Build 26100.3476)::**
- **FreeTube version: 23.3 beta**

## Additional context
Even after testing extensively for finding any potential bugs if still someone gets any problem please tag me on a issue 
I am active and available and I'll check everything asap.