### PR TITLE
Fix #4924 : Hide Search Bar and Filter when less than two content in Add Video to Playlists , History, Channels

### DIFF
--- a/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.vue
+++ b/src/renderer/components/ft-playlist-add-video-prompt/ft-playlist-add-video-prompt.vue
@@ -11,6 +11,7 @@
       }) }}
     </p>
     <div
+      v-if="allPlaylists.length > 1"
       class="searchInputsRow"
     >
       <ft-input
@@ -24,6 +25,7 @@
       />
     </div>
     <div
+      v-if="allPlaylists.length > 1"
       class="optionsRow"
     >
       <div

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -17,7 +17,7 @@
         {{ $t("History.History") }}
       </h2>
       <ft-input
-        v-show="fullData.length > 0"
+        v-show="fullData.length > 1"
         ref="searchBar"
         :placeholder="$t('History.Search bar placeholder')"
         :show-clear-text-button="true"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -10,7 +10,7 @@
         {{ $t('Channels.Title') }}
       </h2>
       <ft-input
-        v-show="subscribedChannels.length > 0"
+        v-show="subscribedChannels.length > 1"
         ref="searchBarChannels"
         :placeholder="$t('Channels.Search bar placeholder')"
         :value="query"


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #4924

## Description
I've updated the app to make the search bar and filters appear only when needed, keeping the interface clean.
- In the "Add Video to Playlist" pages, the search bar and filter will only show up if there are more than one playlists
- In "Channel List" Section it will only shows the search bar and filters if more than one channel are there
- In "History" Section it will only shows search bar and filter if their is more than 1 video present

## Screenshots 

## Add Video to Playlist before
![Screenshot 2025-04-01 143356](https://github.com/user-attachments/assets/faf82fcf-1082-4828-aa69-a9f99f51ba0a)

## Add Video to Playlist after
![Screenshot 2025-04-01 143948](https://github.com/user-attachments/assets/dc0d8ceb-e54d-47b1-89df-cb9936c703ea)

###  Channels Before
![Screenshot 2025-04-01 143513](https://github.com/user-attachments/assets/a50cb786-de4c-4bed-9402-c235d560a315)

###  Channels After
![Screenshot 2025-04-01 144227](https://github.com/user-attachments/assets/924ff182-d2d6-445d-9492-bcc99b52656d)

### History before
![Screenshot 2025-04-01 143458](https://github.com/user-attachments/assets/20253d78-fb8b-4429-b387-f910832730f4)

### History After
![Screenshot 2025-04-01 144331](https://github.com/user-attachments/assets/e0147dbb-1a29-4294-ab1d-0bd88a450b9d)

## Desktop
- **OS:** Windows 11  
- **OS Version:** 24H2 (OS Build 26100.3476)  
- **FreeTube version:** 0.23.2  

## Additional context
This update keeps the UI clean by showing the search bar and filters only when needed. They’ll appear only if there’s more than one playlist, channel, or video in the Add Video to Playlist, Channel List, and History sections, making navigation simpler and more intuitive.