### PR TITLE
Rename Community to Posts

### DIFF
--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -216,7 +216,7 @@
             @keydown.left.right="focusTab('community', $event)"
             @keydown.enter.space.prevent="changeTab('community')"
           >
-            {{ $t("Global.Community").toUpperCase() }}
+            {{ $t("Global.Posts").toUpperCase() }}
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
@@ -4,7 +4,7 @@
       class="vote-count"
     >
       <!-- Format the votes to be split by commas ie. 1000 -> 1,000 -->
-      {{ $t('Channel.Community.votes', {votes: formattedVotes}) }}
+      {{ $t('Channel.Posts.votes', {votes: formattedVotes}) }}
     </div>
     <div
       v-for="(choice, index) in data.content"
@@ -52,13 +52,13 @@
         v-if="!revealAnswer"
         class="option-text"
       >
-        <FontAwesomeIcon :icon="['fas', 'eye']" /> {{ $t('Channel.Community.Reveal Answers') }}
+        <FontAwesomeIcon :icon="['fas', 'eye']" /> {{ $t('Channel.Posts.Reveal Answers') }}
       </div>
       <div
         v-else
         class="option-text"
       >
-        <FontAwesomeIcon :icon="['fas', 'eye-slash']" /> {{ $t('Channel.Community.Hide Answers') }}
+        <FontAwesomeIcon :icon="['fas', 'eye-slash']" /> {{ $t('Channel.Posts.Hide Answers') }}
       </div>
     </div>
   </div>

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -95,7 +95,7 @@
         v-else
         class="hiddenVideo"
       >
-        {{ '[' + $t('Channel.Community.Video hidden by FreeTube') + ']' }}
+        {{ '[' + $t('Channel.Posts.Video hidden by FreeTube') + ']' }}
       </p>
     </div>
     <div
@@ -132,7 +132,7 @@
           query: authorId ? { authorId } : undefined
         }"
         class="commentsLink"
-        :aria-label="$t('Channel.Community.View Full Post')"
+        :aria-label="$t('Channel.Posts.View Full Post')"
       >
         <span
           class="commentCount"

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -67,7 +67,7 @@
           v-on="!hideLiveStreams ? { change: updateHideSubscriptionsLive } : {}"
         />
         <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Subscriptions Community')"
+          :label="$t('Settings.Distraction Free Settings.Hide Subscriptions Posts')"
           :compact="true"
           :default-value="hideSubscriptionsCommunity"
           @change="updateHideSubscriptionsCommunity"
@@ -108,7 +108,7 @@
       </div>
       <div class="switchColumn">
         <ft-toggle-switch
-          :label="$t('Settings.Distraction Free Settings.Hide Channel Community')"
+          :label="$t('Settings.Distraction Free Settings.Hide Channel Posts')"
           :compact="true"
           :default-value="hideChannelCommunity"
           @change="updateHideChannelCommunity"

--- a/src/renderer/components/subscriptions-community/subscriptions-community.vue
+++ b/src/renderer/components/subscriptions-community/subscriptions-community.vue
@@ -7,7 +7,7 @@
     :is-community="true"
     :initial-data-limit="20"
     :last-refresh-timestamp="lastCommunityRefreshTimestamp"
-    :title="$t('Global.Community')"
+    :title="$t('Global.Posts')"
     @refresh="loadPostsForSubscriptionsFromRemote"
   />
 </template>

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -214,7 +214,7 @@
           v-if="!hideChannelCommunity && currentTab === 'community' && latestCommunityPosts.length === 0"
         >
           <p class="message">
-            {{ $t("Channel.Community.This channel currently does not have any posts") }}
+            {{ $t("Channel.Posts.This channel currently does not have any posts") }}
           </p>
         </FtFlexBox>
         <FtElementList

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -96,7 +96,7 @@
             class="subscriptionIcon"
             fixed-width
           />
-          {{ $t("Global.Community") }}
+          {{ $t("Global.Posts") }}
         </div>
       </FtFlexBox>
       <SubscriptionsVideos

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -43,7 +43,7 @@ Global:
   Videos: 'Video''s'
   Shorts: 'Kortvideo’s'
   Live: 'Wêreldwye lewendige'
-  Community: 'Gemeenskap'
+  Posts: 'Plasings'
   Sort By: 'Sorteer volgens'
   Counts:
     Video Count: '1 video | {count} videos'
@@ -565,7 +565,6 @@ Settings:
     Hide Channels Already Exists: 'Kanaal-ID bestaan reeds'
     Hide Featured Channels: 'Versteek uitgeligte kanale'
     Hide Channel Playlists: 'Versteek kanaal-“afspeellys”-oortjie'
-    Hide Channel Community: 'Versteek kanaal-“gemeenskap”-oortjie'
     Hide Channel Shorts: 'Versteek kanaal-“kortvideo’s”-oortjie'
     Hide Channel Podcasts: 'Versteek kanaal-“podsendings”-oortjie'
     Hide Channel Releases: 'Versteek kanaal-“vrystellings”-oortjie'
@@ -576,7 +575,6 @@ Settings:
     Hide Subscriptions Videos: 'Versteek intekenings video’s'
     Hide Subscriptions Shorts: 'Versteek intekenings kortvideo’s'
     Hide Subscriptions Live: 'Versteek intekenings regstreeks'
-    Hide Subscriptions Community: 'Versteek intekenings gemeenskap'
     Show Added Items: Toon toegevoegde items
     Hide Channel Home: Versteek kanaal-“tuis”-oortjie
   Data Settings:
@@ -827,7 +825,7 @@ Channel:
     Joined: 'Lid sedert'
     Location: 'Ligging'
     Featured Channels: 'Uitgeligte kanale'
-  Community:
+  Posts:
     This channel currently does not have any posts: 'Hierdie kanaal het nie tans enige
       plasings nie'
     votes: '{votes} stemme'

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'الفيديوهات'
   Shorts: القصيرة
   Live: بث مباشر
-  Community: المجتمع
+  Posts: المنشورات
   Sort By: ترتيب حسب
 
 # Search Bar
@@ -581,7 +581,6 @@ Settings:
       الكبيرة وعلامات الترقيم بشكل مفرط
     Hide Featured Channels: إخفاء القنوات المميزة
     Hide Channel Playlists: إخفاء علامة التبويب "قوائم التشغيل" للقناة
-    Hide Channel Community: إخفاء علامة التبويب "المجتمع" للقناة
     Hide Channel Shorts: إخفاء علامة التبويب "المقاطع القصيرة" للقناة
     Sections:
       Side Bar: الشريط الجانبي
@@ -595,7 +594,6 @@ Settings:
     Hide Subscriptions Shorts: إخفاء الاشتراكات الفيدوهات القصيرة
     Hide Subscriptions Videos: إخفاء مقاطع فيديو الاشتراكات
     Hide Profile Pictures in Comments: إخفاء صور الملف الشخصي في التعليقات
-    Hide Subscriptions Community: إخفاء مجتمع الاشتراكات
     Hide Channels Invalid: معرف القناة المقدم غير صالح
     Hide Channels Disabled Message: تم حظر بعض القنوات باستخدام المعرّف ولم تتم معالجتها.
       يتم حظر الميزة أثناء تحديث هذه المعرفات
@@ -802,7 +800,7 @@ Channel:
   This channel does not allow searching: هذه القناة لا تسمح بالبحث
   This channel is age-restricted and currently cannot be viewed in FreeTube.: هذه
     القناة مصنفة حسب العمر ولا يمكن عرضها حاليا في FreeTube.
-  Community:
+  Posts:
     This channel currently does not have any posts: لا تحتوي هذه القناة حاليا على
       أي مشاركات
     Hide Answers: إخفاء الأجوبة

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -44,7 +44,6 @@ Global:
   Videos: 'वीडियोज'
   Shorts: 'सार्ट्स'
   Live: 'लाइव'
-  Community: 'समाज (कम्युनिटी)'
   Sort By: 'लाइन से लगावा'
   Counts:
     Video Count: '1 वीडियो | {count} वीडियोज'
@@ -538,7 +537,6 @@ Settings:
     Hide Channels Already Exists: ''
     Hide Featured Channels: ''
     Hide Channel Playlists: ''
-    Hide Channel Community: ''
     Hide Channel Home: ''
     Hide Channel Shorts: ''
     Hide Channel Podcasts: ''
@@ -548,7 +546,6 @@ Settings:
     Hide Subscriptions Videos: ''
     Hide Subscriptions Shorts: ''
     Hide Subscriptions Live: ''
-    Hide Subscriptions Community: ''
     Show Added Items: ''
   Data Settings:
     Data Settings: ''
@@ -762,7 +759,7 @@ Channel:
     Joined: ''
     Location: ''
     Featured Channels: ''
-  Community:
+  Posts:
     This channel currently does not have any posts: ''
     votes: ''
     View Full Post: ''

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -372,7 +372,7 @@ Global:
     Comment Count: 1 şərh | {sayı} şərhlər
   Videos: Videolar
   Live: Canlı
-  Community: İcma
+  Posts: Postlar
   Shorts: Shorts
   Sort By: 'Çeşidləmə'
 Search Listing:

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -41,7 +41,7 @@ Global:
   Videos: 'Відэа'
   Shorts: 'Кароткія відэа'
   Live: 'Ужывую'
-  Community: 'Супольнасць'
+  Posts: 'Публікацыі'
   Sort By: Сартаванне
   Counts:
     Video Count: '1 відэа | {count} відэа'
@@ -585,14 +585,12 @@ Settings:
     Hide Channels Placeholder: 'Ідэнтыфікатар канала'
     Hide Featured Channels: 'Хаваць прапанаваныя каналы'
     Hide Channel Playlists: 'Хаваць укладку «Плэй-лісты»'
-    Hide Channel Community: 'Хаваць укладку «Супольнасць»'
     Hide Channel Shorts: 'Хаваць укладку «Кароткія відэа»'
     Hide Channel Podcasts: 'Хаваць укладку «Падкасты»'
     Hide Channel Releases: 'Хаваць укладку «Выпускі»'
     Hide Subscriptions Videos: 'Хаваць відэа з падпісак'
     Hide Subscriptions Shorts: 'Хаваць кароткія відэа з падпісак'
     Hide Subscriptions Live: 'Хаваць трансляцыі з падпісак'
-    Hide Subscriptions Community: 'Хаваць супольнасць падпісак'
     Hide Channels Already Exists: Ідэнтыфікатар канала ўжо існуе
     Hide Videos and Playlists Containing Text: Хаваць відэа і плэй-лісты, якія змяшчаюць
       тэкст
@@ -853,7 +851,7 @@ Channel:
     Joined: 'Далучыўся'
     Location: 'Месцазнаходжанне'
     Featured Channels: 'Рэкамендаваныя каналы'
-  Community:
+  Posts:
     This channel currently does not have any posts: 'Зараз на гэтым канале няма паведамленняў'
     votes: '{votes} галасоў'
     Reveal Answers: 'Адкрыць адказы'

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Видеа'
   Shorts: Кратки видеа
   Live: На живо
-  Community: Общност
+  Posts: Публикации
   Sort By: Подреждане по
 
   Counts:
@@ -602,7 +602,6 @@ Settings:
       главни букви и препинателни знаци
     Hide Featured Channels: Скриване на препоръчаните канали
     Hide Channel Playlists: Скриване на раздел "Плейлисти"
-    Hide Channel Community: Скриване на раздел "Общност"
     Hide Channel Shorts: Скриване на раздел "Кратки видеа"
     Sections:
       Channel Page: Страница на канала
