### PR TITLE
Mark video as watched when opening external player from the watch view

### DIFF
--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -230,6 +230,14 @@ export default defineComponent({
       return this.$store.getters.getExternalPlayer
     },
 
+    historyEntry: function () {
+      return this.$store.getters.getHistoryCacheById[this.id]
+    },
+
+    historyEntryExists: function () {
+      return typeof this.historyEntry !== 'undefined'
+    },
+
     defaultPlayback: function () {
       return this.$store.getters.getDefaultPlayback
     },
@@ -319,7 +327,28 @@ export default defineComponent({
           playlistLoop: null,
         })
       }
+
       this.openInExternalPlayer(payload)
+
+      if (!this.historyEntryExists) {
+        // Marking as watched
+        const videoData = {
+          videoId: this.id,
+          title: this.title,
+          author: this.channelName,
+          authorId: this.channelId,
+          published: this.published,
+          description: this.description,
+          viewCount: this.viewCount,
+          lengthSeconds: this.lengthSeconds,
+          watchProgress: 0,
+          timeWatched: Date.now(),
+          isLive: false,
+          type: 'video'
+        }
+
+        this.updateHistory(videoData)
+      }
     },
 
     handleDownload: function (index) {
@@ -422,6 +451,7 @@ export default defineComponent({
       'showAddToPlaylistPromptForManyVideos',
       'addVideo',
       'updatePlaylist',
+      'updateHistory',
       'removeVideo',
     ])
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #7664

## Description
When opening a video in an external player from the watch page, marks the video as watched.

## Testing
Open a video's watch page, remove the video from the history, and then open the video in the external player using the button on the watch page, it should now show up again in history
