### PR TITLE
Pause player when opening recommended video in external player

### DIFF
--- a/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.vue
+++ b/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.vue
@@ -14,6 +14,7 @@
       appearance="recommendation"
       force-list-type="list"
       :use-channels-hidden-preference="true"
+      @pause-player="pausePlayer"
     />
   </FtCard>
 </template>
@@ -29,6 +30,12 @@ defineProps({
     required: true
   }
 })
+
+const emit = defineEmits(['pause-player'])
+
+function pausePlayer() {
+  emit('pause-player')
+}
 </script>
 
 <style scoped src="./WatchVideoRecommendations.css" />

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -222,6 +222,7 @@
           watchVideoRecommendationsLowerCard: watchingPlaylist || isLive,
           watchVideoRecommendationsNoCard: !watchingPlaylist || !isLive
         }"
+        @pause-player="pausePlayer"
       />
     </div>
   </div>


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

When you open the currently playing video in an external player or open a video from the playlist box, we pause the video player. At the moment we don't do that when you open a video from the recommended videos list in an external player, this pull request rectifies that.

## Testing

You can pick any external player in the external player settings, you do not have to set it up properly (e.g installing it or configuring the path to it) as the pausing happens before FreeTube launches the external player.

Open a video and click on the open in external player button for one of the videos in the recommended list, the player should pause.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a560499ce11701697aa11e33b4bb1b9f8fb253f1