@@ -616,7 +615,6 @@ Settings:
     Hide Subscriptions Live: Скриване на абонаментите на живо
     Hide Channel Podcasts: Скриване на раздел "Подкасти"
     Hide Profile Pictures in Comments: Скриване на профилните снимки в коментарите
-    Hide Subscriptions Community: Скриване на абонаментите Общност
     Hide Channels Disabled Message: Някои канали бяха блокирани с чрез идентификатор
       и не бяха обработени. Функцията е блокирана, докато тези идентификатори се актуализират
     Hide Channels API Error: Грешка при извличането на потребител с предоставения
@@ -826,7 +824,7 @@ Channel:
     Details: Детайли
     Joined: Присъединен на
     Location: Местоположение
-  Community:
+  Posts:
     This channel currently does not have any posts: В момента този канал няма никакви
       публикации
     votes: '{votes} гласа'

--- a/static/locales/bn.yaml
+++ b/static/locales/bn.yaml
@@ -131,7 +131,7 @@ Global:
     Channel Count: ১ চ্যানেল |{সমষ্টি }চ্যানেল সমূহ
     Like Count: ১টি পছন্দ | {গণনা} পছন্দ করা হয়েছে
     Comment Count: ১টি মন্তব্য | {গণনা} মন্তব্য করা হয়েছে
-  Community: গোষ্ঠী
+  Posts: পোস্ট
 External link opening has been disabled in the general settings: সাধারণ পছন্দসমূহে
   বহিঃসংযোগ খোলা নিষ্ক্রিয় রাখা হয়েছে
 Are you sure you want to open this link?: তুমি কি এই সংযোগটি খোলার ব্যাপারে নিশ্চিত?

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -44,7 +44,6 @@ Global:
   Videos: 'Videoioù'
   Shorts: 'Videoioù berr (Shorts)'
   Live: 'War-eeun'
-  Community: 'Kumuniezh'
   Sort By: 'Rummañ dre'
   Counts:
     Video Count: '1 video | {count} video'
@@ -573,7 +572,6 @@ Settings:
     Hide Channels Already Exists: 'ID ar chadenn a zo anezhañ dija'
     Hide Featured Channels: 'Kuzhat ar chadennoù lakaet war-wel'
     Hide Channel Playlists: 'Kuzhat rolloù-videoioù ar chadennoù'
-    Hide Channel Community: 'Kuzhat ivinell kumuniezh ar chadenn'
     Hide Channel Shorts: 'Kuzhat Shortoù ar chadenn'
     Hide Channel Podcasts: 'Kuzhat Podskignañ at chadenn'
     Hide Channel Releases: 'Kuzhat ermaeziadennoù ar chadenn'
@@ -584,7 +582,6 @@ Settings:
     Hide Subscriptions Videos: 'Kuzhat videoioù ar c''houmanantoù'
     Hide Subscriptions Shorts: 'Kuzhat Shortoù ar c''houmanantoù'
     Hide Subscriptions Live: 'Kuzhat ar skignañ war-eeun deus ar c''houmanantoù'
-    Hide Subscriptions Community: 'Kuzhat Kumuniezh ar c''houmanantoù'
   Data Settings:
     Data Settings: 'Roadennoù'
     Select Export Type: 'Choaz doare ezporzhiañ'
@@ -832,7 +829,7 @@ Channel:
     Joined: 'Enskrivet'
     Location: 'Lec''hiadur'
     Featured Channels: 'Chadennoù lakaet war-wel'
-  Community:
+  Posts:
     This channel currently does not have any posts: 'N''eus ket a gaozeadenn evit
       poent gant ar chadenn-mañ'
     votes: '{votes} a vouezhioù'

--- a/static/locales/ca.yaml
+++ b/static/locales/ca.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Vídeos'
 
   Live: En directe
-  Community: Comunitat
+  Posts: Publicacions
   Sort By: 'Ordena Per'
   Shorts: Curts
 Version {versionNumber} is now available!  Click for more details: 'La versió {versionNumber}

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -41,7 +41,6 @@ Global:
   Videos: 'ڤیدیۆکان'
   Shorts: 'کورتەڤیدیۆکان'
   Live: 'ڕاستەوخۆ'
-  Community: 'کۆمەڵگە'
   Sort By: 'ڕیزکردن بە'
   Counts:
     Video Count: '١ ڤیدیۆ | {count} ڤیدیۆ'
@@ -460,14 +459,12 @@ Settings:
     Hide Channels Already Exists: ''
     Hide Featured Channels: ''
     Hide Channel Playlists: ''
-    Hide Channel Community: ''
     Hide Channel Shorts: ''
     Hide Channel Podcasts: ''
     Hide Channel Releases: ''
     Hide Subscriptions Videos: ''
     Hide Subscriptions Shorts: ''
     Hide Subscriptions Live: ''
-    Hide Subscriptions Community: ''
   Data Settings:
     Data Settings: 'دراوە'
     Select Export Type: 'دیاریکردنی جۆری هەناردە'
@@ -672,7 +669,7 @@ Channel:
     Joined: ''
     Location: ''
     Featured Channels: ''
-  Community:
+  Posts:
     This channel currently does not have any posts: ''
     votes: '{votes} دەنگ'
     Reveal Answers: ''

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videa'
   Shorts: Shorts
   Live: Živě
-  Community: Komunita
+  Posts: Příspěvky
   Sort By: Seřadit podle
 
   Counts:
@@ -551,7 +551,6 @@ Settings:
       použití velkých písmen a interpunkce
     Hide Featured Channels: Skrýt doporučené kanály
     Hide Channel Playlists: Skrýt kartu „Playlisty“ u kanálů
-    Hide Channel Community: Skrýt kartu „Komunita“ u kanálů
     Hide Channel Shorts: Skrýt kartu „Shorts“ u kanálů
     Sections:
       Side Bar: Postranní lišta
@@ -565,7 +564,6 @@ Settings:
     Hide Subscriptions Videos: Skrýt videa odběrů
     Hide Subscriptions Live: Skrýt živá vysílání odběrů
     Hide Profile Pictures in Comments: Skrýt profilové obrázky v komentářích
-    Hide Subscriptions Community: Skrýt komunitu odběratelů
     Hide Channels Invalid: Zadané ID kanálu je neplatné
     Hide Channels Disabled Message: Některé kanály byly zablokovány pomocí ID a nebyly
       zpracovány. Při aktualizaci těchto ID je funkce zablokována
@@ -819,7 +817,7 @@ Channel:
   This channel does not exist: Tento kanál neexistuje
   This channel does not allow searching: Tento kanál neumožňuje vyhledávání
   Channel Tabs: Karty kanálů
-  Community:
+  Posts:
     This channel currently does not have any posts: Tento kanál v současné době nemá
       žádné příspěvky
     Hide Answers: Skrýt odpovědi

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -42,7 +42,6 @@ Global:
   Videos: 'Fideos'
   Shorts: 'Byrion'
   Live: 'Byw'
-  Community: 'Cymuned'
   Sort By: Trefnu yn Ôl
   Counts:
     Video Count: '1 fideo| {count} fideo'
@@ -598,14 +597,12 @@ Settings:
     Hide Channels Already Exists: 'Mae ID y sianel eisoes yn bodoli'
     Hide Featured Channels: 'Cuddio Sianeli Nodwedd'
     Hide Channel Playlists: 'Cuddio Tab "Rhestrau Chwarae" Sianel'
-    Hide Channel Community: 'Cuddio Tab Sianel "Cymuned"'
     Hide Channel Shorts: 'Cuddio Tab Sianel "Byrion"'
     Hide Channel Podcasts: 'Cuddio Tab Sianel "Podlediadau"'
     Hide Channel Releases: 'Cuddio Tab Sianel "Rhyddhau"'
     Hide Subscriptions Videos: 'Cuddio Fideos Tanysgrifiadau'
     Hide Subscriptions Shorts: 'Cuddio Tanysgrifiadau Byrion'
     Hide Subscriptions Live: 'Cuddio Tanysgrifiadau Byw'
-    Hide Subscriptions Community: 'Cuddio Cymuned Tanysgrifiadau'
     Hide Videos and Playlists Containing Text: Cuddio Fideos a Rhestrau Chwarae sy'n
       Cynnwys Testun
     Hide Videos and Playlists Containing Text Placeholder: Gair, Darn o Arian, neu
@@ -867,7 +864,7 @@ Channel:
     Joined: 'Dyddiad ymuno'
     Location: 'Lleoliad'
     Featured Channels: 'Sianeli Enghreifftiol'
-  Community:
+  Posts:
     This channel currently does not have any posts: 'Nid oes gan y sianel hon unrhyw
       bostiadau ar hyn o bryd'
     votes: '{votes} pleidlais'

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -38,7 +38,7 @@ Global:
     Channel Count: 1 kanal | {count} kanaler
     Comment Count: 1 kommentar | {count} kommentarer
     Like Count: 1 kan lide | {count} kan lide
-  Community: Fællesskab
+  Posts: Opslag
   Live: Live
   Sort By: Sortér efter
   Shorts: Shorts
@@ -624,7 +624,6 @@ Settings:
     Hide Channels API Error: Fejl ved hentning af bruger med det angivne ID. Tjek
       venligst igen, om ID'et er korrekt.
     Hide Channel Playlists: Skjul kanal "Playlists" Tab
-    Hide Channel Community: Skjul kanal "Kommunity" Tab
     Hide Channel Podcasts: Skjul fanen »Podcasts« på kanalen
     Hide Channels Invalid: Det angivne kanal-ID var ugyldigt
     Hide Channels Disabled Message: Nogle kanaler blev blokeret med ID og blev ikke
@@ -638,7 +637,6 @@ Settings:
     Hide Channel Courses: Skjul kanal "Courses" Tab
     Hide Subscriptions Live: Skjul liveudsendelser fra abonnementer
     Hide Subscriptions Shorts: Skjul abonnementer Shorts
-    Hide Subscriptions Community: Skjul abonnementsfællesskab
     Hide Subscriptions Videos: Skjul abonnementer Videoer
   The app needs to restart for changes to take effect. Restart and apply change?: App'en
     er nødt til at genstarte, for at ændringer kan træde i kraft. Genstart og anvend
@@ -816,7 +814,7 @@ Channel:
       Tags: Etiketter
     Joined: sluttet sig til
     Location: placering
-  Community:
+  Posts:
     Hide Answers: Skjul Svar
     This channel currently does not have any posts: Denne kanal har i øjeblikket ingen
       opslag

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: Videos
   Shorts: Shorts
   Live: Live
-  Community: Beiträge
+  Posts: Beiträge
   Sort By: Sortieren nach
 
 # Search Bar
@@ -600,7 +600,6 @@ Settings:
     Display Titles Without Excessive Capitalisation: Titel ohne übermäßige Großschreibung
       und Zeichensetzung anzeigen
     Hide Channel Playlists: 'Tab „Playlists“ im Kanal ausblenden'
-    Hide Channel Community: 'Tab „Beiträge“ im Kanal ausblenden'
     Hide Channel Shorts: 'Tab „Shorts“ im Kanal ausblenden'
     Hide Featured Channels: Hervorgehobene Kanäle ausblenden
     Sections:
@@ -615,7 +614,6 @@ Settings:
     Hide Channel Releases: 'Tab „Veröffentlichungen“ im Kanal ausblenden'
     Hide Subscriptions Live: Livestreams aus Abos ausblenden
     Hide Profile Pictures in Comments: Profilbilder in den Kommentaren ausblenden
