### PR TITLE
Fix typo in WRITE_TO_DEFAULT_FOLDER IPC call

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1110,11 +1110,11 @@ function runApp() {
 
     const settingId = kind === DefaultFolderKind.DOWNLOADS ? 'downloadFolderPath' : 'screenshotFolderPath'
 
-    const folderPath = await baseHandlers.settings._findOne(settingId)
+    const folderPath = (await baseHandlers.settings._findOne(settingId))?.value
 
     let directory
-    if (typeof currentPath === 'string' && folderPath.value.length > 0) {
-      directory = folderPath.value
+    if (typeof folderPath === 'string' && folderPath.length > 0) {
+      directory = folderPath
     } else {
       directory = path.join(app.getPath(kind === DefaultFolderKind.DOWNLOADS ? 'downloads' : 'pictures'), 'FreeTube')
     }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue
- closes #7374

## Description

Due to a copy-paste issue the WRITE_TO_DEFAULT_FOLDER IPC call wasn't properly reading the user's chosen default folder for screenshots or downloads and was instead falling back to the pictures or downloads folder for the current system user. This pull request fixes that.

## Testing

1. Turn on screenshots in the player settings
2. Turn on the default folder mode
3. Chose a default folder that is not the pictures folder e.g. desktop
4. Open a video
5. Take a screenshot (button in the player controls or <kbd>U</kbd>
6. Check that it was saved to the correct location

## Desktop
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** bd0b04a61f718930eea154d9b7bf9aa0ef4f08b6