### PR TITLE
Increase PO token snapshot timeout from 3 to 10 seconds

### DIFF
--- a/src/botGuardScript.js
+++ b/src/botGuardScript.js
@@ -63,7 +63,7 @@ export default async function (videoId, visitorData, context) {
   })
 
   const webPoSignalOutput = []
-  const botGuardResponse = await botGuard.snapshot({ webPoSignalOutput })
+  const botGuardResponse = await botGuard.snapshot({ webPoSignalOutput }, 10_000)
 
   const integrityTokenResponse = await fetch(buildURL('GenerateIT', true), {
     method: 'POST',


### PR DESCRIPTION
# Increase PO token snapshot timeout from 3 to 10 seconds

## Pull Request Type

- [x] Bugfix

## Related issue
- closes #7024

## Description

By default bgutils-js times out the snapshot method after 3 seconds to avoid it blocking forever in case something goes wrong, however it seems like some of our users have encountered legitimate scenarios where the snapshot method will run longer than 3 seconds. In the linked issue one user was running the x64 build of FreeTube on an arm64 Mac, so the translation overhead likely resulted in FreeTube running slower.

## Testing

While I haven't personally encountered a timeout from the snapshot method, I decided that jumping to 10 seconds should give it enough time even on slower setups while still achieving the goal of preventing it from blocking forever.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 4ef333da97d7c5e2565e8387242b3e5cafac9d01