### PR TITLE
Local API: Add support for transcript voice replies

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1649,6 +1649,8 @@ export function parseLocalComment(comment, commentThread = undefined) {
     hasReplyToken = true
   }
 
+  const commentTextRuns = comment.voice_reply_container?.transcript_text ? comment.voice_reply_container.transcript_text.runs : comment.content.runs
+
   return {
     id: comment.comment_id,
     dataType: 'local',
@@ -1659,9 +1661,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
     isPinned: comment.is_pinned,
     isOwner: !!comment.author_is_channel_owner,
     isMember: !!comment.is_member,
-    text: comment.content.text.length !== 0 || comment.voice_reply_transcript == null
-      ? Autolinker.link(parseLocalTextRuns(comment.content.runs, 16, { looseChannelNameDetection: true }))
-      : Autolinker.link(parseLocalTextRuns(comment.voice_reply_transcript.runs, 16), { looseChannelNameDetection: true }),
+    text: Autolinker.link(parseLocalTextRuns(commentTextRuns, 16, { looseChannelNameDetection: true })),
     isHearted: !!comment.is_hearted,
     hasOwnerReplied,
     hasReplyToken,


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/7563

## Description
Adds support for displaying voice reply transcript. We may want to add additional styling in the future (ex: an icon)
Relies on: https://github.com/LuanRT/YouTube.js/pull/981

## Screenshots 
![reply is now shown instead of empty](https://github.com/user-attachments/assets/1309bdcc-5e7e-40c0-af49-3ac5d0f09f69)

## Testing
- go to https://www.youtube.com/watch?v=ZJ1N9PLNzT4
- view replies to netherwolf100's comment

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 42
