### PR TITLE
Set properties on DOM elements directly instead of using setAttribute

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -567,7 +567,7 @@ export default defineComponent({
     },
 
     setLocale: function() {
-      document.documentElement.setAttribute('lang', this.locale)
+      document.documentElement.lang = this.locale
       if (this.isLocaleRightToLeft) {
         document.body.dir = 'rtl'
       } else {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -295,8 +295,8 @@ export async function readFileWithPicker(
         .join(',')
 
       const fileInput = document.createElement('input')
-      fileInput.setAttribute('type', 'file')
-      fileInput.setAttribute('accept', joinedExtensions)
+      fileInput.type = 'file'
+      fileInput.accept = joinedExtensions
       fileInput.onchange = () => {
         resolve(fileInput.files[0])
         fileInput.onchange = null
@@ -395,8 +395,8 @@ export async function writeFileWithPicker(
     const url = URL.createObjectURL(content)
 
     const downloadLink = document.createElement('a')
-    downloadLink.setAttribute('download', encodeURIComponent(fileName))
-    downloadLink.setAttribute('href', url)
+    downloadLink.download = encodeURIComponent(fileName)
+    downloadLink.href = url
     downloadLink.click()
 
     // Small timeout to give the browser time to react to the click on the link


### PR DESCRIPTION
# Set properties on DOM elements directly instead of using setAttribute

## Pull Request Type

- [x] Cleanup

## Description

While some attributes can only be set on DOM elements through the `setAttribute` method (e.g. custom ones like `shaka-status` in our custom player components), the ones that we are setting here can also be set with their respective properties, which requires slightly less code.

## Testing

Two out of the three changes need to be tested in a browser, so I would recommend testing all of them there to save time.

1. `yarn dev:web`
2. Change the locale in settings
3. Check in the inspector/elements panel of the devtools that the `lang` attribute on the top-level `<html>` element has changed to your chosen language
4. Import some of your user data in the data settings e.g. playlists
5. Check that is was imported successfully
6. Export some of your user data e.g. playlists
7. Check that it was exported successfully

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d9de46da78f4d99c4aa506b632dfe518f5c0089d