### PR TITLE
Remove unused test script and speed up postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "pack:renderer": "webpack --mode=production --node-env=production --config _scripts/webpack.renderer.config.js",
     "pack:web": "webpack --mode=production --node-env=production --config _scripts/webpack.web.config.js",
     "pack:botGuardScript": "webpack --config _scripts/webpack.botGuardScript.config.js",
-    "postinstall": "run-s --silent patch-shaka",
-    "release": "run-s test build",
+    "postinstall": "yarn run --silent patch-shaka",
     "ci": "yarn install --silent --frozen-lockfile --network-concurrency 1"
   },
   "dependencies": {


### PR DESCRIPTION
## Pull Request Type

- [x] Cleanup

## Description

This pull request removes the unused `release` package.json script, which is broken anyway as it calls the non-existent `test` one. It also changes the `postinstall` hook to call `yarn run` directly, instead of calling `run-s` with a single script which then calls `yarn run`.

## Testing

`yarn run install`

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 40784eea5b614c6b84949f8aa80a531b0db498f6