-    Hide Subscriptions Community: Beiträge aus Abos ausblenden
     Hide Channels Invalid: Kanal-ID war ungültig
     Hide Channels Disabled Message: Einige Kanäle wurden mit ID gesperrt und nicht
       verarbeitet. Die Funktion wird blockiert, während diese IDs aktualisieren
@@ -783,7 +781,7 @@ Channel:
     Kanal ist altersbeschränkt und kann derzeit nicht in FreeTube angesehen werden.
   This channel does not allow searching: Dieser Kanal erlaubt keine Suche
   This channel does not exist: Dieser Kanal existiert nicht
-  Community:
+  Posts:
     This channel currently does not have any posts: Dieser Kanal enthält derzeit keine
       Beiträge
     votes: '{votes} Stimmen'
@@ -1132,7 +1130,7 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: Wenn aktiviert, verwendet FreeTube RSS anstelle der Standardmethode,
       um deinen Abo-Feed abzurufen. RSS ist schneller und verhindert die IP-Blockierung,
-      liefert aber bestimmte Informationen wie Videodauer, den Live-Status oder Community-Beiträge
+      liefert aber bestimmte Informationen wie Videodauer, den Live-Status oder Beiträge
       nicht
     Fetch Automatically: Wenn aktiviert, ruft FreeTube automatisch deinen Abo-Feed
       ab, wenn ein neues Fenster geöffnet wird und wenn du das Profil wechselst.

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Βίντεο'
   Shorts: Σύντομα Βίντεο
   Live: Ζωντανά
-  Community: Κοινότητα
+  Posts: Αναρτήσεις
   Sort By: 'Ταξινόμηση κατά'
 
 # Search Bar
@@ -619,7 +619,6 @@ Settings:
       Subscriptions Page: Σελίδα Συνδρομών
     Hide Featured Channels: Απόκρυψη Προτεινόμενων Καναλιών
     Hide Channel Playlists: Απόκρυψη καναλιών " λίστες αναπαραγωγής" καρτέλα
-    Hide Channel Community: Απόκρυψη καναλιού " Κοινότητα" καρτέλα
     Hide Channel Shorts: Απόκρυψη καναλιού " Σύντομες" καρτέλα
     Hide Channel Releases: Απόκρυψη καναλιού " Kυκλοφοριών" καρτέλα
     Hide Channel Podcasts: Απόκρυψη καναλιού " Πόντκαστ" καρτέλα
@@ -627,7 +626,6 @@ Settings:
     Hide Subscriptions Shorts: Απόκρυψη Shorts Συνδρομών
     Hide Subscriptions Live: Απόκρυψη Live Συνδρομών
     Hide Profile Pictures in Comments: Απόκρυψη Εικόνων Προφίλ στα Σχόλια
-    Hide Subscriptions Community: Απόκρυψη Συνδρομών Κοινότητας
     Hide Channels Invalid: Το αναγνωριστικό καναλιού που δόθηκε δεν ήταν έγκυρο
     Hide Channels Disabled Message: Ορισμένα κανάλια αποκλείστηκαν με χρήση αναγνωριστικού
       και δεν υποβλήθηκαν σε επεξεργασία. Η λειτουργία μπλοκάρεται κατά την ενημέρωση
@@ -851,7 +849,7 @@ Channel:
     FreeTube.
   Channel Tabs: Καρτέλες Καναλιών
   This channel does not exist: Αυτό το κανάλι δεν υπάρχει
-  Community:
+  Posts:
     This channel currently does not have any posts: Αυτό το κανάλι προς το παρόν δεν
       έχει αναρτήσεις
     Reveal Answers: Εμφάνιση Απαντήσεων

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: Videos
   Shorts: Shorts
   Live: Live
-  Community: Community
+  Posts: Posts
   Sort By: Sort by
 
   Counts:
@@ -607,7 +607,7 @@ Settings:
       capitalisation and punctuation
     Hide Featured Channels: Hide featured channels
     Hide Channel Playlists: Hide channel "playlists" tab
-    Hide Channel Community: Hide channel "community" tab
+    Hide Channel Posts: Hide channel "Posts" tab
     Hide Channel Shorts: Hide channel "shorts" tab
     Sections:
       Side Bar: Side bar
@@ -620,7 +620,7 @@ Settings:
     Hide Subscriptions Shorts: Hide subscriptions shorts
     Hide Subscriptions Live: Hide subscriptions live
     Hide Subscriptions Videos: Hide subscriptions videos
-    Hide Subscriptions Community: Hide subscriptions community
+    Hide Subscriptions Posts: Hide subscriptions Posts
     Hide Profile Pictures in Comments: Hide profile pictures in comments
     Hide Channels Invalid: Channel ID provided was invalid
     Hide Channels Disabled Message: Some channels were blocked using ID and weren't
@@ -822,7 +822,7 @@ Channel:
   This channel does not allow searching: This channel does not allow searching
   This channel is age-restricted and currently cannot be viewed in FreeTube.: This
     channel is age resticted and currently cannot be viewed in FreeTube.
-  Community:
+  Posts:
     This channel currently does not have any posts: This channel currently does not
       have any posts
     Reveal Answers: Reveal answers
@@ -1091,7 +1091,7 @@ Tooltips:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method to grab your subscription feed. RSS is faster and prevents IP blocking,
       but it doesn’t provide certain information like video duration, live status
-      or community posts
+      or posts
     Fetch Automatically: When enabled, FreeTube will automatically fetch your subscription
       feed when a new window is opened and when switching profile.
   Player Settings:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -44,7 +44,7 @@ Global:
   Videos: Videos
   Shorts: Shorts
   Live: Live
-  Community: Community
+  Posts: Posts
   Sort By: Sort By
   Counts:
     Video Count: 1 video | {count} videos
@@ -568,7 +568,7 @@ Settings:
     Hide Channels Already Exists: Channel ID already exists
     Hide Featured Channels: Hide Featured Channels
     Hide Channel Playlists: Hide Channel "Playlists" Tab
-    Hide Channel Community: Hide Channel "Community" Tab
+    Hide Channel Posts: Hide Channel "Posts" Tab
     Hide Channel Home: Hide Channel "Home" Tab
     Hide Channel Shorts: Hide Channel "Shorts" Tab
     Hide Channel Podcasts: Hide Channel "Podcasts" Tab
@@ -579,7 +579,7 @@ Settings:
     Hide Subscriptions Videos: Hide Subscriptions Videos
     Hide Subscriptions Shorts: Hide Subscriptions Shorts
     Hide Subscriptions Live: Hide Subscriptions Live
-    Hide Subscriptions Community: Hide Subscriptions Community
+    Hide Subscriptions Posts: Hide Subscriptions Posts
     Show Added Items: Show Added Items
   Data Settings:
     Data Settings: Data
@@ -820,7 +820,7 @@ Channel:
     Joined: Joined
     Location: Location
     Featured Channels: Featured Channels
-  Community:
+  Posts:
     This channel currently does not have any posts: This channel currently does not have any posts
     votes: '{votes} votes'
     View Full Post: View Full Post
@@ -1089,7 +1089,7 @@ Tooltips:
   Subscription Settings:
     Fetch Feeds from RSS: When enabled, FreeTube will use RSS instead of its default
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
-      but doesn't provide certain information like video duration, live status or community posts
+      but doesn't provide certain information like video duration, live status or posts
     Fetch Automatically: When enabled, FreeTube will automatically fetch
       your subscription feed when a new window is opened and when switching profile.
   Experimental Settings:

--- a/static/locales/eo.yaml
+++ b/static/locales/eo.yaml
@@ -21,7 +21,6 @@ Back: 'Reen'
 Forward: 'Antaŭen'
 
 Global:
-  Community: Komunumo
   Sort By: 'Ordigi laŭ'
 
   Videos: Videaĵoj

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -523,7 +523,6 @@ Settings:
       Channel Page: Página del canal
       Subscriptions Page: Página de suscripciones
       General: General
-    Hide Channel Community: Ocultar la pestaña de 'Comunidad' del canal
     Hide Subscriptions Videos: Ocultar las suscripciones de los videos
     Hide Comments: Ocultar comentarios
     Hide Channel Shorts: Ocultar la pestaña de 'Shorts' del canal
@@ -531,7 +530,6 @@ Settings:
     Hide Channel Podcasts: Ocultar la pestaña de 'Podcasts' del canal
     Hide Live Streams: Ocultar transmisiones en vivo
     Hide Channel Playlists: Ocultar la pestaña de 'Listas de reproducción' del canal
-    Hide Subscriptions Community: Ocultar las suscripciones a la comunidad
     Hide Channels: Ocultar los vídeos de los canales
     Hide Subscriptions Live: Ocultar Suscripciones en Vivo
     Hide Subscriptions Shorts: Ocultar las suscripciones para los Shorts
@@ -646,7 +644,7 @@ Global:
     Channel Count: 1 canal | {count} canales
     Like Count: 1 me gusta | {count} me gusta
     Comment Count: 1 comentario | {count} comentarios
-  Community: Comunidad
+  Posts: Publicaciones
   Videos: Videos
   Shorts: Shorts
   Live: En vivo

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: 'Videos'
 
 # Search Bar
-  Community: Comunidad
+  Posts: Publicaciones
   Live: En vivo
   Sort By: 'Ordenar por'
   Counts:

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Vídeos'
   Shorts: Vídeos cortos
   Live: En directo
-  Community: Comunidad
+  Posts: Publicaciones
   Sort By: Ordenar por
 
 # Search Bar
@@ -593,7 +593,6 @@ Settings:
       ni signos de puntuación excesivos
     Hide Featured Channels: Ocultar canales recomendados
     Hide Channel Playlists: Ocultar la pestaña "Listas de reproducción" del canal
-    Hide Channel Community: Ocultar la pestaña "Comunidad" del canal
     Hide Channel Shorts: Ocultar la pestaña "Vídeos cortos" del canal
     Sections:
       Side Bar: Barra lateral
@@ -607,7 +606,6 @@ Settings:
     Hide Subscriptions Videos: Ocultar las suscripciones de los Vídeos
     Hide Subscriptions Live: Ocultar las suscripciones de los directos
     Hide Profile Pictures in Comments: Ocultar fotos de perfil en comentarios
-    Hide Subscriptions Community: Ocultar las suscripciones de la comunidad
     Hide Channels Invalid: El ID del canal proporcionado no es válido
     Hide Channels Disabled Message: Algunos canales se bloquearon por ID y no se procesaron.
       La función está bloqueada mientras se actualizan esos ID
@@ -821,7 +819,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Este
     canal tiene restricciones de edad y actualmente no puede verse en FreeTube.
   Channel Tabs: Ficha del Canal
-  Community:
+  Posts:
     This channel currently does not have any posts: Este canal no tiene actualmente
       ningún mensaje
     Reveal Answers: Revelar las respuestas

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videod'
   Shorts: Lühivideod
   Live: Otseeeter
-  Community: Kogukond
+  Posts: Postitused
   Sort By: 'Järjestus'
 
   Counts:
@@ -603,14 +603,12 @@ Settings:
     Hide Featured Channels: Peaida soovitatud kanalid
     Hide Channel Playlists: Peida kanalite vahekaart „Esitusloendid“
     Hide Channel Shorts: Peida kanalite vahekaart „Lühivideod“
