### PR TITLE
Local API: Implement SABR for VODs

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "autolinker": "^4.1.0",
     "bgutils-js": "^3.2.0",
     "electron-context-menu": "^4.0.5",
+    "googlevideo": "^3.0.0",
     "marked": "^15.0.7",
     "path-browserify": "^1.0.1",
     "portal-vue": "^2.1.7",

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -22,6 +22,8 @@
       @canplay="handleCanPlay"
       @volumechange="updateVolume"
       @timeupdate="handleTimeupdate"
+      @enterpictureinpicture="handleEnterPictureInPicture"
+      @leavepictureinpicture="handleLeavePictureInPicture"
     />
     <!--
       VR playback is only possible for VR videos with "EQUIRECTANGULAR" projection
@@ -65,7 +67,7 @@
         v-else
       >{{ $t('Video.Player.Stats.CodecsVideoAudioNoItags', stats.codecs) }}</span>
       <br>
-      <span>{{ $t('Video.Player.Stats.Player Dimensions', stats.playerDimensions) }}</span>
+      <span>{{ $t('Video.Player.Stats.Player Dimensions', playerDimensions) }}</span>
       <br>
       <template
         v-if="format !== 'audio'"

--- a/src/renderer/helpers/player/EbmlParser.js
+++ b/src/renderer/helpers/player/EbmlParser.js
@@ -1,0 +1,276 @@
+// Based on https://github.com/shaka-project/shaka-player/blob/main/lib/dash/ebml_parser.js
+// Adapted for use in FreeTube:
+// - General changes such as removing Closure compiler specific stuff
+
+import shaka from 'shaka-player'
+
+const ShakaError = shaka.util.Error
+const BufferUtils = shaka.util.BufferUtils
+
+export class EbmlParser {
+  /**
+   * @param {BufferSource} data
+   */
+  constructor(data) {
+    /** @private */
+    this.dataView_ = BufferUtils.toDataView(data)
+
+    /** @private */
+    this.reader_ = new shaka.util.DataViewReader(this.dataView_, shaka.util.DataViewReader.Endianness.BIG_ENDIAN)
+  }
+
+  /**
+   * @returns {boolean} True if the parser has more data, false otherwise.
+   */
+  hasMoreData() {
+    return this.reader_.hasMoreData()
+  }
+
+  /**
+   * Parses an EBML element from the parser's current position, and advances
+   * the parser.
+   * @returns {EbmlElement} The EBML element.
+   * @see http://matroska.org/technical/specs/rfc/index.html
+   */
+  parseElement() {
+    const id = this.parseId_()
+
+    // Parse the element's size.
+    const vint = this.parseVint_()
+    let size
+    if (/** @__NOINLINE__ */isDynamicSizeValue(vint)) {
+      // If this has an unknown size, assume that it takes up the rest of the
+      // data.
+      size = this.dataView_.byteLength - this.reader_.getPosition()
+    } else {
+      size = /** @__NOINLINE__ */ getVintValue(vint)
+    }
+
+    // Note that if the element's size is larger than the buffer then we are
+    // parsing a "partial element". This may occur if for example we are
+    // parsing the beginning of some WebM container data, but our buffer does
+    // not contain the entire WebM container data.
+    const elementSize =
+      this.reader_.getPosition() + size <= this.dataView_.byteLength
+        ? size
+        : this.dataView_.byteLength - this.reader_.getPosition()
+
+    const dataView = BufferUtils.toDataView(this.dataView_, this.reader_.getPosition(), elementSize)
+
+    this.reader_.skip(elementSize)
+
+    return new EbmlElement(id, dataView)
+  }
+
+  /**
+   * Parses an EBML ID from the parser's current position, and advances the
+   * parser.
+   * @returns {number} The EBML ID.
+   * @private
+   */
+  parseId_() {
+    const vint = this.parseVint_()
+
+    if (vint.length > 7) {
+      throw new ShakaError(
+        ShakaError.Severity.CRITICAL,
+        ShakaError.Category.MEDIA,
+        ShakaError.Code.EBML_OVERFLOW
+      )
+    }
+
+    let id = 0
+    for (const /* byte */ b of vint) {
+      // Note that we cannot use << since |value| may exceed 32 bits.
+      id = (256 * id) + b
+    }
+
+    return id
+  }
+
+  /**
+   * Parses a variable sized integer from the parser's current position, and
+   * advances the parser.
+   * For example:
+   *   1 byte  wide: 1xxx xxxx
+   *   2 bytes wide: 01xx xxxx xxxx xxxx
+   *   3 bytes wide: 001x xxxx xxxx xxxx xxxx xxxx
+   * @returns {Uint8Array} The variable sized integer.
+   * @private
+   */
+  parseVint_() {
+    const position = this.reader_.getPosition()
+    const firstByte = this.reader_.readUint8()
+    if (firstByte === 0) {
+      throw new ShakaError(
+        ShakaError.Severity.CRITICAL,
+        ShakaError.Category.MEDIA,
+        ShakaError.Code.EBML_OVERFLOW
+      )
+    }
+
+    // Determine the index of the highest bit set.
+    const index = Math.floor(Math.log2(firstByte))
+    const numBytes = 8 - index
+
+    if (process.env.NODE_ENV === 'development' && (numBytes > 8 || numBytes < 1)) {
+      throw new Error('Assertion failure: Incorrect log2 value')
+    }
+
+    this.reader_.skip(numBytes - 1)
+    return BufferUtils.toUint8(this.dataView_, position, numBytes)
+  }
+}
+
+// Lets us use the type in ./WebmSegmentIndexParser.js without actually exporting the class
+/** @typedef {EbmlElement} EbmlElement */
+
+class EbmlElement {
+  /**
+   * @param {number} id The ID.
+   * @param {DataView} dataView The DataView.
+   */
+  constructor(id, dataView) {
+    /** @type {number} */
+    this.id = id
+
+    /** @private {DataView} */
+    this.dataView_ = dataView
+  }
+
+  /**
+   * Gets the element's offset from the beginning of the buffer.
+   * @returns {number}
+   */
+  getOffset() {
+    return this.dataView_.byteOffset
+  }
+
+  /**
+   * Interpret the element's data as a list of sub-elements.
+   * @returns {EbmlParser} A parser over the sub-elements.
+   */
+  createParser() {
+    return new EbmlParser(this.dataView_)
+  }
+
+  /**
+   * Interpret the element's data as an unsigned integer.
+   * @returns {number}
+   */
+  getUint() {
+    if (this.dataView_.byteLength > 8) {
+      throw new ShakaError(
+        ShakaError.Severity.CRITICAL,
+        ShakaError.Category.MEDIA,
+        ShakaError.Code.EBML_OVERFLOW
+      )
+    }
+
+    // Ensure we have at most 53 meaningful bits.
+    if ((this.dataView_.byteLength === 8) &&
+      (this.dataView_.getUint8(0) & 0xe0)) {
+      throw new ShakaError(
+        ShakaError.Severity.CRITICAL,
+        ShakaError.Category.MEDIA,
+        ShakaError.Code.JS_INTEGER_OVERFLOW
+      )
+    }
+
+    let value = 0
+
+    for (let i = 0; i < this.dataView_.byteLength; i++) {
+      const chunk = this.dataView_.getUint8(i)
+      value = (256 * value) + chunk
+    }
+
+    return value
+  }
+
+  /**
+   * Interpret the element's data as a floating point number
+   * (32 bits or 64 bits). 80-bit floating point numbers are not supported.
+   * @returns {number}
+   */
+  getFloat() {
+    if (this.dataView_.byteLength === 4) {
+      return this.dataView_.getFloat32(0)
+    } else if (this.dataView_.byteLength === 8) {
+      return this.dataView_.getFloat64(0)
+    } else {
+      throw new ShakaError(
+        ShakaError.Severity.CRITICAL,
+        ShakaError.Category.MEDIA,
+        ShakaError.Code.EBML_BAD_FLOATING_POINT_SIZE
+      )
+    }
+  }
+}
+
+/**
+ * Gets the value of a variable sized integer.
+ * For example, the x's below are part of the vint's value.
+ *    7-bit value: 1xxx xxxx
+ *   14-bit value: 01xx xxxx xxxx xxxx
+ *   21-bit value: 001x xxxx xxxx xxxx xxxx xxxx
+ * @param {Uint8Array} vint The variable sized integer.
+ * @returns {number} The value of the variable sized integer.
+ */
+function getVintValue(vint) {
+  // If |vint| is 8 bytes wide then we must ensure that it does not have more
+  // than 53 meaningful bits. For example, assume |vint| is 8 bytes wide,
+  // so it has the following structure,
+  // 0000 0001 | xxxx xxxx ...
+  // Thus, the first 3 bits following the first byte of |vint| must be 0.
+  if ((vint.length === 8) && (vint[1] & 0xe0)) {
+    throw new ShakaError(
+      ShakaError.Severity.CRITICAL,
+      ShakaError.Category.MEDIA,
+      ShakaError.Code.JS_INTEGER_OVERFLOW
+    )
+  }
+
+  let value = 0
+  for (let i = 0; i < vint.length; i++) {
+    const item = vint[i]
+    if (i === 0) {
+      // Mask out the first few bits of |vint|'s first byte to get the most
+      // significant bits of |vint|'s value. If |vint| is 8 bytes wide then
+      // |value| will be set to 0.
+      const mask = 0x1 << (8 - vint.length)
+      value = item & (mask - 1)
+    } else {
+      // Note that we cannot use << since |value| may exceed 32 bits.
+      value = (256 * value) + item
+    }
+  }
+
+  return value
+}
+
+const DYNAMIC_SIZES = [
+  [0xff],
+  [0x7f, 0xff],
+  [0x3f, 0xff, 0xff],
+  [0x1f, 0xff, 0xff, 0xff],
+  [0x0f, 0xff, 0xff, 0xff, 0xff],
+  [0x07, 0xff, 0xff, 0xff, 0xff, 0xff],
+  [0x03, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+  [0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]
+]
+
+/**
+ * Checks if the given variable sized integer represents a dynamic size value.
+ * @param {Uint8Array} vint The variable sized integer.
+ * @returns {boolean} true if |vint| represents a dynamic size value,
+ *   false otherwise.
+ */
+function isDynamicSizeValue(vint) {
+  for (const dynamicSizeConst of DYNAMIC_SIZES) {
+    if (BufferUtils.equal(vint, new Uint8Array(dynamicSizeConst))) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/renderer/helpers/player/Mp4SegmentIndexParser.js
+++ b/src/renderer/helpers/player/Mp4SegmentIndexParser.js
@@ -1,0 +1,178 @@
+// Based on https://github.com/shaka-project/shaka-player/blob/main/lib/dash/mp4_segment_index_parser.js
+// Adapted for use in FreeTube:
+// - General changes such as removing Closure compiler specific stuff
+// - Rewritten to use functions instead of a class
+// - The segment URLs receive the start time and segment number
+
+import shaka from 'shaka-player'
+
+const ShakaError = shaka.util.Error
+const SeverityCritical = ShakaError.Severity.CRITICAL
+const CategoryMedia = ShakaError.Category.MEDIA
+
+/**
+ * Parses SegmentReferences from an ISO BMFF SIDX structure.
+ * @param {BufferSource} sidxData The MP4's container's SIDX.
+ * @param {number} sidxOffset The SIDX's offset, in bytes, from the start of
+ *   the MP4 container.
+ * @param {string} uri The location of the MP4 file that contains the segments.
+ * @param {shaka.media.InitSegmentReference} initSegmentReference
+ * @param {number} timestampOffset
+ * @param {number} appendWindowStart
+ * @param {number} appendWindowEnd
+ * @returns {shaka.media.SegmentReference[]}
+ */
+export function parseMp4SegmentIndex(
+  sidxData,
+  sidxOffset,
+  uri,
+  initSegmentReference,
+  timestampOffset,
+  appendWindowStart,
+  appendWindowEnd
+) {
+  let references
+
+  const parser = new shaka.util.Mp4Parser()
+    .fullBox('sidx', (box) => {
+      references = /** @__NOINLINE__ */ parseSIDX(
+        sidxOffset,
+        initSegmentReference,
+        timestampOffset,
+        appendWindowStart,
+        appendWindowEnd,
+        uri,
+        box
+      )
+    })
+
+  if (sidxData) {
+    parser.parse(sidxData)
+  }
+
+  if (references) {
+    return references
+  } else {
+    console.error('[parseMp4SegmentIndex] Invalid box type, expected "sidx".')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.MP4_SIDX_WRONG_BOX_TYPE
+    )
+  }
+}
+
+/**
+ * Parse a SIDX box from the given reader.
+ *
+ * @param {number} sidxOffset
+ * @param {shaka.media.InitSegmentReference} initSegmentReference
+ * @param {number} timestampOffset
+ * @param {number} appendWindowStart
+ * @param {number} appendWindowEnd
+ * @param {string} uri The location of the MP4 file that contains the segments.
+ * @param {shaka.extern.ParsedBox} box
+ * @returns {shaka.media.SegmentReference[]}
+ */
+function parseSIDX(
+  sidxOffset,
+  initSegmentReference,
+  timestampOffset,
+  appendWindowStart,
+  appendWindowEnd,
+  uri,
+  box
+) {
+  if (process.env.NODE_ENV === 'development' && box.version == null) {
+    throw new Error('Assertion failure: SIDX is a full box and should have a valid version.')
+  }
+
+  const references = []
+
+  // Parse the SIDX structure.
+  // Skip reference_ID (32 bits).
+  box.reader.skip(4)
+
+  const timescale = box.reader.readUint32()
+
+  if (timescale === 0) {
+    console.error('[parseMp4SegmentIndex] Invalid timescale.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.MP4_SIDX_INVALID_TIMESCALE
+    )
+  }
+
+  let earliestPresentationTime
+  let firstOffset
+
+  if (box.version === 0) {
+    earliestPresentationTime = box.reader.readUint32()
+    firstOffset = box.reader.readUint32()
+  } else {
+    earliestPresentationTime = box.reader.readUint64()
+    firstOffset = box.reader.readUint64()
+  }
+
+  // Skip reserved (16 bits).
+  box.reader.skip(2)
+
+  // Add references.
+  const referenceCount = box.reader.readUint16()
+
+  // Subtract the presentation time offset
+  let unscaledStartTime = earliestPresentationTime
+  let startByte = sidxOffset + box.size + firstOffset
+
+  for (let i = 0; i < referenceCount; i++) {
+    // |chunk| is 1 bit for |referenceType|, and 31 bits for |referenceSize|.
+    const chunk = box.reader.readUint32()
+    const referenceType = (chunk & 0x80000000) >>> 31
+    const referenceSize = chunk & 0x7FFFFFFF
+
+    const subsegmentDuration = box.reader.readUint32()
+
+    // Skipping 1 bit for |startsWithSap|, 3 bits for |sapType|, and 28 bits
+    // for |sapDelta|.
+    box.reader.skip(4)
+
+    // If |referenceType| is 1 then the reference is to another SIDX.
+    // We do not support this.
+    if (referenceType === 1) {
+      console.error('[parseMp4SegmentIndex] Hierarchical SIDXs are not supported.')
+      throw new ShakaError(
+        SeverityCritical,
+        CategoryMedia,
+        ShakaError.Code.MP4_SIDX_TYPE_NOT_SUPPORTED
+      )
+    }
+
+    // The media timestamps inside the container.
+    const nativeStartTime = unscaledStartTime / timescale
+    const nativeEndTime =
+      (unscaledStartTime + subsegmentDuration) / timescale
+
+    const uris = [`${uri}&startTimeMs=${Math.round((nativeStartTime + timestampOffset) * 1000)}&sq=${i + 1}`]
+
+    references.push(
+      new shaka.media.SegmentReference(
+        nativeStartTime + timestampOffset,
+        nativeEndTime + timestampOffset,
+        () => uris,
+        startByte,
+        startByte + referenceSize - 1,
+        initSegmentReference,
+        timestampOffset,
+        appendWindowStart,
+        appendWindowEnd
+      )
+    )
+
+    unscaledStartTime += subsegmentDuration
+    startByte += referenceSize
+  }
+
+  box.parser.stop()
+  return references
+}

--- a/src/renderer/helpers/player/SabrManifestParser.js
+++ b/src/renderer/helpers/player/SabrManifestParser.js
@@ -1,0 +1,703 @@
+import shaka from 'shaka-player'
+import { parseWebmSegmentIndex } from './WebmSegmentIndexParser'
+import { parseMp4SegmentIndex } from './Mp4SegmentIndexParser'
+import { QUALITY } from 'googlevideo'
+
+/**
+ * @typedef {{
+ *   duration: number,
+ *   formats: {
+ *     itag: number,
+ *     lastModified: string,
+ *     mimeType: string,
+ *     xtags: string | undefined,
+ *     bitrate: number,
+ *     initRange: {
+ *       start: number,
+ *       end: number
+ *     },
+ *     indexRange: {
+ *       start: number,
+ *       end: number
+ *     },
+ *     width: number | undefined,
+ *     height: number | undefined,
+ *     frameRate: number | undefined,
+ *     quality: string,
+ *     language: string | undefined,
+ *     audioSampleRate: number | undefined,
+ *     audioChannels: number | undefined,
+ *     isDrc: boolean | undefined,
+ *     isOriginal: boolean | undefined,
+ *     isDubbed: boolean | undefined,
+ *     isAutoDubbed: boolean | undefined,
+ *     isDescriptive: boolean | undefined,
+ *     isSecondary: boolean | undefined,
+ *     spatialAudio: boolean
+ *     label: string | undefined,
+ *     colorTransferCharacteristics: 'BT709' | 'BT2020_10' | 'SMPTEST2084' | 'ARIB_STD_B67' | undefined,
+ *     colorPrimaries: 'BT709' | 'BT2020' | undefined
+ *   }[],
+ *   captions: {
+ *     id: string,
+ *     label: string,
+ *     mimeType: string,
+ *     language: string,
+ *     url: string
+ *   }[],
+ *   storyboards: {
+ *     templateUrl: string,
+ *     mimeType: string,
+ *     columns: number,
+ *     rows: number,
+ *     thumbnailCount: number,
+ *     thumbnailWidth: number,
+ *     thumbnailHeight: number,
+ *     storyboardCount: number,
+ *     interval: number
+ *   }[]
+ * }} SabrManifest
+ */
+
+const NetworkingEngine = shaka.net.NetworkingEngine
+
+export const MANIFEST_TYPE_SABR = 'application/sabr+json'
+
+const CODECS_REGEX = /codecs="?([^"]+)"?/
+
+const VIDEO_CODEC_PRIORITIES = [
+  'av01',
+  'vp09',
+  'vp9',
+  'avc1'
+]
+
+/**
+ * @implements {shaka.extern.ManifestParser}
+ */
+class SabrManifestParser {
+  constructor() {
+    /**
+     * @private
+     * @type {shaka.extern.ManifestConfiguration | null}
+     */
+    this._config = null
+  }
+
+  /**
+   * @param {string} _uri
+   */
+  banLocation(_uri) {
+  }
+
+  /**
+   * @param {shaka.extern.ManifestConfiguration} config
+   * @param {(() => boolean) | undefined} _isPreloadFn
+   */
+  configure(config, _isPreloadFn) {
+    this._config = config
+  }
+
+  /**
+   * @param {shaka.extern.Variant} _variant
+   */
+  onInitialVariantChosen(_variant) {
+  }
+
+  /**
+   * @param {HTMLMediaElement | null} _mediaElement
+   */
+  setMediaElement(_mediaElement) {
+  }
+
+  /**
+   * @param {string} uri
+   * @param {shaka.extern.ManifestParser.PlayerInterface} playerInterface
+   * @returns {Promise<shaka.extern.Manifest>}
+   */
+  async start(uri, { filter, networkingEngine }) {
+    // As SABR manifests are a FreeTube internal thing we can skip going through the networking engine
+    // because we know it will always have the same format
+
+    // "data:" (5) + mime type length + "," (1)
+    const uriPrefixLength = 5 + MANIFEST_TYPE_SABR.length + 1
+
+    /** @type {SabrManifest} */
+    const manifestData = JSON.parse(decodeURIComponent(uri.slice(uriPrefixLength)))
+
+    const presentationTimeline = new shaka.media.PresentationTimeline(0, 0, true)
+    presentationTimeline.setStatic(true)
+    presentationTimeline.setSegmentAvailabilityDuration(Infinity)
+    presentationTimeline.lockStartTime()
+    presentationTimeline.setDuration(manifestData.duration)
+
+    let currentId = 0
+
+    /** @type {shaka.extern.Stream[]} */
+    const audioStreams = []
+    /** @type {shaka.extern.Stream[]} */
+    const videoStreams = []
+
+    const hasDrcAudio = manifestData.formats.some(format => format.isDrc)
+
+    // For audio only playback we still need to specify a video fromat ID
+    // the server won't return it but it will error if we don't list one
+    // so lets pick the worst video quality  just in case
+    let fakeVideoFormatId
+
+    if (this._config.disableVideo) {
+      const worstVideoFormat = manifestData.formats.reduce((previousFormat, currentFormat) => {
+        if (currentFormat.width === undefined) {
+          return previousFormat
+        } else if (previousFormat === null) {
+          return currentFormat
+        } else {
+          return currentFormat.bitrate < previousFormat.bitrate ? currentFormat : previousFormat
+        }
+      }, null)
+
+      fakeVideoFormatId = buildFormatId(worstVideoFormat)
+    }
+
+    manifestData.formats.forEach((format) => {
+      if (format.mimeType.startsWith('audio/')) {
+        audioStreams.push(
+          /** @__NOINLINE__ */ createAudioStream(
+            format,
+            currentId++,
+            hasDrcAudio,
+            presentationTimeline,
+            networkingEngine,
+            fakeVideoFormatId
+          )
+        )
+      } else if (!this._config.disableVideo) {
+        videoStreams.push(
+          /** @__NOINLINE__ */ createVideoStream(format, currentId++, presentationTimeline, networkingEngine)
+        )
+      }
+    })
+
+    audioStreams.sort((a, b) => b.bandwidth - a.bandwidth)
+
+    if (!this._config.disableVideo) {
+      videoStreams.sort((a, b) => {
+        return VIDEO_CODEC_PRIORITIES.findIndex(codec => a.codecs.startsWith(codec)) -
+          VIDEO_CODEC_PRIORITIES.findIndex(codec => b.codecs.startsWith(codec))
+      })
+    }
+
+    /** @type {shaka.extern.Variant[]} */
+    const variants = []
+    let variantId = 0
+
+    if (this._config.disableVideo) {
+      for (const stream of audioStreams) {
+        variants.push({
+          id: variantId++,
+          audio: stream,
+          bandwidth: stream.bandwidth,
+          language: stream.language,
+          allowedByApplication: true,
+          allowedByKeySystem: true,
+          decodingInfos: [],
+          disabledUntilTime: 0,
+          primary: stream.primary,
+          video: null
+        })
+      }
+    } else {
+      for (const audioStream of audioStreams) {
+        for (const videoStream of videoStreams) {
+          variants.push({
+            id: variantId++,
+            audio: audioStream,
+            video: videoStream,
+            bandwidth: audioStream.bandwidth + videoStream.bandwidth,
+            language: audioStream.language,
+            allowedByApplication: true,
+            allowedByKeySystem: true,
+            decodingInfos: [],
+            disabledUntilTime: 0,
+            primary: audioStream.primary
+          })
+        }
+      }
+    }
+
+    const textStreams = /** @__NOINLINE__ */ createTextStreams(manifestData.captions, presentationTimeline, currentId)
+    currentId += textStreams.length
+
+    const imageStreams = /** @__NOINLINE__ */ createImageStreams(manifestData.storyboards, presentationTimeline, currentId)
+    currentId += imageStreams.length
+
+    const manifest = {
+      type: 'SABR',
+      startTime: 0,
+      variants,
+      textStreams,
+      imageStreams,
+      presentationTimeline,
+
+      gapCount: 0,
+      ignoreManifestTimestampsInSegmentsMode: false,
+      isLowLatency: false,
+      nextUrl: null,
+      offlineSessionIds: [],
+      periodCount: 1,
+      sequenceMode: false,
+      serviceDescription: null,
+    }
+
+    await filter(manifest)
+
+    return manifest
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  stop() {
+    this._config = null
+    return Promise.resolve()
+  }
+}
+
+/**
+ * @param {SabrManifest['formats'][0]} format
+ */
+function buildFormatId(format) {
+  return `${format.itag}-${format.lastModified ?? 0}-${format.xtags ?? ''}`
+}
+
+/**
+ * @param {SabrManifest['formats'][0]} format
+ * @param {number} id
+ * @param {boolean} hasDrcAudio
+ * @param {shaka.media.PresentationTimeline} presentationTimeline
+ * @param {shaka.net.NetworkingEngine} networkingEngine
+ * @param {string | undefined} fakeVideoFormatId
+ */
+function createAudioStream(
+  format,
+  id,
+  hasDrcAudio,
+  presentationTimeline,
+  networkingEngine,
+  fakeVideoFormatId
+) {
+  const roles = []
+
+  if (format.isOriginal) {
+    roles.push('main')
+  } else if (format.isDrc) {
+    roles.push('drc')
+  } else if (format.isDubbed) {
+    roles.push('dubbed')
+  } else if (format.isAutoDubbed) {
+    roles.push('dubbed-auto')
+  } else if (format.isDescriptive) {
+    roles.push('descriptive')
+  } else if (format.isSecondary) {
+    roles.push('secondary')
+  }
+
+  let label = null
+
+  if (format.label) {
+    label = format.label
+  } else if (hasDrcAudio) {
+    label = format.isDrc ? 'Stable Volume' : 'Original'
+  }
+
+  /** @type {shaka.extern.Stream} */
+  const stream = {
+    type: 'audio',
+    id,
+    originalId: buildFormatId(format),
+    mimeType: format.mimeType.split(';')[0],
+    codecs: format.mimeType.match(CODECS_REGEX)[1],
+    fullMimeTypes: new Set([format.mimeType]),
+    bandwidth: format.bitrate,
+    audioSamplingRate: format.audioSampleRate ?? null,
+    channelsCount: format.audioChannels ?? null,
+    label,
+    language: format.language ?? 'und',
+    originalLanguage: format.language ?? null,
+    spatialAudio: format.spatialAudio,
+    roles,
+    primary: roles.includes('main'),
+    segmentIndex: null,
+    createSegmentIndex: async () => {
+      // shaka-player sometimes calls the create function even when the segment index already exists
+      if (stream.segmentIndex) { return }
+
+      stream.segmentIndex = await createMediaSegmentIndex(
+        format,
+        stream,
+        presentationTimeline,
+        networkingEngine,
+        fakeVideoFormatId
+      )
+    },
+    closeSegmentIndex: () => {
+      if (stream.segmentIndex) {
+        stream.segmentIndex.release()
+        stream.segmentIndex = null
+      }
+    },
+
+    accessibilityPurpose: null,
+    closedCaptions: null,
+    drmInfos: [],
+    emsgSchemeIdUris: null,
+    encrypted: false,
+    external: false,
+    fastSwitching: false,
+    forced: false,
+    groupId: null,
+    isAudioMuxedInVideo: false,
+    keyIds: new Set(),
+    trickModeVideo: null
+  }
+
+  return stream
+}
+
+/**
+ * @param {SabrManifest['formats'][0]} format
+ * @param {number} id
+ * @param {shaka.media.PresentationTimeline} presentationTimeline
+ * @param {shaka.net.NetworkingEngine} networkingEngine
+ */
+function createVideoStream(format, id, presentationTimeline, networkingEngine) {
+  const colorGamut = format.colorPrimaries === 'BT2020' ? 'rec2020' : 'srgb'
+
+  let hdr = 'SDR'
+
+  if (format.colorTransferCharacteristics === 'SMPTEST2084') {
+    hdr = 'PQ'
+  } else if (format.colorTransferCharacteristics === 'ARIB_STD_B67') {
+    hdr = 'HLG'
+  }
+
+  /** @type {shaka.extern.Stream} */
+  const stream = {
+    type: 'video',
+    id,
+    originalId: buildFormatId(format),
+    mimeType: format.mimeType.split(';')[0],
+    codecs: format.mimeType.match(CODECS_REGEX)[1],
+    fullMimeTypes: new Set([format.mimeType]),
+    bandwidth: format.bitrate,
+    width: format.width,
+    height: format.height,
+    frameRate: format.frameRate,
+    colorGamut,
+    hdr,
+    roles: [],
+    segmentIndex: null,
+    createSegmentIndex: async () => {
+      // shaka-player sometimes calls the create function even when the segment index already exists
+      if (stream.segmentIndex) { return }
+
+      stream.segmentIndex = await createMediaSegmentIndex(format, stream, presentationTimeline, networkingEngine)
+    },
+    closeSegmentIndex: () => {
+      if (stream.segmentIndex) {
+        stream.segmentIndex.release()
+        stream.segmentIndex = null
+      }
+    },
+
+    accessibilityPurpose: null,
+    audioSamplingRate: null,
+    channelsCount: null,
+    closedCaptions: null,
+    drmInfos: [],
+    emsgSchemeIdUris: null,
+    encrypted: false,
+    external: false,
+    fastSwitching: false,
+    forced: false,
+    groupId: null,
+    isAudioMuxedInVideo: false,
+    keyIds: new Set(),
+    label: null,
+    language: 'und',
+    originalLanguage: null,
+    primary: false,
+    spatialAudio: false,
+    trickModeVideo: null
+  }
+
+  return stream
+}
+
+/**
+ * @param {SabrManifest['captions']} captions
+ * @param {shaka.media.PresentationTimeline} presentationTimeline
+ * @param {number} currentId
+ */
+function createTextStreams(captions, presentationTimeline, currentId) {
+  return captions.map((caption) => {
+    /** @type {shaka.extern.Stream} */
+    const stream = {
+      type: 'text',
+      id: currentId++,
+      originalId: caption.id,
+      mimeType: caption.mimeType,
+      fullMimeTypes: new Set([caption.mimeType]),
+      label: caption.label,
+      language: caption.language,
+      originalLanguage: caption.language,
+      kind: 'captions',
+      segmentIndex: null,
+      createSegmentIndex: () => {
+        stream.segmentIndex = shaka.media.SegmentIndex.forSingleSegment(
+          0,
+          presentationTimeline.getDuration(),
+          [caption.url]
+        )
+        return Promise.resolve()
+      },
+      closeSegmentIndex: () => {
+        if (stream.segmentIndex) {
+          stream.segmentIndex.release()
+          stream.segmentIndex = null
+        }
+      },
+
+      accessibilityPurpose: null,
+      audioSamplingRate: null,
+      channelsCount: null,
+      closedCaptions: null,
+      codecs: '',
+      drmInfos: [],
+      emsgSchemeIdUris: null,
+      encrypted: false,
+      external: false,
+      fastSwitching: false,
+      forced: false,
+      groupId: null,
+      isAudioMuxedInVideo: false,
+      keyIds: new Set(),
+      primary: false,
+      roles: [],
+      spatialAudio: false,
+      trickModeVideo: null
+    }
+
+    return stream
+  })
+}
+
+/**
+ * @param {SabrManifest['storyboards']} storyboards
+ * @param {shaka.media.PresentationTimeline} presentationTimeline
+ * @param {number} currentId
+ */
+function createImageStreams(storyboards, presentationTimeline, currentId) {
+  return storyboards.map((storyboard) => {
+    const tilesLayout = `${storyboard.columns}x${storyboard.rows}`
+
+    /** @type {shaka.extern.Stream} */
+    const stream = {
+      type: 'image',
+      id: currentId++,
+      mimeType: storyboard.mimeType,
+      fullMimeTypes: new Set([storyboard.mimeType]),
+      tilesLayout,
+      width: storyboard.thumbnailWidth * storyboard.columns,
+      height: storyboard.thumbnailHeight * storyboard.rows,
+      segmentIndex: null,
+      createSegmentIndex: () => {
+        const duration = presentationTimeline.getDuration()
+
+        const interval = storyboard.interval > 0 ? storyboard.interval : duration / storyboard.thumbnailCount
+        const segmentDuration = interval * storyboard.columns * storyboard.rows
+
+        const references = []
+
+        for (let i = 0; i < storyboard.storyboardCount; i++) {
+          const startTime = i * segmentDuration
+          const endTime = Math.min(startTime + segmentDuration, duration)
+
+          const urls = [storyboard.templateUrl.replace('$M', i)]
+
+          const segmentReference = new shaka.media.SegmentReference(
+            startTime,
+            endTime,
+            () => urls,
+            0,
+            null,
+            null,
+            0,
+            0,
+            Infinity,
+            undefined,
+            tilesLayout,
+            interval
+          )
+
+          segmentReference.mimeType = storyboard.mimeType
+
+          references.push(segmentReference)
+        }
+
+        stream.segmentIndex = new shaka.media.SegmentIndex(references)
+
+        return Promise.resolve()
+      },
+      closeSegmentIndex: () => {
+        if (stream.segmentIndex) {
+          stream.segmentIndex.release()
+          stream.segmentIndex = null
+        }
+      },
+
+      accessibilityPurpose: null,
+      audioSamplingRate: null,
+      channelsCount: null,
+      closedCaptions: null,
+      codecs: '',
+      drmInfos: [],
+      emsgSchemeIdUris: null,
+      encrypted: false,
+      external: false,
+      fastSwitching: false,
+      forced: false,
+      groupId: null,
+      isAudioMuxedInVideo: false,
+      keyIds: new Set(),
+      label: null,
+      language: 'und',
+      originalId: null,
+      originalLanguage: null,
+      primary: false,
+      roles: [],
+      spatialAudio: false,
+      trickModeVideo: null
+    }
+
+    return stream
+  })
+}
+
+/**
+ * @param {SabrManifest['formats'][0]} format
+ * @param {shaka.extern.Stream} stream
+ * @param {shaka.media.PresentationTimeline} presentationTimeline
+ * @param {shaka.net.NetworkingEngine} networkingEngine
+ * @param {string | undefined} fakeVideoFormatId
+ */
+async function createMediaSegmentIndex(
+  format,
+  stream,
+  presentationTimeline,
+  networkingEngine,
+  fakeVideoFormatId = undefined
+) {
+  let url = `sabr://${stream.type}?formatId=${encodeURIComponent(stream.originalId)}`
+
+  if (fakeVideoFormatId) {
+    url += `&videoFormatId=${encodeURIComponent(fakeVideoFormatId)}`
+  }
+
+  if (format.isDrc) {
+    url += '&drc'
+  }
+
+  if (stream.type === 'video') {
+    const resolution = QUALITY[format.quality.toUpperCase()]
+
+    url += `&resolution=${resolution}`
+  }
+
+  /** @type {shaka.extern.Request} */
+  const request = {
+    method: 'GET',
+    uris: [`${url}&init`],
+    contentType: stream.type,
+    body: null,
+    headers: {},
+    allowCrossSiteCredentials: false,
+    retryParameters: NetworkingEngine.defaultRetryParameters(),
+    licenseRequestType: null,
+    sessionId: null,
+    drmInfo: null,
+    initData: null,
+    initDataType: null,
+    streamDataCallback: null,
+  }
+
+  /** @type {shaka.extern.Response} */
+  const response = await networkingEngine.request(
+    NetworkingEngine.RequestType.SEGMENT,
+    request,
+    {
+      stream: stream,
+      type: NetworkingEngine.AdvancedRequestType.INIT_SEGMENT
+    }
+  ).promise
+
+  return /** @__NOINLINE__ */ createVodMediaSegmentIndex(url, response, format, stream, presentationTimeline.getDuration())
+}
+
+/**
+ * @param {string} url
+ * @param {shaka.extern.Response} response
+ * @param {SabrManifest['formats'][0]} format
+ * @param {shaka.extern.Stream} stream
+ * @param {number} duration
+ */
+function createVodMediaSegmentIndex(url, response, format, stream, duration) {
+  /** @type {shaka.extern.MediaQualityInfo} */
+  const mediaQuality = {
+    contentType: stream.type,
+    bandwidth: stream.bandwidth,
+    mimeType: stream.mimeType,
+    codecs: stream.codecs,
+    language: stream.language,
+    label: stream.label,
+    audioSamplingRate: stream.audioSamplingRate,
+    channelsCount: stream.channelsCount,
+    width: stream.width ?? null,
+    height: stream.height ?? null,
+    frameRate: stream.frameRate ?? null,
+    roles: stream.roles,
+    pixelAspectRatio: stream.pixelAspectRatio ?? null
+  }
+
+  const buffer = ArrayBuffer.isView(response.data) ? response.data.buffer : response.data
+
+  const initData = buffer.slice(format.initRange.start, format.initRange.end + 1)
+  const indexData = buffer.slice(format.indexRange.start, format.indexRange.end + 1)
+
+  const initUrls = [`${url}&init`]
+
+  const initSegmentReference = new shaka.media.InitSegmentReference(
+    () => initUrls,
+    format.initRange.start,
+    format.initRange.end,
+    mediaQuality,
+    null,
+    initData,
+    null
+  )
+
+  initSegmentReference.mimeType = stream.mimeType
+  initSegmentReference.codecs = stream.codecs
+
+  let references
+
+  if (stream.mimeType.endsWith('/webm')) {
+    references = /** @__NOINLINE__ */ parseWebmSegmentIndex(indexData, initData, url, initSegmentReference, 0, 0, duration)
+  } else {
+    references = /** @__NOINLINE__ */ parseMp4SegmentIndex(indexData, format.indexRange.start, url, initSegmentReference, 0, 0, duration)
+  }
+
+  return new shaka.media.SegmentIndex(references)
+}
+
+shaka.media.ManifestParser.registerParserByMime(MANIFEST_TYPE_SABR, () => new SabrManifestParser())

--- a/src/renderer/helpers/player/WebmSegmentIndexParser.js
+++ b/src/renderer/helpers/player/WebmSegmentIndexParser.js
@@ -1,0 +1,338 @@
+// Based on https://github.com/shaka-project/shaka-player/blob/main/lib/dash/webm_segment_index_parser.js
+// Adapted for use in FreeTube:
+// - General changes such as removing Closure compiler specific stuff
+// - Rewritten to use functions instead of a class
+// - The segment URLs receive the start time and segment number
+
+import shaka from 'shaka-player'
+import { EbmlParser } from './EbmlParser'
+
+const EBML_ID = 0x1a45dfa3
+const SEGMENT_ID = 0x18538067
+const INFO_ID = 0x1549a966
+const TIMECODE_SCALE_ID = 0x2ad7b1
+const DURATION_ID = 0x4489
+const CUES_ID = 0x1c53bb6b
+const CUE_POINT_ID = 0xbb
+const CUE_TIME_ID = 0xb3
+const CUE_TRACK_POSITIONS_ID = 0xb7
+const CUE_CLUSTER_POSITION = 0xf1
+
+const ShakaError = shaka.util.Error
+const SeverityCritical = ShakaError.Severity.CRITICAL
+const CategoryMedia = ShakaError.Category.MEDIA
+
+/**
+ * Parses SegmentReferences from a WebM container.
+ * @param {BufferSource} cuesData The WebM container's "Cueing Data" section.
+ * @param {BufferSource} initData The WebM container's headers.
+ * @param {string} uri The location of the WebM file that contains the segments.
+ * @param {shaka.media.InitSegmentReference} initSegmentReference
+ * @param {number} timestampOffset
+ * @param {number} appendWindowStart
+ * @param {number} appendWindowEnd
+ * @returns {shaka.media.SegmentReference[]}
+ * @see http://www.matroska.org/technical/specs/index.html
+ * @see http://www.webmproject.org/docs/container/
+ */
+export function parseWebmSegmentIndex(
+  cuesData,
+  initData,
+  uri,
+  initSegmentReference,
+  timestampOffset,
+  appendWindowStart,
+  appendWindowEnd
+) {
+  const tuple = /** @__NOINLINE__ */ parseWebmContainer(initData)
+  const parser = new EbmlParser(cuesData)
+  const cuesElement = parser.parseElement()
+  if (cuesElement.id !== CUES_ID) {
+    console.error('[parseWebmSegmentIndex] Not a Cues element.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_CUES_ELEMENT_MISSING
+    )
+  }
+
+  return /** @__NOINLINE__ */ parseCues(
+    cuesElement,
+    tuple.segmentOffset,
+    tuple.timecodeScale,
+    tuple.duration,
+    uri,
+    initSegmentReference,
+    timestampOffset,
+    appendWindowStart,
+    appendWindowEnd
+  )
+}
+
+/**
+ * Parses a WebM container to get the segment's offset, timecode scale, and
+ * duration.
+ *
+ * @param {BufferSource} initData
+ * @returns {{segmentOffset: number, timecodeScale: number, duration: number}}
+ *   The segment's offset in bytes, the segment's timecode scale in seconds,
+ *   and the duration in seconds.
+ */
+function parseWebmContainer(initData) {
+  const parser = new EbmlParser(initData)
+
+  // Check that the WebM container data starts with the EBML header, but
+  // skip its contents.
+  const ebmlElement = parser.parseElement()
+  if (ebmlElement.id !== EBML_ID) {
+    console.error('Not an EBML element.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_EBML_HEADER_ELEMENT_MISSING
+    )
+  }
+
+  const segmentElement = parser.parseElement()
+  if (segmentElement.id !== SEGMENT_ID) {
+    console.error('[parseWebmSegmentIndex] Not a Segment element.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_SEGMENT_ELEMENT_MISSING
+    )
+  }
+
+  // This value is used as the initial offset to the first referenced segment.
+  const segmentOffset = segmentElement.getOffset()
+
+  // Parse the Segment element to get the segment info.
+  const segmentInfo = /** @__NOINLINE__ */ parseSegment(segmentElement)
+  return {
+    segmentOffset: segmentOffset,
+    timecodeScale: segmentInfo.timecodeScale,
+    duration: segmentInfo.duration,
+  }
+}
+
+/**
+ * Parses a WebM Info element to get the segment's timecode scale and
+ * duration.
+ * @param {import('./EbmlParser').EbmlElement} segmentElement
+ * @returns {{timecodeScale: number, duration: number}} The segment's timecode
+ *   scale in seconds and duration in seconds.
+ */
+function parseSegment(segmentElement) {
+  const parser = segmentElement.createParser()
+
+  // Find the Info element.
+  let infoElement = null
+  while (parser.hasMoreData()) {
+    const elem = parser.parseElement()
+    if (elem.id !== INFO_ID) {
+      continue
+    }
+
+    infoElement = elem
+
+    break
+  }
+
+  if (!infoElement) {
+    console.error('[parseWebmSegmentIndex] Not an Info element.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_INFO_ELEMENT_MISSING
+    )
+  }
+
+  return /** @__NOINLINE__ */ parseInfo(infoElement)
+}
+
+/**
+ * Parses a WebM Info element to get the segment's timecode scale and
+ * duration.
+ * @param {import('./EbmlParser').EbmlElement} infoElement
+ * @returns {{timecodeScale: number, duration: number}} The segment's timecode
+ *   scale in seconds and duration in seconds.
+ */
+function parseInfo(infoElement) {
+  const parser = infoElement.createParser()
+
+  // The timecode scale factor in units of [nanoseconds / T], where [T] are
+  // the units used to express all other time values in the WebM container.
+  // By default it's assumed that [T] == [milliseconds].
+  let timecodeScaleNanoseconds = 1000000
+  /** @type {?number} */
+  let durationScale = null
+
+  while (parser.hasMoreData()) {
+    const elem = parser.parseElement()
+    if (elem.id === TIMECODE_SCALE_ID) {
+      timecodeScaleNanoseconds = elem.getUint()
+    } else if (elem.id === DURATION_ID) {
+      durationScale = elem.getFloat()
+    }
+  }
+  if (durationScale == null) {
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_DURATION_ELEMENT_MISSING
+    )
+  }
+
+  // The timecode scale factor in units of [seconds / T].
+  const timecodeScale = timecodeScaleNanoseconds / 1000000000
+  // The duration is stored in units of [T]
+  const durationSeconds = durationScale * timecodeScale
+
+  return { timecodeScale: timecodeScale, duration: durationSeconds }
+}
+
+/**
+ * Parses a WebM CuesElement.
+ * @param {import('./EbmlParser').EbmlElement} cuesElement
+ * @param {number} segmentOffset
+ * @param {number} timecodeScale
+ * @param {number} duration
+ * @param {string} uri
+ * @param {shaka.media.InitSegmentReference} initSegmentReference
+ * @param {number} timestampOffset
+ * @param {number} appendWindowStart
+ * @param {number} appendWindowEnd
+ * @returns {shaka.media.SegmentReference[]}
+ */
+function parseCues(
+  cuesElement,
+  segmentOffset,
+  timecodeScale,
+  duration,
+  uri,
+  initSegmentReference,
+  timestampOffset,
+  appendWindowStart,
+  appendWindowEnd
+) {
+  const references = []
+
+  const parser = cuesElement.createParser()
+
+  let lastTime = null
+  let lastOffset = null
+  let sq = 1
+
+  while (parser.hasMoreData()) {
+    const elem = parser.parseElement()
+    if (elem.id !== CUE_POINT_ID) {
+      continue
+    }
+
+    const tuple = parseCuePoint(elem)
+    if (!tuple) {
+      continue
+    }
+
+    // Subtract the presentation time offset from the unscaled time
+    const currentTime = timecodeScale * tuple.unscaledTime
+    const currentOffset = segmentOffset + tuple.relativeOffset
+
+    if (lastTime != null) {
+      if (process.env.NODE_ENV === 'development' && lastOffset == null) {
+        throw new Error('Assertion failure: last offset cannot be null')
+      }
+
+      const uris = [`${uri}&startTimeMs=${Math.round((lastTime + timestampOffset) * 1000)}&sq=${sq++}`]
+
+      references.push(
+        new shaka.media.SegmentReference(
+          lastTime + timestampOffset,
+          currentTime + timestampOffset,
+          () => uris,
+          /* startByte= */ lastOffset, /* endByte= */ currentOffset - 1,
+          initSegmentReference,
+          timestampOffset,
+          appendWindowStart,
+          appendWindowEnd
+        )
+      )
+    }
+
+    lastTime = currentTime
+    lastOffset = currentOffset
+  }
+
+  if (lastTime != null) {
+    if (process.env.NODE_ENV === 'development' && lastOffset == null) {
+      throw new Error('Assertion failure: last offset cannot be null')
+    }
+
+    const uris = [`${uri}&startTimeMs=${Math.round((lastTime + timestampOffset) * 1000)}&sq=${sq}`]
+
+    references.push(
+      new shaka.media.SegmentReference(
+        lastTime + timestampOffset,
+        duration + timestampOffset,
+        () => uris,
+        /* startByte= */ lastOffset, /* endByte= */ null,
+        initSegmentReference,
+        timestampOffset,
+        appendWindowStart,
+        appendWindowEnd
+      )
+    )
+  }
+
+  return references
+}
+
+/**
+ * Parses a WebM CuePointElement to get an "unadjusted" segment reference.
+ * @param {import('./EbmlParser').EbmlElement} cuePointElement
+ * @returns {{unscaledTime: number, relativeOffset: number}} The referenced
+ *   segment's start time in units of [T] (see parseInfo_()), and the
+ *   referenced segment's offset in bytes, relative to a WebM Segment
+ *   element.
+ */
+function parseCuePoint(cuePointElement) {
+  const parser = cuePointElement.createParser()
+
+  // Parse CueTime element.
+  const cueTimeElement = parser.parseElement()
+  if (cueTimeElement.id !== CUE_TIME_ID) {
+    console.warn('[parseWebmSegmentIndex] Not a CueTime element.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_CUE_TIME_ELEMENT_MISSING
+    )
+  }
+  const unscaledTime = cueTimeElement.getUint()
+
+  // Parse CueTrackPositions element.
+  const cueTrackPositionsElement = parser.parseElement()
+  if (cueTrackPositionsElement.id !== CUE_TRACK_POSITIONS_ID) {
+    console.warn('[parseWebmSegmentIndex] Not a CueTrackPositions element.')
+    throw new ShakaError(
+      SeverityCritical,
+      CategoryMedia,
+      ShakaError.Code.WEBM_CUE_TRACK_POSITIONS_ELEMENT_MISSING
+    )
+  }
+
+  const cueTrackParser = cueTrackPositionsElement.createParser()
+  let relativeOffset = 0
+
+  while (cueTrackParser.hasMoreData()) {
+    const elem = cueTrackParser.parseElement()
+    if (elem.id !== CUE_CLUSTER_POSITION) {
+      continue
+    }
+
+    relativeOffset = elem.getUint()
+    break
+  }
+
+  return { unscaledTime: unscaledTime, relativeOffset: relativeOffset }
+}

