### PR TITLE
Handle more YouTube URLs

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -477,6 +477,16 @@ export default defineComponent({
             break
           }
 
+          case 'trending':
+          case 'subscriptions':
+          case 'history':
+          case 'userplaylists':
+            openInternalPath({
+              path: `/${result.urlType}`,
+              doCreateNewWindow
+            })
+            break
+
           case 'invalid_url': {
             // Do nothing
             break

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -473,6 +473,17 @@ function goToSearch(queryText, { event }) {
         break
       }
 
+      case 'trending':
+      case 'subscriptions':
+      case 'history':
+      case 'userplaylists':
+        openInternalPath({
+          path: `/${result.urlType}`,
+          doCreateNewWindow,
+          searchQueryText: queryText
+        })
+        break
+
       case 'invalid_url':
       default: {
         openInternalPath({

--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -220,6 +220,10 @@ export default defineComponent({
             case 'channel':
             case 'hashtag':
             case 'post':
+            case 'trending':
+            case 'subscriptions':
+            case 'history':
+            case 'userplaylists':
               isYoutubeLink = true
               break
 

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -464,12 +464,14 @@ const actions = {
     const hashtagPattern = /^\/hashtag\/(?<tag>[^#&/?]+)$/
 
     const postPattern = /^\/post\/(?<postId>.+)/
+    const feedPattern = /^\/feed\/(?<type>trending|subscriptions|history|playlists|you|library)/
     const typePatterns = new Map([
       ['playlist', /^(\/playlist\/?|\/embed(\/?videoseries)?)$/],
       ['search', /^\/results|search\/?$/],
       ['hashtag', hashtagPattern],
+      ['post', postPattern],
+      ['feed', feedPattern],
       ['channel', channelPattern],
-      ['post', postPattern]
     ])
 
     for (const [type, pattern] of typePatterns) {
@@ -643,6 +645,16 @@ const actions = {
           // The original URL could be from Invidious.
           // We need to make sure it starts with youtube.com, so that YouTube's resolve endpoint can recognise it
           url: `https://www.youtube.com${url.pathname}`
+        }
+      }
+      case 'feed': {
+        /** @type {'trending' | 'subscriptions' | 'history' | 'playlists' | 'you' | 'library'} */
+        const feedType = url.pathname.match(feedPattern).groups.type
+
+        if (feedType === 'playlists' || feedType === 'you' || feedType === 'library') {
+          return { urlType: 'userplaylists' }
+        } else {
+          return { urlType: feedType }
         }
       }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

- closes #7632

## Description

This pull request adds support for more YouTube URLs in FreeTube:
- `/feed/trending` -> trending
- `/feed/subscriptions` -> subscriptions
- `/feed/history` -> history
- `/feed/playlists` -> user playlists
- `/feed/you` -> user playlists (the feature request suggested mapping it to the profile manager page but in my mind mapping it to the user playlists page made more sense)
- `/feed/library` -> user playlists (`m.youtube.com` uses this instead of `/feed/you`)

## Testing

Test the following URLs in FreeTube's search bar and check that they open the correct pages as documented in the description section above.

https://youtube.com/feed/trending
https://youtube.com/feed/subscriptions
https://youtube.com/feed/history
https://youtube.com/feed/playlists
https://youtube.com/feed/you
https://youtube.com/feed/library

## Desktop

- **OS:** Windows
- **OS Version:** 10