### PR TITLE
Cleanup event listener pass-through inline handlers

### DIFF
--- a/src/renderer/components/FtShareButton/FtShareButton.vue
+++ b/src/renderer/components/FtShareButton/FtShareButton.vue
@@ -34,7 +34,7 @@
         <FtButton
           class="action"
           aria-describedby="youtubeShareImage"
-          @click="copyYoutube()"
+          @click="copyYoutube"
         >
           <FontAwesomeIcon :icon="['fas', 'copy']" />
           {{ $t("Share.Copy Link") }}
@@ -42,7 +42,7 @@
         <FtButton
           class="action"
           aria-describedby="youtubeShareImage"
-          @click="openYoutube()"
+          @click="openYoutube"
         >
           <FontAwesomeIcon :icon="['fas', 'globe']" />
           {{ $t("Share.Open Link") }}
@@ -52,7 +52,7 @@
           class="action"
           aria-describedby="youtubeShareImage"
           background-color="var(--accent-color-active)"
-          @click="copyYoutubeEmbed()"
+          @click="copyYoutubeEmbed"
         >
           <FontAwesomeIcon :icon="['fas', 'copy']" />
           {{ $t("Share.Copy Embed") }}
@@ -62,7 +62,7 @@
           class="action"
           aria-describedby="youtubeShareImage"
           background-color="var(--accent-color-active)"
-          @click="openYoutubeEmbed()"
+          @click="openYoutubeEmbed"
         >
           <FontAwesomeIcon :icon="['fas', 'globe']" />
           {{ $t("Share.Open Embed") }}
@@ -82,7 +82,7 @@
         <FtButton
           aria-describedby="invidiousShare"
           class="action"
-          @click="copyInvidious()"
+          @click="copyInvidious"
         >
           <FontAwesomeIcon :icon="['fas', 'copy']" />
           {{ $t("Share.Copy Link") }}
@@ -90,7 +90,7 @@
         <FtButton
           aria-describedby="invidiousShare"
           class="action"
-          @click="openInvidious()"
+          @click="openInvidious"
         >
           <FontAwesomeIcon :icon="['fas', 'globe']" />
           {{ $t("Share.Open Link") }}
@@ -100,7 +100,7 @@
           aria-describedby="invidiousShare"
           class="action"
           background-color="var(--accent-color-active)"
-          @click="copyInvidiousEmbed()"
+          @click="copyInvidiousEmbed"
         >
           <FontAwesomeIcon :icon="['fas', 'copy']" />
           {{ $t("Share.Copy Embed") }}
@@ -110,7 +110,7 @@
           aria-describedby="invidiousShare"
           class="action"
           background-color="var(--accent-color-active)"
-          @click="openInvidiousEmbed()"
+          @click="openInvidiousEmbed"
         >
           <FontAwesomeIcon :icon="['fas', 'globe']" />
           {{ $t("Share.Open Embed") }}

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -135,7 +135,7 @@
             theme="secondary"
             :icon="['fas', 'file-video']"
             :dropdown-options="formatTypeOptions"
-            @click="changeFormat($event)"
+            @click="changeFormat"
           />
           <ft-share-button
             v-if="!hideSharingActions"

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
@@ -127,7 +127,7 @@
         ref="liveChatComments"
         class="liveChatComments"
         :style="{ blockSize: chatHeight }"
-        @mousewheel="e => onScroll(e)"
+        @mousewheel="onScroll"
         @scrollend="e => onScroll(e, true)"
       >
         <div

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -23,7 +23,7 @@
         :show-clear-text-button="true"
         :show-action-button="false"
         :value="query"
-        @input="(input) => handleQueryChange(input)"
+        @input="handleQueryChange"
         @clear="() => handleQueryChange('')"
       />
       <div

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -17,7 +17,7 @@
         :show-clear-text-button="true"
         :show-action-button="false"
         :maxlength="255"
-        @input="(input) => handleQueryChange(input)"
+        @input="handleQueryChange"
         @clear="() => handleQueryChange('')"
       />
       <ft-flex-box

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -35,7 +35,7 @@
             :show-clear-text-button="true"
             :show-action-button="false"
             :maxlength="255"
-            @input="(input) => handleQueryChange(input)"
+            @input="handleQueryChange"
             @clear="() => handleQueryChange('')"
           />
         </div>


### PR DESCRIPTION
# Cleanup event listener pass-through inline handlers

## Pull Request Type

- [x] Performance improvement

## Description

Vue supports two ways of listening to events, inline event handlers and method event handlers. Inline event handlers are great if you only need to do something simple like flipping a boolean value and method handlers are great if you have an existing function that you want to call. At build time Vue creates a function for each inline event handler.

This pull request replaces some inline event handlers whose only purpose was to pass all parameters it received on to the event handler with no other logic with method handlers. This avoids having to generate those extra pass-through functions. You can see the difference in the snippets below taking from the `yarn pack:renderer` output, which was formatted with `npx prettier@2.8.8 --write --no-config dist/renderer.js` (prettier 3 doesn't seem to format files for me, prettier is a very opinionated formatter and will aggressively reformat code which makes it difficult to use for normal code but great for when you want to view a mimified file).

Output before:
```js
t("ft-input", {
  directives: [
    {
      name: "show",
      rawName: "v-show",
      value: e.fullData.length > 1,
      expression: "fullData.length > 1",
    },
  ],
  ref: "searchBar",
  attrs: {
    placeholder: e.$t("History.Search bar placeholder"),
    "show-clear-text-button": !0,
    "show-action-button": !1,
    value: e.query,
  },
  on: {
    input: (t) => e.handleQueryChange(t),
    clear: () => e.handleQueryChange(""),
  },
})
```

Output afterwards:
```js
t("ft-input", {
  directives: [
    {
      name: "show",
      rawName: "v-show",
      value: e.fullData.length > 1,
      expression: "fullData.length > 1",
    },
  ],
  ref: "searchBar",
  attrs: {
    placeholder: e.$t("History.Search bar placeholder"),
    "show-clear-text-button": !0,
    "show-action-button": !1,
    value: e.query,
  },
  on: {
    input: e.handleQueryChange,
    clear: () => e.handleQueryChange(""),
  },
})
```

## Testing

Check that searching still works on the history page and the buttons work in the share menu for example.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a9958582732c2f45551107bcaff14d8c56e4a38c