### PR TITLE
Use GH_TOKEN environment variable in auto merge workflow

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, auto_merge_disabled, ready_for_review]
 
+permissions: {}
+
 jobs:
   build:
     if: ${{ !github.event.pull_request.draft && (contains(github.event.pull_request.base.ref, 'development') || contains(github.event.pull_request.base.ref, 'RC')) }}
@@ -10,8 +12,6 @@ jobs:
 
     steps:
     - name: Auto Merge PR
-      run: |
-        echo ${{ secrets.PUSH_TOKEN }} >> auth.txt
-        gh auth login --with-token < auth.txt
-        rm auth.txt
-        gh pr merge https://github.com/FreeTubeApp/FreeTube/pull/${{ github.event.pull_request.number }} --auto --squash
+      env:
+        GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+      run: gh pr merge https://github.com/FreeTubeApp/FreeTube/pull/${{ github.event.pull_request.number }} --auto --squash


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

In the auto-merge workflow we currently write the `PUSH_TOKEN` to a file, pipe it into the gh auth login command and then delete that file, these days however `gh` also supports reading the token from the `GH_TOKEN` environment variable, which is also the documented way to use gh in GitHub Actions (see link below). This pull request switches to using that environment variable and also disables all permissions for the standard `GITHUB_TOKEN` token as we don't use it in this workflow.

https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows

## Testing
