### PR TITLE
Add sorting options to history page (#5595)

### DIFF
--- a/src/renderer/store/modules/history.js
+++ b/src/renderer/store/modules/history.js
@@ -10,8 +10,20 @@ const state = {
 }
 
 const getters = {
-  getHistoryCacheSorted(state) {
-    return state.historyCacheSorted
+  getHistoryCacheSorted: (state) => (sortOrder = 'viewed_latest_first') => {
+    const history = [...state.historyCacheSorted]
+    switch (sortOrder) {
+      case 'viewed_latest_first':
+        return history.sort((a, b) => new Date(b.timeWatched) - new Date(a.timeWatched))
+      case 'viewed_earliest_first':
+        return history.sort((a, b) => new Date(a.timeWatched) - new Date(b.timeWatched))
+      case 'uploaded_latest_first':
+        return history.sort((a, b) => new Date(b.published) - new Date(a.published))
+      case 'uploaded_earliest_first':
+        return history.sort((a, b) => new Date(a.published) - new Date(b.published))
+      default:
+        return history
+    }
   },
 
   getHistoryCacheById(state) {

--- a/src/renderer/views/History/History.css
+++ b/src/renderer/views/History/History.css
@@ -24,6 +24,15 @@
   margin-inline-start: auto;
 }
 
+@media only screen and (width <= 800px) {
+  .optionsRow {
+    /* Switch to 2 rows from 2 columns */
+    grid-template-columns: auto;
+    grid-template-rows: auto auto;
+    align-items: stretch;
+  }
+}
+
 @media only screen and (width <= 680px) {
   .card {
     inline-size: 90%;

--- a/src/renderer/views/History/History.css
+++ b/src/renderer/views/History/History.css
@@ -12,6 +12,18 @@
   color: var(--primary-color);
 }
 
+.optionsRow {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: 1fr;
+  align-items: center;
+}
+
+.sortSelect {
+  /* Put it on the right */
+  margin-inline-start: auto;
+}
+
 @media only screen and (width <= 680px) {
   .card {
     inline-size: 90%;

--- a/src/renderer/views/History/History.js
+++ b/src/renderer/views/History/History.js
@@ -8,9 +8,16 @@ import FtButton from '../../components/ft-button/ft-button.vue'
 import FtInput from '../../components/ft-input/ft-input.vue'
 import FtAutoLoadNextPageWrapper from '../../components/ft-auto-load-next-page-wrapper/ft-auto-load-next-page-wrapper.vue'
 import FtToggleSwitch from '../../components/ft-toggle-switch/ft-toggle-switch.vue'
-import { ctrlFHandler, debounce } from '../../helpers/utils'
+import FtSelect from '../../components/ft-select/ft-select.vue'
+import { ctrlFHandler, debounce, getIconForSortPreference } from '../../helpers/utils'
 
 const identity = (v) => v
+const SORT_BY_VALUES = {
+  ViewedLatestFirst: 'viewed_latest_first',
+  ViewedEarliestFirst: 'viewed_earliest_first',
+  UploadedLatestFirst: 'uploaded_latest_first',
+  UploadedEarliestFirst: 'uploaded_earliest_first',
+}
 
 function filterVideosWithQuery(videos, query, attrProcessor = identity) {
   return videos.filter((video) => {
@@ -34,6 +41,7 @@ export default defineComponent({
     'ft-flex-box': FtFlexBox,
     'ft-element-list': FtElementList,
     'ft-button': FtButton,
+    'ft-select': FtSelect,
     'ft-input': FtInput,
     'ft-auto-load-next-page-wrapper': FtAutoLoadNextPageWrapper,
     'ft-toggle-switch': FtToggleSwitch,
@@ -47,11 +55,12 @@ export default defineComponent({
       showLoadMoreButton: false,
       query: '',
       activeData: [],
+      sortBy: SORT_BY_VALUES.ViewedLatestFirst,
     }
   },
   computed: {
     historyCacheSorted: function () {
-      return this.$store.getters.getHistoryCacheSorted
+      return this.$store.getters.getHistoryCacheSorted(this.sortBy)
     },
 
     fullData: function () {
@@ -60,6 +69,27 @@ export default defineComponent({
       } else {
         return this.historyCacheSorted.slice(0, this.dataLimit)
       }
+    },
+
+    sortBySelectNames() {
+      return Object.values(SORT_BY_VALUES).map((k) => {
+        switch (k) {
+          case SORT_BY_VALUES.ViewedEarliestFirst:
+            return this.$t('History.Sort By.EarliestPlayedFirst')
+          case SORT_BY_VALUES.ViewedLatestFirst:
+            return this.$t('History.Sort By.LatestPlayedFirst')
+          case SORT_BY_VALUES.UploadedEarliestFirst:
+            return this.$t('History.Sort By.EarliestUploadedFirst')
+          case SORT_BY_VALUES.UploadedLatestFirst:
+            return this.$t('History.Sort By.LatestUploadedFirst')
+          default:
+            console.error(`Unknown sortBy: ${k}`)
+            return k
+        }
+      })
+    },
+    sortBySelectValues() {
+      return Object.values(SORT_BY_VALUES)
     },
   },
   watch: {
@@ -101,6 +131,7 @@ export default defineComponent({
     document.removeEventListener('keydown', this.keyboardShortcutHandler)
   },
   methods: {
+    getIconForSortPreference: (s) => getIconForSortPreference(s),
     handleQueryChange(query, { limit = null, doCaseSensitiveSearch = null, filterNow = false } = {}) {
       this.query = query
 

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -36,6 +36,16 @@
           :default-value="doCaseSensitiveSearch"
           @change="doCaseSensitiveSearch = !doCaseSensitiveSearch"
         />
+        <ft-select
+          v-if="fullData.length > 1"
+          class="sortSelect"
+          :value="sortBy"
+          :select-names="sortBySelectNames"
+          :select-values="sortBySelectValues"
+          :placeholder="$t('Global.Sort By')"
+          :icon="getIconForSortPreference(sortBy)"
+          @change="sortBy = $event"
+        />
       </div>
       <ft-flex-box
         v-show="fullData.length === 0"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -267,6 +267,13 @@ History:
   Empty Search Message: There are no videos in your history that match your search
   Search bar placeholder: "Search in History"
   Case Sensitive Search: Case Sensitive Search
+
+  Sort By:
+    LatestUploadedFirst: 'Recently Uploaded'
+    EarliestUploadedFirst: 'Earliest Uploaded'
+
+    LatestPlayedFirst: 'Recently Played'
+    EarliestPlayedFirst: 'Earliest Played'
 Settings:
   # On Settings Page
   Settings: Settings


### PR DESCRIPTION
Add sort by date to the history page #5595

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #5595 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR implements the feature requested in [#5595](https://github.com/FreeTubeApp/FreeTube/issues/5595), allowing users to sort videos in the History page by:

 - Recently Played

 - Earliest Played

 - Recently Uploaded

 - Earliest Uploaded

Changes include:

 - New sorting options added to the Vuex store (history.js)

 - Sorting UI integrated with the history page filter button

Tested:

Sorting behavior with various history states

## Screenshots <!-- If appropriate -->
Before -
![image](https://github.com/user-attachments/assets/87d54449-a284-4f67-9c6c-d098a7f872ad)

After -
![image](https://github.com/user-attachments/assets/995ec1cf-e817-4e27-bf96-286f2d229b8a)

<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Manually tested the History page by:

 - Opening the new Sort By dropdown.

 - Selecting each option (Recently Played, Earliest Played, Recently Uploaded, Earliest Uploaded).

 - Confirming that the list updates accordingly based on the selected criteria.

 - Verified functionality across multiple videos in the history.

 - Checked for styling consistency with the existing UI elements.

 - Ran npm run lint to ensure no major linting issues.

 - No breaking changes observed during testing.
 
 - Not translated the dropdown values to all languages

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11
- **OS Version:** 24H2
- **FreeTube version:** 0.23.3

## Additional context
<!-- Add any other context about the pull request here. -->
This PR adds a sort by date feature to the History page as requested in [#5595](https://github.com/FreeTubeApp/FreeTube/issues/5595).

A dropdown menu was added

Sorting logic was implemented in the Vuex store and integrated into the History view.

Translations were added to en-US.yaml following the style of existing sort labels.

Style and layout were matched with the app’s existing components.

Not translated the dropdown values to all languages

This is my first contribution to FreeTube. Happy to receive any feedback or suggestions!
