### PR TITLE
Remove broken Alpine builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -82,7 +82,6 @@ body:
       label: Installation Method
       description: When you select an unofficial installation method, you must have verified that the bug is also present in one of the official installation methods. Please make sure you uninstall the unofficial installation before installing one of the official installations. If you can't reproduce this in one of the official installation methods, you should report the bug to the maintainer of the unofficial installation method you used.
       options:
-        - .apk (Alpine Linux Package)
         - .AppImage
         - .deb
         - .dmg
@@ -93,6 +92,7 @@ body:
         - .rpm
         - .zip / .7z
         - .apk (FreeTubeAndroid Unofficial)
+        - .apk (Alpine Linux Package Unofficial)
         - AUR (Unofficial)
         - Chocolatey (Unofficial)
         - Homebrew (Unofficial)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,27 +213,6 @@ jobs:
         name: freetube-${{ steps.versionNumber.outputs.result }}.arm64.rpm
         path: build/freetube-${{ steps.versionNumber.outputs.result }}.aarch64.rpm
 
-    - name: Upload Alpine .apk x64 Artifact
-      uses: actions/upload-artifact@v4
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
-      with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-alpine-amd64.apk
-        path: build/freetube-${{ steps.versionNumber.outputs.result }}.apk
-
-    - name: Upload Alpine .apk ARMv7l Artifact
-      uses: actions/upload-artifact@v4
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-alpine-armv7l.apk
-        path: build/freetube-${{ steps.versionNumber.outputs.result }}-armv7l.apk
-
-    - name: Upload Alpine .apk ARM64 Artifact
-      uses: actions/upload-artifact@v4
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
-      with:
-        name: freetube-${{ steps.versionNumber.outputs.result }}-alpine-arm64.apk
-        path: build/freetube-${{ steps.versionNumber.outputs.result }}-arm64.apk
-
     - name: Upload Pacman .pacman x64 Artifact
       uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,39 +249,6 @@ jobs:
         asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.aarch64.rpm
         asset_content_type: application/x-rpm
 
-    - name: Upload Alpine .apk x64 Release
-      uses: actions/upload-release-asset@v1
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-alpine-amd64.apk
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.apk
-        asset_content_type: application/octet-stream
-
-    - name: Upload Alpine .apk ARMv7l Release
-      uses: actions/upload-release-asset@v1
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-alpine-armv7l.apk
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.apk
-        asset_content_type: application/octet-stream
-
-    - name: Upload Alpine .apk ARM64 Release
-      uses: actions/upload-release-asset@v1
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-alpine-arm64.apk
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.apk
-        asset_content_type: application/octet-stream
-
     - name: Upload Pacman .pacman x64 Release
       uses: actions/upload-release-asset@v1
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')

--- a/_scripts/build.js
+++ b/_scripts/build.js
@@ -37,7 +37,7 @@ if (platform === 'darwin') {
     arch = Arch.armv7l
   }
 
-  targets = Platform.LINUX.createTarget(['deb', 'zip', '7z', 'apk', 'rpm', 'AppImage', 'pacman'], arch)
+  targets = Platform.LINUX.createTarget(['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'], arch)
 }
 
 builder

--- a/_scripts/ebuilder.config.js
+++ b/_scripts/ebuilder.config.js
@@ -52,7 +52,7 @@ const config = {
   linux: {
     category: 'Network',
     icon: '_icons/icon.svg',
-    target: ['deb', 'zip', '7z', 'apk', 'rpm', 'AppImage', 'pacman'],
+    target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'],
   },
   // See the following issues for more information
   // https://github.com/jordansissel/fpm/issues/1503


### PR DESCRIPTION
# Remove broken Alpine builds

## Pull Request Type

- [x] Bugfix
- [x] Other

## Related issue

- closes #7106

## Description

All of Electron's official builds are linked against glibc but Alpine Linux uses muslc, so our Alpine apk builds don't actually run on Alpine Linux. I have already removed the broken builds from the existing releases that had them (0.23.0, 0.23.1, 0.23.2 and 0.23.3) and they are not listed on the website so they don't need removing from there.

Alpine Linux users should use the flatpak or the unofficial package in the Alpine Linux repositories which is a custom build compiled specifically for Alpine Linux.