### PR TITLE
Fix opening URL in a new window restores main window (in Windows)

### DIFF
--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -217,11 +217,11 @@ export default {
   },
 
   /**
-   * @param {(url: string, isLaunchLink: boolean) => void} handler
+   * @param {(url: string) => void} handler
    */
   handleOpenUrl: (handler) => {
-    ipcRenderer.on(IpcChannels.OPEN_URL, (_, url, isLaunchLink) => {
-      handler(url, isLaunchLink)
+    ipcRenderer.on(IpcChannels.OPEN_URL, (_, url) => {
+      handler(url)
     })
     ipcRenderer.send(IpcChannels.APP_READY)
   },

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -150,10 +150,6 @@ export default defineComponent({
     appTitle: function () {
       return this.$store.getters.getAppTitle
     },
-
-    openDeepLinksInNewWindow: function () {
-      return this.$store.getters.getOpenDeepLinksInNewWindow
-    }
   },
   watch: {
     windowTitle: 'setWindowTitle',
@@ -495,9 +491,9 @@ export default defineComponent({
     },
 
     enableOpenUrl: function () {
-      window.ftElectron.handleOpenUrl((url, isLaunchLink) => {
+      window.ftElectron.handleOpenUrl((url) => {
         if (url) {
-          this.handleYoutubeLink(url, { doCreateNewWindow: this.openDeepLinksInNewWindow && !isLaunchLink })
+          this.handleYoutubeLink(url)
         }
       })
     },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/6242#issuecomment-2854382777

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
https://www.electronjs.org/docs/latest/tutorial/launch-app-from-url-in-another-app
macOS and (windows + linux) use different handlers so it might be why it was only bugged in windows + linux
Updated code for both groups

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
N/A

## Testing
`second-instance` code only run on prod build so DO NOT use dev to test
Custom build with this branch only
https://github.com/PikachuEXE/FreeTube/actions/runs/15358443814

(A) Open freetube:// ... a New Window off
- Turn the setting off
- Open at least 2 windows, minimize all (for macOS use Cmd+M)
- Open a deeplink via browser extension 
  - (i.e. click on video link with extension installed e.g. https://youtu.be/9hDvWVJtljE)
- Ensure only 1 window (probably 1st window) restored and focused and page switched to that video

(B) Open freetube:// ... a New Window on
- Turn the setting on
- Open at least 2 windows, minimize all
- Open a deeplink via browser extension 
  - (i.e. click on video link with extension installed e.g. https://youtu.be/9hDvWVJtljE)
- Ensure only NO window restored and new window created and page switched to that video


## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
No more receiving URL in main process, throw to renderer process and sometimes throw it back to main process...
