### PR TITLE
Add Support For Disabling Hardware Media Keys

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,9 @@ const IpcChannels = {
   GET_REPLACE_HTTP_CACHE: 'get-replace-http-cache',
   TOGGLE_REPLACE_HTTP_CACHE: 'toggle-replace-http-cache',
 
+  GET_DISABLE_HARDWARE_MEDIA_KEYS: 'get-disable-hardware-media-keys',
+  TOGGLE_DISABLE_HARDWARE_MEDIA_KEYS: 'toggle-disable-hardware-media-keys',
+
   PLAYER_CACHE_GET: 'player-cache-get',
   PLAYER_CACHE_SET: 'player-cache-set',
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -259,6 +259,13 @@ function runApp() {
     app.commandLine.appendSwitch('disable-http-cache')
   }
 
+  const DISABLE_HARDWARE_MEDIA_KEYS_PATH = `${userDataPath}/experiment-disable-hardware-media-keys`
+  const disableHardwareMediaKeys = existsSync(DISABLE_HARDWARE_MEDIA_KEYS_PATH)
+
+  if (disableHardwareMediaKeys) {
+    app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling')
+  }
+
   const PLAYER_CACHE_PATH = `${userDataPath}/player_cache`
 
   // See: https://stackoverflow.com/questions/45570589/electron-protocol-handler-not-working-on-windows
@@ -1232,6 +1239,22 @@ function runApp() {
     } else {
       // create an empty file
       const handle = await asyncFs.open(REPLACE_HTTP_CACHE_PATH, 'w')
+      await handle.close()
+    }
+
+    relaunch()
+  })
+
+  ipcMain.handle(IpcChannels.GET_DISABLE_HARDWARE_MEDIA_KEYS, () => {
+    return disableHardwareMediaKeys
+  })
+
+  ipcMain.once(IpcChannels.TOGGLE_DISABLE_HARDWARE_MEDIA_KEYS, async () => {
+    if (disableHardwareMediaKeys) {
+      await asyncFs.rm(DISABLE_HARDWARE_MEDIA_KEYS_PATH)
+    } else {
+      // create an empty file
+      const handle = await asyncFs.open(DISABLE_HARDWARE_MEDIA_KEYS_PATH, 'w')
       await handle.close()
     }
 

--- a/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
+++ b/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
@@ -13,7 +13,16 @@
         :default-value="replaceHttpCache"
         :disabled="replaceHttpCacheLoading"
         :tooltip="$t('Tooltips.Experimental Settings.Replace HTTP Cache')"
-        @change="handleRestartPrompt"
+        @change="handleReplaceHttpCacheRestartPrompt"
+      />
+      <FtToggleSwitch
+        tooltip-position="top"
+        :label="$t('Settings.Experimental Settings.Disable Hardware Media Keys')"
+        compact
+        :default-value="disableHardwareMediaKeys"
+        :disabled="disableHardwareMediaKeysLoading"
+        :tooltip="$t('Tooltips.Experimental Settings.Disable Hardware Media Keys')"
+        @change="handleDisableHardwareMediaKeysRestartPrompt"
       />
     </FtFlexBox>
     <FtPrompt
@@ -21,7 +30,7 @@
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
       :option-names="[$t('Yes, Restart'), $t('Cancel')]"
       :option-values="['restart', 'cancel']"
-      @click="handleReplaceHttpCache"
+      @click="handleRestart"
     />
   </FtSettingsSection>
 </template>
@@ -38,39 +47,69 @@ import { IpcChannels } from '../../../constants'
 
 const replaceHttpCacheLoading = ref(true)
 const replaceHttpCache = ref(false)
+const disableHardwareMediaKeys = ref(false)
+const disableHardwareMediaKeysLoading = ref(false)
 const showRestartPrompt = ref(false)
+const toggleEvent = ref(undefined)
 
 onMounted(async () => {
   if (process.env.IS_ELECTRON) {
     const { ipcRenderer } = require('electron')
     replaceHttpCache.value = await ipcRenderer.invoke(IpcChannels.GET_REPLACE_HTTP_CACHE)
+    disableHardwareMediaKeys.value = await ipcRenderer.invoke(IpcChannels.GET_DISABLE_HARDWARE_MEDIA_KEYS)
   }
 
   replaceHttpCacheLoading.value = false
+  disableHardwareMediaKeysLoading.value = false
 })
 
 /**
  * @param {boolean} value
  */
-function handleRestartPrompt(value) {
+function handleReplaceHttpCacheRestartPrompt(value) {
   replaceHttpCache.value = value
+  toggleEvent.value = IpcChannels.TOGGLE_REPLACE_HTTP_CACHE
+  showRestartPrompt.value = true
+}
+
+/**
+ * @param {boolean} value
+ */
+function handleDisableHardwareMediaKeysRestartPrompt(value) {
+  disableHardwareMediaKeys.value = value
+  toggleEvent.value = IpcChannels.TOGGLE_DISABLE_HARDWARE_MEDIA_KEYS
   showRestartPrompt.value = true
 }
 
 /**
  * @param {'restart' | 'cancel' | null} value
  */
-function handleReplaceHttpCache(value) {
+function handleRestart(value) {
   showRestartPrompt.value = false
 
-  if (value === null || value === 'cancel') {
-    replaceHttpCache.value = !replaceHttpCache.value
+  if (toggleEvent.value === null || toggleEvent.value === '') {
+    return
+  }
+
+  if (toggleEvent.value === IpcChannels.TOGGLE_REPLACE_HTTP_CACHE) {
+    if (value === null || value === 'cancel') {
+      replaceHttpCache.value = !replaceHttpCache.value
+      toggleEvent.value = null
+      return
+    }
+  } else if (toggleEvent.value === IpcChannels.TOGGLE_DISABLE_HARDWARE_MEDIA_KEYS) {
+    if (value === null || value === 'cancel') {
+      disableHardwareMediaKeys.value = !disableHardwareMediaKeys.value
+      toggleEvent.value = null
+      return
+    }
+  } else {
     return
   }
 
   if (process.env.IS_ELECTRON) {
     const { ipcRenderer } = require('electron')
-    ipcRenderer.send(IpcChannels.TOGGLE_REPLACE_HTTP_CACHE)
+    ipcRenderer.send(toggleEvent.value)
   }
 }
 </script>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -677,6 +677,7 @@ Settings:
     Experimental Settings: Experimental
     Warning: These settings are experimental, they may cause crashes while enabled. Making backups is highly recommended. Use at your own risk!
     Replace HTTP Cache: Replace HTTP Cache
+    Disable Hardware Media Keys: Disable Hardware Media Keys
   Password Dialog:
     Password: Password
     Enter Password To Unlock: Enter password to unlock settings
@@ -1094,6 +1095,7 @@ Tooltips:
       your subscription feed on startup and when a new window is opened.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
+    Disable Hardware Media Keys: Disables hardware media keys (play/pause/next/etc.) controlling video playback.
   SponsorBlock Settings:
     UseDeArrowTitles: Replace video titles with user-submitted titles from DeArrow.
     UseDeArrowThumbnails: Replace video thumbnails with thumbnails from DeArrow.


### PR DESCRIPTION
# Add Support For Disabling Hardware Media Keys

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ x ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #1465 

## Description
Currently be default FreeTube has hardware media keys enabled to control playback (play/pause/next/previous button(s) on keyboards).  This is a behavior which comes from Electron.  This can be disabled by manually adding `-disable-features=HardwareMediaKeyHandling` command line argument however this is annoying to do and not all users are tech savvy.  Some users (myself included) prefer to use the hardware media keys to control music playback and would like the option to disable this feature.

This PR fixes the issue by adding a new toggle to the Experimental Settings section which appends the command line argument.

## Screenshots <!-- If appropriate -->
![image](https://github.com/user-attachments/assets/b8e85796-9161-497f-9aa9-464373606eef)

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
1. Launch FreeTube with no command line arguments & open any video.  Press the Play/Pause hardware media key (if your keyboard doesn't have one you will need to remap a key or just trust me).
    a.  You should see the video playback play/pause when you this the media keys 
2. Click on Settings & scroll down to Experimental Settings
3. Click on the 'Disable Hardware Media Keys' toggle and hit 'Yes Restart'
4. Navigate to any video and press the Play/Pause hardware media key
    a.  The playback should no play/pause

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 10 Pro
- **OS Version:** 10.0.19045 Build 19045
- **FreeTube version:** v0.23.4 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
