### PR TITLE
Move General section within the Distraction Free Settings to top

### DIFF
--- a/src/renderer/components/distraction-settings/distraction-settings.css
+++ b/src/renderer/components/distraction-settings/distraction-settings.css
@@ -3,3 +3,7 @@
     display: none;
   }
 }
+
+.containingTextFlexBox {
+  margin-block-end: 2em;
+}

--- a/src/renderer/components/distraction-settings/distraction-settings.vue
+++ b/src/renderer/components/distraction-settings/distraction-settings.vue
@@ -76,7 +76,7 @@
         @toggle-show-tags="handleAddedChannelsHidden"
       />
     </ft-flex-box>
-    <ft-flex-box>
+    <ft-flex-box class="containingTextFlexBox">
       <ft-input-tags
         :label="$t('Settings.Distraction Free Settings.Hide Videos and Playlists Containing Text')"
         :tag-name-placeholder="$t('Settings.Distraction Free Settings.Hide Videos and Playlists Containing Text Placeholder')"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Visual change


## Description
<!-- Please write a clear and concise description of what the pull request does. -->
General being at the bottom of the the Distraction Free Settings seems a bit silly so i moved it to the top to make to make the order of the sections more logical

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="1920" height="935" alt="VirtualBoxVM_VJwMLTsGyR" src="https://github.com/user-attachments/assets/1b727c26-7fdb-41bf-999b-396aa034b2ce" />


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Go to the Distraction Free Settings
2. Check if General section is the first one listed