### PR TITLE
Change Close button color to white in the Search Filters modal

### DIFF
--- a/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
+++ b/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
@@ -58,8 +58,8 @@
       />
       <FtButton
         :label="$t('Close')"
-        background-color="var(--primary-color)"
-        text-color="var(--text-with-main-color)"
+        background-color="null"
+        text-color="null"
         @click="hideSearchFilters"
       />
     </div>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Chore

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/4374

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
PR listed above made all Close/Cancel buttons white but forgot this one

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="1920" height="935" alt="VirtualBoxVM_WlTaGXkkaj" src="https://github.com/user-attachments/assets/f1535962-6a51-4426-a18f-485208b9fdc4" />


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Click on Search Filters icon
2. See that Cancel button is white now with black text
