### PR TITLE
Local API: Add PO tokens to the caption URLs

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -200,7 +200,7 @@ export async function getLocalSearchContinuation(continuationData) {
 export async function getLocalVideoInfo(id) {
   const webInnertube = await createInnertube({ withPlayer: true, generateSessionLocally: false })
 
-  // based on the videoId (added to the body of the /player request)
+  // based on the videoId (added to the body of the /player request and to caption URLs)
   let contentPoToken
   // based on the visitor data (added to the streaming URLs)
   let sessionPoToken
@@ -224,6 +224,8 @@ export async function getLocalVideoInfo(id) {
     }
   }
 
+  let clientName = webInnertube.session.context.client.clientName
+
   const info = await webInnertube.getInfo(id)
 
   // temporary workaround for SABR-only responses
@@ -232,6 +234,8 @@ export async function getLocalVideoInfo(id) {
   if (mwebInfo.playability_status.status === 'OK' && mwebInfo.streaming_data) {
     info.playability_status = mwebInfo.playability_status
     info.streaming_data = mwebInfo.streaming_data
+
+    clientName = 'MWEB'
   }
 
   let hasTrailer = info.has_trailer
@@ -266,6 +270,8 @@ export async function getLocalVideoInfo(id) {
 
       hasTrailer = false
       trailerIsAgeRestricted = false
+
+      clientName = webEmbeddedInnertube.session.context.client.clientName
     }
   }
 
@@ -308,6 +314,18 @@ export async function getLocalVideoInfo(id) {
       }
 
       info.streaming_data.dash_manifest_url = url
+    }
+  }
+
+  if (info.captions?.caption_tracks) {
+    for (const captionTrack of info.captions.caption_tracks) {
+      const url = new URL(captionTrack.base_url)
+
+      url.searchParams.set('potc', '1')
+      url.searchParams.set('pot', contentPoToken)
+      url.searchParams.set('c', clientName)
+
+      captionTrack.base_url = url.toString()
     }
   }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #7420

## Description

YouTube has started requiring PO tokens on the caption/subtitle URLs and if you don't provide one they return a 200 response code but with an empty response, which makes shaka-player throw an `INVALID_TEXT_HEADER` error. Most users will only notice this because the subtitles won't show up but sometimes this seems to cause problems with navigating to the next video.

This pull request adds the content/video ID based PO token to the captions URL, the same one that is used for the `/player` request.

## Screenshots

See linked issue for a screenshot of the error message.

## Testing

1. Open a video with subtitles
2. Select a subtitle track.
3. You should see subtitles 🥳

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 01f1a8255adbeeff48e0f3997c20bd00c296edab