-    Hide Channel Community: Peida kanalite vahekaart „Kogukond“
     Hide Channel Podcasts: Peida kanalite vahekaart „Taskuhäälingud“
     Hide Channel Releases: Peida kanalite vahekaart „Väljalasked“
     Hide Subscriptions Videos: Peida tellimuste videod
     Hide Subscriptions Shorts: Peida tellimuste lühivideod
     Hide Subscriptions Live: Peida tellimuste otse-eetrid
     Hide Profile Pictures in Comments: Peida kommentaaride profiilipildid
-    Hide Subscriptions Community: Peida tellijate loend
     Hide Channels Invalid: Sisestatud kanali tunnus on vigane
     Hide Channels Disabled Message: Mõned kanalid on blokeeritud nende tunnuste alusel
       ja nende andmeid ei töödelda. See funktsionaalsus pole kasutusel, kui nendes
@@ -825,7 +823,7 @@ Channel:
     Live: Otseeeter
     This channel does not currently have any live streams: Sellel kanalil pole hetkel
       ühtegi otseeetrit
-  Community:
+  Posts:
     This channel currently does not have any posts: Sellel kanalil pole hetkel postitusi
     Reveal Answers: Näita vastuseid
     Hide Answers: Peida vastused

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -1,5 +1,5 @@
 # Put the name of your locale in the same language
-Locale Name: 'Euskera'
+Locale Name: 'Euskara'
 
 # Webkit Menu Bar
 File: 'Fitxategia'
@@ -40,7 +40,7 @@ Global:
     Comment Count: Iruzkin 1 | {count} iruzkin
   Live: Zuzenekoa
   Shorts: Laburrak
-  Community: Komunitatea
+  Posts: Argitalpenak
   Sort By: Honen arabera ordenatu
 Version {versionNumber} is now available!  Click for more details: '{versionNumber}
   bertsioa erabilgarri! Klikatu azalpen gehiagorako'
@@ -559,7 +559,6 @@ Settings:
       letra larriz eta puntuaziorik gabe
     Hide Channels Placeholder: Kanalaren IDa
     Hide Channel Playlists: Ezkutatu kanaleko "erreprodukzio-zerrendak" fitxa
-    Hide Channel Community: Ezkutatu kanalaren "komunitatea" fitxa
     Hide Channel Podcasts: Ezkutatu kanaleko "podcastak" fitxa
     Hide Videos and Playlists Containing Text: Ezkutatu testua duten bideoak eta erreprodukzio-zerrendak
     Hide Channels: Ezkutatu bideoak kanaletatik
@@ -576,7 +575,6 @@ Settings:
     Hide Videos and Playlists Containing Text Placeholder: Hitza, Hitzaren zatia edo
       esaldia
     Hide Subscriptions Live: Ezkutatu zuzenekoen harpidetzak
-    Hide Subscriptions Community: Ezkutatu harpidetzen komunitateak
     Hide Featured Channels: Ezkutatu nabarmendutako kanalak
     Hide Channels Disabled Message: Kanal batzuk IDa erabiliz blokeatu dira eta ez
       dira prozesatu. Eginbidea blokeatuta dago ID horiek eguneratzen ari diren bitartean
@@ -836,7 +834,7 @@ Channel:
     This channel does not currently have any releases: Une honetan kanal honek ez
       du argitalpenik
     Releases: Argitalpenak
-  Community:
+  Posts:
     Hide Answers: Erantzunak ezkutatu
     votes: '{votes} bozka'
     This channel currently does not have any posts: Une honetan kanal honek ez du

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -549,7 +549,6 @@ Settings:
     Hide Chapters: پنهان کردن فصل ها
     Hide Channels Placeholder: شناسه کانال
     Hide Subscriptions Live: مخفی کردن اشتراک های زنده
-    Hide Channel Community: مخفی کردن "انجمن" کانال
     Hide Channel Shorts: مخفی کردن "ویدئو های کوتاه" کانال
     Hide Subscriptions Shorts: مخفی کردن شورت اشتراک ها
     Hide Channel Podcasts: پنهان کردن "پادکست‌های" کانال
@@ -560,7 +559,6 @@ Settings:
     Hide Channels Already Exists: شناسه کانال از قبل وجود دارد
     Hide Videos and Playlists Containing Text: ویدیوها و لیست های پخش حاوی متن را
       مخفی کنید
-    Hide Subscriptions Community: مخفی کردن انجمن دنبال‌شده ها
     Hide Channel Home: مخفی کردن "صفحه اصلی" کانال
     Hide Channels API Error: خطای بازیابی کاربر با شناسه ارائه شده. لطفا دوباره بررسی
       کنید که شناسه درست باشد.
@@ -714,8 +712,8 @@ Channel:
     Releases: منتشر شده
     This channel does not currently have any releases: این کانال در حال حاضر هیچ نسخه
       ای ندارد
-  Community:
-    Community: انجمن
+  Posts:
+    Posts: پست‌ها
     votes: '{votes} رأی'
     Reveal Answers: پاسخ ها را فاش کن
     This channel currently does not have any posts: این کانال در حال حاضر هیچ پستی
@@ -1019,7 +1017,7 @@ Global:
     Video Count: ۱ ویدیو | {count} ویدیو
     Like Count: 1 پسند | {count} پسند
     Comment Count: 1 نظر | {count} نظر
-  Community: جامعه
+  Posts: پست‌ها
 Share:
   Share Playlist: لیست پخش را به اشتراک بگذارید
   Share Channel: اشتراک گذاری کانال

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: 'Videot'
   Shorts: Shorts
   Live: Livenä
-  Community: Yhteisö
+  Posts: Postaukset
   Sort By: Järjestä
   Counts:
     Video Count: 1 video | {count} videota
@@ -497,7 +497,6 @@ Settings:
       isoja kirjaimia
     Hide Featured Channels: Piilota esillä olevat kanavat
     Hide Channel Playlists: Piilota kanavan soittolistat
-    Hide Channel Community: Piilota kanava yhteisö
     Hide Channel Shorts: Piilota kanavan lyhytelokuvat
     Sections:
       Side Bar: Sivupalkki
@@ -512,7 +511,6 @@ Settings:
     Hide Profile Pictures in Comments: Piilota profiilikuvat kommenteissa
     Hide Channels Invalid: Annettu kanavatunnus oli virheellinen
     Hide Subscriptions Shorts: Piilota tilattujen kanavien Shorts-videot
-    Hide Subscriptions Community: Piilota tilattujen kanavien yhteisö
   The app needs to restart for changes to take effect. Restart and apply change?: Sovellus
     on käynnistettävä uudelleen, jotta muutokset tulevat voimaan. Käynnistetäänkö
     uudelleen?
@@ -654,7 +652,7 @@ Channel:
     kanava on ikärajoitettu, eikä sitä voi tällä hetkellä katsoa FreeTubessa.
   This channel does not exist: Tätä kanavaa ei ole olemassa
   This channel does not allow searching: Tämä kanava ei salli etsintää
-  Community:
+  Posts:
     This channel currently does not have any posts: Tällä kanavalla ei ole tällä hetkellä
       mitään
     Reveal Answers: Näytä vastaukset

--- a/static/locales/fil.yaml
+++ b/static/locales/fil.yaml
@@ -94,7 +94,7 @@ Global:
   Videos: Mga Video
   Shorts: Mga Shorts
   Sort By: 'Pag-uri-uriin ayon'
-  Community: Komunidad
+  Posts: Mga Post
 Search Bar:
   Clear Input: Alisin ang Input
 External link opening has been disabled in the general settings: Ang pag bukas ng

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: 'Vidéos'
   Shorts: Shorts
   Live: En direct
-  Community: Communauté
+  Posts: Posts
   Sort By: Trier par
 
 # Search Bar
@@ -612,7 +612,6 @@ Settings:
       ni ponctuation excessives
     Hide Channel Playlists: Masquer l’onglet « Listes de lecture » de la chaine
     Hide Featured Channels: Masquer les chaines en vedette
-    Hide Channel Community: Masquer l’onglet « Communauté » de la chaine
     Hide Channel Shorts: Masquer l’onglet « Shorts » de la chaine
     Sections:
       Channel Page: Page de la chaine
@@ -626,7 +625,6 @@ Settings:
     Hide Subscriptions Shorts: Masquer les shorts des abonnements
     Hide Subscriptions Live: Masquer les diffusions en direct des abonnements
     Hide Profile Pictures in Comments: Masquer les photos de profil dans les commentaires
-    Hide Subscriptions Community: Masquer les communautés abonnées
     Hide Channels Invalid: L’identifiant de chaine fourni n’est pas valide
     Hide Channels Disabled Message: Certaines chaines ont été bloquées à l’aide d’un
       identifiant et n’ont pas été traitées. La fonctionnalité est bloquée le temps
@@ -797,7 +795,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Cette
     chaîne est limitée par l'âge et ne peut actuellement pas être visionnée dans FreeTube.
   Channel Tabs: Onglets des chaînes
-  Community:
+  Posts:
     This channel currently does not have any posts: Cette chaîne n'a actuellement
       aucune publication
     votes: '{votes} votes'

--- a/static/locales/gl.yaml
+++ b/static/locales/gl.yaml
@@ -29,7 +29,7 @@ Forward: 'Adiante'
 # Anything shared among components / views should be put here
 Global:
   Videos: 'Vídeos'
-  Community: Comunidade
+  Posts: Publicacións
 
   Shorts: Cortos
   Live: En vivo
@@ -532,7 +532,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Esta
     canle ten unha limitación de idade e actualmente non se pode ver en FreeTube.
   Channel Tabs: Pestanas das canles
-  Community:
+  Posts:
     This channel currently does not have any posts: Esta canle actualmente non ten
       publicacións
 Video:

--- a/static/locales/gsw.yaml
+++ b/static/locales/gsw.yaml
@@ -108,7 +108,6 @@ Global:
     Watching Count: 1 lueget zue {count} luege zue
   Live: live
   Shorts: shorts
-  Community: Gemeinschaft
   Sort By: Sortieren nach
 Search character limit: Die Suchanfrage ist länger als das erlaubte Limit von {searchCharacterLimit}
   Zeichen

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'סרטונים'
   Shorts: Shorts
   Live: חי
-  Community: קהילה
+  Posts: פוסטים
   Sort By: מיון לפי
 
   Counts:
@@ -541,7 +541,6 @@ Settings:
       וסימני פיסוק מיותרים
     Hide Featured Channels: הסתרת ערוצים מומלצים
     Hide Channel Playlists: הסתרת לשונית „רשימות נגינה” של ערוץ
-    Hide Channel Community: הסתרת לשונית ה„קהילת” הערוץ
     Hide Channel Shorts: הסתרת לשונית ה־„Shorts” של הערוץ
     Sections:
       Watch Page: עמוד הצפייה
@@ -555,7 +554,6 @@ Settings:
     Hide Subscriptions Shorts: הסתרת Shorts של המינויים
     Hide Subscriptions Videos: הסתרת סרטוני מינוי
     Hide Profile Pictures in Comments: הסתרת תמונות הפרופיל בהערות
-    Hide Subscriptions Community: הסתרת קהילת המינויים
     Hide Videos and Playlists Containing Text Placeholder: מילה, חלק מילה או ביטוי
     Hide Channels Invalid: ID הערוץ שסופק לא תקין
     Hide Channels Disabled Message: חלק מהערוצים נחסמו באמצעות ID ולא טופלו. התכונה
@@ -758,7 +756,7 @@ Channel:
   This channel does not exist: הערוץ הזה לא קיים
   This channel is age-restricted and currently cannot be viewed in FreeTube.: הערוץ
     מוגבל לפי גיל וכרגע אי אפשר לצפות בו ב־FreeTube.
