### PR TITLE
CI: Use faster D: drive for yarn cache on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: 'Use faster D: drive for yarn cache on Windows'
+      if: startsWith(matrix.os, 'windows')
+      run: yarn config set cache-folder D:\ft_yarn_cache
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: 'Use faster D: drive for yarn cache on Windows'
+      if: startsWith(matrix.os, 'windows')
+      run: yarn config set cache-folder D:\ft_yarn_cache
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

Yarn's default cache location is `C:\Users\{username}\AppData\Local\Yarn\Cache\v6`, which works fine on most computers where the main drive is generally pretty fast, but on GitHub Actions the `D:` drive seems to be a lot faster than the `C:` drive, so the default cache location is not ideal. This pull request changes yarn's config in the build and release workflows on the Windows runners to `D:\ft_yarn_cache`.

I've recorded the times from runs before and after the change both without a cache (lockfile changed due to dependency updates etc) and with a cache (dependencies didn't change since the previous run), as you can see the difference is pretty impressive.

| Run \\ Step | "Use Node.js 22.x"<br>no cache | "Run yarn run ci"<br>no cache | | "Use Node.js 22.x"<br>with cache | "Run yarn run ci"<br>with cache |
| --- | --- | --- | --- | --- | --- |
| "win-x64" before | 6s | 3m 51s | | 1m 29s | 26s |
| "win-x64" after | 6s | 1m 34s | | 16s | 20s |
| | | | | | |
| "win-arm64" before | 7s | 3m 49s | | 1m 34s | 28s |
| "win-arm64" after | 5s | 1m 51s | | 20s | 21s |

## Testing

Before without cache: https://github.com/FreeTubeApp/FreeTube/actions/runs/16276244757
Before with cache: https://github.com/FreeTubeApp/FreeTube/actions/runs/16263531496/job/45913993365
After without cache: https://github.com/absidue/FreeTube/actions/runs/16315682784
After with cache: https://github.com/absidue/FreeTube/actions/runs/16315902686/

## Additional context

I'm not sure why the simple step of calling `yarn config set cache-folder D:\ft_yarn_cache` is so slow in GitHub Actions (8-18s) but even with those extra seconds restoring the cache and running yarn install is still faster.