### PR TITLE
catppuccinMocha card bg color change

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -299,7 +299,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
   --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --secondary-card-bg-color: #5f5fc9;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION
Improved Color Contrast for Uploader Comments in Catppuccin Mocha Theme

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/6597

## Description
This pull request changes the color styling of the theme catppuccinMocha at :
CSS properties : secondary-card-bg-color for .catppuccinMocha

from --secondary-card-bg-color: #1e1e2e to -> --secondary-card-bg-color: #5f5fc9
This change ensures a correct contrast ratio.

## Screenshots <!-- If appropriate -->
before:
<img width="959" alt="lala" src="https://github.com/user-attachments/assets/acc1704f-bce1-4c4c-9dc3-88e79c11ca76" />
after:
![lala23](https://github.com/user-attachments/assets/dbd816d6-6a73-4161-b984-032d3f004a78)


## Testing
The code is straightforward, and no additional testing was required.



## Desktop
Desktop
OS: Windows 11 pro
OS Version: 10.0.26100
FreeTube version: 0.23.2


