### PR TITLE
[Enhancement] Hide home channel tab when no content is available.

### DIFF
--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -486,7 +486,7 @@ const tabInfoValues = computed(() => {
   const values = [...channelTabs.value]
 
   // remove tabs from the array based on user settings
-  if (hideChannelHome.value) {
+  if (hideChannelHome.value || !homeData.value || homeData.value.length === 0) {
     removeFromArrayIfExists(values, 'home')
   }
 


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #7444 

## Description

Hides the channel Home tab if there is no content available.

## Screenshots 

### No content in the home tab.
<img width="1915" height="335" alt="0" src="https://github.com/user-attachments/assets/bf27c69f-bf89-4ba0-8a31-6b529e916f8d" />

### Content in the home tab.
<img width="1914" height="613" alt="1" src="https://github.com/user-attachments/assets/5847272e-ec6a-4d52-8628-b534d67c2e1f" />


## Testing

1. Example channels:
- https://www.youtube.com/channel/UCE-OgqkD1g1yLSDAz6_rJAw
- https://www.youtube.com/channel/UCnU7uoC6VtGE3D-Qhk3wqyw
- https://www.youtube.com/channel/UCMv9TWAlcnu4UlD9FdTIBxw
- https://www.youtube.com/channel/UC8zlKZbamfZcyIeqVLVVsvg

2. Open one of them and see that there is no home tab being shown.
3. Open an active channel.
4. See the home tab displayed.

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta
