### PR TITLE
Support LockupView videos in the up next feed

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1220,6 +1220,52 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         videoCount: extractNumberFromString(thumbnailOverlayBadgeView.badges[0].text)
       }
     }
+    case 'VIDEO': {
+      let publishedText
+      let lengthSeconds = ''
+      let liveNow = false
+
+      /** @type {YTNodes.ThumbnailOverlayBadgeView | undefined} */
+      const thumbnailOverlayBadgeView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailOverlayBadgeView)
+
+      if (thumbnailOverlayBadgeView) {
+        if (thumbnailOverlayBadgeView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
+          liveNow = true
+        } else {
+          const durationBadge = thumbnailOverlayBadgeView.badges.find(badge => /^[\d:]+$/.test(badge.text))
+
+          if (durationBadge) {
+            lengthSeconds = Utils.timeToSeconds(durationBadge.text)
+          }
+
+          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.[1].text?.text
+        }
+      }
+
+      let viewCount = null
+
+      const viewsText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.[0].text?.text
+
+      if (viewsText) {
+        const views = parseLocalSubscriberCount(viewsText)
+
+        if (!isNaN(views)) {
+          viewCount = views
+        }
+      }
+
+      return {
+        type: 'video',
+        videoId: lockupView.content_id,
+        title: lockupView.metadata.title.text,
+        author: lockupView.metadata.metadata?.metadata_rows[0].metadata_parts?.[0].text?.text,
+        authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId,
+        viewCount,
+        published: calculatePublishedDate(publishedText, liveNow),
+        lengthSeconds,
+        liveNow
+      }
+    }
     default:
       console.warn(`Unknown lockup content type: ${lockupView.content_type}`, lockupView)
       return null
@@ -1338,28 +1384,41 @@ function parseListItem(item) {
 }
 
 /**
- * @param {import('youtubei.js').YTNodes.CompactVideo} video
+ * @param {YTNodes.CompactVideo | YTNodes.CompactMovie | YTNodes.LockupView} video
  */
 export function parseLocalWatchNextVideo(video) {
-  let publishedText
+  if (video.is(YTNodes.CompactMovie)) {
+    return {
+      type: 'video',
+      videoId: video.id,
+      title: video.title.text,
+      author: video.author.name,
+      authorId: video.author.id,
+      lengthSeconds: video.duration.seconds
+    }
+  } else if (video.is(YTNodes.LockupView)) {
+    return parseLockupView(video)
+  } else {
+    let publishedText
 
-  if (video.published != null && !video.published.isEmpty()) {
-    publishedText = video.published.text
-  }
+    if (video.published != null && !video.published.isEmpty()) {
+      publishedText = video.published.text
+    }
 
-  const published = calculatePublishedDate(publishedText, video.is_live, video.is_premiere)
+    const published = calculatePublishedDate(publishedText, video.is_live, video.is_premiere)
 
-  return {
-    type: 'video',
-    videoId: video.video_id,
-    title: video.title.text,
-    author: video.author.name,
-    authorId: video.author.id,
-    viewCount: video.view_count == null ? null : extractNumberFromString(video.view_count.text),
-    published,
-    lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
-    liveNow: video.is_live,
-    isUpcoming: video.is_premiere
+    return {
+      type: 'video',
+      videoId: video.video_id,
+      title: video.title.text,
+      author: video.author.name,
+      authorId: video.author.id,
+      viewCount: video.view_count == null ? null : extractNumberFromString(video.view_count.text),
+      published,
+      lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
+      liveNow: video.is_live,
+      isUpcoming: video.is_premiere
+    }
   }
 }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -405,7 +405,10 @@ export default defineComponent({
         this.isFamilyFriendly = result.basic_info.is_family_safe
 
         const recommendedVideos = result.watch_next_feed
-          ?.filter((item) => item.type === 'CompactVideo' || item.type === 'CompactMovie')
+          ?.filter((item) => {
+            return item.type === 'CompactVideo' || item.type === 'CompactMovie' ||
+              (item.type === 'LockupView' && item.content_type === 'VIDEO')
+          })
           .map(parseLocalWatchNextVideo) ?? []
 
         // place watched recommended videos last


### PR DESCRIPTION
# Support LockupView videos in the up next feed

## Pull Request Type

- [x] Bugfix

## Related issue

Surprisingly nobody has reported this yet

## Description

This pull request fixes the up next feed occasionally being empty, by adding support for `VIDEO` `LockupView`s and also fixes movies not being parsed correctly (their video ID was being set to undefined, which meant the thumbnail didn't appear and clicking on it produced an error). This doesn't currently support upcoming videos as I wasn't able to find an example of one appearing in the up next feed.

## Screenshots

Before with LockupViews
![before-lockup-views](https://github.com/user-attachments/assets/762e7e83-bd7b-409c-a551-c3c68e63c3aa)

After with LockupViews
![after-lockup-views](https://github.com/user-attachments/assets/0c7c6f82-0055-4458-9468-0281b8706b6c)

Before with CompactMovies
![before-movies](https://github.com/user-attachments/assets/f75b8e76-d686-4bae-bfe3-29aa20c361cd)

After with CompactMovies
![after-movies](https://github.com/user-attachments/assets/d22c4719-5482-427c-9041-c07efca1b223)

## Testing

LockupViews appearing in the up next feed still seems to be somewhat random, so that isn't the easiest thing to test but testing the movie parsing changes is doable as you just need to find a YouTube Movie (they usually only have YouTube movies in their up next lists).

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 9b372e8dc335de6d860f28ee620a1d0e042759c1