### PR TITLE
Fix channel about tab

### DIFF
--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -857,17 +857,17 @@ async function getChannelAboutLocal() {
 
       location.value = about.country.isEmpty() ? null : about.country.text
     } else {
-      description.value = about.description ? autolinker.link(about.description) : ''
+      description.value = about.metadata.description ? autolinker.link(about.metadata.description) : ''
 
-      const viewCount_ = extractNumberFromString(about.view_count)
+      const viewCount_ = extractNumberFromString(about.metadata.view_count)
       viewCount.value = isNaN(viewCount_) ? null : viewCount_
 
-      const videoCount_ = extractNumberFromString(about.video_count)
+      const videoCount_ = extractNumberFromString(about.metadata.video_count)
       videoCount.value = isNaN(videoCount_) ? null : videoCount_
 
-      joined.value = about.joined_date && !about.joined_date.isEmpty() ? Date.parse(about.joined_date.text.replace('Joined').trim()) : 0
+      joined.value = about.metadata.joined_date && !about.metadata.joined_date.isEmpty() ? Date.parse(about.metadata.joined_date.text.replace('Joined').trim()) : 0
 
-      location.value = about.country ?? null
+      location.value = about.metadata.country ?? null
     }
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue
- closes #7442

## Description

This pull request fixes the extraction of the information for the about tab with the local API. The featured channels and channel tags are taken from the home tab response, which is why they were not affected by this issue.

P.S. TypeScript would have caught this, but then again turning on type checking in FreeTube would result in so many false positives at the moment, that I probably still would have missed it.

## Testing

https://youtube.com/@LinusTechTips/about

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** c4bae15b95569b57db5db1c4567e7b5797ed9ecd