### PR TITLE
Fix Live Now video thumbnail timestamp

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -712,7 +712,7 @@ export default defineComponent({
       }
 
       this.description = this.data.description
-      this.isLive = this.data.liveNow || this.data.lengthSeconds === 'undefined'
+      this.isLive = this.data.liveNow || this.data.lengthSeconds === 'undefined' || Number.isNaN(this.data.lengthSeconds)
       this.isUpcoming = this.data.isUpcoming || this.data.premiere
       this.is4k = this.data.is4k
       this.is8k = this.data.is8k

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1139,7 +1139,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
 
     const published = calculatePublishedDate(
       publishedText,
-      video.is_live,
+      video.duration.text === 'LIVE',
       video.is_upcoming || video.is_premiere,
       video.upcoming
     )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #7586 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
If timestamp returns NaN, assume the video is a Live stream
Check GridVideo duration text instead of undefined is_live property

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
before
![2025-06-24_22-35-14](https://github.com/user-attachments/assets/aac50436-72ac-46f0-842e-9eae4326f17b)

after
![2025-06-24_22-31-45](https://github.com/user-attachments/assets/0dcc5ba6-8847-4750-9e7d-9f271c06352b)

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->

