### PR TITLE
Fix translated placeholders in strings

### DIFF
--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -942,11 +942,11 @@ Video:
       Bitrate: 'Bitrate: {bitrate} kbps'
       CodecAudio: 'Codec: {audioCodec} ({audioItag})'
       Volume: 'Lydstyrke: {volumePercentage}%'
-      CodecsVideoAudioNoItags: 'Codecs: {videoCodec} / {lydkodec}'
+      CodecsVideoAudioNoItags: 'Codecs: {videoCodec} / {audioCodec}'
       Dropped Frames / Total Frames: 'Tabte rammer: {droppedFrames} (tabte billeder)
         / Samlet antal rammer: {totalFrames}'
       CodecsVideoAudio: 'Kodeks: {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
-      Player Dimensions: 'Spillerens dimensioner: {bredde}x{højde}'
+      Player Dimensions: 'Spillerens dimensioner: {width}x{height}'
       Buffered: 'Bufret: {bufferedPercentage}%'
     Skipped segment: Sprang {segmentCategory} segment over
     Playback will resume automatically when your connection comes back: Afspilning
@@ -1288,15 +1288,15 @@ KeyboardShortcutPrompt:
   Toggle Developer Tools: Skift udviklerværktøjer
   Focus Search: Fokuser på søgelinjen
 Channel Hidden: '{kanal} tilføjet til kanalfilter'
-KeyboardShortcutTemplate: '{label} ({genvej})'
+KeyboardShortcutTemplate: '{label} ({shortcut})'
 Moments Ago: for et øjeblik siden
 Yes, Delete: Ja, Slet
-Display Label: '{label}: {værdi}'
+Display Label: '{label}: {value}'
 Yes, Restart: Ja, genstart
 Ok: ok
 shortcutJoinOperator: +
 Trimmed input must be at least N characters long: Trimmet input skal være mindst 1
-  tegn langt | Trimmet input skal være mindst {længde} tegn langt
+  tegn langt | Trimmet input skal være mindst {length} tegn langt
 Yes, Open Link: Ja, Åbn link
 Tag already exists: »{tagName}"-tagget findes allerede
 Cancel: annullere

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -222,12 +222,12 @@ User Playlists:
   Remove from Playlist: Αφαίρεση από τη λίστα αναπαραγωγής
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Είστε
     σίγουροι ότι θέλετε να αφαιρέσετε 1 διπλό βίντεο από αυτή τη λίστα αναπαραγωγής;
-    Αυτό δεν μπορεί να αναιρεθεί. Είστε σίγουροι ότι θέλετε να αφαιρέσετε {λίστα αναπαραγωγήςItemCount}
+    Αυτό δεν μπορεί να αναιρεθεί. Είστε σίγουροι ότι θέλετε να αφαιρέσετε {playlistItemCount}
     διπλά βίντεο από αυτή τη λίστα; Αυτό δεν μπορεί να αναιρεθεί.
   This playlist currently has no videos.: Αυτή η λίστα αναπαραγωγής προς το παρόν
     δεν έχει βίντεο.
   Create New Playlist: Δημιουργία νέας λίστας αναπαραγωγής
-  TotalTimePlaylist: 'Συνολικός χρόνος: {διάρκεια}'
+  TotalTimePlaylist: 'Συνολικός χρόνος: {duration}'
   Enable Quick Bookmark With This Playlist: Ενεργοποίηση γρήγορου σελιδοδείκτη με
     αυτή τη λίστα αναπαραγωγής
   You have no playlists. Click on the create new playlist button to create a new one.: Δεν
@@ -978,7 +978,7 @@ Video:
     Exit Full Window: Έξοδος πλήρους παραθύρου
     Stats:
       Video ID: 'Αναγνωριστικό βίντεο: {videoId}'
-      Player Dimensions: 'Διαστάσεις Αναπαραγωγέα: {πλάτος}x{ύψος}'
+      Player Dimensions: 'Διαστάσεις Αναπαραγωγέα: {width}x{height}'
       CodecsVideoAudio: 'Κωδικοποιητές: {videoCodec} ({videoItag}) / {audioCodec}
         ({audioItag})'
       Bandwidth: 'Εύρος ζώνης: {bandwidth} kbps'

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -767,7 +767,7 @@ KeyboardShortcutPrompt:
   Search in New Window: 새 창에서 검색
   Fullscreen: 전체화면
 Right-click or hold to see history: 우클릭하거나 길게 눌러 기록을 확인하세요
