### PR TITLE
Use better v-for keys in various places

### DIFF
--- a/src/renderer/components/FtCheckboxList/FtCheckboxList.vue
+++ b/src/renderer/components/FtCheckboxList/FtCheckboxList.vue
@@ -8,7 +8,7 @@
     >
       <input
         :id="id + values[index]"
-        :key="index"
+        :key="'value' + values[index]"
         v-model="modelValue"
         :name="id"
         :value="values[index]"
@@ -17,7 +17,7 @@
         type="checkbox"
       >
       <label
-        :key="label"
+        :key="'label' + values[index]"
         :for="id + values[index]"
       >
         {{ label }}

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -4,7 +4,7 @@
   >
     <FtListLazyWrapper
       v-for="(result, index) in data"
-      :key="`${dataType || result.type}-${result.videoId || result.playlistId || result.postId || result.id || result._id || result.authorId || result.title}-${index}-${result.lastUpdatedAt || 0}`"
+      :key="`${dataType || result.type}-${result.videoId || result.playlistId || result.postId || result.id || result._id || result.authorId || result.title}-${result.playlistItemId || index}-${result.lastUpdatedAt || 0}`"
       appearance="result"
       :data="result"
       :data-type="dataType || result.type"

--- a/src/renderer/components/FtRadioButton/FtRadioButton.vue
+++ b/src/renderer/components/FtRadioButton/FtRadioButton.vue
@@ -8,7 +8,7 @@
     >
       <input
         :id="id + values[index]"
-        :key="index"
+        :key="'value' + values[index]"
         :name="id"
         :value="values[index]"
         :checked="value === values[index]"
@@ -18,7 +18,7 @@
         @change="handleChange(values[index])"
       >
       <label
-        :key="label"
+        :key="'label' + values[index]"
         :for="id + values[index]"
       >
         {{ label }}

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -202,8 +202,8 @@
         v-if="!hideActiveSubscriptions"
       >
         <router-link
-          v-for="(channel, index) in activeSubscriptions"
-          :key="index"
+          v-for="channel in activeSubscriptions"
+          :key="channel.id"
           :to="`/channel/${channel.id}`"
           class="navChannel channelLink mobileHidden"
           :title="channel.name"

--- a/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.vue
+++ b/src/renderer/components/WatchVideoRecommendations/WatchVideoRecommendations.vue
@@ -8,8 +8,8 @@
       </h3>
     </div>
     <FtListVideoLazy
-      v-for="(video, index) in data"
-      :key="index"
+      v-for="video in data"
+      :key="video.videoId"
       :data="video"
       appearance="recommendation"
       force-list-type="list"

--- a/src/renderer/components/ft-select/ft-select.js
+++ b/src/renderer/components/ft-select/ft-select.js
@@ -1,4 +1,4 @@
-import { defineComponent, nextTick } from 'vue'
+import { defineComponent } from 'vue'
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import { sanitizeForHtmlId } from '../../helpers/accessibility'
 
@@ -57,18 +57,6 @@ export default defineComponent({
   computed: {
     sanitizedPlaceholder: function() {
       return sanitizeForHtmlId(this.placeholder)
-    }
-  },
-  watch: {
-    // update the selected value in the menu when the list of values changes
-
-    // e.g. when you change the display language, the locations list gets updated
-    // as the locations list is sorted alphabetically for the language, the ordering can be different
-    // so we need to ensure that the correct location is selected after a language change
-    selectValues: function () {
-      nextTick(() => {
-        this.$refs.select.value = this.value
-      })
     }
   },
   methods: {

--- a/src/renderer/components/ft-select/ft-select.vue
+++ b/src/renderer/components/ft-select/ft-select.vue
@@ -13,7 +13,7 @@
     >
       <option
         v-for="(name, index) in selectNames"
-        :key="index"
+        :key="selectValues[index]"
         :value="selectValues[index]"
         :lang="isLocaleSelector && selectValues[index] !== 'system' ? selectValues[index] : null"
       >

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.js
@@ -228,6 +228,7 @@ export default defineComponent({
       const badge = comment.author.badges.find(badge => badge.type === 'LiveChatAuthorBadge' && badge.custom_thumbnail)
 
       const parsedComment = {
+        id: comment.id,
         message: autolinker.link(parseLocalTextRuns(comment.message.runs, 20)),
         author: {
           name: comment.author.name,

--- a/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
+++ b/src/renderer/components/watch-video-live-chat/watch-video-live-chat.vue
@@ -56,8 +56,8 @@
         class="superChatComments"
       >
         <div
-          v-for="(comment, index) in superChatComments"
-          :key="index"
+          v-for="comment in superChatComments"
+          :key="comment.id"
           :aria-label="$t('Video.Show Super Chat Comment')"
           :style="{ backgroundColor: 'var(--primary-color)' }"
           class="superChat"
@@ -131,8 +131,8 @@
         @scrollend="e => onScroll(e, true)"
       >
         <div
-          v-for="(comment, index) in comments"
-          :key="index"
+          v-for="comment in comments"
+          :key="comment.id"
           class="comment"
           :class="comment.superChat ? `superChatMessage ${comment.superChat.colorClass}` : ''"
         >


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

This pull request adds keys based on the items themselves instead of the array index in various places in the app. I wasn't able to change everywhere just yet as we don't have a good way of uniquely identifying items in some arrays yet.

<details><summary>Highlevel recap of how Vue's rendering system works</summary>

Vue uses a virtual DOM (similar to React), that means that before it makes any changes to the actual DOM/the actual page, it first renderers the components into virtual DOM, compares it to the real DOM and then patches the real DOM where necessary (e.g. adding or removing classes, updating text, adding and removing elements etc). So in an ideal world you want to ensure that Vue doesn't have to make any more changes than necessary to the page, which is where the `key` attribute comes into play. When a list is updated most of the time the entire list doesn't change, instead it may be sorted differently or some items may have been added or removed (either deleted or filtered out). The `key` attribute is used by Vue to identify items across renders.

So for the best outcome you want to chose a value for the `key` that uniquely identifies that item in the list, regardless of its position in the list. Unfortunately we currently use the array `index` as the key in quite a fey places, causing Vue to do more updates to the DOM than necessary. E.g. if we remove item at array index 0 from the array, we want Vue to realise that that item was deleted and remove the corresponding DOM nodes, which works if the keys identify the items, but if you use an array index, Vue will instead delete the DOM nodes for the last item and patch all other ones (the data for the second item is patched onto the DOM nodes for the first item, the data for the third item onto the DOM nodes for the second item and so forth).

</details>

## Testing

One way to test that this pull request works as intended is to highlight an element in a list in the devtools and then check that it moves around as expected when the data changes. E.g. highlighting the DOM node for a message in the live chat and then watching it move up in the devtools when new messages come in or highlighting the DOM node for the second subscribed channel in the side bar, unsubscribing from the channel that is first in the list and checking that the element you selected moved into the first place (on the dev branch your highlighted element stays in the same place but its text and image would change instead).

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d7a3f17d535d5b4e17514e4c2efc874525c7dd41