### PR TITLE
Fix the channel name and ID missing on the channel home tab

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -737,17 +737,14 @@ export function parseLocalChannelHeader(channel, onlyIdNameThumbnail = false) {
  * @param {string} channelName
  */
 export function parseLocalChannelVideos(videos, channelId, channelName) {
-  const parsedVideos = videos.map(parseLocalListVideo)
-
-  // fix empty author info
-  parsedVideos.forEach(video => {
-    video.author = channelName
-    video.authorId = channelId
-  })
-
-  return parsedVideos
+  return videos.map((video) => parseLocalListVideo(video, channelId, channelName))
 }
 
+/**
+ * @param {YTNodes.ReelItem | YTNodes.ShortsLockupView} short
+ * @param {string} [channelId]
+ * @param {string} [channelName]
+ */
 export function parseShort(short, channelId, channelName) {
   if (short.type === 'ReelItem') {
     /** @type {import('youtubei.js').YTNodes.ReelItem} */
@@ -780,8 +777,8 @@ export function parseShort(short, channelId, channelName) {
 
 /**
  * @param {(import('youtubei.js').YTNodes.ReelItem | import('youtubei.js').YTNodes.ShortsLockupView)[]} shorts
- * @param {string} channelId
- * @param {string} channelName
+ * @param {string} [channelId]
+ * @param {string} [channelName]
  */
 export function parseLocalChannelShorts(shorts, channelId, channelName) {
   return shorts.map(short => parseShort(short, channelId, channelName))
@@ -888,8 +885,10 @@ function handleSearchResponse(response) {
 
 /**
  * @param {import('youtubei.js').YT.Channel} homeTab
+ * @param {string} [channelId]
+ * @param {string} [channelName]
  */
-export function parseChannelHomeTab(homeTab) {
+export function parseChannelHomeTab(homeTab, channelId, channelName) {
   /**
    * @type {import('youtubei.js').YTNodes.ItemSection | import('youtubei.js').YTNodes.RichSection}
    */
@@ -911,7 +910,7 @@ export function parseChannelHomeTab(homeTab) {
         if (!playlistId || !playlistId.startsWith('UUMO')) {
           shelves.push({
             title: shelf.title.text,
-            content: shelf.content.items.map(parseListItem).filter(_ => _),
+            content: shelf.content.items.map((item) => parseListItem(item, channelId, channelName)).filter(_ => _),
             playlistId,
             subtitle: shelf.subtitle?.text
           })
@@ -921,14 +920,14 @@ export function parseChannelHomeTab(homeTab) {
         const shelf = itemSection.contents.at(0)
         shelves.push({
           title: shelf.title.text,
-          content: shelf.items.map(parseListItem).filter(_ => _)
+          content: shelf.items.map((item) => parseListItem(item, channelId, channelName)).filter(_ => _)
         })
       } else if (itemSection.contents.at(0).type === 'HorizontalCardList') {
         /** @type {import('youtubei.js').YTNodes.HorizontalCardList} */
         const shelf = itemSection.contents.at(0)
         shelves.push({
           title: shelf.header.title.text,
-          content: shelf.cards.map(parseListItem).filter(_ => _),
+          content: shelf.cards.map((item) => parseListItem(item, channelId, channelName)).filter(_ => _),
           subtitle: shelf.header.subtitle.text
         })
       }
@@ -938,7 +937,7 @@ export function parseChannelHomeTab(homeTab) {
         const shelf = section.content
         shelves.push({
           title: shelf.title?.text,
-          content: shelf.contents.map(e => parseListItem(e.content)),
+          content: shelf.contents.map(e => parseListItem(e.content, channelId, channelName)),
           subtitle: shelf.subtitle?.text,
           playlistId: shelf.endpoint?.metadata.url.includes('/playlist') ? shelf.endpoint?.metadata.url.replace('/playlist?list=', '') : null
         })
@@ -1074,8 +1073,10 @@ export function parseLocalPlaylistVideo(video) {
 
 /**
  * @param {import('youtubei.js').YTNodes.Video | import('youtubei.js').YTNodes.Movie} item
+ * @param {string} [channelId]
+ * @param {string} [channelName]
  */
-export function parseLocalListVideo(item) {
+export function parseLocalListVideo(item, channelId, channelName) {
   if (item.type === 'Movie') {
     /** @type {import('youtubei.js').YTNodes.Movie} */
     const movie = item
@@ -1084,8 +1085,8 @@ export function parseLocalListVideo(item) {
       type: 'video',
       videoId: movie.id,
       title: movie.title.text,
-      author: movie.author.name,
-      authorId: movie.author.id !== 'N/A' ? movie.author.id : null,
+      author: movie.author.name !== 'N/A' ? movie.author.name : channelName,
+      authorId: movie.author.id !== 'N/A' ? movie.author.id : channelId,
       description: movie.description_snippet?.text,
       lengthSeconds: isNaN(movie.duration.seconds) ? '' : movie.duration.seconds,
       liveNow: false,
@@ -1112,8 +1113,8 @@ export function parseLocalListVideo(item) {
       type: 'video',
       videoId: video.video_id,
       title: video.title.text,
-      author: video.author?.name,
-      authorId: video.author?.id,
+      author: video.author?.name ?? channelName,
+      authorId: video.author?.id ?? channelId,
       viewCount: video.views.text == null ? null : extractNumberFromString(video.views.text),
       published,
       lengthSeconds: Utils.timeToSeconds(video.duration.text),
@@ -1127,8 +1128,8 @@ export function parseLocalListVideo(item) {
       type: 'video',
       videoId: movie.id,
       title: movie.title.text,
-      author: movie.author.name,
-      authorId: movie.author.id !== 'N/A' ? movie.author.id : null,
+      author: movie.author.name !== 'N/A' ? movie.author.name : channelName,
+      authorId: movie.author.id !== 'N/A' ? movie.author.id : channelId,
       lengthSeconds: isNaN(movie.duration.seconds) ? '' : movie.duration.seconds,
       isUpcoming: movie.is_upcoming,
       premiereDate: movie.upcoming
@@ -1162,8 +1163,8 @@ export function parseLocalListVideo(item) {
       type: 'video',
       videoId: video.video_id,
       title: video.title.text,
-      author: video.author.name,
-      authorId: video.author.id,
+      author: video.author.name !== 'N/A' ? video.author.name : channelName,
+      authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
       description: video.description,
       viewCount,
       published,
@@ -1229,15 +1230,17 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
 
 /**
  * @param {import('youtubei.js').Helpers.YTNode} item
+ * @param {string} [channelId]
+ * @param {string} [channelName]
  */
-function parseListItem(item) {
+function parseListItem(item, channelId, channelName) {
   switch (item.type) {
     case 'Movie':
     case 'Video':
     case 'GridVideo':
     case 'GridMovie':
     case 'VideoCard':
-      return parseLocalListVideo(item)
+      return parseLocalListVideo(item, channelId, channelName)
     case 'GameCard': {
       /** @type {import('youtubei.js').YTNodes.GameCard} */
       const channel = item
@@ -1323,18 +1326,18 @@ function parseListItem(item) {
     }
     case 'ReelItem':
     case 'ShortsLockupView': {
-      return parseShort(item)
+      return parseShort(item, channelId, channelName)
     }
     case 'CompactStation':
     case 'GridPlaylist':
     case 'Playlist': {
-      return parseLocalListPlaylist(item)
+      return parseLocalListPlaylist(item, channelId, channelName)
     }
     case 'Post': {
       return parseLocalCommunityPost(item)
     }
     case 'LockupView':
-      return parseLockupView(item)
+      return parseLockupView(item, channelId, channelName)
   }
 }
 

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -334,6 +334,7 @@ let autoRefreshOnSortByChangeEnabled = false
 let channelInstance = null
 /** @type {'local' | 'invidious' | ''} */
 let apiUsed = ''
+let mayContainContentFromOtherChannels = false
 
 const isLoading = ref(true)
 const isElementListLoading = ref(false)
@@ -552,6 +553,7 @@ watch(route, () => {
   searchResults.value = []
   apiUsed = ''
   channelInstance = null
+  mayContainContentFromOtherChannels = false
   isArtistTopicChannel.value = false
   videoContinuationData.value = null
   shortContinuationData.value = null
@@ -720,6 +722,10 @@ async function getChannelLocal() {
     bannerUrl.value = parsedHeader.bannerUrl ?? null
     isFamilyFriendly.value = !!channelInstance.metadata.is_family_safe
     isArtistTopicChannel.value = channelName_.endsWith('- Topic') && !!channelInstance.metadata.music_artist_name
+
+    mayContainContentFromOtherChannels = isArtistTopicChannel.value ||
+      !!channelInstance.header?.is(YTNodes.CarouselHeader, YTNodes.InteractiveTabbedHeader) ||
+      !!(channelInstance.header?.is(YTNodes.PageHeader) && channelInstance.header.content?.animated_image)
 
     if (channelInstance.metadata.tags) {
       tags_.push(...channelInstance.metadata.tags)
@@ -891,7 +897,14 @@ function getChannelHomeLocal() {
       return
     }
 
-    const homeData_ = parseChannelHomeTab(homeTab)
+    let homeData_
+
+    if (mayContainContentFromOtherChannels) {
+      homeData_ = parseChannelHomeTab(homeTab)
+    } else {
+      homeData_ = parseChannelHomeTab(homeTab, id.value, channelName.value)
+    }
+
     if (!hideChannelHome.value) {
       homeData.value = homeData_
     }
@@ -1221,7 +1234,15 @@ async function getChannelShortsLocal() {
       return
     }
 
-    latestShorts.value = parseLocalChannelShorts(shortsTab.videos, id.value, channelName.value)
+    let parsedShorts
+
+    if (mayContainContentFromOtherChannels) {
+      parsedShorts = parseLocalChannelShorts(shortsTab.videos)
+    } else {
+      parsedShorts = parseLocalChannelShorts(shortsTab.videos, id.value, channelName.value)
+    }
+
+    latestShorts.value = parsedShorts
     shortContinuationData.value = shortsTab.has_continuation ? shortsTab : null
     isElementListLoading.value = false
 
@@ -1256,7 +1277,15 @@ async function getChannelShortsLocalMore() {
      */
     const continuation = await shortContinuationData.value.getContinuation()
 
-    latestShorts.value = latestShorts.value.concat(parseLocalChannelShorts(continuation.videos, id.value, channelName.value))
+    let parsedShorts
+
+    if (mayContainContentFromOtherChannels) {
+      parsedShorts = parseLocalChannelShorts(continuation.videos)
+    } else {
+      parsedShorts = parseLocalChannelShorts(continuation.videos, id.value, channelName.value)
+    }
+
+    latestShorts.value = latestShorts.value.concat(parsedShorts)
     shortContinuationData.value = continuation.has_continuation ? continuation : null
   } catch (err) {
     console.error(err)

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -148,7 +148,7 @@ async function getInvidiousHashtag(page = 1) {
 async function getLocalHashtag() {
   try {
     const hashtagData = await getHashtagLocal(hashtag.value)
-    videos.value = hashtagData.videos.map(parseLocalListVideo)
+    videos.value = hashtagData.videos.map((video) => parseLocalListVideo(video))
     apiUsed.value = 'local'
     hashtagContinuationData.value = hashtagData.has_continuation ? hashtagData : null
     isLoading.value = false
@@ -171,7 +171,7 @@ async function getLocalHashtag() {
 async function getLocalHashtagMore() {
   try {
     const continuation = await hashtagContinuationData.value.getContinuation()
-    const newVideos = continuation.videos.map(parseLocalListVideo)
+    const newVideos = continuation.videos.map((video) => parseLocalListVideo(video))
     hashtagContinuationData.value = continuation.has_continuation ? continuation : null
     videos.value = videos.value.concat(newVideos)
   } catch (error) {


### PR DESCRIPTION
# Fix the channel name and ID missing on the channel home tab

## Pull Request Type

- [x] Bugfix

## Related issue

- closes #6805 

## Description

This pull request fixes two issues on channel pages. The first issue is that the channel name and ID were not being added to the videos on the home page of user channels and the second issue is that the channel name and ID were incorrectly being added to videos on the shorts tab of auto-generated game channels, as those shorts are from other channels. This pull request specifically only adds the missing channel name and ID to the videos on the home pages of user channels, as the auto-generated channels (e.g artist topic and game topic ones) as well as the system channels (Gaming, Live, Learning, etc) mostly list content from other channels and we don't want to mislabel them as belonging to the system channels.

## Screenshots

<details><summary><h3>YouTube home tab</h3></summary>

#### Before (missing the channel name)
![youtube-home-before](https://github.com/user-attachments/assets/13eac6ec-0599-4597-9a5c-d6e9b1cc5fe7)

#### After (channel name added)
![youtube-home-after](https://github.com/user-attachments/assets/946be38e-ddce-4fcc-b437-eb49cc154322)

</details>

<details><summary><h3>LinusTechTips home tab</h3></summary>

#### Before (missing the channel name)
![ltt-home-before](https://github.com/user-attachments/assets/2afddae5-8ecb-4ce4-b4ca-d5501a6afb4c)

#### After (channel name added)
![ltt-home-after](https://github.com/user-attachments/assets/2f893bfe-9268-4b79-a775-8f4598d49a56)

</details>

<details><summary><h3>Minecraft shorts tab</h3></summary>

#### Before (incorrectly showing the Mincraft channel name)
![minecraft-shorts-before](https://github.com/user-attachments/assets/cdbdad47-6a35-49bc-8fc6-e8687dfc4dae)

#### After (correctly not showing a channel name as it is unknown)
![minecraft-shorts-after](https://github.com/user-attachments/assets/5a11c7ef-11f7-4736-a76b-a7ae7a6f5eac)

</details>

## Testing

Channel name and ID should now appear on the home page:
YouTube: https://www.youtube.com/channel/UCBR8-60-B28hp2BmDPdntcQ
LinusTechTips: https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw

Check that the shorts (on the home and shorts tabs) don't have the name or channel ID (as they are from different channels)
Minecraft: https://www.youtube.com/channel/UCQvWX73GQygcwXOTSf_VDVg

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 3ea6368c777613b36691aff6d43fa145c08e4094