### PR TITLE
Manually apply ad-hoc signature to macOS (ARM) app to fix "app is damaged" errors

### DIFF
--- a/_scripts/ebuilder.config.js
+++ b/_scripts/ebuilder.config.js
@@ -30,6 +30,9 @@ const config = {
   // electron-builder will however still spend time scanning the `node_modules` folder and building up a list of dependencies,
   // returning `false` from the `beforeBuild` hook skips that.
   beforeBuild: () => Promise.resolve(false),
+  // electron-builder doesn't seem to handle ad-hoc signatures on macOS properly. To work around this, manually call
+  // the `codesign` command after building the app but before packaging it into distributable forms (dmg, etc.).
+  afterPack: './_scripts/signMacBeforePackaging.js',
   dmg: {
     contents: [
       {

--- a/_scripts/signMacBeforePackaging.js
+++ b/_scripts/signMacBeforePackaging.js
@@ -1,0 +1,13 @@
+const { execSync } = require('child_process')
+const builder = require('electron-builder')
+const path = require('path')
+
+exports.default = async function(context) {
+  if (context.electronPlatformName === 'darwin' && context.arch === builder.Arch.arm64) {
+    const appPath = path.join(context.appOutDir, 'FreeTube.app')
+    const frameworksPath = path.join(appPath, 'Contents/Frameworks')
+
+    execSync(`/usr/bin/codesign --force --sign - ${frameworksPath.toString()}/*`)
+    execSync(`/usr/bin/codesign --force --sign - ${appPath.toString()}`)
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #6691

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
macOS on ARM shows "app is damaged" errors due to an invalid signature. This appears to be an issue with the way `electron-builder` handles the build, breaking the automatic linker-applied ad-hoc signature. To fix this we can re-sign the affected parts of the app bundle using the `codesign` command after `electron-builder` does this work but before it places it into the DMG/ZIP/7z container.

## Screenshots <!-- If appropriate -->
The warning now shows as
<img width="372" alt="Screenshot 2025-04-02 at 4 57 11 PM" src="https://github.com/user-attachments/assets/a1826060-dad0-4ebe-94dc-1455092f2b88" />
And System Settings shows an option to bypass the warning
<img width="701" alt="Screenshot 2025-04-02 at 4 57 22 PM" src="https://github.com/user-attachments/assets/ab42ff79-6b4a-403e-b637-26e1e946214a" />



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
I tested the build GitHub actions workflow on my fork and verified that the build does not show a damaged warning on my machine. (It still shows a Gatekeeper warning, but this is expected without notarization and can be bypassed without the use of Terminal.)

## Desktop
<!-- Please complete the following information-->
- **OS:** macOS
- **OS Version:** 15.4 (24E248)
- **FreeTube version:** 0.23.3

## Additional context
<!-- Add any other context about the pull request here. -->
Documentation may need updating to move away from the suggestions of `xattr` and towards [the GUI method of bypassing the warning](https://support.apple.com/en-us/102445#openanyway)?
