### PR TITLE
Use the streaming data from MWEB to avoid SABR-only responses

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -226,6 +226,14 @@ export async function getLocalVideoInfo(id) {
 
   const info = await webInnertube.getInfo(id)
 
+  // temporary workaround for SABR-only responses
+  const mwebInfo = await webInnertube.getBasicInfo(id, 'MWEB')
+
+  if (mwebInfo.playability_status.status === 'OK' && mwebInfo.streaming_data) {
+    info.playability_status = mwebInfo.playability_status
+    info.streaming_data = mwebInfo.streaming_data
+  }
+
   let hasTrailer = info.has_trailer
   let trailerIsAgeRestricted = info.getTrailerInfo() === null
 


### PR DESCRIPTION
# Use the streaming data from MWEB to avoid SABR-only responses

## Pull Request Type

- [x] Bugfix

## Related issue
- #7119

## Description

This pull request temporarily switches to using the streaming data from the MWEB client to avoid SABR-only responses, as the SABR implemenation still has various issues and this allows us to do a quick hotfix. The only known downside is that we lose support for multiple audio tracks (you'll only get the original one now) but Stable Volume is still available.

## Testing

Open a few videos and check that they work.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 818290941946e65703cc01c2f71cc9d1306ff365