### PR TITLE
Use `maxVideoPlaybackRate` for the max value of Default Playback Rate

### DIFF
--- a/src/renderer/components/player-settings/player-settings.vue
+++ b/src/renderer/components/player-settings/player-settings.vue
@@ -151,7 +151,7 @@
         :label="$t('Settings.Player Settings.Default Playback Rate')"
         :default-value="defaultPlayback"
         :min-value="parseFloat(videoPlaybackRateInterval)"
-        :max-value="8"
+        :max-value="maxVideoPlaybackRate"
         :step="parseFloat(videoPlaybackRateInterval)"
         value-extension="x"
         @change="updateDefaultPlayback"


### PR DESCRIPTION
# Use `maxVideoPlaybackRate` for the max value of Default Playback Rate

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Default Playback Rate slider doesn't exceed max value set by Max Video Playback Rate slider

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

1. Set Max Video Playback Rate slider to a value, e.g. 2x
2. Use Default Playback Rate slider to check that you cant go beyond previously set value

## Desktop
<!-- Please complete the following information-->
- **OS: Ubuntu**
- **OS Version: 24.04 LTS**
- **FreeTube version: latest**

## Additional context
<!-- Add any other context about the pull request here. -->
I noticed that the Default Playback Rate slider was set to max value of 8x but the Max Video Playback Rate slider goes up to 10x so i initially wanted to adjust that to 10x just to fix that inconsistency. Then i noticed that when I set the Max Video Playback Rate slider to 2x and i was able to set the Default Playback Rate slider to values >2x and the video player happily played at those speeds but didn't show them in the video player. So i guess a kind of 2 birds with one stone kind of situation here.

Also related but already existing behavior:

Sliders values don't automatically auto adjust. It requires user interaction before it uses the new values. If user doesnt interact with the slider than the player also plays the value. Any ideas how we could address that?


https://github.com/user-attachments/assets/7119745e-8078-448f-81c5-740a20c46045




