### PR TITLE
Fix filename tooltip not showing under screenshot in player settings

### DIFF
--- a/src/renderer/components/player-settings/player-settings.css
+++ b/src/renderer/components/player-settings/player-settings.css
@@ -18,3 +18,12 @@
   flex-grow: 1;
   margin-block-start: 10px;
 }
+
+.screenshotFilenamePatternTitle {
+  position: relative;
+  margin-inline-end: 20px;
+}
+
+.tooltip {
+  margin-block-start: -12px;
+}


### PR DESCRIPTION

# Fix filename tooltip not showing under screenshot settings

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
The tooltip under the screenshot heading in player settings is hidden on small displays because it is actually stuck in the top corner of the page. This causes overflow as well because the tooltip is not contained within the player settings section. This PR addresses this by adding `position: relative` to `.screenshotFilenamePatternTitle` and adding margins to the tooltip to put it in a visually acceptable place as to prevent overflow.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
|before|after|
|--|--|
|![2025-04-06-134813_hyprshot](https://github.com/user-attachments/assets/a23f26e5-d47a-45d3-861f-44d0a68161f6)|![2025-04-06-134802_hyprshot](https://github.com/user-attachments/assets/51357344-6d7f-4ac1-a27e-47c0136cf2f6)|


## Testing <!-- for code that is not small enough to be easily understandable -->
1. Open up player settings
2. Reduce the window width to below `680px`
3. Ensure the tooltip icon remains visible and there is no horizontal scrollbar on the page

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora w/ Hyprland
- **OS Version:** 41
- **FreeTube version:** a058ccdab0616e81d54df86818a54fea99bda8ec
