### PR TITLE
Ensure there is at most one power save blocker per open window

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1117,20 +1117,17 @@ export default defineComponent({
 
     // #region power save blocker
 
-    let powerSaveBlocker = null
-
-    async function startPowerSaveBlocker() {
-      if (process.env.IS_ELECTRON && powerSaveBlocker === null) {
+    function startPowerSaveBlocker() {
+      if (process.env.IS_ELECTRON) {
         const { ipcRenderer } = require('electron')
-        powerSaveBlocker = await ipcRenderer.invoke(IpcChannels.START_POWER_SAVE_BLOCKER)
+        ipcRenderer.send(IpcChannels.START_POWER_SAVE_BLOCKER)
       }
     }
 
     function stopPowerSaveBlocker() {
-      if (process.env.IS_ELECTRON && powerSaveBlocker !== null) {
+      if (process.env.IS_ELECTRON) {
         const { ipcRenderer } = require('electron')
-        ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER, powerSaveBlocker)
-        powerSaveBlocker = null
+        ipcRenderer.send(IpcChannels.STOP_POWER_SAVE_BLOCKER)
       }
     }
 


### PR DESCRIPTION
# Ensure there is at most one power save blocker per open window

## Pull Request Type

- [x] Bugfix

## Description

Electron's power save blocking works by returning an identifier from the `.start()` function that you then pass to the `.stop()` function afterwards to stop that specific blocker. Currently we store those identifiers in our video player component, unfortunately due to users restarting windows despite our advice to not do that, there are race conditions where certain blockers won't get cleared until FreeTube has stopped running. This is especially problematic on macOS where the idea is that the application keeps running in the background after you close the last window, so it could be days, weeks or even right up until the user installs the next update before FreeTube is closed.

This pull request moves the management of those power save identifers into the main process, which means we can ensure that if a window has already started a power save blocker and tries to start another one, we reuse the existing blocker for that window. Additionally when a window is closed we now explicitly stop the blocker associated with that window, if there is one to make sure there are no rogue power save blockers sticking around that will never be cleared.

## Testing

Test that the power save blocker still works when you are watching a video, works best on laptops or a desktop with a configured auto-lock or auto-sleep setting (e.g. pick a long video, leave it running and come back to your computer a while later and see if it still active).

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** c7a3baba2cc94d403f9b39cfe77c6d43a7d971c7