### PR TITLE
Remember playlist sort

### DIFF
--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -307,6 +307,7 @@ const state = {
   defaultInvidiousInstance: '',
   defaultVolume: 1,
   uiScale: 100,
+  userPlaylistsSortBy: 'latest_played_first',
 }
 
 const sideEffectHandlers = {

--- a/src/renderer/views/UserPlaylists/UserPlaylists.js
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.js
@@ -52,10 +52,18 @@ export default defineComponent({
       query: '',
       doSearchPlaylistsWithMatchingVideos: false,
       activeData: [],
-      sortBy: SORT_BY_VALUES.LatestPlayedFirst,
     }
   },
   computed: {
+    sortBy: {
+      get() {
+        return this.$store.getters.getUserPlaylistsSortBy
+      },
+      set(value) {
+        this.$store.dispatch('updateUserPlaylistsSortBy', value)
+      },
+    },
+
     locale: function () {
       return this.$i18n.locale
     },
@@ -180,20 +188,12 @@ export default defineComponent({
       this.activeData = this.fullData
       this.filterPlaylist()
     },
-    sortBy() {
-      sessionStorage.setItem('UserPlaylists/sortBy', this.sortBy)
-    },
   },
   created: function () {
     document.addEventListener('keydown', this.keyboardShortcutHandler)
     const limit = sessionStorage.getItem('UserPlaylists/dataLimit')
     if (limit !== null) {
       this.dataLimit = limit
-    }
-
-    const sortBy = sessionStorage.getItem('UserPlaylists/sortBy')
-    if (sortBy != null) {
-      this.sortBy = sortBy
     }
 
     this.filterPlaylistDebounce = debounce(this.filterPlaylist, 500)


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #5008

## Description
This PR migrate the user playlist sort preference from sessionStorage to Vuex store ensuring that the sorting preference saves even after the app reopens. 

## Desktop
- **OS:** Windows 11  
- **OS Version:** 24H2 (OS Build 26100.3476)  
- **FreeTube version:** 0.23.2  

## Additional context
This feature improves user experience by keeping sorting preferences saved permanently, rather than resetting after each session.