-  Community:
+  Posts:
     This channel currently does not have any posts: אין רשומות בערוץ הזה כרגע
     votes: '{votes} הצבעות'
     Reveal Answers: חשיפת התשובות

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videa'
   Shorts: Kratka videa
   Live: Uživo
-  Community: Zajednica
+  Posts: Postovi
   Sort By: Redoslijed
 
 # Search Bar
@@ -574,7 +574,6 @@ Settings:
       korištenja velikih slova i interpunkcije
     Hide Featured Channels: Sakrij istaknute kanale
     Hide Channel Playlists: Sakrij karticu „Zbirke” kanala
-    Hide Channel Community: Sakrij karticu „Zajednica” kanala
     Hide Channel Shorts: Sakrij karticu „Kratka videa” kanala
     Sections:
       Watch Page: Stranica gledanja
@@ -588,7 +587,6 @@ Settings:
     Hide Subscriptions Live: Sakrij pretplate videa uživo
     Hide Subscriptions Videos: Sakrij pretplate videa
     Hide Profile Pictures in Comments: Sakrij slike profila u komentarima
-    Hide Subscriptions Community: Sakrij pretplate zajednice
     Hide Channels Invalid: Navedeni ID kanala nije bio ispravan
     Hide Channels Disabled Message: Neki su kanali blokirani upotrebom ID-a i nisu
       obrađeni. Funkcija je blokirana tijekom aktualiziranje tih ID-ova
@@ -798,7 +796,7 @@ Channel:
     Live: Uživo
     This channel does not currently have any live streams: Ovaj kanal trenutačno nema
       prijenosa uživo
-  Community:
+  Posts:
     This channel currently does not have any posts: Ovaj kanal trenutačno nema objava
     Reveal Answers: Prikaži odgovore
     Hide Answers: Sakrij odgovore

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videók'
   Shorts: Rövid videók
   Live: Élő
-  Community: Közösség
+  Posts: Bejegyzések
   Sort By: Rendezési szempont
 
   Counts:
@@ -608,7 +608,6 @@ Settings:
       és írásjelek nélkül való megjelenítése
     Hide Featured Channels: Kiemelt csatornák elrejtése
     Hide Channel Playlists: Csatorna „lejátszási listák” lap elrejtése
-    Hide Channel Community: Csatorna „közösség” lap elrejtése
     Hide Channel Shorts: Csatorna „rövid videók” lap elrejtése
     Sections:
       Side Bar: Oldalsáv
@@ -622,7 +621,6 @@ Settings:
     Hide Subscriptions Videos: Feliratkozási videók elrejtése
     Hide Subscriptions Live: Élő feliratkozások elrejtése
     Hide Profile Pictures in Comments: Profilképek elrejtése a hozzászólásokban
-    Hide Subscriptions Community: Közösségi feliratkozások elrejtése
     Hide Channels Invalid: Érvénytelen a megadott csatornaazonosító
     Hide Channels Disabled Message: Egyes csatornákat letiltottak az azonosító miatt,
       és nem dolgozták fel őket. A funkció le van tiltva, amíg ezek az azonosítók
@@ -838,7 +836,7 @@ Channel:
     This channel does not currently have any live streams: Jelenleg nincs élő közvetítés
       ezen a csatornán
     Live: Élő
-  Community:
+  Posts:
     This channel currently does not have any posts: Ezen a csatornán jelenleg nincsenek
       bejegyzések
     Reveal Answers: Válaszok felfedése

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -38,7 +38,7 @@ Global:
     Watching Count: 1 sedang menonton | {count} sedang menonton
     Comment Count: 1 komentar | {count} komentar
     Like Count: 1 suka | {count} suka
-  Community: Komunitas
+  Posts: Postingan
   Live: Siaran Langsung
   Shorts: Video Singkat
   Sort By: Urut Menurut
@@ -597,10 +597,8 @@ Settings:
     Hide Upcoming Premieres: Sembunyikan Siaran Langsung yang Akan Datang
     Hide Live Streams: Sembunyikan Siaran Langsung
     Hide Channel Playlists: Sembunyikan Tab "Daftar Putar" Saluran
-    Hide Channel Community: Sembunyikan Tab "Komunitas" Saluran
     Hide Sharing Actions: Sembunyikan Tindakan Bagikan Video
     Hide Featured Channels: Sembunyikan Kanal Unggulan
-    Hide Subscriptions Community: Sembunyikan Komunitas dalam Langganan
     Hide Channels: Sembunyikan Video dari Kanal
     Hide Channels Placeholder: ID Kanal
     Hide Channels API Error: Galat menemukan pengguna dengan ID yang diberikan. Mohon
@@ -820,7 +818,7 @@ Channel:
     Live: Siaran Langsung
     This channel does not currently have any live streams: Kanal ini belum memiliki
       siaran langsung apa pun
-  Community:
+  Posts:
     Hide Answers: Sembunyikan jawaban
     Reveal Answers: Tampilkan jawaban
     Video hidden by FreeTube: Video disembunyikan oleh FreeTube

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Myndskeið'
   Shorts: Símamyndir
   Live: Í beinni
-  Community: Samfélag
+  Posts: Færslur
   Sort By: Raða eftir
 
   Counts:
@@ -559,7 +559,6 @@ Settings:
       Subscriptions Page: Áskriftasíða
     Hide Channel Shorts: Fela símamyndaflipa rása
     Hide Channel Playlists: Fela spilunarlistaflipa rása
-    Hide Channel Community: Fela samfélagsflipa rása
     Hide Featured Channels: Fela rásir í deiglunni
     Hide Channel Podcasts: Fela hlaðvarpsflipa rása
     Hide Channel Releases: Fela útgáfuflipa rása
@@ -567,7 +566,6 @@ Settings:
     Hide Subscriptions Live: Fela bein streymi áskrifta
     Hide Subscriptions Videos: Fela myndskeið áskrifta
     Hide Profile Pictures in Comments: Fela auðkennismyndir í athugasemdum
-    Hide Subscriptions Community: Fela samfélag áskrifenda
     Hide Channels Invalid: Uppgefið auðkenni rásar er ógilt
     Hide Channels Disabled Message: Sumar rásir voru útilokaðar út frá auðkenni og
       voru ekki meðhöndlaðar. Lokað er á eiginleikann á meðan verið er að uppfæra
@@ -831,7 +829,7 @@ Channel:
     Live: Í beinni
     This channel does not currently have any live streams: Þessi rás er í augnablikinu
       ekki með nein bein streymi
-  Community:
+  Posts:
     This channel currently does not have any posts: Þessi rás er ekki með neinar færslur
     Reveal Answers: Birta svör
     Hide Answers: Fela svör

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Video'
   Shorts: Video brevi
   Live: Dal vivo
-  Community: Comunità
+  Posts: Post
   Sort By: Ordina per
 
 # Search Bar
@@ -600,7 +600,6 @@ Settings:
       e punteggiatura eccessive
     Hide Featured Channels: Nascondi i canali in evidenza
     Hide Channel Playlists: Nascondi la scheda "Playlist" del canale
-    Hide Channel Community: Nascondi la scheda "Comunità" del canale
     Hide Channel Shorts: Nascondi i "Video brevi" del canale
     Sections:
       General: Generale
@@ -614,7 +613,6 @@ Settings:
     Hide Subscriptions Videos: Nascondi i video delle iscrizioni
     Hide Subscriptions Shorts: Nascondi le iscrizioni ai video brevi
     Hide Profile Pictures in Comments: Nascondi le immagini del profilo nei commenti
-    Hide Subscriptions Community: Nascondi la comunità di iscritti
     Hide Channels Invalid: L'ID canale fornito non è valido
     Hide Channels Disabled Message: Alcuni canali sono stati bloccati usando l'ID
       e non sono stati elaborati. La funzionalità è bloccata durante l'aggiornamento
@@ -783,7 +781,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Questo
     canale è soggetto a limiti di età e al momento non può essere visualizzato su
     FreeTube.
-  Community:
+  Posts:
     This channel currently does not have any posts: Questo canale attualmente non
       ha alcun post
     votes: '{votes} voti'

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: '動画'
   Shorts: ショート動画
   Live: ライブ配信
-  Community: コミュニティ
+  Posts: 投稿
   Sort By: 並び替え
 
 # Search Bar
@@ -529,7 +529,6 @@ Settings:
     Hide Channels Placeholder: チャンネル ID
     Display Titles Without Excessive Capitalisation: 過剰な大文字や句読点のないタイトルの表示
     Hide Channel Playlists: チャンネルの「再生リスト」タブを隠す
-    Hide Channel Community: チャンネルの「コミュニティ」タブを隠す
     Sections:
       Side Bar: サイドバー
       Channel Page: チャンネル ページ
@@ -544,7 +543,6 @@ Settings:
     Hide Subscriptions Videos: 登録チャンネルの動画の非表示
     Hide Channel Releases: チャンネルの「新着情報」タブを隠す
     Hide Profile Pictures in Comments: コメント欄のプロフィール写真を隠す
-    Hide Subscriptions Community: 登録チャンネルのコミュニティの非表示
     Hide Channels Invalid: 提供されたチャンネル ID が無効です
     Hide Channels Disabled Message: 一部のチャンネルが ID を使用してブロックされ、処理されませんでした。これらの ID が更新されている間、機能はブロックされます
     Hide Channels Already Exists: チャンネル ID は既に存在します
@@ -688,7 +686,7 @@ Channel:
   Added channel to your subscriptions: チャンネルを登録しました
   Channel has been removed from your subscriptions: チャンネルがあなたの登録チャンネルから削除されました
   Removed subscription from {count} other channel(s): ほかの {count} チャンネルから登録を削除しました
-  Community:
+  Posts:
     This channel currently does not have any posts: このチャンネルには現在投稿がありません
     votes: '{votes} 投票'
     Reveal Answers: 回答を表示

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: '동영상'
 
   Live: 실시간
-  Community: 커뮤니티
+  Posts: 게시물
   Shorts: 쇼츠
   Sort By: '정렬하기'
   Counts:

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -37,7 +37,6 @@ Global:
 # Search Bar
   Live: ژیاوازی
   Shorts: شورتەکان
-  Community: کۆمەڵگا
   Counts:
     Video Count: 1 ڤیدیۆ | {count} ڤیدیۆکان
   Videos: ویدیوەکان

--- a/static/locales/lt.yaml
+++ b/static/locales/lt.yaml
@@ -33,7 +33,7 @@ Global:
 
   Live: Tiesiogiai
   Shorts: Šortai
-  Community: Bendruomenė
+  Posts: Įrašai
   Sort By: 'Rūšiuoti pagal'
   Counts:
     Subscriber Count: 1 prenumeruoti | {count} prenumeratorių
@@ -336,7 +336,6 @@ Settings:
     Hide Channels Placeholder: Kanalo pavadinimas arba ID
     Hide Featured Channels: Slėpti Teminiai kanalai
     Hide Channel Playlists: Slėpti Kanalo Grojaraščiai
-    Hide Channel Community: Slėpti Kanalo Bendruomenę
     Hide Channel Shorts: Slėpti Kanalo Šortus
   Data Settings:
     Data Settings: 'Duomenų nustatymai'

--- a/static/locales/lv.yaml
+++ b/static/locales/lv.yaml
@@ -42,7 +42,7 @@ Global:
   Videos: 'Video'
   Shorts: 'Īsie'
   Live: 'Tiešraides'