--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -136,7 +136,7 @@ export function sortCaptions(captions) {
 
   const collator = new Intl.Collator([currentLocale, 'en'])
 
-  return captions.slice().sort((captionA, captionB) => {
+  return captions.sort((captionA, captionB) => {
     const aCode = captionA.language.split('-') // ex. [en,US] or [en]
     const bCode = captionB.language.split('-')
     const aName = captionA.label // ex: english (auto-generated)

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -21,6 +21,7 @@
           ref="player"
           :manifest-src="manifestSrc"
           :manifest-mime-type="manifestMimeType"
+          :sabr-data="sabrData"
           :legacy-formats="legacyFormats"
           :start-time="startTimeSeconds"
           :captions="captions"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4978,6 +4978,13 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
 
+googlevideo@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/googlevideo/-/googlevideo-3.0.0.tgz#383137303553c6625bafae32c1b8a7203be565a8"
+  integrity sha512-8LGFjbZFG4RCsyhMbjX2+IlU5Suj94FeQr1JandPSsKfAMrqL08pOoQsBYl/5P+bqIFm0wQEVpKIhm5wpiekwg==
+  dependencies:
+    "@bufbuild/protobuf" "^2.0.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"


### PR DESCRIPTION
# Local API: Implement SABR for VODs

## Pull Request Type

- [x] Feature Implementation

## Description

Opening as a draft because when it works it works well but when it doesn't it currently errors with errors that I haven't been able to figure out how to resolve...

This pull request implements support for SABR playback with the local API for VODs, for live streams and post-live DVRs we use the manifests provided by YouTube. This also includes some code copied and adapted from shaka-player as they didn't export the MP4 and WebM segment index parsers outside of the package and I needed to make some changes to them.

## Testing

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d875cc6642ac8277dad6cb42c7023ec6e7202c67