### PR TITLE
Fix search suggestions cut off when selected with keyboard

### DIFF
--- a/src/renderer/components/ft-input/ft-input.js
+++ b/src/renderer/components/ft-input/ft-input.js
@@ -158,6 +158,9 @@ export default defineComponent({
   },
   methods: {
     handleClick: function (e) {
+      const selectedValue = this.searchStateKeyboardSelectedOptionValue
+      const query = (selectedValue != null && selectedValue !== '') ? selectedValue : this.inputData
+      this.inputData = query
       // No action if no input text
       if (!this.inputDataPresent) {
         return
@@ -167,8 +170,8 @@ export default defineComponent({
       this.searchState.selectedOption = -1
       this.searchState.keyboardSelectedOptionIndex = -1
       this.removeButtonSelectedIndex = -1
-      this.$emit('input', this.inputData)
-      this.$emit('click', this.inputData, { event: e })
+      this.$emit('input', query)
+      this.$emit('click', query, { event: e })
     },
 
     handleInput: function (val) {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

Closes #7183 

## Description

Fixes a bug that would cause the search query to not fully populate if the user selected a suggestion using the keyboard.

https://github.com/user-attachments/assets/2b52bc10-fff3-46da-b9a2-4c5b34441777

## Testing
Case A:

1. Type something that triggers search suggestions
2. Use arrow down to complete the search query
3. Click anywhere so the suggestions close
4. Attempt search
5. See that search query in search bar is what you selected and the search is correct

Case B:

1. Type something that triggers search suggestions e.g test
2. Use arrow down to complete the search query
3. Shift + click search icon to open the search query in a new window
4. See that query in new window is what you selected and the search is correct

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24.04.2 LTS
- **FreeTube version:** v0.23.5 Beta