### PR TITLE
Enhancement: Add fast forward and rewind pop up to video player

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -112,7 +112,7 @@
   pointer-events: none;
 }
 
-.valueChangePopup.invert-icon-order {
+.valueChangePopup.invert-content-order {
   flex-direction: row-reverse;
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -112,6 +112,10 @@
   pointer-events: none;
 }
 
+.valueChangePopup.invert-icon-order {
+  flex-direction: row-reverse;
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.5s ease;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1958,9 +1958,11 @@ export default defineComponent({
       } else {
         video_.currentTime = newTime
       }
-      const icon = seconds > 0 ? 'arrow-right' : 'arrow-left'
+      const popUpLayout = seconds > 0
+        ? { icon: 'arrow-right', invertIconOrder: true }
+        : { icon: 'arrow-left', invertIconOrder: false }
       const formattedSeconds = Math.abs(seconds)
-      showValueChange(`${formattedSeconds}s`, icon)
+      showValueChange(`${formattedSeconds}s`, popUpLayout.icon, popUpLayout.invertIconOrder)
     }
 
     // #endregion mouse and keyboard helpers
@@ -2959,12 +2961,14 @@ export default defineComponent({
     const showValueChangePopup = ref(false)
     const valueChangeMessage = ref('')
     const valueChangeIcon = ref(null)
+    const invertValueChangeIconOrder = ref(false)
     let valueChangeTimeout = null
 
-    function showValueChange(message, icon = null) {
+    function showValueChange(message, icon = null, invertIconOrder = false) {
       valueChangeMessage.value = message
       valueChangeIcon.value = icon
       showValueChangePopup.value = true
+      invertValueChangeIconOrder.value = invertIconOrder
 
       if (valueChangeTimeout) {
         clearTimeout(valueChangeTimeout)
@@ -3002,7 +3006,8 @@ export default defineComponent({
 
       valueChangeMessage,
       valueChangeIcon,
-      showValueChangePopup
+      showValueChangePopup,
+      invertValueChangeIconOrder,
     }
   }
 })

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1959,10 +1959,10 @@ export default defineComponent({
         video_.currentTime = newTime
       }
       const popUpLayout = seconds > 0
-        ? { icon: 'arrow-right', invertIconOrder: true }
-        : { icon: 'arrow-left', invertIconOrder: false }
+        ? { icon: 'arrow-right', invertContentOrder: true }
+        : { icon: 'arrow-left', invertContentOrder: false }
       const formattedSeconds = Math.abs(seconds)
-      showValueChange(`${formattedSeconds}s`, popUpLayout.icon, popUpLayout.invertIconOrder)
+      showValueChange(`${formattedSeconds}s`, popUpLayout.icon, popUpLayout.invertContentOrder)
     }
 
     // #endregion mouse and keyboard helpers
@@ -2961,14 +2961,20 @@ export default defineComponent({
     const showValueChangePopup = ref(false)
     const valueChangeMessage = ref('')
     const valueChangeIcon = ref(null)
-    const invertValueChangeIconOrder = ref(false)
+    const invertValueChangeContentOrder = ref(false)
     let valueChangeTimeout = null
 
-    function showValueChange(message, icon = null, invertIconOrder = false) {
+    /**
+     * Shows a popup with a message and an icon on top of the video player.
+     * @param {string} message - The message to display.
+     * @param {string} icon - The icon to display.
+     * @param {boolean} invertContentOrder - Whether to invert the order of the icon and message.
+     */
+    function showValueChange(message, icon = null, invertContentOrder = false) {
       valueChangeMessage.value = message
       valueChangeIcon.value = icon
       showValueChangePopup.value = true
-      invertValueChangeIconOrder.value = invertIconOrder
+      invertValueChangeContentOrder.value = invertContentOrder
 
       if (valueChangeTimeout) {
         clearTimeout(valueChangeTimeout)
@@ -3007,7 +3013,7 @@ export default defineComponent({
       valueChangeMessage,
       valueChangeIcon,
       showValueChangePopup,
-      invertValueChangeIconOrder,
+      invertValueChangeContentOrder,
     }
   }
 })

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1934,8 +1934,9 @@ export default defineComponent({
     /**
      * @param {number} seconds The number of seconds to seek by, positive values seek forwards, negative ones seek backwards
      * @param {boolean} canSeekResult Allow functions that have already checked whether seeking is possible, to skip the extra check (e.g. frameByFrame)
+     * @param {boolean} showPopUp Whether to show a pop-up with the seconds seeked
      */
-    function seekBySeconds(seconds, canSeekResult = false) {
+    function seekBySeconds(seconds, canSeekResult = false, showPopUp = false) {
       if (!(canSeekResult || canSeek())) {
         return
       }
@@ -1958,11 +1959,13 @@ export default defineComponent({
       } else {
         video_.currentTime = newTime
       }
-      const popUpLayout = seconds > 0
-        ? { icon: 'arrow-right', invertContentOrder: true }
-        : { icon: 'arrow-left', invertContentOrder: false }
-      const formattedSeconds = Math.abs(seconds)
-      showValueChange(`${formattedSeconds}s`, popUpLayout.icon, popUpLayout.invertContentOrder)
+      if (showPopUp) {
+        const popUpLayout = seconds > 0
+          ? { icon: 'arrow-right', invertContentOrder: true }
+          : { icon: 'arrow-left', invertContentOrder: false }
+        const formattedSeconds = Math.abs(seconds)
+        showValueChange(`${formattedSeconds}s`, popUpLayout.icon, popUpLayout.invertContentOrder)
+      }
     }
 
     // #endregion mouse and keyboard helpers
@@ -2117,12 +2120,12 @@ export default defineComponent({
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_REWIND:
           // Rewind by 2x the time-skip interval (in seconds)
           event.preventDefault()
-          seekBySeconds(-defaultSkipInterval.value * player.getPlaybackRate() * 2)
+          seekBySeconds(-defaultSkipInterval.value * player.getPlaybackRate() * 2, false, true)
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_FAST_FORWARD:
           // Fast-Forward by 2x the time-skip interval (in seconds)
           event.preventDefault()
-          seekBySeconds(defaultSkipInterval.value * player.getPlaybackRate() * 2)
+          seekBySeconds(defaultSkipInterval.value * player.getPlaybackRate() * 2, false, true)
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.DECREASE_VIDEO_SPEED:
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.DECREASE_VIDEO_SPEED_ALT:
@@ -2179,7 +2182,7 @@ export default defineComponent({
             video_.currentTime = props.chapters[props.currentChapterIndex - 1].startSeconds
           } else {
             // Rewind by the time-skip interval (in seconds)
-            seekBySeconds(-defaultSkipInterval.value * player.getPlaybackRate())
+            seekBySeconds(-defaultSkipInterval.value * player.getPlaybackRate(), false, true)
           }
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_FAST_FORWARD:
@@ -2189,7 +2192,7 @@ export default defineComponent({
             video_.currentTime = (props.chapters[props.currentChapterIndex + 1].startSeconds)
           } else {
             // Fast-Forward by the time-skip interval (in seconds)
-            seekBySeconds(defaultSkipInterval.value * player.getPlaybackRate())
+            seekBySeconds(defaultSkipInterval.value * player.getPlaybackRate(), false, true)
           }
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.PICTURE_IN_PICTURE:

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1958,6 +1958,9 @@ export default defineComponent({
       } else {
         video_.currentTime = newTime
       }
+      const icon = seconds > 0 ? 'arrow-right' : 'arrow-left'
+      const formattedSeconds = Math.abs(seconds)
+      showValueChange(`${formattedSeconds}s`, icon)
     }
 
     // #endregion mouse and keyboard helpers

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -79,21 +79,13 @@
       <div
         v-if="showValueChangePopup"
         class="valueChangePopup"
+        :class="{ 'invert-icon-order': invertValueChangeIconOrder }"
       >
-        <template v-if="!invertValueChangeIconOrder">
-          <font-awesome-icon
-            v-if="valueChangeIcon"
-            :icon="['fas', valueChangeIcon]"
-          />
-          {{ valueChangeMessage }}
-        </template>
-        <template v-else>
-          {{ valueChangeMessage }}
-          <font-awesome-icon
-            v-if="valueChangeIcon"
-            :icon="['fas', valueChangeIcon]"
-          />
-        </template>
+        <font-awesome-icon
+          v-if="valueChangeIcon"
+          :icon="['fas', valueChangeIcon]"
+        />
+        <span>{{ valueChangeMessage }}</span>
       </div>
     </Transition>
     <div

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -80,11 +80,20 @@
         v-if="showValueChangePopup"
         class="valueChangePopup"
       >
-        <font-awesome-icon
-          v-if="valueChangeIcon"
-          :icon="['fas', valueChangeIcon]"
-        />
-        {{ valueChangeMessage }}
+        <template v-if="!invertValueChangeIconOrder">
+          <font-awesome-icon
+            v-if="valueChangeIcon"
+            :icon="['fas', valueChangeIcon]"
+          />
+          {{ valueChangeMessage }}
+        </template>
+        <template v-else>
+          {{ valueChangeMessage }}
+          <font-awesome-icon
+            v-if="valueChangeIcon"
+            :icon="['fas', valueChangeIcon]"
+          />
+        </template>
       </div>
     </Transition>
     <div

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -79,7 +79,7 @@
       <div
         v-if="showValueChangePopup"
         class="valueChangePopup"
-        :class="{ 'invert-icon-order': invertValueChangeIconOrder }"
+        :class="{ 'invert-content-order': invertValueChangeContentOrder }"
       >
         <font-awesome-icon
           v-if="valueChangeIcon"


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description

Adds a pop up when the user fast forwards or rewinds a video.

## Screenshots

<img width="1213" height="882" alt="a" src="https://github.com/user-attachments/assets/6469ab26-f371-47b4-a1f8-8e18360eac12" />

<img width="1217" height="900" alt="b" src="https://github.com/user-attachments/assets/2cbd0e13-d005-4b60-b875-8ff185725985" />

## Testing

1. Open a video
2. Use the keyboard to fast forward or rewind
3. See a popup with an arrow and the seconds.

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta