### PR TITLE
Fix playlist videos disappearing when sorted differently

### DIFF
--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -1,9 +1,8 @@
 <template>
   <div
     v-if="showResult"
-    v-observe-visibility="firstScreen ? false : {
-      callback: onVisibilityChanged,
-      once: true,
+    v-observe-visibility="visible ? false : {
+      callback: onVisibilityChanged
     }"
     :class="{
       grid: layout === 'grid',
@@ -259,7 +258,9 @@ const visible = ref(props.firstScreen)
  * @param {boolean} isVisible
  */
 function onVisibilityChanged(isVisible) {
-  visible.value = isVisible
+  if (isVisible) {
+    visible.value = isVisible
+  }
 }
 
 /**

--- a/src/renderer/components/FtListVideoNumbered/FtListVideoNumbered.vue
+++ b/src/renderer/components/FtListVideoNumbered/FtListVideoNumbered.vue
@@ -1,8 +1,7 @@
 <template>
   <div
-    v-observe-visibility="initialVisibleState || visible ? false : {
-      callback: onVisibilityChanged,
-      once: true,
+    v-observe-visibility="visible ? false : {
+      callback: onVisibilityChanged
     }"
     :class="{ placeholder: !visible }"
   >

--- a/src/renderer/components/ft-list-video-lazy/ft-list-video-lazy.vue
+++ b/src/renderer/components/ft-list-video-lazy/ft-list-video-lazy.vue
@@ -1,8 +1,7 @@
 <template>
   <div
-    v-observe-visibility="{
-      callback: onVisibilityChanged,
-      once: true,
+    v-observe-visibility="visible ? false : {
+      callback: onVisibilityChanged
     }"
     :style="{ display }"
   >


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #7469

## Description

This pull request fixes a bug in the code that existed before #7447 but was hidden until that pull request fixed the v-for key handling in playlists. Previously because our keys used the index instead of the playlist item id, when you changed the sort order Vue destroyed and re-rendered everything but now that we use the playlist item id, the items move around instead and also keep their state.

The bug here is that for items that we predict will be visible (hard coded to be the first 16 items), we don't even bother adding a visibility listener, so when you change the sort order and one of those items was moved to be after the 16th position, the listener would be added, it would move off-screen, the listener would fire setting the visibility to false and then because it was a once listener it would never be set to visible, even when move back on screen by changing the sort order again. The fix is to add the listener based on the visible property and only take the visibility value from the listener if it is visible, that way items that are already visible will never have a visibility listener added to them regardless of where they move to and items that become visible will have their listener removed when they become visible.

## Screenshots

A video of the issue was provided in the linked issue.

## Testing

1. Open a playlist with more videos than fit in the visible area of the page (if you like to use FreeTube in full screen or maximised, you may want to exit into windowed mode for this).
2. Change the sort order multiple times.
3. Videos should only become visible, not invisible.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** fe175585f8c870efc995b907a062e1fd893e7d25