### PR TITLE
Fix video player screen-fitting for portrait mode

### DIFF
--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -199,6 +199,14 @@
 
   @media only screen and (width <= 1050px) {
     @include single-column-template;
+
+    .videoArea,
+    .infoArea,
+    .sidebarArea {
+      max-inline-size: 100%;
+      overflow-x: auto;
+      overflow-wrap: anywhere;
+    }
   }
 
   @media only screen and (width >= 1051px) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
#2230 (additionally [#402](https://github.com/MarmadileManteater/FreeTubeAndroid/issues/402))

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
In portrait mode (vertical resolutions), the UI sometimes does not fit the screen and appears zoomed in. This seems to happen primarily from video aspect ratios or long text (e.g. channel name or hyperlinks). This PR addresses the causes by restricting the size of relevant elements (videoArea, infoArea, sidebarArea) to the containing block, along with changing word-wrap to anywhere, in cases of excessively long words.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before             |  After
:-------------------------:|:-------------------------:
<img width="921" height="1236" alt="Screenshot 2025-07-29 142601" src="https://github.com/user-attachments/assets/ff074917-7b1d-4cbe-abbe-5a01b8912d5c" />  |  <img width="910" height="1226" alt="Screenshot 2025-07-29 142159" src="https://github.com/user-attachments/assets/0ea58bb2-f5c1-4fb8-9029-43a2f5e2d65c" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
* Toggle device toolbar (enable mobile mode)
* Adjust width to <= 1050px
* Find channel with long name (e.g. https://www.youtube.com/@new-account) and pla video and see that video player fits in screen and long text is wrapped as expected

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11, 24H2
- **FreeTube version:** 0.23.5 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
This is my first PR and the primary issue is older, so please let me know if I am missing context or if there are other fixes for this already. Currently, I am able to reproduce the issues with certain videos that have significantly larger aspect ratios than the device screen, but I do see that the text issue is more reproducible for long channel names and links in video descriptions.