### PR TITLE
Fix getting community posts on subscription page

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -526,7 +526,7 @@ export async function getLocalChannelCommunity(id) {
 
     // if the channel doesn't have a community tab, YouTube returns the home tab instead
     // so we need to check that we got the right tab
-    if (communityTab.current_tab?.endpoint.metadata.url?.endsWith('/community')) {
+    if (communityTab.current_tab?.endpoint.metadata.url?.endsWith('/posts')) {
       return parseLocalCommunityPosts(communityTab.posts)
     } else {
       return []


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Related issue
This fixes getting community posts on subscription page: https://github.com/FreeTubeApp/FreeTube/issues/7601

## Description
This PR does not rely on the change here which fixes the community posts tab on channels: https://github.com/LuanRT/YouTube.js/pull/986

## Testing
- Subscribe to Linus Tech Tips
- Go to subscription page => Posts tab
- Refresh posts
- See posts from channels again   


## Desktop
- **OS:** Fedora Linux
- **OS Version:** 42 KDE

