### PR TITLE
Fix variant selection when no variant's audio role marked as main

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1340,7 +1340,11 @@ export default defineComponent({
         variants = variants.filter(variant => variant.label === label)
       } else if (hasMultipleAudioTracks.value) {
         // default audio track
-        variants = variants.filter(variant => variant.audioRoles.includes('main'))
+        const filteredVariants = variants.filter(variant => variant.audioRoles.includes('main'))
+        // Sometimes there is nothing marked as main, don't filter in this case
+        if (filteredVariants.length > 0) {
+          variants = filteredVariants
+        }
       }
 
       const isPortrait = variants[0].height > variants[0].width


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/7435

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Error caused by certain videos like https://youtu.be/PZJCBd_DhfE from https://github.com/FreeTubeApp/FreeTube/issues/7435
Where no variant got audio role `main` so the filtered variants is empty and reading stuff from the first one = error
This PR makes it to NOT filter variants if no `main` audio role variant found

![image](https://github.com/user-attachments/assets/bd828484-81d6-4226-9fa9-bab444401fa1)


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- Play https://youtu.be/PZJCBd_DhfE
- No error no fallback

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
