### PR TITLE
add default paths for external media players

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -9,6 +9,9 @@
         "value": "mpv",
         "cmdArguments": {
             "defaultExecutable": "mpv",
+            "windowsPath":"C:/mpv/mpv.exe",
+            "linuxPath": "/usr/bin/mpv",
+            "macPath": "/Applications/mpv.app/Contents/MacOS/mpv",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -26,6 +29,9 @@
         "value": "vlc",
         "cmdArguments": {
             "defaultExecutable": "vlc",
+            "windowsPath":"%ProgramFiles%/VideoLAN/VLC/vlc.exe",
+            "macPath": "/Applications/VLC.app/Contents/MacOS/VLC",
+            "linuxPath": "/usr/bin/vlc",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": false,
             "videoUrl": "",
@@ -43,6 +49,7 @@
         "value": "iina",
         "cmdArguments": {
             "defaultExecutable": "iina",
+            "macPath": "/Applications/IINA.app/Contents/MacOS/IINA",
             "defaultCustomArguments": ["--no-stdin"],
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -60,6 +67,9 @@
         "value": "smplayer",
         "cmdArguments": {
             "defaultExecutable": "smplayer",
+            "windowsPath":"%ProgramFiles(x86)%/SMPlayer/smplayer.exe",
+            "macPath": "/Applications/SMPlayer.app/Contents/MacOS/SMPlayer",
+            "linuxPath": "/usr/bin/smplayer",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -77,6 +87,7 @@
         "value": "mpc-be",
         "cmdArguments": {
             "defaultExecutable": "mpc-be64",
+            "windowsPath":"%ProgramFiles%/MPC-BE/mpc-be64.exe",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -94,6 +105,7 @@
         "value": "mpc-hc",
         "cmdArguments": {
             "defaultExecutable": "mpc-hc64",
+            "windowsPath":"%ProgramFiles%/MPC-HC/mpc-hc64.exe",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -111,6 +123,7 @@
         "value": "potplayer",
         "cmdArguments": {
             "defaultExecutable": "potplayermini64",
+            "windowsPath":"%ProgramFiles(x86)%/DAUM/PotPlayer/PotPlayerMini64.exe",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": false,
             "videoUrl": "",
@@ -128,6 +141,7 @@
       "value": "clapper",
       "cmdArguments": {
           "defaultExecutable": "clapper",
+          "linuxPath":"/usr/local/bin/clapper",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",
@@ -145,6 +159,7 @@
       "value": "celluloid",
       "cmdArguments": {
           "defaultExecutable": "celluloid",
+          "linuxPath":"/usr/bin/celluloid",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",
@@ -162,6 +177,7 @@
       "value": "haruna",
       "cmdArguments": {
           "defaultExecutable": "haruna",
+          "linuxPath":"/var/lib/flatpak/app/org.kde.haruna/current/active/files/bin/haruna",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #5215 
## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This pull request creates default paths for external media players (shown in external-player-map.json) and has the ExternalPlayerSettings.vue script pass them into the executable function.
## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Run the supported media players without inputting a custom path and see if it launches.
## Desktop
<!-- Please complete the following information-->
- **OS: All**
- **OS Version: All**
- **FreeTube version: 0.23.5 Beta**

## Additional context
<!-- Add any other context about the pull request here. -->