-Go to page: '{페이지}로 이동'
+Go to page: '{page}로 이동'
 Feed:
   Feed Last Updated: '{feedName} 피드 마지막 업데이트: {date}'
   Refresh Feed: '{subscriptionName} 새로 고침'

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -39,12 +39,12 @@ Global:
   Shorts: شورتەکان
   Counts:
     Video Count: 1 ڤیدیۆ | {count} ڤیدیۆکان
-    Subscriber Count: 1 بەشداربوو | {ژماردن} بەشداربووان
-    Channel Count: 1 کەناڵ | {ژماردن} کەناڵەکان
-    View Count: 1 بینین | {ژماردن} بینینەکان
-    Like Count: 1 لایک | {ژماردن} لایک
-    Comment Count: 1 کۆمێنت | {ژماردن} کۆمێنتەکان
-    Watching Count: 1 سەیرکردنی | {ژماردن} سەیرکردن
+    Subscriber Count: 1 بەشداربوو | {count} بەشداربووان
+    Channel Count: 1 کەناڵ | {count} کەناڵەکان
+    View Count: 1 بینین | {count} بینینەکان
+    Like Count: 1 لایک | {count} لایک
+    Comment Count: 1 کۆمێنت | {count} کۆمێنتەکان
+    Watching Count: 1 سەیرکردنی | {count} سەیرکردن
   Videos: ویدیوەکان
   Posts: پۆستەکان
 Search / Go to URL: 'گەڕان / بڕۆ بۆ لینک'

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -971,24 +971,24 @@ Video:
       Player Dimensions: 'Dimensiuni player: {width}x{height}'
       Dropped Frames / Total Frames: 'Cadre eliminate: {droppedFrames} / Total cadre:
         {totalFrames}'
-      CodecsVideoAudio: 'Codecuri: {Codec video} ({etichetă video}) / {Codec audio}
-        ({Itag audio})'
-      CodecAudio: 'Codec: {codec audio} ({etichetă audio})'
-      CodecsVideoAudioNoItags: 'Codecuri: {Codec video} / {Codec audio}'
+      CodecsVideoAudio: 'Codecuri: {videoCodec} ({videoItag}) / {audioCodec}
+        ({audioItag})'
+      CodecAudio: 'Codec: {audioCodec} ({audioItag})'
+      CodecsVideoAudioNoItags: 'Codecuri: {videoCodec} / {audioCodec}'
       Stats: Statistici
       Video ID: 'ID videoclip: {videoId}'
       Media Formats: 'Formate media: {formate}'
       Bitrate: 'Rată de biți: {bitrate} kbps'
-      Volume: 'Volum: {volum Procentage}%'
+      Volume: 'Volum: {volumePercentage}%'
       Bandwidth: 'Lățime de bandă: {bandwidth} kbps'
-      Buffered: 'Buffered: {buffered Procentage}%'
+      Buffered: 'Buffered: {bufferedPercentage}%'
     Show Stats: Afișează statistici
     Hide Stats: ascunde statistici
     You appear to be offline: Pari a fi offline.
     Playback will resume automatically when your connection comes back: Redarea se
       va relua automat când se reia conexiunea.
-    Skipped segment: Segment {segment Category} omis
-    TranslatedCaptionTemplate: '{limba} (tradus din „{limba originală}”)'
+    Skipped segment: Segment {segmentCategory} omis
+    TranslatedCaptionTemplate: '{language} (tradus din „{originalLanguage}”)'
     Full Window: Fereastra plină
     Exit Full Window: Ieșiți din fereastra completă
   More Options: Mai multe opțiuni

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -243,7 +243,7 @@ User Playlists:
   Export Playlist: Bu Oynatma Listesini Dışa Aktar
   The playlist has been successfully exported: Oynatma listesi başarılı bir şekilde
     dışa aktarıldı
-  TotalTimePlaylist: 'Toplam süre: {süre}'
+  TotalTimePlaylist: 'Toplam süre: {duration}'
 History:
   # On History Page
   History: 'Geçmiş'


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

This pull request is another round of correcting various placeholders that were translated in the strings, as they won't be replaced at runtime by vue-i18n if they don't have the correct names. There are probably more that are wrong, but these are the ones I've caught.

## Desktop

- **OS:** Window
- **OS Version:** 10
- **FreeTube version:** 4f5b932e8fbd2ea9b6ef6edb6238230f1c6d281b