### PR TITLE
Add z-index to .infoArea to fix media formats menu cut off when Hide Sharing Actions is enabled

### DIFF
--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -139,6 +139,7 @@
   .infoArea {
     grid-area: info;
     position: relative;
+    z-index: 2;
   }
 
   .sidebarArea {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #4162 

## Description

This PR adds a z-index to fix a visual bug that displays the media format menu behind the recommended videos when Hide Sharing Actions is enabled.

## Screenshots

<img width="309" height="201" alt="media format menu" src="https://github.com/user-attachments/assets/dfaf4fe2-c779-4da3-b89f-a3b661cf829a" />

## Testing

1. Enable Hide Sharing Actions under Distraction Free Settings
2. Go to any video
3. Click on the Change Media Formats button
4. See that menu is fully displayed

(Before, it would not show up correctly, since part of it would be behind the recommended videos.)

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta