### PR TITLE
Add new setting for storing user data inside app folder for windows

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,9 @@ const IpcChannels = {
   GET_SCREENSHOT_FALLBACK_FOLDER: 'get-screenshot-fallback-folder',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   WRITE_TO_DEFAULT_FOLDER: 'write-to-default-folder',
+
+  GET_STORE_USER_DATA_IN_APP_FOLDER: 'get-store-user-data-in-app-folder',
+  TOGGLE_STORE_USER_DATA_IN_APP_FOLDER: 'toggle-store-user-data-in-app-folder',
 }
 
 const DBActions = {
@@ -222,6 +225,9 @@ const MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT = 4
 // Displayed on the about page and used in the main.js file to only allow bitcoin URLs with this wallet address to be opened
 const ABOUT_BITCOIN_ADDRESS = '1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS'
 
+// Filename for enabling user data storage in app folder (Windows)
+const STORE_USER_DATA_IN_APP_FOLDER_SWITCH_FILENAME = 'store-user-data-in-app-folder'
+
 export {
   IpcChannels,
   DBActions,
@@ -235,4 +241,5 @@ export {
   SEARCH_RESULTS_DISPLAY_LIMIT,
   MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT,
   ABOUT_BITCOIN_ADDRESS,
+  STORE_USER_DATA_IN_APP_FOLDER_SWITCH_FILENAME,
 }

--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -3,11 +3,12 @@ import Datastore from '@seald-io/nedb'
 let dbPath = null
 
 if (process.env.IS_ELECTRON_MAIN) {
-  const { app } = require('electron')
   const { join } = require('path')
   // this code only runs in the electron main process, so hopefully using sync fs code here should be fine 😬
   const { statSync, realpathSync } = require('fs')
-  const userDataPath = app.getPath('userData') // This is based on the user's OS
+
+  const { getUserDataPath } = require('../main/userDataFolder')
+  const userDataPath = getUserDataPath()
   dbPath = (dbName) => {
     let path = join(userDataPath, `${dbName}.db`)
 

--- a/src/main/userDataFolder.js
+++ b/src/main/userDataFolder.js
@@ -1,0 +1,62 @@
+import { app } from 'electron'
+import { existsSync } from 'fs'
+import path from 'path'
+import asyncFs from 'fs/promises'
+import {
+  STORE_USER_DATA_IN_APP_FOLDER_SWITCH_FILENAME,
+} from '../constants'
+
+const DEFAULT_USER_DATA_PATH = app.getPath('userData')
+const APP_FOLDER_PATH = path.dirname(process.execPath)
+const APP_FOLDER_USER_DATA_PATH = path.join(APP_FOLDER_PATH, 'userData')
+const USER_DATA_IN_APP_FOLDER_SWITCH_FILE_PATH = path.join(APP_FOLDER_PATH, STORE_USER_DATA_IN_APP_FOLDER_SWITCH_FILENAME)
+const TO_BE_MIGRATED_FILES = [
+  // All files in src/datastores/index.js & flag file for experimental setting
+  'settings.db',
+  'profiles.db',
+  'playlists.db',
+  'history.db',
+  'search-history.db',
+  'subscription-cache.db',
+  'experiment-replace-http-cache',
+]
+
+export function getUserDataPath() {
+  return getStoreUserDataInAppFolderEnabled() ? APP_FOLDER_USER_DATA_PATH : DEFAULT_USER_DATA_PATH
+}
+
+export function getStoreUserDataInAppFolderEnabled() {
+  return process.platform === 'win32' && existsSync(USER_DATA_IN_APP_FOLDER_SWITCH_FILE_PATH)
+}
+
+export async function toggleStoreUserDataInAppFolderEnabledAndMigrateFiles() {
+  // Migrate files first, only toggle setting when migration successful
+  if (getStoreUserDataInAppFolderEnabled()) {
+    await migrateFilesFromHereToThere(APP_FOLDER_USER_DATA_PATH, DEFAULT_USER_DATA_PATH)
+    await asyncFs.rm(USER_DATA_IN_APP_FOLDER_SWITCH_FILE_PATH)
+  } else {
+    await migrateFilesFromHereToThere(DEFAULT_USER_DATA_PATH, APP_FOLDER_USER_DATA_PATH)
+    // create an empty file
+    const handle = await asyncFs.open(USER_DATA_IN_APP_FOLDER_SWITCH_FILE_PATH, 'w')
+    await handle.close()
+  }
+}
+
+async function migrateFilesFromHereToThere(herePath, therePath) {
+  await asyncFs.mkdir(therePath, { recursive: true })
+
+  return Promise.all(
+    TO_BE_MIGRATED_FILES.map(async (filename) => {
+      const sourceFilepath = path.join(herePath, filename)
+      const destFilepath = path.join(therePath, filename)
+      if (!existsSync(sourceFilepath)) {
+        if (existsSync(destFilepath)) {
+          return asyncFs.rm(destFilepath)
+        }
+        return
+      }
+
+      return asyncFs.copyFile(sourceFilepath, destFilepath)
+    })
+  )
+}

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -70,6 +70,17 @@ export default {
     ipcRenderer.send(IpcChannels.TOGGLE_REPLACE_HTTP_CACHE)
   },
 
+  /**
+   * @returns {Promise<boolean>}
+   */
+  getStoreUserDataInAppFolder: () => {
+    return ipcRenderer.invoke(IpcChannels.GET_STORE_USER_DATA_IN_APP_FOLDER)
+  },
+
+  toggleStoreUserDataInAppFolder: () => {
+    ipcRenderer.send(IpcChannels.TOGGLE_STORE_USER_DATA_IN_APP_FOLDER)
+  },
+
   // Allows programmatic toggling of picture-in-picture mode without accompanying user interaction.
   // See: https://developer.mozilla.org/en-US/docs/Web/Security/User_activation#transient_activation
   requestPiP: () => {

--- a/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
+++ b/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
@@ -11,9 +11,20 @@
         :label="$t('Settings.Experimental Settings.Replace HTTP Cache')"
         compact
         :default-value="replaceHttpCache"
-        :disabled="replaceHttpCacheLoading"
+        :disabled="settingValuesLoading"
         :tooltip="$t('Tooltips.Experimental Settings.Replace HTTP Cache')"
-        @change="handleRestartPrompt"
+        @change="handleReplaceHttpCacheChange"
+      />
+    </FtFlexBox>
+    <FtFlexBox v-if="storeUserDataInAppFolderAllowedOnPlatform">
+      <FtToggleSwitch
+        tooltip-position="top"
+        :label="$t('Settings.Experimental Settings.Store User Data In App Folder.Label')"
+        compact
+        :default-value="storeUserDataInAppFolder"
+        :disabled="settingValuesLoading"
+        :tooltip="$t('Settings.Experimental Settings.Store User Data In App Folder.Tooltip')"
+        @change="handleStoreUserDataInAppFolderChange"
       />
     </FtFlexBox>
     <FtPrompt
@@ -21,7 +32,7 @@
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
       :option-names="[$t('Yes, Restart'), $t('Cancel')]"
       :option-values="['restart', 'cancel']"
-      @click="handleReplaceHttpCache"
+      @click="handleRestartPromptClick"
     />
   </FtSettingsSection>
 </template>
@@ -34,39 +45,83 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from '../ft-toggle-switch/ft-toggle-switch.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 
-const replaceHttpCacheLoading = ref(true)
+const settingValuesLoading = ref(true)
 const replaceHttpCache = ref(false)
+const storeUserDataInAppFolder = ref(false)
 const showRestartPrompt = ref(false)
+
+const storeUserDataInAppFolderAllowedOnPlatform = process.platform === 'win32'
+
+const NextActions = {
+  // Simply use 1-N unique values
+  NOTHING: 0,
+  TOGGLE_REPLACE_HTTP_CACHE: 1,
+  TOGGLE_STORE_USER_DATA_IN_APP_FOLDER: 2,
+}
+
+let nextAction = NextActions.NOTHING
 
 onMounted(async () => {
   if (process.env.IS_ELECTRON) {
     replaceHttpCache.value = await window.ftElectron.getReplaceHttpCache()
+    if (storeUserDataInAppFolderAllowedOnPlatform) {
+      storeUserDataInAppFolder.value = await window.ftElectron.getStoreUserDataInAppFolder()
+    }
   }
 
-  replaceHttpCacheLoading.value = false
+  settingValuesLoading.value = false
 })
 
 /**
  * @param {boolean} value
  */
-function handleRestartPrompt(value) {
+function handleReplaceHttpCacheChange(value) {
   replaceHttpCache.value = value
+  nextAction = NextActions.TOGGLE_REPLACE_HTTP_CACHE
+  showRestartPrompt.value = true
+}
+
+/**
+ * @param {boolean} value
+ */
+function handleStoreUserDataInAppFolderChange(value) {
+  storeUserDataInAppFolder.value = value
+  nextAction = NextActions.TOGGLE_STORE_USER_DATA_IN_APP_FOLDER
   showRestartPrompt.value = true
 }
 
 /**
  * @param {'restart' | 'cancel' | null} value
  */
-function handleReplaceHttpCache(value) {
+function handleRestartPromptClick(value) {
   showRestartPrompt.value = false
 
-  if (value === null || value === 'cancel') {
-    replaceHttpCache.value = !replaceHttpCache.value
-    return
-  }
+  switch (nextAction) {
+    case NextActions.TOGGLE_REPLACE_HTTP_CACHE: {
+      if (value === null || value === 'cancel') {
+        replaceHttpCache.value = !replaceHttpCache.value
+        return
+      }
 
-  if (process.env.IS_ELECTRON) {
-    window.ftElectron.toggleReplaceHttpCache()
+      if (process.env.IS_ELECTRON) {
+        window.ftElectron.toggleReplaceHttpCache()
+      }
+      break
+    }
+    case NextActions.TOGGLE_STORE_USER_DATA_IN_APP_FOLDER: {
+      if (value === null || value === 'cancel') {
+        storeUserDataInAppFolder.value = !storeUserDataInAppFolder.value
+        return
+      }
+
+      if (process.env.IS_ELECTRON) {
+        window.ftElectron.toggleStoreUserDataInAppFolder()
+      }
+      break
+    }
+    default: {
+      console.error('[Internal] nextAction has unexpected value', nextAction)
+    }
   }
 }
 </script>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -677,6 +677,9 @@ Settings:
     Experimental Settings: Experimental
     Warning: These settings are experimental, they may cause crashes while enabled. Making backups is highly recommended. Use at your own risk!
     Replace HTTP Cache: Replace HTTP Cache
+    Store User Data In App Folder:
+      Label: Store User Data In App Folder
+      Tooltip: User data files will be stored inside the folder where the executable resides. Making backups before enabling is highly recommended. Use at your own risk!
   Password Dialog:
     Password: Password
     Enter Password To Unlock: Enter password to unlock settings


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/issues/746

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
It's common for a portable app to store user data (settings and other data files) 

https://portableapps.com/about/what_is_a_portable_app#definition

> A portable app is a computer program that doesn't need to be installed into Windows like traditional apps so you can carry it with you on a portable device or synced cloud folder and use on any Windows computer. When your USB flash drive, portable hard drive, or other portable device is plugged in or your cloud drive is synced, you have access to your software and personal data just as you would on your own PC. And when you unplug the device, none of your personal data is left behind.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

![image](https://github.com/user-attachments/assets/43e5ef78-e804-47d5-89b0-327c4059f00c)

## Testing
** Backup data before testing **
Suggest to test with non dev version to be accurate (I have never tested this with dev on windows)
Custom build: https://github.com/PikachuEXE/FreeTube/actions/runs/15431198924

A. Windows
- Open app
- Ensure all data like subscribed channels/profiles, sub cache, playlist, settings, etc. are still present
- Ensure new setting DOES appear and disabled
- Turn OFF `Replace HTTP Cache` (for later special setting sync test)
- Close app
- Create folder `userData` under the app folder (if you want to test auto folder creation you can do that later)
  e.g. if executable is at `C:\FreeTube\Freetube.exe`, create `C:\FreeTube\userData`
- Create empty file `experiment-replace-http-cache` inside that folder (which should be absent when `Replace HTTP Cache` disabled)
- Open app, turn ON new setting
- Ensure all data like subscribed channels/profiles, sub cache, playlist, settings, etc. are still present
- Ensure  `Replace HTTP Cache` still OFF (and empty file `experiment-replace-http-cache` is gone)
- Ensure data files (`*.db`) now present in new `userData` folder in app folder
- Turn ON `Replace HTTP Cache`
- Ensure no empty file `experiment-replace-http-cache` present in default user data folder
- Optionally do some updates and ensure only files in app folder updated not those in default folder
- DELETE data files in default user data folder
- Turn OFF new setting
- Ensure all data like subscribed channels/profiles, sub cache, playlist, settings, etc. are still present
-  Ensure  `Replace HTTP Cache` still ON
- Ensure data files now present in default `userData` folder (`%APPDATA%\FreeTube`, see https://www.electronjs.org/docs/latest/api/app#appgetpathname)

B. Non windows (macOS/Linux)
- Open app
- Ensure all data like subscribed channels/profiles, sub cache, playlist, settings, etc. are still present
- Ensure new setting does NOT appear

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
