### PR TITLE
Fix progress bar not staying in video card when video duration is 1 second

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -231,11 +231,11 @@ export default defineComponent({
     },
 
     progressPercentage: function () {
-      if (typeof this.lengthSeconds !== 'number') {
+      if (typeof this.lengthSeconds !== 'number' || this.lengthSeconds === 0) {
         return 0
       }
-
-      return (this.watchProgress / this.lengthSeconds) * 100
+      const percentage = (this.watchProgress / this.lengthSeconds) * 100
+      return Math.min(percentage, 100)
     },
 
     hideSharingActions: function() {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #3313 

## Description

This fixes a visual bug where the video progress bar would extend beyond the video card for 1 second long, fully watched videos.

The `progressPercentage` function was generating values over 100%, which incorrectly set the bar's length. This update caps the maximum returned value at 100%.

I also added a check for division by zero, though a video with zero duration is unlikely.

## Screenshots

### Before:
<img width="1274" height="880" alt="before" src="https://github.com/user-attachments/assets/d9deae97-3e25-4316-81eb-ccd8200d56ea" />

### After:
<img width="1184" height="882" alt="after" src="https://github.com/user-attachments/assets/987d44e3-eea3-436e-8d2a-816af7229949" />

## Testing

1. Go to https://youtube.com/playlist?list=PLDC5minhgvGqdCy6kVlAv1yHJPR32CbnF
2. Let all videos play
3. Go to history
4. See the progress bar inside of the video card

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta