### PR TITLE
Fix handleSyncSubscriptionCache using the SYNC_PLAYLISTS IPC channel

### DIFF
--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -295,7 +295,7 @@ export default {
    * @param {(event: number, data: any) => void} handler
    */
   handleSyncSubscriptionCache: (handler) => {
-    ipcRenderer.on(IpcChannels.SYNC_PLAYLISTS, (_, { event, data }) => {
+    ipcRenderer.on(IpcChannels.SYNC_SUBSCRIPTION_CACHE, (_, { event, data }) => {
       handler(event, data)
     })
   }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

Thankfully this hasn't landed in a release yet...

## Desktop

- **OS:** Windows
- **OS Version:** 10