### PR TITLE
added video is private or unavailable error and solve undefine view count error

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1462,7 +1462,7 @@ export function parseLocalWatchNextVideo(video) {
       title: video.title.text,
       author: video.author.name,
       authorId: video.author.id,
-      viewCount: video.view_count == null ? null : extractNumberFromString(video.view_count.text),
+      viewCount: video.view_count == null ? null : extractNumberFromString(video.view_count?.text),
       published,
       lengthSeconds: isNaN(video.duration.seconds) ? '' : video.duration.seconds,
       liveNow: video.is_live,

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -851,7 +851,7 @@ async function getChannelAboutLocal() {
     if (about.is(YTNodes.ChannelAboutFullMetadata)) {
       description.value = about.description.isEmpty() ? '' : autolinker.link(about.description.text)
 
-      const viewCount_ = extractNumberFromString(about.view_count.text)
+      const viewCount_ = extractNumberFromString(about.view_count?.text || '0')
       viewCount.value = isNaN(viewCount_) ? null : viewCount_
 
       videoCount.value = null
@@ -862,7 +862,7 @@ async function getChannelAboutLocal() {
     } else {
       description.value = about.metadata.description ? autolinker.link(about.metadata.description) : ''
 
-      const viewCount_ = extractNumberFromString(about.metadata.view_count)
+      const viewCount_ = extractNumberFromString(about.metadata?.view_count || '0')
       viewCount.value = isNaN(viewCount_) ? null : viewCount_
 
       const videoCount_ = extractNumberFromString(about.metadata.video_count)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -427,13 +427,13 @@ export default defineComponent({
 
         // extract localised title first and fall back to the not localised one
         this.videoTitle = result.primary_info?.title.text ?? result.basic_info.title
-        this.videoViewCount = result.basic_info.view_count ?? (result.primary_info.view_count ? extractNumberFromString(result.primary_info.view_count.text) : null)
-        this.license = result.secondary_info.metadata.rows.find(element => element.title?.text === 'License')?.contents[0]?.text
+        this.videoViewCount = result.basic_info?.view_count ?? (result.primary_info?.view_count ? extractNumberFromString(result.primary_info.view_count.text) : null)
+        this.license = result.secondary_info?.metadata?.rows?.find(element => element.title?.text === 'License')?.contents?.[0]?.text
 
-        this.channelId = result.basic_info.channel_id ?? result.secondary_info.owner?.author.id
-        this.channelName = result.basic_info.author ?? result.secondary_info.owner?.author.name
+        this.channelId = result.basic_info?.channel_id ?? result.secondary_info?.owner?.author?.id
+        this.channelName = result.basic_info?.author ?? result.secondary_info?.owner?.author?.name
 
-        if (result.secondary_info.owner?.author) {
+        if (result.secondary_info?.owner?.author) {
           this.channelThumbnail = result.secondary_info.owner.author.best_thumbnail?.url ?? ''
         } else {
           this.channelThumbnail = ''


### PR DESCRIPTION
# Add video is private or unavailable error and solve undefine view count error

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #7690

## Description
Added video is private or undefined error by fetching api response correctly.
Eliminated "Cannot read properties of undefined (reading 'view_count')" and "Cannot read properties of undefined (reading 'owner')" errors.
Added the JavaScript optional chaining operator (?.) where undefined access was occurring

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Navigate to search and open any private video.
Check the error if they and see the correct errors.

## Desktop
<!-- Please complete the following information-->
- **OS: Windows**
- **OS Version: Windows 11 Home Single Language - 24H2**
- **FreeTube version: 0.23.5**
