### PR TITLE
Bump linter, build and release workflows to Node.js 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         runtime:
           - linux-x64
           - linux-armv7l

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,10 +18,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js 20.x
+    - name: Use Node.js 22.x
       uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 22.x
         cache: "yarn"
     - run: yarn run ci
     - run: yarn run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
         runtime:
           - linux-x64
           - linux-armv7l


### PR DESCRIPTION
# Bump linter, build and release workflows to Node.js 22

## Pull Request Type

- [x] Other

## Description

Node.js 22 has been the current LTS version for quite a while now, so it's probably a good idea to switch to it now.

## Testing

Linter: see checks section on this PR
Build: https://github.com/absidue/FreeTube/actions/runs/14285865571
Release uses the same build steps as the build workflow, it just uses a different version number and uploads to a different location, so if the build one works the release one will too.