### PR TITLE
Fix `select` value not updating when options load asynchronously

### DIFF
--- a/src/renderer/components/ft-select/ft-select.js
+++ b/src/renderer/components/ft-select/ft-select.js
@@ -59,6 +59,20 @@ export default defineComponent({
       return sanitizeForHtmlId(this.placeholder)
     }
   },
+  watch: {
+    value(newVal) {
+      if (this.$refs.select) {
+        this.$refs.select.value = newVal
+      }
+    },
+    selectValues() {
+      this.$nextTick(() => {
+        if (this.$refs.select) {
+          this.$refs.select.value = this.value
+        }
+      })
+    }
+  },
   methods: {
     change: function(value) {
       this.$emit('change', value)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

closes #7526 

## Description

Added watchers in `ft-select.js` to ensure the native select element stays synchronized with Vue's reactive data.
Before, the component would show the first element on the list, as seen in the related issue.

## Testing

1 - Set default landing page to Settings
2 - Set your trending location to any country you want
3 - Close FT
4 - Open FT
5 - The region selected will be the same you set before (previously, the country would be set to the first element on the list).

## Desktop

- **OS:** Linux - Ubuntu
- **OS Version:**  24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta

## Additional context

I believe the problem was caused by the ft-select component rendering before the list of countries was loaded. When the options were finally populated, the native <select> element would fail to update and thus display the first country on the list by default.