### PR TITLE
Fix live streams not working on the local API

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -697,7 +697,7 @@ export default defineComponent({
           }
         }
 
-        if (!this.isUpcoming || (this.isUpcoming && this.playabilityStatus === 'OK')) {
+        if ((!this.isUpcoming && !this.isLive && !this.isPostLiveDvr) || (this.isUpcoming && this.playabilityStatus === 'OK')) {
           this.videoLengthSeconds = result.basic_info.duration
           if (result.streaming_data) {
             this.streamingDataExpiryDate = result.streaming_data.expires


### PR DESCRIPTION
# Fix live streams not working on the local API

## Pull Request Type

- [x] Bugfix

## Related issue

Follow up to #6375

## Description

This pull request fixes live streams not playing properly, due to a bug in the pull request that added support for trailers on upcoming videos.

## Testing

Normal video: https://youtu.be/jNQXAC9IVRw
Lofi Girl livestream: https://youtu.be/jfKfPfyJRdk

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 89dea10845ad419419b29dc54b6430a581f63ff7