### PR TITLE
Fix referrer handling when opening links

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -787,7 +787,7 @@ function runApp() {
       const url = URL.parse(details.url)
 
       // Only handle valid URLs that came from a FreeTube page
-      if (url !== null && isFreeTubeUrl(details.referrer.url)) {
+      if (url !== null && isFreeTubeUrl(newWindow.webContents.getURL())) {
         if (isFreeTubeUrl(url)) {
           createWindow({
             replaceMainWindow: false,

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -247,12 +247,7 @@ function createNewWindow() {
   const url = new URL(window.location.href)
   url.hash = landingPage.value
 
-  if (process.env.IS_ELECTRON) {
-    // Don't pass noreferrer in Electron as we use the referrer to check if the call came from a FreeTube app URL.
-    window.open(url.toString(), '_blank')
-  } else {
-    window.open(url.toString(), '_blank', 'noreferrer')
-  }
+  window.open(url.toString(), '_blank', 'noreferrer')
 }
 
 const usingOnlySearchHistoryResults = computed(() => lastSuggestionQuery.value.length === 0)

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -212,12 +212,7 @@ export async function copyToClipboard(content, { messageOnSuccess = null, messag
  * @param {string} url the URL to open
  */
 export async function openExternalLink(url) {
-  if (process.env.IS_ELECTRON) {
-    // Don't pass noreferrer in Electron as we use the referrer to check if the call came from a FreeTube app URL.
-    window.open(url, '_blank')
-  } else {
-    window.open(url, '_blank', 'noreferrer')
-  }
+  window.open(url, '_blank', 'noreferrer')
 }
 
 /**


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #7415
- #7380

## Description

When switching to using `window.open()` for handling link opening, I didn't realise that Electron handles the referrers differently for `http://localhost/index.html` URLs and custom URL schemes like our `app://bundle/index.html` URLs. So while I dev mode the referrer URL was available, in our production builds Electron always returns `{ url: '', policy: 'strict-origin-when-cross-origin' }` even when the request is to open the same URL as the one that the request is coming from.

To workaround that this pull request switches to checking the current URL of the webcontents as that is always available. As we no longer need the referrer I also simplified the code on the other end, so we no longer have separate code paths for Electron and outside of Electron.

## Testing

Please test the Create New Window button in the navigation bar, as well as clicking on external links (e.g. Patreon link in a video description), in both development mode and a production build, I have created a build for this branch here: https://github.com/absidue/FreeTube/actions/runs/15031380448

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** e62b19588eb1f0f4b03e3c50b1f19595386ad5a8