### PR TITLE
Add missing FontAwesomeIcon imports to `<script setup>` components

### DIFF
--- a/src/renderer/components/ChannelHome/ChannelHome.vue
+++ b/src/renderer/components/ChannelHome/ChannelHome.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup>
-
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed } from 'vue'
 import FtElementList from '../FtElementList/FtElementList.vue'
 import store from '../../store/index'

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup>
-
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, onBeforeUnmount, onMounted, ref, shallowRef } from 'vue'
 
 import FtLoader from '../../components/FtLoader/FtLoader.vue'

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -81,6 +81,7 @@
 </template>
 
 <script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 import { useRoute, useRouter } from 'vue-router/composables'

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -130,6 +130,7 @@
 </template>
 
 <script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, ref, watch } from 'vue'
 
 import FtCard from '../../components/ft-card/ft-card.vue'


### PR DESCRIPTION
## Pull Request Type

- [x] Cleanup

## Description

Most of the components that have been migrated to the composition API import the FontAwesomeIcon component directly. This pull request adds the import to the four components that are missing it.

Background: Currently we globally register the FontAwesomeIcon component at the app level and I would eventually like to remove that global registration for a few reasons:
1. Vue's TypeScript support and IDE integrations automatically pick up locally imported components, whereas globally registered components also have to be globally registered with the types.
2. When you import the component in in a <script setup> composition API component (aka "local registration") Vue is able to do the component lookup at build time and generate code with direct references to the component but with globally registered components it has to output the component name as a string and look up that component in the global registrations at runtime.

## Desktop

- **OS:** Windows
- **OS Version:** 10