-  Community: 'Kopiena'
+  Posts: 'Ziņas'
   Sort By: Kārto pēc
   Counts:
     Video Count: '1 video | {count} video'
@@ -461,14 +461,12 @@ Settings:
     Hide Channels Placeholder: 'Kanāla ID'
     Hide Featured Channels: 'Paslēpt izceltos kanālus'
     Hide Channel Playlists: 'Slēpt kanālā "Atskaņošanas saraksti" cilni'
-    Hide Channel Community: 'Slēpt kanālā "Kopiena" cilni'
     Hide Channel Shorts: 'Slēpt kanālā "Īsie video" cilni'
     Hide Channel Podcasts: 'Slēpt kanālā "Podkāsti" cilni'
     Hide Channel Releases: 'Slēpt kanālā "Relīzes" cilni'
     Hide Subscriptions Videos: 'Paslēp abonementu video'
     Hide Subscriptions Shorts: 'Paslēp abonementu īsos video'
     Hide Subscriptions Live: 'Paslēp abonementu tiešraides'
-    Hide Subscriptions Community: 'Paslēp abonementu komūnu'
     Hide Channels Already Exists: Kanāla ID jau eksistē
     Hide Videos and Playlists Containing Text Placeholder: Vārds, vārda daļa, vai
       frāze
@@ -689,7 +687,7 @@ Channel:
     Joined: 'Pievienojās'
     Location: 'Vieta'
     Featured Channels: 'Izceltie kanāli'
-  Community:
+  Posts:
     This channel currently does not have any posts: 'Šajā kanālā pašlaik nav ierakstu'
     votes: ''
     Reveal Answers: 'Atklāj atbildes'

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -39,10 +39,10 @@ Are you sure you want to open this link?: ''
 # Global
 # Anything shared among components / views should be put here
 Global:
-  Videos: ''
+  Videos: 'ဗီဒီယိုများ'
   Shorts: ''
-  Live: ''
-  Community: ''
+  Live: 'တိုက်ရိုက်လွှင့်နေသော'
+  Posts: 'ို့စ်'
   Counts:
     Video Count: ''
     Channel Count: ''
@@ -519,7 +519,6 @@ Settings:
     Hide Channels Already Exists: ''
     Hide Featured Channels: ''
     Hide Channel Playlists: ''
-    Hide Channel Community: ''
     Hide Channel Home: ''
     Hide Channel Shorts: ''
     Hide Channel Podcasts: ''
@@ -529,7 +528,6 @@ Settings:
     Hide Subscriptions Videos: ''
     Hide Subscriptions Shorts: ''
     Hide Subscriptions Live: ''
-    Hide Subscriptions Community: ''
     Show Added Items: ''
   Data Settings:
     Data Settings: ''
@@ -743,7 +741,7 @@ Channel:
     Joined: ''
     Location: ''
     Featured Channels: ''
-  Community:
+  Posts:
     This channel currently does not have any posts: ''
     votes: ''
     View Full Post: ''

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videoer'
   Shorts: Shorts-videoer
   Live: Direktesendinger
-  Community: Fellesskap
+  Posts: Innlegg
   Sort By: Sorter etter
 
 # Search Bar
@@ -610,7 +610,6 @@ Settings:
     Display Titles Without Excessive Capitalisation: Vis titler uten overdreven bruk
       av store bokstaver
     Hide Featured Channels: Skjul fremhevede kanaler
-    Hide Channel Community: Skjul «Fellesskap»-fanen i kanaler
     Hide Channel Shorts: Skjul «Shorts»-fanen i kanaler
     Sections:
       Side Bar: Sidefelt
@@ -636,7 +635,6 @@ Settings:
     Show Added Items: Vis videoer lagt til
     Hide Channels API Error: En feil oppsto ved henting av brukeren med den oppgitte
       ID-en. Vennligst sjekk om ID-en er riktig.
-    Hide Subscriptions Community: Skjul abonnementsfellesskap
     Hide Channel Courses: Skjul «Kurs»-fanen i kanaler
   The app needs to restart for changes to take effect. Restart and apply change?: Start
     programmet på nytt for å ta i bruk endringene?
@@ -766,7 +764,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Denne
     kanalen er aldersbegrenset og kan derfor ikke vises i FreeTube.
   Channel Tabs: Kanalfaner
-  Community:
+  Posts:
     This channel currently does not have any posts: Denne kanalen har ingen oppføringer
     Hide Answers: Skjul svar
     votes: '{votes} stemmer'

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -42,7 +42,7 @@ Global:
     Channel Count: 1 kanaal | {count} kanalen
     Like Count: 1 vind ik leuk | {count} vind ik leuks
     Comment Count: 1 commentaar | {count} commentaren
-  Community: Gemeenschap
+  Posts: Posts
 Search / Go to URL: 'Zoeken / Ga naar URL'
   # In Filter Button
 Search Filters:
@@ -599,7 +599,6 @@ Settings:
     Hide Upcoming Premieres: Aankomende premières verbergen
     Hide Featured Channels: Uitgelichte kanalen verbergen
     Hide Channel Playlists: '"Kanaal­afspeellijsten" Tabblad Verbergen'
-    Hide Channel Community: '"Kanaal­gemeenschap" Tabblad Verbergen'
     Hide Channels: Video's van kanalen verbergen
     Hide Channels Placeholder: Kanaal-ID
     Hide Channel Podcasts: Kanaal "Podcasts" Tabblad Verbergen
@@ -609,7 +608,6 @@ Settings:
     Hide Channel Shorts: Kanaal "Shorts" Tabblad Verbergen
     Hide Subscriptions Shorts: Abonnement-Shorts verbergen
     Hide Profile Pictures in Comments: Profielfoto's in opmerkingen verbergen
-    Hide Subscriptions Community: Abonnement­gemeenschappen verbergen
     Hide Channels Already Exists: Kanaal ID bestaat reeds
     Hide Channels Invalid: Opgegeven kanaal-id is ongeldig
     Hide Videos and Playlists Containing Text Placeholder: Woord, woord­fragment of
@@ -781,8 +779,8 @@ Channel:
     Podcasts: Podcasts
     This channel does not currently have any podcasts: Dit kanaal heeft momenteel
       geen podcasts
-  Community:
-    Community: Gemeenschap
+  Posts:
+    Posts: Posts
     Reveal Answers: Antwoorden onthullen
     Hide Answers: Antwoorden verbergen
     votes: '{votes} stemmen'

--- a/static/locales/nn.yaml
+++ b/static/locales/nn.yaml
@@ -38,7 +38,7 @@ Global:
     View Count: 1 visning | {count} visningar
   Shorts: Shorts
   Live: Direkte
-  Community: Fellesskap
+  Posts: Innlegg
   Sort By: 'Sorter etter'
 Version {versionNumber} is now available!  Click for more details: 'Versjon {versionNumber}
   er no tilgjengeleg! Klikk for meir informasjon'

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: 'Filmy'
   Shorts: Filmy Short
   Live: Transmisje
-  Community: Społeczność
+  Posts: Posty
   Sort By: Sortuj według
 
 # Search Bar
@@ -593,7 +593,6 @@ Settings:
     Hide Channels Placeholder: ID kanału
     Display Titles Without Excessive Capitalisation: Wyświetlaj tytuły nie nadużywając
       wielkich liter i interpunkcji
-    Hide Channel Community: Schowaj kartę kanału „Społeczność”
     Hide Channel Shorts: Schowaj kartę kanału „Filmy Short”
     Hide Featured Channels: Schowaj polecane kanały
     Hide Channel Playlists: Schowaj kartę kanału „Playlisty”
@@ -609,7 +608,6 @@ Settings:
     Hide Subscriptions Shorts: Schowaj filmy Short z subskrypcji
     Hide Subscriptions Live: Schowaj transmisje live z subskrypcji
     Hide Profile Pictures in Comments: Nie pokazuj zdjęć profilowych w komentarzach
-    Hide Subscriptions Community: Schowaj „Społeczność” kanałów
     Hide Channels Invalid: Podane ID kanału jest niepoprawne
     Hide Channels Disabled Message: Niektóre z kanałów nie zostały przetworzone, ponieważ
       zostały zablokowane po swoim ID. Funkcja jest zablokowana, aż do momentu, w
@@ -775,7 +773,7 @@ Channel:
   Channel Tabs: Karty kanału
   This channel does not exist: Nie ma takiego kanału
   This channel does not allow searching: Ten kanał nie zezwala na przeszukiwanie
-  Community:
+  Posts:
     This channel currently does not have any posts: Ten kanał nie ma obecnie żadnych
       wpisów
     votes: '{votes} głosów'

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: 'Vídeos'
   Shorts: Shorts
   Live: Ao vivo
-  Community: Comunidade
+  Posts: Posts
   Sort By: Ordenar por
 
 # Search Bar
@@ -599,7 +599,6 @@ Settings:
       Subscriptions Page: Página de inscrições
     Hide Featured Channels: Ocultar canais em destaque
     Hide Channel Playlists: Ocultar a guia "Playlists" do canal
-    Hide Channel Community: Ocultar a guia "Comunidade" do canal
     Hide Channel Shorts: Ocultar a guia "Shorts" do canal
     Hide Channel Podcasts: Ocultar a guia "Podcasts" do canal
     Hide Channel Releases: Ocultar a guia "Lancamentos" do canal
@@ -607,7 +606,6 @@ Settings:
     Hide Subscriptions Shorts: Ocultar "Shorts" de suas inscrições
     Hide Subscriptions Live: Ocultar transmissões ao vivo de suas inscrições
     Hide Profile Pictures in Comments: Ocultar foto de perfis nos comentários
-    Hide Subscriptions Community: Ocultar comunidade de suas inscrições
     Hide Channels Invalid: ID do canal fornecido é inválido
     Hide Channels Disabled Message: Alguns canais foram bloqueados por ID e não foram
       processados. A função está bloqueada enquanto esses IDs estão sendo atualizados
@@ -771,7 +769,7 @@ Channel:
   This channel does not allow searching: Este canal não permite buscas
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Este
     canal tem restrição de idade e atualmente não pode ser visualizado no FreeTube.
-  Community:
+  Posts:
     This channel currently does not have any posts: Este canal atualmente não tem
       nenhuma postagem
     votes: '{votes} voto(s)'

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: Vídeos
   Shorts: Curtos
   Live: Em direto
-  Community: Comunidade
+  Posts: Publicações
   Sort By: Ordenar por
 
   Counts:
@@ -550,7 +550,6 @@ Settings:
       ou pontuação em excesso
     Hide Featured Channels: Ocultar canais em destaque
     Hide Channel Playlists: Ocultar separador "Listas de reprodução" nos canais
-    Hide Channel Community: Ocultar separador "Comunidade" nos canais
     Hide Channel Shorts: Ocultar separador "Curtos" nos canais
     Sections:
       Side Bar: Barra lateral
@@ -565,7 +564,6 @@ Settings:
     Hide Subscriptions Live: Ocultar subscrições de emissões em direto
     Hide Profile Pictures in Comments: Ocultar imagens de perfil nos comentários
     Hide Channels Already Exists: Este ID já existe
-    Hide Subscriptions Community: Ocultar subscrições de comunidades
     Hide Channels Disabled Message: Alguns canais foram bloqueados e não foram processados.
       A funcionalidade está bloqueada enquanto estiver a ocorrer a atualização dos
       ID.
@@ -828,7 +826,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Este
     canal tem restrição de idade e, atualmente, não pode ser visto no Free Tube.
   Channel Tabs: Separadores de canais
