### PR TITLE
Instruct webpack to embed JSON imports as literals instead of JSON.parse

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -25,6 +25,11 @@ const config = {
         use: path.join(__dirname, 'mime-db-shrinking-loader.js')
       }
     ],
+    generator: {
+      json: {
+        JSONParse: false
+      }
+    }
   },
   // webpack defaults to only optimising the production builds, so having this here is fine
   optimization: {

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -108,6 +108,11 @@ const config = {
         }
       },
     ],
+    generator: {
+      json: {
+        JSONParse: false
+      }
+    }
   },
   // webpack defaults to only optimising the production builds, so having this here is fine
   optimization: {

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -102,6 +102,11 @@ const config = {
         }
       },
     ],
+    generator: {
+      json: {
+        JSONParse: false
+      }
+    }
   },
   // webpack defaults to only optimising the production builds, so having this here is fine
   optimization: {


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

For JSON imports webpack inlines them as strings wrapped in `JSON.parse`, which apparently can be benefitial performance wise for large JSON blobs but in the FreeTube code bases, the imported stuff is quite small: name and version from the `package.json` file, list of active locales, our already much smaller mime-db. So I highly doubt that we are benefitting from those large file `JSON.parse` advantages, especially because webpack is clever enough to remove all unused properties from our package.json imports and even mangles the names of the properties, sample taking from the renderer.js output: `rZ=JSON.parse('{"tZ":"FreeTube","rE":"0.23.5"}')`.

So this pull request turns of that JSON.parse wrapping, so now they'll get embedded directly as object and array literals: `rZ={"tZ":"FreeTube","rE":"0.23.5"}`.

renderer.js: -54 bytes
main.js: -74 bytes
web.js: -32 bytes

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 13139c6809e8e69d744bd56e3d2aa927bb1cc397