### PR TITLE
Fix 'more' button not closing

### DIFF
--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="sideNavMoreOptions">
+  <div
+    ref="menuRef"
+    class="sideNavMoreOptions"
+  >
     <div
       class="navOption moreOptionNav"
       tabindex="0"
@@ -32,6 +35,7 @@
         :title="$t('Channels.Channels')"
         :aria-label="hideLabelsSideBar ? $t('Channels.Channels') : null"
         to="/subscribedchannels"
+        @click="closeMenu"
       >
         <div
           class="thumbnailContainer"
@@ -57,6 +61,7 @@
         :title="$t('Trending.Trending')"
         :aria-label="hideLabelsSideBar ? $t('Trending.Trending') : null"
         to="/trending"
+        @click="closeMenu"
       >
         <FontAwesomeIcon
           :icon="['fas', 'fire']"
@@ -77,6 +82,7 @@
         :title="$t('Most Popular')"
         :aria-label="hideLabelsSideBar ? $t('Most Popular') : null"
         to="/popular"
+        @click="closeMenu"
       >
         <FontAwesomeIcon
           :icon="['fas', 'users']"
@@ -96,6 +102,7 @@
         :title="$t('About.About')"
         :aria-label="hideLabelsSideBar ? $t('About.About') : null"
         to="/about"
+        @click="closeMenu"
       >
         <FontAwesomeIcon
           :icon="['fas', 'info-circle']"
@@ -115,6 +122,7 @@
         :title="$t('Settings.Settings')"
         :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
         to="/settings"
+        @click="closeMenu"
       >
         <FontAwesomeIcon
           :icon="['fas', 'sliders-h']"
@@ -189,11 +197,14 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
+import router from '../../router/index.js'
 
 import store from '../../store/index'
 
 const openMoreOptions = ref(false)
+
+const menuRef = ref(null)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideTrendingVideos = computed(() => {
@@ -215,6 +226,30 @@ const applyNavIconExpand = computed(() => {
   return {
     navIconExpand: hideLabelsSideBar.value
   }
+})
+
+function closeMenu() {
+  openMoreOptions.value = false
+}
+
+function handleClickOutside(event) {
+  if (
+    openMoreOptions.value &&
+    menuRef.value &&
+    !menuRef.value.contains(event.target)
+  ) {
+    closeMenu()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+  router.afterEach(() => {
+    closeMenu()
+  })
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
 })
 </script>
 

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -233,11 +233,7 @@ function closeMenu() {
 }
 
 function handleClickOutside(event) {
-  if (
-    openMoreOptions.value &&
-    menuRef.value &&
-    !menuRef.value.contains(event.target)
-  ) {
+  if (openMoreOptions.value && menuRef.value && !menuRef.value.contains(event.target)) {
     closeMenu()
   }
 }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #7712 

## Description

This Pull Request fixes a bug that prevented the "more" navbar from closing when the user clicked on one of its elements or outside of it.

## Testing

1. Make your window small to see the navbar at the bottom with the "more" option available.
2. Click on "more".
3. Click on one of its options.
4. See that it closes.
5. Click on "more"
6. Click outside of it
7. See that it closes.

(previously, the "more" options would not close.)

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS 
- **FreeTube version:** v0.23.5 Beta
