### PR TITLE
Fix images getting occasionally ratelimited

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -454,6 +454,13 @@ function runApp() {
         requestHeaders['Sec-Fetch-Site'] = 'same-origin'
         requestHeaders['Sec-Fetch-Mode'] = 'same-origin'
         requestHeaders['X-Youtube-Bootstrap-Logged-In'] = 'false'
+      } else if (
+        urlObj.origin.endsWith('.googleusercontent.com') ||
+        urlObj.origin.endsWith('.ggpht.com') ||
+        urlObj.origin.endsWith('.ytimg.com')
+      ) {
+        requestHeaders.Referer = 'https://www.youtube.com/'
+        requestHeaders.Origin = 'https://www.youtube.com'
       } else if (urlObj.origin.endsWith('.googlevideo.com') && urlObj.pathname === '/videoplayback') {
         requestHeaders.Referer = 'https://www.youtube.com/'
         requestHeaders.Origin = 'https://www.youtube.com'


### PR DESCRIPTION
# Fix images getting occasionally ratelimited

## Pull Request Type

- [x] Bugfix

## Description

When I disable the experimental image cache in dev various image requests seem to get ratelimited by Google's servers. Setting the referer and origin headers to YouTube seems to fix this issue.

## Testing

1. Run FreeTube with `yarn dev`
2. Turn off the experimental HTTP cache setting if you have it enabled.
3. Try loading lots of images e.g. scrolling down the subscription feed quickly

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** aee841a691aae3af8091657731d54f517cb22883