### PR TITLE
Added default paths for external media players

### DIFF
--- a/src/renderer/components/ExternalPlayerSettings.vue
+++ b/src/renderer/components/ExternalPlayerSettings.vue
@@ -147,7 +147,7 @@ function expandEnvVars(str) {
   return str.replaceAll(/%([^%]+)%/g, (_, name) => process.env[name] || '')
 }
 
-/** @param {string} str */
+/** @param {string} value */
 function updateExternalPlayerExecutable(value) {
   if (value?.trim()) {
     store.dispatch('updateExternalPlayerExecutable', value)

--- a/src/renderer/components/ExternalPlayerSettings.vue
+++ b/src/renderer/components/ExternalPlayerSettings.vue
@@ -142,66 +142,38 @@ function updateExternalPlayerIgnoreDefaultArgs(value) {
   store.dispatch('updateExternalPlayerIgnoreDefaultArgs', value)
 }
 
-/**
- * Replace any %VAR% tokens (like %Program Files%) in a path string with the corresponding process.env.VAR value.
- * @param {string} str
- * @returns {string}
- */
+
+/** @param {string} value */
 function expandEnvVars(str) {
   return str.replaceAll(/%([^%]+)%/g, (_, name) => process.env[name] || '')
 }
 
-/**
- * Detect os
- * @returns {'Windows'|'macOS'|'Linux'|'Unknown'}
- */
-function detectOS() {
-  // first try client hints
-  const uaData = navigator.userAgentData
-  if (uaData?.platform) {
-    const plat = uaData.platform.toLowerCase()
-    if (plat.includes('win')) return 'Windows'
-    if (plat.includes('mac')) return 'macOS'
-    if (plat.includes('linux')) return 'Linux'
-  }
-  // then fallback to ua
-  const ua = navigator.userAgent.toLowerCase()
-  if (ua.includes('windows nt')) return 'Windows'
-  if (ua.includes('mac os x')) return 'macOS'
-  if (ua.includes('linux')) return 'Linux'
-
-  return 'Unknown'
-}
-/**
- * @param {string} value
- */
-// gets default path for the external player, sets it as default for the executable
-// first checks if the user has set a custom path, if not, gets the default path
+/** @param {string} value */
 function updateExternalPlayerExecutable(value) {
-  if (value && value.trim() !== '') {
+  if (value?.trim()) {
     store.dispatch('updateExternalPlayerExecutable', value)
-  } else {
-    const playerData = jsonData.find(p => p.value === externalPlayer.value)
-    if (playerData && playerData.cmdArguments) {
-      const os = detectOS()
-      let defaultPath = ''
-      if (os === 'Windows') {
-        defaultPath = expandEnvVars(playerData.cmdArguments.windowsPath)
-      } else if (os === 'macOS') {
-        defaultPath = playerData.cmdArguments.macPath
-      } else if (os === 'Linux') {
-        defaultPath = playerData.cmdArguments.linuxPath
-      }
-
-      console.warn('[updateExternalPlayerExecutable] playerData=', playerData)
-      console.warn('[updateExternalPlayerExecutable] detected OS=', os)
-
-      store.dispatch(
-        'updateExternalPlayerExecutable',
-        defaultPath || ''
-      )
-    }
+    return
   }
+
+  const playerData = jsonData.find(p => p.value === store.getters.getExternalPlayer)
+  console.warn('[updateExternalPlayerExecutable] playerData=', playerData)
+  if (!playerData?.cmdArguments) return
+
+  // Pick the correct path based on process.platform
+  let rawPath
+  if (process.platform === 'win32') rawPath = playerData.cmdArguments.windowsPath
+  else if (process.platform === 'darwin') rawPath = playerData.cmdArguments.macPath
+  else if (process.platform === 'linux') rawPath = playerData.cmdArguments.linuxPath
+
+  console.warn(
+    '[updateExternalPlayerExecutable] platform=',
+    process.platform,
+    'rawPath=',
+    rawPath
+  )
+
+  const defaultPath = rawPath ? expandEnvVars(rawPath) : ''
+  store.dispatch('updateExternalPlayerExecutable', defaultPath)
 }
 /**
  * @param {string[]} args

--- a/src/renderer/components/ExternalPlayerSettings.vue
+++ b/src/renderer/components/ExternalPlayerSettings.vue
@@ -142,13 +142,12 @@ function updateExternalPlayerIgnoreDefaultArgs(value) {
   store.dispatch('updateExternalPlayerIgnoreDefaultArgs', value)
 }
 
-
-/** @param {string} value */
+/** @param {string} str */
 function expandEnvVars(str) {
   return str.replaceAll(/%([^%]+)%/g, (_, name) => process.env[name] || '')
 }
 
-/** @param {string} value */
+/** @param {string} str */
 function updateExternalPlayerExecutable(value) {
   if (value?.trim()) {
     store.dispatch('updateExternalPlayerExecutable', value)

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -9,6 +9,9 @@
         "value": "mpv",
         "cmdArguments": {
             "defaultExecutable": "mpv",
+            "windowsPath":"C:/mpv/mpv.exe",
+            "linuxPath": "/usr/bin/mpv",
+            "macPath": "/Applications/mpv.app/Contents/MacOS/mpv",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -26,6 +29,9 @@
         "value": "vlc",
         "cmdArguments": {
             "defaultExecutable": "vlc",
+            "windowsPath":"%ProgramFiles%/VideoLAN/VLC/vlc.exe",
+            "macPath": "/Applications/VLC.app/Contents/MacOS/VLC",
+            "linuxPath": "/usr/bin/vlc",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": false,
             "videoUrl": "",
@@ -43,6 +49,7 @@
         "value": "iina",
         "cmdArguments": {
             "defaultExecutable": "iina",
+            "macPath": "/Applications/IINA.app/Contents/MacOS/IINA",
             "defaultCustomArguments": ["--no-stdin"],
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -60,6 +67,9 @@
         "value": "smplayer",
         "cmdArguments": {
             "defaultExecutable": "smplayer",
+            "windowsPath":"%ProgramFiles(x86)%/SMPlayer/smplayer.exe",
+            "macPath": "/Applications/SMPlayer.app/Contents/MacOS/SMPlayer",
+            "linuxPath": "/usr/bin/smplayer",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -77,6 +87,7 @@
         "value": "mpc-be",
         "cmdArguments": {
             "defaultExecutable": "mpc-be64",
+            "windowsPath":"%ProgramFiles%/MPC-BE/mpc-be64.exe",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -94,6 +105,7 @@
         "value": "mpc-hc",
         "cmdArguments": {
             "defaultExecutable": "mpc-hc64",
+            "windowsPath":"%ProgramFiles%/MPC-HC/mpc-hc64.exe",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": true,
             "videoUrl": "",
@@ -111,6 +123,7 @@
         "value": "potplayer",
         "cmdArguments": {
             "defaultExecutable": "potplayermini64",
+            "windowsPath":"%ProgramFiles(x86)%/DAUM/PotPlayer/PotPlayerMini64.exe",
             "defaultCustomArguments": null,
             "supportsYtdlProtocol": false,
             "videoUrl": "",
@@ -128,6 +141,7 @@
       "value": "clapper",
       "cmdArguments": {
           "defaultExecutable": "clapper",
+          "linuxPath":"/usr/local/bin/clapper",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",
@@ -145,6 +159,7 @@
       "value": "celluloid",
       "cmdArguments": {
           "defaultExecutable": "celluloid",
+          "linuxPath":"/usr/bin/celluloid",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",
@@ -162,6 +177,7 @@
       "value": "haruna",
       "cmdArguments": {
           "defaultExecutable": "haruna",
+          "linuxPath":"/var/lib/flatpak/app/org.kde.haruna/current/active/files/bin/haruna",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",

--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -177,7 +177,7 @@
       "value": "haruna",
       "cmdArguments": {
           "defaultExecutable": "haruna",
-          "linuxPath":"/var/lib/flatpak/app/org.kde.haruna/current/active/files/bin/haruna",
+          "linuxPath":"/usr/local/bin/haruna",
           "defaultCustomArguments": null,
           "supportsYtdlProtocol": false,
           "videoUrl": "",

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -606,6 +606,8 @@ Settings:
     Hide Channel Home: إخفاء علامة التبويب "الصفحة الرئيسية" للقناة
     Show Added Items: إظهار العناصر المضافة
     Hide Channel Courses: إخفاء علامة التبويب "دورات" القناة
+    Hide Channel Posts: إخفاء علامة تبويب "المنشورات" للقناة
+    Hide Subscriptions Posts: إخفاء منشورات الاشتراكات
   The app needs to restart for changes to take effect. Restart and apply change?: البرنامج
     يحتاج لإعادة التشغيل كي يسري مفعول التغييرات. هل تريد إعادة التشغيل و تطبيق التغييرات؟
   Proxy Settings:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
#5215 
## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds default paths to the external-player-map.json file and edits the ExternalPlayerSettings.vue script to accept these changes by replacing a blank executable with the defaults from JSON
## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Can be tested by using FreeTube with an external media player and not adding a custom executable
## Desktop
<!-- Please complete the following information-->
- **OS: All**
- **OS Version: Any**
- **FreeTube version: 0.23.5 Beta**

## Additional context
<!-- Add any other context about the pull request here. -->
