### PR TITLE
Clean up included by default babel class properties transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,8 +9,5 @@
         }
       }
     ]
-  ],
-  "plugins": [
-    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",
-    "@babel/plugin-transform-class-properties": "^7.27.1",
     "@babel/preset-env": "^7.28.0",
     "@double-great/stylelint-a11y": "^3.0.4",
     "@eslint/js": "^9.30.1",


### PR DESCRIPTION
## Pull Request Type

- [x] Cleanup

## Description
Class properties were stablised as part of ES2022 and have been included in `@babel/preset-env` since then, so we no longer need to explicitly list it in our babel config and development dependencies (notice how the `yarn.lock` file didn't change as it still gets included by `@babel/preset-env`).