### PR TITLE
Fix parsing grid channels without a subscriber count

### DIFF
--- a/src/renderer/components/FtListChannel/FtListChannel.vue
+++ b/src/renderer/components/FtListChannel/FtListChannel.vue
@@ -155,7 +155,7 @@ function parseLocalData() {
     subscriberCount = props.data.subscribers
   }
 
-  if (props.data.videoCount != null) {
+  if (props.data.videos != null) {
     videoCount = props.data.videos
   }
 

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1324,7 +1324,10 @@ function parseListItem(item, channelId, channelName) {
       let subscribers = null
       let videos = null
 
-      subscribers = parseLocalSubscriberCount(channel.subscribers.text)
+      if (channel.subscribers?.text) {
+        subscribers = parseLocalSubscriberCount(channel.subscribers.text)
+      }
+
       videos = extractNumberFromString(channel.video_count.text)
 
       return {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue
- closes #7485

## Description

This pull request fixes the error when the subscriber count is missing for GridChannel nodes and an extra bug I noticed where the video count wasn't showing up.

## Screenshots

After parsing fix:
![parsing-fix](https://github.com/user-attachments/assets/9d0441a6-4590-4d29-84db-e38125d3c658)

After video count fix:
![videos-fix](https://github.com/user-attachments/assets/df2fd6ed-327a-4c66-8c0d-71990a736c80)

## Testing

1. Open https://www.youtube.com/channel/UCD_2nYVTpyaLeF6r83vCrJw
2. Check that the error log is gone and that the home page shows up.
3. Scroll down to the "Featured Channels" section and check that the video count shows up for both channels and the subscriber count only for the "GRM Daily" channel.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** 45ecc6b4276c9803a64cc08987f3bc071f47c473