### PR TITLE
Hide the Electron specific -electron-corner-smoothing CSS rule

### DIFF
--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -61,7 +61,8 @@ export async function generatePoToken(videoId, visitorData, context, proxyUrl) {
       v8CacheOptions: 'none',
       session: theSession,
       offscreen: true,
-      webSecurity: false
+      webSecurity: false,
+      disableBlinkFeatures: 'ElectronCSSCornerSmoothing'
     }
   })
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

I noticed that we weren't hiding the Electron specific `-electron-corner-smoothing` CSS rule in our Bot Guard webview, so this pull request hides it.

I want to be very clear that I have no idea if this is being detected or not and if this will help with playback issues, I just noticed that it existed in the Electron docs and decided that we should probably disable it.

https://www.electronjs.org/docs/latest/api/corner-smoothing-css#controlling-availibility

## Desktop

- **OS:** Windows
- **OS Version:** 10