### PR TITLE
Move settings to `more` menu on smaller mobile devices

### DIFF
--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -249,3 +249,17 @@
     inline-size: 100%;
   }
 }
+
+@media only screen and (width <= 400px) {
+  /* Hide settings so that they appear in the more dropdown on smaller screens */
+  .smallMobileOnlyHidden {
+    display: none;
+  }
+}
+
+@media only screen and (width > 400px) {
+  .smallMobileOnlyHidden {
+    display: block;
+  }
+}
+

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -152,7 +152,7 @@
       </router-link>
       <hr>
       <router-link
-        class="navOption mobileShow"
+        class="navOption mobileShow smallMobileOnlyHidden"
         role="button"
         to="/settings"
         :title="settingsTitle"

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
@@ -82,3 +82,16 @@
     block-size: 1.3em;
   }
 }
+
+@media only screen and (width <= 400px) {
+  /* Show settings in more dropdown on smaller screens */
+  .smallMobileOnlyShow {
+    display: block;
+  }
+}
+
+@media only screen and (width > 400px) {
+  .smallMobileOnlyShow {
+    display: none;
+  }
+}

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -110,6 +110,24 @@
           {{ $t("About.About") }}
         </p>
       </router-link>
+      <router-link
+        class="navOption smallMobileOnlyShow"
+        :title="$t('Settings.Settings')"
+        :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
+        to="/settings"
+      >
+        <FontAwesomeIcon
+          :icon="['fas', 'sliders-h']"
+          class="navIcon"
+          :class="applyNavIconExpand"
+        />
+        <p
+          id="settingsNavLabel"
+          class="navLabel"
+        >
+          {{ $t("Settings.Settings") }}
+        </p>
+      </router-link>
     </div>
     <router-link
       class="navOption mobileShow"


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Related issue
Closes https://github.com/FreeTubeApp/FreeTube/issues/7371

## Description
Settings will now move to the `more` menu when screen width is below 400px.
360px should be the minimum width we need to support for mobile devices and it seems to be working as expected.

## Screenshots 

![image](https://github.com/user-attachments/assets/28ffe6d1-359c-453c-bc57-ddb37c6955bc)
![image](https://github.com/user-attachments/assets/0465e926-51da-4544-ab6a-dcf0382180bc)


## Testing
- decrease screen size, settings should move to `More` menu when screen gets smaller

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora Linux
- **OS Version:** 42
- **FreeTube version:** latest git commit

