### PR TITLE
Add shorts player parameters to help with 403s

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -59,7 +59,13 @@ async function createInnertube({ withPlayer = false, location = undefined, safet
     client_type: clientType,
 
     // use browser fetch
-    fetch: (input, init) => fetch(input, init),
+    fetch: (input, init) => {
+      if (input.url?.startsWith('https://www.youtube.com/youtubei/v1/player')) {
+        init.body = init.body.replace('"videoId":', '"params":"8AEB","videoId":')
+      }
+
+      return fetch(input, init)
+    },
     cache,
     generate_session_locally: !!generateSessionLocally
   })


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes: #7659


## Description

This pull request introduces a temporary workaround to help with the recent HTTP 403 errors. These are the same player parameters that yt-dlp uses.

## Testing

Try watching a few videos and check that the 403s are gone or at least occur less frequently.

## Desktop

- **OS:** Windows
- **OS Version:** 10