### PR TITLE
Use shadow color for light themes

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -161,6 +161,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --primary-text-color: #212121;
   --secondary-text-color: #424242;
   --tertiary-text-color: #757575;
+  --primary-shadow-color: rgb(200 200 200 / 75%);
   --title-color: #3f7ac6;
   --bg-color: #f1f1f1;
   --favorite-icon-color: #0c0;


### PR DESCRIPTION
# Use shadow color for light themes

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #6654

## Description
The light themes now use a similar shadow color setup as the dark themes. This results in them also having a valid separator.

## Screenshots
![image](https://github.com/user-attachments/assets/f6f3e43e-e40a-47e6-bb34-9b4a0f197d7c)
![image](https://github.com/user-attachments/assets/c24f986c-ac47-4b29-8bb0-b5869cd4f820)

## Testing
I looked at every changed theme and they look good.

## Desktop
- **OS:** Arch Linux (btw)
- **FreeTube version:** Newest dev commit
