### PR TITLE
Switch from OPEN_EXTERNAL_LINK IPC call to window.open()

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,6 @@
 const IpcChannels = {
   ENABLE_PROXY: 'enable-proxy',
   DISABLE_PROXY: 'disable-proxy',
-  OPEN_EXTERNAL_LINK: 'open-external-link',
   GET_SYSTEM_LOCALE: 'get-system-locale',
   GET_NAVIGATION_HISTORY: 'get-navigation-history',
   STOP_POWER_SAVE_BLOCKER: 'stop-power-save-blocker',

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -244,14 +244,14 @@ const newWindowText = computed(() => {
 })
 
 function createNewWindow() {
-  if (process.env.IS_ELECTRON) {
-    const { ipcRenderer } = require('electron')
-    ipcRenderer.send(IpcChannels.CREATE_NEW_WINDOW)
-  } else {
-    const url = new URL(window.location.href)
-    url.hash = landingPage.value
+  const url = new URL(window.location.href)
+  url.hash = landingPage.value
 
+  if (process.env.IS_ELECTRON) {
+    // Don't pass noreferrer in Electron as we use the referrer to check if the call came from a FreeTube app URL.
     window.open(url.toString(), '_blank')
+  } else {
+    window.open(url.toString(), '_blank', 'noreferrer')
   }
 }
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -212,14 +212,10 @@ export async function copyToClipboard(content, { messageOnSuccess = null, messag
  */
 export async function openExternalLink(url) {
   if (process.env.IS_ELECTRON) {
-    const ipcRenderer = require('electron').ipcRenderer
-    const success = await ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_LINK, url)
-
-    if (!success) {
-      showToast(i18n.t('Blocked opening potentially unsafe URL', { url }))
-    }
-  } else {
+    // Don't pass noreferrer in Electron as we use the referrer to check if the call came from a FreeTube app URL.
     window.open(url, '_blank')
+  } else {
+    window.open(url, '_blank', 'noreferrer')
   }
 }
 

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -1164,8 +1164,6 @@ Age Restricted:
   This video is age restricted: 'Hierdie video het ’n ouderdomsperk'
 External link opening has been disabled in the general settings: 'Die open van eksterne
   skakels is gedeaktiveer in die algemene instellings'
-'Blocked opening potentially unsafe URL': 'Open van potensiële onveilige URL is versper:
-  “{url}”.'
 Downloading has completed: '“{videoTitle}” is afgelaai'
 Starting download: 'Begin aflaai van “{videoTitle}”'
 Downloading failed: 'Daar was ’n probleem by die aflaai van “{videoTitle}”'

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -1209,8 +1209,6 @@ Search Listing:
     360 Video: 360°
     New: جديد
     3D: ثلاثي الابعاد
-'Blocked opening potentially unsafe URL': 'تم حظر فتح الرابط الذي يحتمل أن يكون غير
-  آمن: "{url}".'
 Right-click or hold to see history: انقر زر الفارة الأيمن أو اضغط مطولا لعرض السجل
 KeyboardShortcutPrompt:
   Force Restart Window: إجبار إعادة تشغيل النافذة

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -1025,7 +1025,6 @@ Age Restricted:
   This channel is age restricted: ''
   This video is age restricted: ''
 External link opening has been disabled in the general settings: ''
-'Blocked opening potentially unsafe URL': ''
 Downloading has completed: ''
 Starting download: ''
 Downloading failed: ''

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -1241,8 +1241,6 @@ Channel Hidden: '{channel} дададзены ў фільтр каналаў'
 Age Restricted:
   This channel is age restricted: Гэты канал мае ўзроставыя абмежаванні
   This video is age restricted: Гэты відэа мае ўзроставыя абмежаванні
-'Blocked opening potentially unsafe URL': 'Заблакіравана адкрыццё патэнцыйна небяспечнага
-  URL: "{url}".'
 Channel Unhidden: '{channel} выдалены з фільтра каналаў'
 KeyboardShortcutPrompt:
   Show Keyboard Shortcuts: Паказаць спалучэнні клавіш

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -1246,8 +1246,6 @@ Search Listing:
     8K: 8K
     360 Video: 360°
     New: Нов
-'Blocked opening potentially unsafe URL': 'Блокирано отваряне на потенциално опасен
-  URL адрес: "{url}".'
 Description:
   Collapse Description: По-малко
   Expand Description: '...още'

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -1167,8 +1167,6 @@ Age Restricted:
   This video is age restricted: 'Ur vevenn oad a zo d''ar video-mañ'
 External link opening has been disabled in the general settings: 'Diweredekaet eo
   al liammoù diavaez en arventennoù hollek'
-'Blocked opening potentially unsafe URL': 'Stanket eo an URL a c''hell bezañ arvarus :
-  "{url}".'
 Downloading has completed: '"{videoTitle}" a zo bet pellgarget'
 Starting download: 'Kregiñ da bellgargañ "{videoTitle}"'
 Downloading failed: 'C''hoarvezet ez eus ur gudenn en ur bellgargañ "{videoTitle}"'

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -1234,8 +1234,6 @@ Search Listing:
     8K: 8K
     VR180: VR180
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Zablokováno otevření potenciálně nebezpečné
-  adresy URL: „{url}“.'
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 shortcutJoinOperator: +
 Keys:

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -1258,8 +1258,6 @@ Age Restricted:
 Moments Ago: eiliad yn ôl
 checkmark: ✓
 Display Label: '{label}: {value}'
-'Blocked opening potentially unsafe URL': 'Wedi rhwystro URL a allai fod yn anniogel
-  wrth agor : "{url}".'
 Trimmed input must be at least N characters long: Rhaid i fewnbwn wedi'i docio fod
   o leiaf 1 nod o hyd | Rhaid i fewnbwn wedi'i docio fod o leiaf {length} nod
 Tag already exists: Mae'r tag "{tagName}" eisoes yn bodoli

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -1303,6 +1303,4 @@ Cancel: annullere
 Autoplay Interruption Timer: Autoplay afbrudt på grund af {autoplayInterruptionIntervalHours}
   timers inaktivitet
 shortcutLabelSeparator: ｜
-'Blocked opening potentially unsafe URL': 'Blokeret åbning af potentielt usikker URL:
-  »{url}«.'
 checkmark: ✓

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1273,8 +1273,6 @@ Search Listing:
     360 Video: 360°
     New: Neu
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Das Öffnen einer potenziell unsicheren
-  URL wurde blockiert: „{url}“.'
 Keys:
   arrowdown: Pfeil nach unten
   arrowleft: Pfeil nach links

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -1342,8 +1342,6 @@ Yes, Open Link: Ναι, Άνοιγμα συνδέσμου
 Description:
   Expand Description: '...περισσότερα'
   Collapse Description: Εμφάνιση λιγότερων
-'Blocked opening potentially unsafe URL': 'Αποκλεισμός ανοίγματος δυνητικά μη ασφαλούς
-  URL: «{url}».'
 shortcutJoinOperator: +
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 Age Restricted:

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -1215,8 +1215,6 @@ Trimmed input must be at least N characters long: Trimmed input must be at least
 Yes, Delete: Yes, delete
 Yes, Restart: Yes, restart
 Yes, Open Link: Yes, open link
-'Blocked opening potentially unsafe URL': 'Blocked opening potentially unsafe URL:
-  ‘{url}’.'
 Search Listing:
   Label:
     4K: 4K

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1126,7 +1126,6 @@ Age Restricted:
   This channel is age restricted: This channel is age restricted
   This video is age restricted: This video is age restricted
 External link opening has been disabled in the general settings: 'External link opening has been disabled in the general settings'
-'Blocked opening potentially unsafe URL': 'Blocked opening potentially unsafe URL: "{url}".'
 Downloading has completed: '"{videoTitle}" has finished downloading'
 Starting download: 'Starting download of "{videoTitle}"'
 Downloading failed: 'There was an issue downloading "{videoTitle}"'

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -1250,8 +1250,6 @@ Search Listing:
     8K: 8K
     VR180: VR180
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Bloqueada la apertura de la URL potencialmente
-  insegura: «{url}».'
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 Right-click or hold to see history: Clic con el botón derecho del ratón o mantén presionado
   para ver el historial

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -1231,8 +1231,6 @@ Search Listing:
     8K: 8K
     VR180: VR180
     360 Video: 360°
-'Blocked opening potentially unsafe URL': 'Blokeerisime võimaliku ohtliku aadressi
-  avamise: „{url}“.'
 shortcutJoinOperator: +
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 Keys:

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -1261,8 +1261,6 @@ Search Listing:
     360 Video: 360º
     New: Berria
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Insegurua izan daitekeen URLa irekitzea
-  blokeatu da: "{url}".'
 Keys:
   arrowleft: Gezia ezkerrera
   arrowright: Gezia eskuinera

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -1212,7 +1212,6 @@ Trimmed input must be at least N characters long: ورودی بریده شده �
 Tag already exists: برچسب "{tagName}" از قبل وجود دارد
 checkmark: ✓
 Channel Unhidden: '{channel} از فیلتر کانال حذف شد'
-'Blocked opening potentially unsafe URL': 'باز کردن آدرس بالقوه ناامن مسدود شد: "{url}".'
 Channel Hidden: '{channel} به فیلتر کانال اضافه شد'
 Yes, Open Link: بله بازکردن پیوند
 KeyboardShortcutTemplate: '{label} ({shortcut})'

--- a/static/locales/fil.yaml
+++ b/static/locales/fil.yaml
@@ -99,8 +99,6 @@ Search Bar:
   Clear Input: Alisin ang Input
 External link opening has been disabled in the general settings: Ang pag bukas ng
   link sa panlabas ay pinasara sa general settings
-'Blocked opening potentially unsafe URL': 'I-Blinock ang URL na possibleng hindi ligtas:
-  "{url]".'
 Age Restricted:
   This channel is age restricted: Itong channel ay pinaghihigpitan sa edad
   This video is age restricted: Ang video na ito ay pinaghihigpitan sa edad

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -1287,8 +1287,6 @@ Search Listing:
     360 Video: 360°
     New: Nouveau
     3D: 3D
-'Blocked opening potentially unsafe URL': "Blocage de l'ouverture d'une URL potentiellement
-  dangereuse : « {url} »."
 shortcutJoinOperator: +
 Keys:
   ctrl: Ctrl

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -1125,7 +1125,6 @@ Yes, Restart: כן, להפעיל מחדש
 Yes, Delete: כן, למחוק
 Yes, Open Link: כן, לפתוח את הקישור
 Cancel: ביטול
-'Blocked opening potentially unsafe URL': 'נחסמה פתיחת כתובת שחשודה כמפוקפקת: „{url}”.'
 checkmark: ✓
 Tag already exists: התגית „{tagName}” כבר קיימת
 Moments Ago: לפני מס׳ רגעים

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -1201,8 +1201,6 @@ Search Listing:
     360 Video: 360°
     New: Novi
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Blokirano je otvaranje potencijalno nesigurnog
-  URL-a: „{url}”.'
 Right-click or hold to see history: Pritisni desnu tipku miša ili zadrži za prikaz
   povijest
 Description:

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -1261,8 +1261,6 @@ Search Listing:
     360 Video: 360°
     New: Új
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Potenciálisan nem biztonságos webcím megnyitása
-  letiltva: „{url}”.'
 Keys:
   arrowup: Felfele nyíl
   alt: Alt

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -1296,8 +1296,6 @@ Age Restricted:
 Trimmed input must be at least N characters long: Input yang dipangkas harus memiliki
   panjang minimal 1 karakter | Input yang dipangkas harus memiliki panjang minimal
   {length} karakter
-'Blocked opening potentially unsafe URL': 'Pembukaan URL yang berpotensi tidak aman
-  diblokir: "{url}".'
 KeyboardShortcutTemplate: '{label} ({pintasan})'
 shortcutJoinOperator: +
 Chapters:

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -1236,8 +1236,6 @@ Search character limit: Leitarstrengurinn er kominn yfir hámarksfjöldann {sear
 Yes, Restart: Já, endurræsa
 Yes, Open Link: Já, opna tengil
 Cancel: Hætta við
-'Blocked opening potentially unsafe URL': 'Lokaði á opnun mögulega óöruggrar slóðar:
-  "{url}".'
 Yes, Delete: Já, eyða
 checkmark: ✓
 Trimmed input must be at least N characters long: Stytt úttak verður að minnsta kosti

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -1260,8 +1260,6 @@ Search Listing:
     360 Video: 360°
     New: Nuovo
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Apertura di URL potenzialmente non sicura
-  bloccata: "{url}".'
 shortcutJoinOperator: +
 Keys:
   ctrl: Ctrl

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -612,7 +612,7 @@ Settings:
   Experimental Settings:
     Replace HTTP Cache: HTTP キャッシュの置換
     Experimental Settings: 試験的
-    Warning: 
+    Warning:
       これらの設定は実験的なものであり、有効にするとアプリのクラッシュを引き起こす恐れがあります。バックアップをとっておくことを強くお勧めします。自己責任で使用してください！
   Password Settings:
     Password Settings: パスワード
@@ -831,7 +831,7 @@ Video:
   DeArrow:
     Show Original Details: 元の情報を表示
     Show Modified Details: 変更された詳細を表示
-  DRMProtected: 
+  DRMProtected:
     DRM保護された動画はFreeTubeでは再生できません。これらの動画には、独自の非オープンソースのコンポーネントが必要です。この動画を視聴したい場合は、DRM対応のウェブブラウザで公式のYouTubeウェブサイトでご覧ください。
 #& Playlists
   Save Watched Progress: 視聴進捗を保存
@@ -1013,7 +1013,7 @@ Tooltips:
       ID は、大文字と小文字を区別するので完全に一致させてください。
     Hide Subscriptions Live: この設定は、アプリ全体の "{appWideSetting}" 設定により上書きされます。"{settingsSection}"
       項目の "{subsection}" にあります
-    Hide Videos and Playlists Containing Text: FreeTube 
+    Hide Videos and Playlists Containing Text: FreeTube
       全体での履歴やあなたの再生リストと再生リスト内の動画を除き、元のタイトルにその単語を含む動画や単語の一部または、フレーズ（大文字と小文字を区別しない）が含まれているすべての動画と再生リストを非表示にします。
   SponsorBlock Settings:
     UseDeArrowTitles: 動画のタイトルを DeArrow からユーザーが投稿したタイトルに置き換えます。
@@ -1088,7 +1088,6 @@ Age Restricted:
   This channel is age restricted: このチャンネルには年齢制限があります
 Trimmed input must be at least N characters long: トリミングされた入力は少なくとも1文字以上でなければなりません
   | トリミングされた入力は少なくとも {length} 文字以上でなければなりません
-'Blocked opening potentially unsafe URL': '安全でない可能性のあるURLをブロックしました： "{url}"。'
 Display Label: '{label}：{value}'
 KeyboardShortcutTemplate: '{label} （{shortcut}）'
 shortcutJoinOperator: +

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -1005,7 +1005,6 @@ Age Restricted:
   This channel is age restricted: ''
   This video is age restricted: ''
 External link opening has been disabled in the general settings: ''
-'Blocked opening potentially unsafe URL': ''
 Downloading has completed: ''
 Starting download: ''
 Downloading failed: ''

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -1290,8 +1290,6 @@ Autoplay Interruption Timer: Automatisk avspilling stoppet på grunn av {autopla
 Age Restricted:
   This video is age restricted: Denne videoen er aldersbegrenset
   This channel is age restricted: Denne kanalen er aldersbegrenset
-'Blocked opening potentially unsafe URL': 'Forhindret åpning av potensielt usikker
-  URL: «{url}».'
 Channel Hidden: '{channel} lagt til i kanalfilteret'
 Channel Unhidden: '{channel} fjernet fra kanalfilteret'
 Tag already exists: «{tagName}»-taggen eksisterer allerede

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -1252,8 +1252,6 @@ Search Listing:
     VR180: VR180
     360 Video: 360°
     New: Nieuw
-'Blocked opening potentially unsafe URL': 'Openen van mogelijk onveilige URL geblokkeerd:
-  ‘{url}’.'
 Right-click or hold to see history: Rechts klikken of vasthouden om kijkgeschiedenis
   weer te geven
 Description:

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -1248,8 +1248,6 @@ Search Listing:
     VR180: VR180
     8K: 8K
     360 Video: 360°
-'Blocked opening potentially unsafe URL': 'Zablokowano otwarcie potencjalnie niebezpiecznego
-  URL: "{url}".'
 Keys:
   arrowup: Strzałka do góry
   arrowright: Strzałka w prawo

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -1246,8 +1246,6 @@ Search Listing:
     360 Video: 360°
     3D: 3D
     New: Novo
-'Blocked opening potentially unsafe URL': 'Impedido de abrir URL potencialmente inseguro:
-  "{url}".'
 Keys:
   alt: Alt
   arrowup: Seta para cima

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -1329,5 +1329,3 @@ Right-click or hold to see history: Clique com o botão direito do rato ou mante
 Description:
   Expand Description: '...mais'
   Collapse Description: Mostrar menos
-'Blocked opening potentially unsafe URL': 'Bloqueada a abertura de um URL potencialmente
-  inseguro: “{url}”.'

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -1327,8 +1327,6 @@ Keys:
 Description:
   Expand Description: '...mais'
   Collapse Description: Mostrar menos
-'Blocked opening potentially unsafe URL': 'Bloqueada a abertura de um URL potencialmente
-  inseguro: “{url}”.'
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 Right-click or hold to see history: Clique com o botão direito do rato ou mantenha-o
   premido para ver o histórico

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -1322,8 +1322,6 @@ Keys:
   ctrl: ctrl
   arrowdown: Săgeată în jos
 checkmark: ✓
-'Blocked opening potentially unsafe URL': 'Blocarea deschiderii URL potențial nesigure:
-  „{url}”.'
 Yes, Delete: da, șterge
 Yes, Open Link: Da, Link deschis
 Display Label: '{label}: {valoare}'

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -1224,8 +1224,6 @@ Search Listing:
     360 Video: 360°
     New: Новинка
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Заблокировано открытие потенциально небезопасного
-  URL: "{url}".'
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 shortcutJoinOperator: +
 Keys:

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -1229,8 +1229,6 @@ Search Listing:
     360 Video: 360°
     New: Ново
     3D: 3D
-'Blocked opening potentially unsafe URL': 'Блокирано отварање потенцијално небезбедне
-  URL адресе: „{url}“.'
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 Keys:
   alt: Alt

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -1226,8 +1226,6 @@ Trimmed input must be at least N characters long: Trimmad inmatning måste vara 
 Description:
   Expand Description: '...mer'
   Collapse Description: Visa mindre
-'Blocked opening potentially unsafe URL': 'Blockerad öppning av potentiellt osäker
-  webbadress: "{url}".'
 Yes, Delete: Ja, Radera
 Autoplay Interruption Timer: Autouppspelningen avbröts på grund av {autoplayInterruptionIntervalHours}
   timmars inaktivitet

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -1209,8 +1209,6 @@ Age Restricted:
   This video is age restricted: 'இந்த வீடியோ அகவை தடைசெய்யப்பட்டுள்ளது'
 External link opening has been disabled in the general settings: 'பொது அமைப்புகளில்
   வெளிப்புற இணைப்பு திறப்பு முடக்கப்பட்டுள்ளது'
-'Blocked opening potentially unsafe URL': 'தடுக்கப்பட்ட திறப்பு பாதுகாப்பற்ற URL:
-  "{url}".'
 Downloading has completed: '"{videoTitle}" பதிவிறக்கம் முடித்துவிட்டது'
 Starting download: '"{videoTitle}" இன் பதிவிறக்கத்தைத் தொடங்குகிறது'
 Downloading failed: '"{videoTitle}" ஐ பதிவிறக்குவதில் சிக்கல் இருந்தது'

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -1245,8 +1245,6 @@ Search Listing:
     New: Yeni
     3D: 3B
     8K: 8K
-'Blocked opening potentially unsafe URL': "Güvenli olmayabilir URL'nin açılması engellendi:
-  \"{url}\"."
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 Keys:
   arrowdown: Aşağı Ok

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -1226,8 +1226,6 @@ Search Listing:
 Right-click or hold to see history: ПКМ або утримуйте для перегляду історії
 Display Label: '{label}: {value}'
 Tag already exists: Тег "{tagName}" вже існує
-'Blocked opening potentially unsafe URL': 'Блоковано відкриття потенційно небезпечної
-  URL-адреси: "{url}".'
 shortcutJoinOperator: +
 Keys:
   arrowright: Стрілка вправо

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -1211,7 +1211,6 @@ Search Listing:
     New: Mới
     3D: 3D
     Closed Captions: Có phụ đề
-'Blocked opening potentially unsafe URL': 'Đã chặn mở URL tiềm ẩn không an toàn: "{url}".'
 Search character limit: Chuỗi tìm kiếm vượt quá độ dài {searchCharacterLimit} ký tự
   cho phép
 Yes, Open Link: Có, mở liên kết

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -946,7 +946,6 @@ Age Restricted:
   This channel is age restricted: ''
   This video is age restricted: ''
 External link opening has been disabled in the general settings: ''
-'Blocked opening potentially unsafe URL': ''
 Downloading has completed: ''
 Starting download: ''
 Downloading failed: ''

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -462,7 +462,7 @@ Settings:
     Are you sure you want to clear out your search history and cache?: 你确定要清除搜索历史和缓存吗？
     Search history and cache have been cleared: 已清除搜索历史和缓存
     Watched Progress Saving Mode:
-      Tooltip: 
+      Tooltip:
         “自动”=每次视频结束以及发生错误（如速率受限和观看会话过期）退出视频页面时进行保存。“半自动”=除视频页面退出外和“自动”类似，可通过位于视频播放器下方的“保存已观看进度”按钮手动保存进度。
       Modes:
         Auto: 自动
@@ -1079,7 +1079,6 @@ Search Listing:
     8K: 8K
     VR180: VR180
     360 Video: 360°
-'Blocked opening potentially unsafe URL': 阻止了打开潜在不安全的 URL： "{url}".
 Keys:
   alt: Alt
   ctrl: Ctrl

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -1073,7 +1073,6 @@ Search Listing:
     360 Video: 360°
     New: 新
     3D: 3D
-'Blocked opening potentially unsafe URL': 已阻止開啟可能不安全的 URL：「{url}」。
 KeyboardShortcutTemplate: '{label} ({shortcut})'
 shortcutJoinOperator: +
 Keys:


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [x] Security improvement

## Description

This pull request removes the `OPEN_EXTERNAL_LINK` IPC call in favour of using `window.open()` in combination with `webContents.setWindowOpenHandler`. I also replaced the parameterless IPC call to `CREATE_NEW_WINDOW` with `window.open()` to the app URL, I unfortunately wasn't able to get rid of the `CREATE_NEW_WINDOW` IPC call, as the other usage in `openInternalPath` passes through the `searchQueryText`, not just a URL (I am open to ideas on how we could deal with that).

## Testing

1. Test that the new window button in the top navigation bar still opens a new window to your configured landing page.
2. Find a video with external links in the description (e.g. donation link or merch store) and check that clicking on them still opens them in your web browser.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** bd0b04a61f718930eea154d9b7bf9aa0ef4f08b6