-  Community:
+  Posts:
     This channel currently does not have any posts: Este canal não tem, atualmente,
       quaisquer publicações
     Reveal Answers: Mostrar respostas

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Vídeos'
   Shorts: Curtos
   Live: Em direto
-  Community: Comunidade
+  Posts: Publicações
   Sort By: Ordenar por
 
   Counts:
@@ -641,7 +641,6 @@ Settings:
       ou pontuação em excesso
     Hide Featured Channels: Ocultar canais em destaque
     Hide Channel Playlists: Ocultar separador "Listas de reprodução" nos canais
-    Hide Channel Community: Ocultar separador "Comunidade" nos canais
     Hide Channel Shorts: Ocultar separador "Curtos" nos canais
     Sections:
       Side Bar: Barra lateral
@@ -655,7 +654,6 @@ Settings:
     Hide Subscriptions Shorts: Ocultar subscrições de curtos
     Hide Subscriptions Live: Ocultar subscrições de emissões em direto
     Hide Profile Pictures in Comments: Ocultar imagens de perfil nos comentários
-    Hide Subscriptions Community: Ocultar subscrições de comunidades
     Hide Channels Invalid: O ID do canal não é válido
     Hide Channels Disabled Message: Alguns canais foram bloqueados e não foram processados.
       A funcionalidade está bloqueada enquanto estiver a ocorrer a atualização dos
@@ -832,10 +830,10 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Este
     canal tem restrição de idade e, atualmente, não pode ser visto no Free Tube.
   Channel Tabs: Separadores de canais
-  Community:
+  Posts:
     This channel currently does not have any posts: Este canal não tem, atualmente,
       quaisquer publicações
-    Community: Comunidade
+    Posts: Publicações
     Hide Answers: Ocultar respostas
     Reveal Answers: Mostrar respostas
     votes: '{votes} votos'

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videoclipuri'
   Shorts: Shorts
   Live: Live
-  Community: Comunitate
+  Posts: Postări
   Sort By: Sortează după
   Counts:
     Video Count: 1 videoclip | {count} videoclipuri
@@ -620,7 +620,6 @@ Settings:
     Hide Subscriptions Videos: Ascundeți Abonamente Videoclipuri
     Hide Subscriptions Live: Ascundeți Abonamente Live
     Hide Channels: Ascundeți videoclipurile din canale
-    Hide Channel Community: Ascunde fila „Comunitate” canal
     Hide Channel Shorts: Ascundeți fila "Shorts" a canalului
     Hide Featured Channels: Ascundeți canalele recomandate
     Hide Channels Placeholder: ID-ul canalului
@@ -640,7 +639,6 @@ Settings:
     Hide Channels API Error: Eroare la preluarea utilizatorului cu ID-ul furnizat.
       Vă rugăm să verificați din nou dacă ID-ul este corect.
     Hide Channel Courses: Ascunde fila „Cursuri” a canalului
-    Hide Subscriptions Community: Ascunde comunitatea abonamentelor
   SponsorBlock Settings:
     Notify when sponsor segment is skipped: Notificare atunci când segmentul sponsorului
       este sărit
@@ -826,8 +824,8 @@ Channel:
     Tags:
       Search for: Căutați "{tag}"
       Tags: Tags
-  Community:
-    Community: Comunitate
+  Posts:
+    Posts: Postări
     This channel currently does not have any posts: Acest canal nu are momentan nicio
       postare
     Reveal Answers: Dezvăluie Răspunsuri

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: 'Видео'
   Shorts: Короткие видео
   Live: Трансляции
-  Community: Сообщество
+  Posts: Записи
   Sort By: Сортировать по
 
 # Search Bar
@@ -576,7 +576,6 @@ Settings:
       заглавных букв и знаков препинания
     Hide Featured Channels: Скрыть избранные каналы
     Hide Channel Playlists: Скрыть вкладку "Списки воспроизведения" канала
-    Hide Channel Community: Скрыть вкладку "Сообщество" канала
     Hide Channel Shorts: Скрыть вкладку "Шорты" канала
     Sections:
       Side Bar: Боковая Панель
@@ -591,7 +590,6 @@ Settings:
     Hide Subscriptions Shorts: Скрыть короткие видео из подписок
     Hide Profile Pictures in Comments: Скрыть изображения профилей в комментариях
     Hide Channels Invalid: Указанный идентификатор канала недействителен
-    Hide Subscriptions Community: Скрыть сообщество подписок
     Hide Channels Disabled Message: Некоторые каналы были заблокированы по идентификатору
       и не были обработаны. Функция заблокирована, пока эти идентификаторы обновляются
     Hide Channels Already Exists: Идентификатор канала уже существует
@@ -754,7 +752,7 @@ Channel:
   Channel Tabs: Вкладки каналов
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Этот
     канал ограничен по возрасту и в настоящее время не может быть просмотрен во FreeTube.
-  Community:
+  Posts:
     This channel currently does not have any posts: На этом канале в настоящее время
       нет никаких записей
     votes: 'Голосов: {votes}'

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -37,7 +37,7 @@ Global:
     Like Count: 1 like | {count} likes
     Comment Count: 1 komentár | {count} komentárov
   Live: Naživo
-  Community: Komunita
+  Posts: Príspevky
   Shorts: Shorts
   Sort By: 'Triediť podľa'
 Search / Go to URL: 'Hľadať / Ísť na URL adresu'

--- a/static/locales/sm.yaml
+++ b/static/locales/sm.yaml
@@ -39,7 +39,7 @@ Global:
   Videos: ''
   Shorts: ''
   Live: ''
-  Community: ''
+  Posts: ''
   Counts:
     Video Count: ''
     Channel Count: ''
@@ -338,14 +338,12 @@ Settings:
     Hide Channels Placeholder: ''
     Hide Featured Channels: ''
     Hide Channel Playlists: ''
-    Hide Channel Community: ''
     Hide Channel Shorts: ''
     Hide Channel Podcasts: ''
     Hide Channel Releases: ''
     Hide Subscriptions Videos: ''
     Hide Subscriptions Shorts: ''
     Hide Subscriptions Live: ''
-    Hide Subscriptions Community: ''
   Data Settings:
     Data Settings: ''
     Select Export Type: ''
@@ -542,7 +540,7 @@ Channel:
     Joined: ''
     Location: ''
     Featured Channels: ''
-  Community:
+  Posts:
     This channel currently does not have any posts: ''
     votes: ''
     Reveal Answers: ''

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -39,7 +39,7 @@ Global:
     Comment Count: 1 коментар | {count} коментара
     Like Count: 1 свиђање | {count} свиђања
   Live: Уживо
-  Community: Заједница
+  Posts: Постови
   Shorts: Shorts
   Sort By: Сортирање по
 Version {versionNumber} is now available!  Click for more details: 'Верзија {versionNumber}
@@ -553,7 +553,6 @@ Settings:
       Channel Page: Страница канала
       Subscriptions Page: Страница праћења
       General: Опште
-    Hide Channel Community: Сакриј картицу „Заједница“ канала
     Hide Subscriptions Videos: Сакриј видео снимке канала које пратите
     Hide Comments: Сакриј коментаре
     Hide Channel Shorts: Сакриј картицу „Shorts“ канала
@@ -561,7 +560,6 @@ Settings:
     Hide Channel Podcasts: Сакриј картицу „Подкасти“ канала
     Hide Live Streams: Сакриј стримове уживо
     Hide Channel Playlists: Сакриј картицу „Плејлисте“ канала
-    Hide Subscriptions Community: Сакриј заједницу канала које пратите
     Hide Channels: Сакриј видео снимке са канала
     Hide Subscriptions Live: Сакриј стримове уживо канала које пратите
     Hide Subscriptions Shorts: Сакриј Shorts снимке канала које пратите
@@ -819,7 +817,7 @@ Channel:
       Tags: Ознаке
     Details: Детаљи
     Location: Локација
-  Community:
+  Posts:
     This channel currently does not have any posts: Овај канал тренутно нема ниједну
       објаву
     Reveal Answers: Откриј одговоре

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videor'
   Shorts: Shorts
   Live: Live
-  Community: Gemenskap
+  Posts: Inlägg
   Sort By: Sortera efter
 
   Counts:
@@ -598,7 +598,6 @@ Settings:
       Channel Page: Kanal sida
       Watch Page: Titta sida
       Subscriptions Page: Prenumerationssida
-    Hide Channel Community: Dölj Kanalfliken "Gemenskap"
     Hide Channel Playlists: Dölj Kanalfliken "Spellistor"
     Hide Channel Podcasts: Dölj Kanalfliken "Podcasts"
     Hide Channel Releases: Dölj Kanalfliken "Släpp"
@@ -606,7 +605,6 @@ Settings:
     Hide Subscriptions Shorts: Dölj prenumerationsshorts
     Hide Subscriptions Live: Dölj prenumerations Live-sändningar
     Hide Profile Pictures in Comments: Dölj profilbilder i kommentarer
-    Hide Subscriptions Community: Dölj prenumerationsgemenskap
     Hide Channels Invalid: Det angivna kanal-ID var ogiltigt
     Hide Channels Disabled Message: Vissa kanaler blockerades med ID och bearbetades
       inte. Funktionen är blockerad medan dessa ID:n uppdateras
@@ -817,7 +815,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Denna
     kanalen är ålderbegränsad och kan inte ses i FreeTube.
   Channel Tabs: Kanalflikar
-  Community:
+  Posts:
     This channel currently does not have any posts: Denna kanal har för närvarande
       inga inlägg
     votes: '{votes} röster'

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -43,7 +43,7 @@ Global:
   Videos: 'வீடியோக்கள்'
   Shorts: 'குறுக்குகள்'
   Live: 'வாழ'
-  Community: 'சமூகம்'
+  Posts: 'இடுகைகள்'
   Sort By: 'வரிசைப்படுத்தவும்'
   Counts:
     Video Count: '1 வீடியோ | {count} வீடியோக்கள்'
@@ -577,7 +577,6 @@ Settings:
     Hide Channels Already Exists: 'சேனல் ஐடி ஏற்கனவே உள்ளது'
     Hide Featured Channels: 'பிரத்யேக சேனல்களை மறைக்கவும்'
     Hide Channel Playlists: 'சேனல் "பிளேலிச்ட்கள்" தாவலை மறைக்கவும்'
-    Hide Channel Community: 'சேனல் "சமூகம்" தாவலை மறைக்கவும்'
     Hide Channel Shorts: 'சேனல் "சார்ட்ச்" தாவலை மறைக்கவும்'
     Hide Channel Podcasts: 'சேனல் "பாட்காச்ட்கள்" தாவலை மறைக்கவும்'
     Hide Channel Releases: 'சேனல் "வெளியீடுகள்" தாவலை மறைக்கவும்'
@@ -588,7 +587,6 @@ Settings:
     Hide Subscriptions Videos: 'சந்தா வீடியோக்களை மறைக்கவும்'
     Hide Subscriptions Shorts: 'சந்தாக்கள் குறும்படங்களை மறைக்கவும்'
     Hide Subscriptions Live: 'சந்தாக்களை நேரடியாக மறைக்கவும்'
-    Hide Subscriptions Community: 'சந்தாக்கள் சமூகத்தை மறைக்கவும்'
     Show Added Items: சேர்க்கப்பட்ட உருப்படிகளைக் காட்டு
     Hide Channel Home: சேனல் "முகப்பு" தாவலை மறைக்கவும்
   Data Settings:
