### PR TITLE
Use raw query for suggestions

### DIFF
--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -523,7 +523,6 @@ function updateSearchInputText(text) {
  * @param {string} query
  */
 function getSearchSuggestionsDebounce(query) {
-  const trimmedQuery = query.trim()
   if (query === lastSuggestionQuery.value) {
     return
   }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #7443 

## Description

Fixes a bug that would incorrectly tag search suggestion as part of the search history.

## Screenshots

### Before:

My search history:

<img width="405" height="179" alt="0" src="https://github.com/user-attachments/assets/819cb555-96b8-4824-9a3c-3cffb0194dcb" />


Searching for "cpu"

<img width="398" height="216" alt="before0" src="https://github.com/user-attachments/assets/689439d0-da4f-469a-893c-3eaa8300439c" />


Searching for "cpu " (empty space at the end, showing "cpu cooler" as if it were part of my search history)

<img width="399" height="203" alt="before1" src="https://github.com/user-attachments/assets/cff81659-605f-4f91-91d8-73b01d972073" />

---

### After:

Searching for "cpu"

<img width="401" height="182" alt="1" src="https://github.com/user-attachments/assets/f022707c-f904-4a02-8f17-1a9e8f68b9b7" />


Searching for "cpu " ("cpu cooler" no longer shows as part of my search history)

<img width="389" height="231" alt="2" src="https://github.com/user-attachments/assets/9d8e6432-8e40-4d1e-b072-d52c49982e9c" />

## Testing

1. Search something
2. Click on search bar
3. Press spacebar
4. See that it no longer shows the first search suggestion as part of the search history.

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta