### PR TITLE
Switch ALLOWED_RENDERER_FILES variable from let to const

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -138,6 +138,15 @@ export default [
     },
   },
 
+  {
+    files: ['src/main/index.js'],
+    languageOptions: {
+      globals: {
+        __FREETUBE_ALLOWED_PATHS__: 'readable'
+      }
+    }
+  },
+
   ...eslintPluginJsonc.configs['flat/base'],
   {
     files: ['**/*.json'],

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -57,13 +57,12 @@ Options:
 
 function runApp() {
   /** @type {Set<string>} */
-  let ALLOWED_RENDERER_FILES
+  const ALLOWED_RENDERER_FILES = process.env.NODE_ENV === 'production'
+    // __FREETUBE_ALLOWED_PATHS__ is replaced by the injectAllowedPaths.mjs script
+    ? new Set(__FREETUBE_ALLOWED_PATHS__)
+    : new Set()
 
   if (process.env.NODE_ENV === 'production') {
-    // __FREETUBE_ALLOWED_PATHS__ is replaced by the injectAllowedPaths.mjs script
-    // eslint-disable-next-line no-undef
-    ALLOWED_RENDERER_FILES = new Set(__FREETUBE_ALLOWED_PATHS__)
-
     protocol.registerSchemesAsPrivileged([{
       scheme: 'app',
       privileges: {


### PR DESCRIPTION
## Pull Request Type

- [x] Code cleanup

## Description

This pull request switches our `ALLOWED_RENDERER_FILES` from a `let` to a `const`, it is never changed and is accessed any time the renderer loads files, which happens multiple times right after a window is opened (index.html, renderer.js, renderer.{hash}.css, static/locales/en-US.json.br, static/invidious-instances.json, static/external-player-map.json), so giving the JavaScript parser an extra hint that it really is a constant may help a bit. It certainly won't hurt.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** a560499ce11701697aa11e33b4bb1b9f8fb253f1