### PR TITLE
Update single user playlist view to remove videos immediately on exit

### DIFF
--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -37,9 +37,9 @@ let idCounter = 0
 const toasts = shallowReactive([])
 
 /**
- * @param {CustomEvent<{ message: string, time: number | null, action: Function | null }>} event
+ * @param {CustomEvent<{ message: string, time: number | null, action: Function | null, abortSignal: AbortSignal | null }>} event
  */
-function open({ detail: { message, time, action } }) {
+function open({ detail: { message, time, action, abortSignal } }) {
   /** @type {Toast} */
   const toast = {
     message,
@@ -50,6 +50,11 @@ function open({ detail: { message, time, action } }) {
   }
 
   toast.timeout = setTimeout(close, time || 3000, toast)
+  if (abortSignal != null) {
+    abortSignal.addEventListener('abort', () => {
+      close(toast)
+    })
+  }
 
   nextTick(() => {
     toast.isOpen = true

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -166,13 +166,15 @@ export const ToastEventBus = new EventTarget()
  * @param {string} message
  * @param {number} time
  * @param {Function} action
+ * @param {AbortSignal} abortSignal
  */
-export function showToast(message, time = null, action = null) {
+export function showToast(message, time = null, action = null, abortSignal = null) {
   ToastEventBus.dispatchEvent(new CustomEvent('toast-open', {
     detail: {
       message,
       time,
-      action
+      action,
+      abortSignal,
     }
   }))
 }

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -51,6 +51,7 @@ export default defineComponent({
         continuationData: this.continuationData,
       })
     }
+    this.removeToBeDeletedVideosSometimes()
     next()
   },
   data: function () {
@@ -82,7 +83,8 @@ export default defineComponent({
       promptOpen: false,
       deletedVideoIds: [],
       deletedPlaylistItemIds: [],
-      isUndoToast: false
+      isUndoToast: false,
+      isUndoClicked: false,
     }
   },
   computed: {
@@ -600,7 +602,6 @@ export default defineComponent({
       try {
         const playlistItems = [].concat(this.playlistItems)
         const tempPlaylistItems = [].concat(this.playlistItems)
-        let isUndoClicked = false
 
         const videoIndex = this.playlistItems.findIndex((video) => {
           return video.videoId === videoId && video.playlistItemId === playlistItemId
@@ -620,29 +621,35 @@ export default defineComponent({
               5000,
               () => {
                 this.playlistItems = tempPlaylistItems
-                isUndoClicked = true
+                this.isUndoClicked = true
                 this.isUndoToast = false
                 this.deletedVideoIds = []
                 this.deletedPlaylistItemIds = []
               }
             )
             setTimeout(() => {
-              if (!isUndoClicked) {
-                this.removeVideos({
-                  _id: this.playlistId,
-                  videoIds: this.deletedVideoIds,
-                  playlistItemIds: this.deletedPlaylistItemIds,
-                })
-                this.deletedVideoIds = []
-                this.deletedPlaylistItemIds = []
-                this.isUndoToast = false
-              }
+              this.removeToBeDeletedVideosSometimes()
             }, 5000)
           }
         }
       } catch (e) {
         showToast(this.$t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'))
         console.error(e)
+      }
+    },
+
+    removeToBeDeletedVideosSometimes() {
+      if (this.isLoading) { return }
+
+      if (this.deletedPlaylistItemIds.length > 0 && !this.isUndoClicked) {
+        this.removeVideos({
+          _id: this.playlistId,
+          videoIds: this.deletedVideoIds,
+          playlistItemIds: this.deletedPlaylistItemIds,
+        })
+        this.deletedVideoIds = []
+        this.deletedPlaylistItemIds = []
+        this.isUndoToast = false
       }
     },
 

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -81,7 +81,6 @@ export default defineComponent({
       videoSearchQuery: '',
 
       promptOpen: false,
-      deletedVideoIds: [],
       deletedPlaylistItemIds: [],
       isUndoToast: false,
       isUndoClicked: false,
@@ -608,7 +607,6 @@ export default defineComponent({
         })
 
         if (videoIndex !== -1) {
-          this.deletedVideoIds.push(this.playlistItems[videoIndex].videoId)
           this.deletedPlaylistItemIds.push(this.playlistItems[videoIndex].playlistItemId)
           playlistItems.splice(videoIndex, 1)
           this.playlistItems = playlistItems
@@ -623,7 +621,6 @@ export default defineComponent({
                 this.playlistItems = tempPlaylistItems
                 this.isUndoClicked = true
                 this.isUndoToast = false
-                this.deletedVideoIds = []
                 this.deletedPlaylistItemIds = []
               }
             )
@@ -644,10 +641,8 @@ export default defineComponent({
       if (this.deletedPlaylistItemIds.length > 0 && !this.isUndoClicked) {
         this.removeVideos({
           _id: this.playlistId,
-          videoIds: this.deletedVideoIds,
           playlistItemIds: this.deletedPlaylistItemIds,
         })
-        this.deletedVideoIds = []
         this.deletedPlaylistItemIds = []
         this.isUndoToast = false
       }

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -82,7 +82,8 @@ export default defineComponent({
 
       promptOpen: false,
       deletedPlaylistItemIds: [],
-      isUndoToast: false,
+      // Present = shown
+      undoToastAbortController: null,
       isUndoClicked: false,
     }
   },
@@ -612,17 +613,18 @@ export default defineComponent({
           this.playlistItems = playlistItems
 
           // Only show toast when no existing toast shown
-          if (!this.isUndoToast) {
-            this.isUndoToast = true
+          if (this.undoToastAbortController == null) {
+            this.undoToastAbortController = new AbortController()
             showToast(
               this.$t('User Playlists.SinglePlaylistView.Toast["Video has been removed. Click here to undo."]'),
               5000,
               () => {
                 this.playlistItems = tempPlaylistItems
                 this.isUndoClicked = true
-                this.isUndoToast = false
                 this.deletedPlaylistItemIds = []
-              }
+                this.undoToastAbortController = null
+              },
+              this.undoToastAbortController.signal,
             )
             setTimeout(() => {
               this.removeToBeDeletedVideosSometimes()
@@ -644,7 +646,8 @@ export default defineComponent({
           playlistItemIds: this.deletedPlaylistItemIds,
         })
         this.deletedPlaylistItemIds = []
-        this.isUndoToast = false
+        this.undoToastAbortController?.abort()
+        this.undoToastAbortController = null
       }
     },
 

--- a/src/renderer/views/Playlist/Playlist.js
+++ b/src/renderer/views/Playlist/Playlist.js
@@ -84,7 +84,6 @@ export default defineComponent({
       deletedPlaylistItemIds: [],
       // Present = shown
       undoToastAbortController: null,
-      isUndoClicked: false,
     }
   },
   computed: {
@@ -615,20 +614,20 @@ export default defineComponent({
           // Only show toast when no existing toast shown
           if (this.undoToastAbortController == null) {
             this.undoToastAbortController = new AbortController()
+            const actualRemoveVideosTimeout = setTimeout(() => {
+              this.removeToBeDeletedVideosSometimes()
+            }, 5000)
             showToast(
               this.$t('User Playlists.SinglePlaylistView.Toast["Video has been removed. Click here to undo."]'),
               5000,
               () => {
                 this.playlistItems = tempPlaylistItems
-                this.isUndoClicked = true
+                clearTimeout(actualRemoveVideosTimeout)
                 this.deletedPlaylistItemIds = []
                 this.undoToastAbortController = null
               },
               this.undoToastAbortController.signal,
             )
-            setTimeout(() => {
-              this.removeToBeDeletedVideosSometimes()
-            }, 5000)
           }
         }
       } catch (e) {
@@ -640,7 +639,7 @@ export default defineComponent({
     removeToBeDeletedVideosSometimes() {
       if (this.isLoading) { return }
 
-      if (this.deletedPlaylistItemIds.length > 0 && !this.isUndoClicked) {
+      if (this.deletedPlaylistItemIds.length > 0) {
         this.removeVideos({
           _id: this.playlistId,
           playlistItemIds: this.deletedPlaylistItemIds,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -213,7 +213,7 @@ User Playlists:
       This video cannot be moved up.: This video cannot be moved up.
       This video cannot be moved down.: This video cannot be moved down.
       Video has been removed: Video has been removed
-      Video has been removed. Click here to undo.: Video has been removed. Click here to undo.
+      Video has been removed. Click here to undo.: Video has been removed. Click here to undo. Exiting this view will remove them immediately (cannot undo).
       There was a problem with removing this video: There was a problem with removing this video
 
       This playlist is already being used for quick bookmark.: This playlist is already being used for quick bookmark.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Undo introduced in https://github.com/FreeTubeApp/FreeTube/pull/5885

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
1. Error raised if out of playlist view when scheduled task for actual removing videos from playlist run
2. IMO annoying to need to stay in the view for 5s when I am just trying to remove 1 finished video and play another one
  Undo still useful for removing multiple videos

![Screenshot 2025-06-10 at 09 19 35](https://github.com/user-attachments/assets/3991196d-216c-4c08-9eca-44bab0c0b885)

This PR makes single playlist view remove videos queued for removal after 5s to be removed immediately once 


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- Create some really long user playlist (easier for testing, e.g. copy one from LTT long playlist
- Create 2+ windows to ensure change sync (optional, nothing changed on that side
- Remove 2+ videos, undo, ensure all removal undone (no change on other windows
- Remove 2+ videos, wait 5s, repeat N times, ensure videos are really removed (can go to another view and back to ensure
- Remove 2+ videos, exit view immediately (go back to playlists view or about/settings view or start playing one of the items)
  Ensure videos removed and toast closed on view changed (no longer able to undo)

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
