### PR TITLE
Change `no-array-push-push` to `prefer-single-call` in eslint.config.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,7 +92,7 @@ export default [
       'n/no-callback-literal': 'warn',
       'n/no-path-concat': 'warn',
       'unicorn/better-regex': 'error',
-      'unicorn/no-array-push-push': 'error',
+      'unicorn/prefer-single-call': 'error',
       'unicorn/prefer-keyboard-event-key': 'error',
       'unicorn/prefer-regexp-test': 'error',
       'unicorn/prefer-string-replace-all': 'error',


### PR DESCRIPTION
# Change no-array-push-push to prefer-single-call in eslint.config.mjs

## Pull Request Type

- [x] Other

## Related issue
- https://github.com/FreeTubeApp/FreeTube/pull/7288

## Description

In the recent update to the eslint-plugin-unicorn package, they renamed the `no-array-push-push` rule to `prefer-single-call`, as it now handles other similar situations too, such as `.classList.add()`.

https://redirect.github.com/sindresorhus/eslint-plugin-unicorn/pull/2617

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b67d5ff3a1c80f357cee94b0c4dfefa09fed31a7