@@ -841,7 +839,7 @@ Channel:
     Joined: 'இணைந்தது'
     Location: 'இடம்'
     Featured Channels: 'பிரத்யேக சேனல்கள்'
-  Community:
+  Posts:
     This channel currently does not have any posts: 'இந்த சேனலில் தற்போது எந்த இடுகைகளும்
       இல்லை'
     votes: '{votes} வாக்குகள்'

--- a/static/locales/tok.yaml
+++ b/static/locales/tok.yaml
@@ -70,7 +70,6 @@ Video:
   Live: tenpo ni
 Tooltips: {}
 Global:
-  Community: kulupu
   Videos: sitelen tawa
   Shorts: lili
   Live: tenpo ni

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Videolar'
   Shorts: Kısa Videolar
   Live: Canlı
-  Community: Topluluk
+  Posts: Gönderiler
   Sort By: Sıralama ölçütü
 
   Counts:
@@ -599,7 +599,6 @@ Settings:
       Noktalama İşaretleri Kullanmadan Görüntüle
     Hide Featured Channels: Öne Çıkan Kanalları Gizle
     Hide Channel Playlists: Kanal "Oynatma Listelerini" Sekmesini Gizle
-    Hide Channel Community: Kanal "Topluluk" Sekmesini Gizle
     Hide Channel Shorts: Kanal "Kısa Videolar" Sekmesini Gizle
     Sections:
       Side Bar: Kenar Çubuğu
@@ -613,7 +612,6 @@ Settings:
     Hide Subscriptions Shorts: Abonelik Kısa Videolarını Gizle
     Hide Subscriptions Live: Abonelik Canlı Yayınlarını Gizle
     Hide Profile Pictures in Comments: Yorumlardaki Profil Resimlerini Gizle
-    Hide Subscriptions Community: Abonelik Topluluğunu Gizle
     Hide Channels Invalid: Belirtilen kanal kimliği geçersiz
     Hide Channels Disabled Message: Bazı kanallar kimliği kullanılarak engellendi
       ve işlenmedi. Bu kimlikler güncellenirken özellik engellenir
@@ -825,7 +823,7 @@ Channel:
   Channel Tabs: Kanal Sekmeleri
   This channel does not allow searching: Bu kanal aramaya izin vermiyor
   This channel does not exist: Bu kanal mevcut değil
-  Community:
+  Posts:
     This channel currently does not have any posts: Bu kanalda şu anda herhangi bir
       gönderi yok
     votes: '{votes} oy'

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -31,7 +31,7 @@ Global:
   Videos: 'Відео'
   Shorts: Shorts
   Live: Наживо
-  Community: Спільнота
+  Posts: Дописи
   Sort By: Сортувати за
 
   Counts:
@@ -553,7 +553,6 @@ Settings:
       капіталізації та пунктуації
     Hide Featured Channels: Сховати пропоновані канали
     Hide Channel Playlists: Сховати добірки каналу
-    Hide Channel Community: Сховати вкладку "Спільнота" каналу
     Hide Channel Shorts: Сховати вкладку "Shorts" каналу
     Sections:
       Side Bar: Бічна панель
@@ -567,7 +566,6 @@ Settings:
     Hide Subscriptions Shorts: Сховати Shorts із підписок
     Hide Subscriptions Live: Сховати трансляції з підписок
     Hide Profile Pictures in Comments: Сховати зображення профілю в коментарях
-    Hide Subscriptions Community: Сховати спільноту підписників
     Hide Channels Invalid: Вказаний ID каналу недійсний
     Hide Channels Disabled Message: Деякі канали були заблоковані за допомогою ID
       і не були оброблені. Функція заблокована в той час, як ці ID оновлювалися
@@ -819,7 +817,7 @@ Channel:
   This channel is age-restricted and currently cannot be viewed in FreeTube.: Цей
     канал має вікові обмеження і наразі не може бути переглянутий на FreeTube.
   Channel Tabs: Вкладки каналів
-  Community:
+  Posts:
     This channel currently does not have any posts: Зараз на цьому каналі немає публікацій
     votes: 'Голосів: {votes}'
     Reveal Answers: Розгорнути відповіді

--- a/static/locales/ur.yaml
+++ b/static/locales/ur.yaml
@@ -228,7 +228,7 @@ Global:
   Videos: ویڈیوز
   Shorts: شورٹس
   Live: لاؤو
-  Community: کمیونٹی
+  Posts: پوسٹس
   Sort By: ترتیب بہ لحاظ
 Close Banner: بینر بندکریں
 Preferences: ترجیحات

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -32,7 +32,7 @@ Global:
 # Search Bar
   Live: Trực tiếp
   Shorts: Shorts
-  Community: Cộng đồng
+  Posts: Bài đăng
   Sort By: 'Sắp xếp theo'
   Counts:
     Subscriber Count: 1 người đăng ký | {count} người đăng ký
@@ -559,13 +559,11 @@ Settings:
     Hide Channel Releases: Ẩn trang "Xuất bản" của kênh
     Hide Videos and Playlists Containing Text: Ẩn các video và danh sách phát có chứa
     Hide Channels Invalid: ID kênh không hợp lệ
-    Hide Channel Community: Ẩn trang "Cộng đồng" của kênh
     Hide Channel Shorts: Ẩn trang "Shorts" của kênh
     Hide Subscriptions Shorts: Ẩn short từ các đăng ký
     Hide Subscriptions Live: Ẩn video phát trực tiếp từ các đăng ký
     Hide Upcoming Premieres: Ẩn video sắp ra mắt
     Hide Channel Podcasts: Ẩn trang "Podcast" của kênh
-    Hide Subscriptions Community: Ẩn bài đăng cộng đồng từ các đăng ký
     Hide Channels Already Exists: ID kênh đã tồn tại
     Hide Videos and Playlists Containing Text Placeholder: Từ, tiếng, hoặc cụm từ
     Hide Subscriptions Videos: Ẩn video từ các đăng ký
@@ -756,8 +754,8 @@ Channel:
       bất kì luồng phát trực tiếp nào
   This channel does not allow searching: Kênh này không cho phép tìm kiếm
   This channel does not exist: Kênh không tồn tại
-  Community:
-    Community: Cộng đồng
+  Posts:
+    Posts: Bài đăng
     This channel currently does not have any posts: Kênh này hiện không có bất kì
       bài đăng nào
     votes: '{votes} bình chọn'

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -43,7 +43,6 @@ Global:
   Videos: 'Videos'
   Shorts: 'Korte videos'
   Live: 'Rechtstreeks'
-  Community: 'Gemjinschap'
   Sort By: 'Azwu sorteern'
   Counts:
     Video Count: '1 video | {count} videos'
@@ -485,7 +484,6 @@ Settings:
     Hide Channels Already Exists: ''
     Hide Featured Channels: ''
     Hide Channel Playlists: ''
-    Hide Channel Community: ''
     Hide Channel Shorts: ''
     Hide Channel Podcasts: ''
     Hide Channel Releases: ''
@@ -494,7 +492,6 @@ Settings:
     Hide Subscriptions Videos: ''
     Hide Subscriptions Shorts: ''
     Hide Subscriptions Live: ''
-    Hide Subscriptions Community: ''
   Data Settings:
     Data Settings: ''
     Select Export Type: ''
@@ -703,7 +700,7 @@ Channel:
     Joined: ''
     Location: ''
     Featured Channels: ''
-  Community:
+  Posts:
     This channel currently does not have any posts: ''
     votes: ''
     View Full Post: ''

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: '视频'
   Shorts: 短视频
   Live: 直播
-  Community: 社区
+  Posts: 帖子
   Sort By: 排序依据
 
 # Search Bar
@@ -529,7 +529,6 @@ Settings:
     Display Titles Without Excessive Capitalisation: 去除标题中对字母大写和标点符号的过度使用
     Hide Featured Channels: 隐藏精选频道
     Hide Channel Playlists: 隐藏频道“播放列表”标签
-    Hide Channel Community: 隐藏频道“社区”标签
     Hide Channel Shorts: 隐藏频道“短视频”标签
     Sections:
       Side Bar: 侧边栏
@@ -543,7 +542,6 @@ Settings:
     Hide Subscriptions Videos: 隐藏订阅视频
     Hide Subscriptions Live: 隐藏订阅直播
     Hide Profile Pictures in Comments: 在评论中隐藏个人资料图片
-    Hide Subscriptions Community: 隐藏订阅社区
     Hide Channels Invalid: 提供的频道 ID 无效
     Hide Channels Disabled Message: 使用 ID 屏蔽了某些频道，这些频道未被处理。当这些 ID 在升级时，功能被停用
     Hide Channels Already Exists: 频道 ID 已存在
@@ -690,7 +688,7 @@ Channel:
   Channel Tabs: 频道标签页
   This channel does not exist: 此频道不存在
   This channel does not allow searching: 此频道不允许搜索
-  Community:
+  Posts:
     This channel currently does not have any posts: 此频道当前没有任何帖子
     votes: '{votes} 票'
     Reveal Answers: 揭晓答案

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -28,7 +28,7 @@ Global:
   Videos: '影片'
   Shorts: 短片
   Live: 直播
-  Community: 社群
+  Posts: 貼文
   Sort By: '排序方式'
 
 # Search Bar
@@ -525,7 +525,6 @@ Settings:
     Display Titles Without Excessive Capitalisation: 顯示沒有過多大寫與標點符號的標題
     Hide Featured Channels: 隱藏精選頻道
     Hide Channel Playlists: 隱藏頻道「播放清單」分頁
-    Hide Channel Community: 隱藏頻道「社群」分頁
     Hide Channel Shorts: 隱藏頻道「短片」分頁
     Sections:
       Side Bar: 側邊欄
@@ -539,7 +538,6 @@ Settings:
     Hide Subscriptions Videos: 隱藏訂閱影片
     Hide Subscriptions Live: 隱藏訂閱直播
     Hide Profile Pictures in Comments: 在留言中隱藏個人檔案圖片
-    Hide Subscriptions Community: 隱藏訂閱社群
     Hide Channels Invalid: 提供的頻道 ID 無效
     Hide Channels Disabled Message: 某些頻道被使用 ID 封鎖且無法處理。當這些 ID 更新時，功能將會被封鎖
     Hide Channels Already Exists: 頻道 ID 已存在
@@ -686,7 +684,7 @@ Channel:
   Channel Tabs: 頻道分頁
   This channel does not exist: 此頻道不存在
   This channel does not allow searching: 此頻道不允許搜尋
-  Community:
+  Posts:
     This channel currently does not have any posts: 此頻道目前沒有任何貼文
     votes: '{votes} 票'
     Reveal Answers: 揭露答案


### PR DESCRIPTION
# Rename Community to Posts

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Chore

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube has renamed the channel Community tab to Posts, in the iOS app some channels now have a dedicated Community page which is labelled as being in Beta. This PR changes the string to Posts in anticipation of community page making its way to the website.

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
- Go to Subscriptions page and check that the string changed
- Go to a Channel page and see check the string changed
- Check that https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/blob/255f3572cf2688d4c3a211ee70532f5db538ba21/static/locales/en-US.yaml#L823 didnt break strings that fall under it

## Additional context
<!-- Add any other context about the pull request here. -->
This probably wasn't really necessary but i changed https://github.com/efb4f5ff-1298-471a-8973-3d47447115dc/FreeTube/blob/255f3572cf2688d4c3a211ee70532f5db538ba21/static/locales/en-US.yaml#L823 because translators can use this for more context to provide the correct strings