### PR TITLE
Fix HTTP 429 errors for auto-translated subtitles

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -524,7 +524,7 @@ function runApp() {
         requestHeaders['Sec-Fetch-Site'] = 'same-origin'
         requestHeaders['Sec-Fetch-Mode'] = 'same-origin'
         requestHeaders['X-Youtube-Bootstrap-Logged-In'] = 'false'
-      } else if (url === 'https://www.youtube.com/sw.js_data') {
+      } else if (url === 'https://www.youtube.com/sw.js_data' || url.startsWith('https://www.youtube.com/api/timedtext')) {
         requestHeaders.Referer = 'https://www.youtube.com/sw.js'
         requestHeaders['Sec-Fetch-Site'] = 'same-origin'
         requestHeaders['Sec-Fetch-Mode'] = 'same-origin'

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2316,7 +2316,11 @@ export default defineComponent({
 
       // text related errors aren't serious (captions and seek bar thumbnails), so we should just log them
       // TODO: consider only emitting when the severity is crititcal?
-      if (!ignoreErrors && error.category !== shaka.util.Error.Category.TEXT) {
+      if (
+        !ignoreErrors &&
+        error.category !== shaka.util.Error.Category.TEXT &&
+        !(error.code === shaka.util.Error.Code.BAD_HTTP_STATUS && error.data[0].startsWith('https://www.youtube.com/api/timedtext'))
+      ) {
         // don't react to multiple consecutive errors, otherwise we don't give the format fallback from the previous error a chance to work
         ignoreErrors = true
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1653,7 +1653,8 @@ export default defineComponent({
       }
 
       const url = new URL(trackToTranslate.base_url)
-      url.searchParams.set('fmt', 'vtt')
+      // Requesting fmt=vtt with the tlang parameter set returns HTTP 429 errors, but requesting srt instead seems to work
+      url.searchParams.set('fmt', 'srt')
       url.searchParams.set('tlang', translationCode)
 
       const label = this.$t('Video.Player.TranslatedCaptionTemplate', {
@@ -1665,7 +1666,7 @@ export default defineComponent({
         url: url.toString(),
         label,
         language: translationCode,
-        mimeType: 'text/vtt',
+        mimeType: 'text/srt',
         isAutotranslated: true
       }
     },


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue
- closes #7708

## Description

This pull request fixes the auto-translated subtitles returning HTTP 429 errors and blocking the video playback with an error screen. The first change is to request auto-translated subtitles as SRT instead of WebVTT as that works for some reason and the second change is to only log subtitle 429 errors instead of showing an error screen to avoid blocking video playback.

## Testing

0. Make sure your FreeTube display language is not Russian
1. Open https://youtu.be/1lOcv8NWsCo
2. Select the subtitle track that has been auto-translated into English
3. You should see the subtitles

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** d73f43db5bea0b56aea38b5230a32cd0f77ad9db