### PR TITLE
Fix view count parity for shorts across pages

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -428,6 +428,10 @@ export default defineComponent({
         // extract localised title first and fall back to the not localised one
         this.videoTitle = result.primary_info?.title.text ?? result.basic_info.title
         this.videoViewCount = result.basic_info.view_count ?? (result.primary_info.view_count ? extractNumberFromString(result.primary_info.view_count.text) : null)
+        if (result.basic_info.duration <= 60 && result.primary_info?.view_count?.view_count?.text) {
+          // for shorts, use the same view count source as search results
+          this.videoViewCount = Math.max(extractNumberFromString(result.primary_info.view_count.view_count.text), this.videoViewCount)
+        }
         this.license = result.secondary_info.metadata.rows.find(element => element.title?.text === 'License')?.contents[0]?.text
 
         this.channelId = result.basic_info.channel_id ?? result.secondary_info.owner?.author.id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #7470 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Ensures parity in the view counts for shorts across the search page and watch/history pages. Currently the view count displayed when watching shorts is the engaged views (views meeting minimum time requirement and not replays); this instead uses the total views if available, matching the count shown when seeing the page on search.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
| Search Page |
| --- |
| <img width="1720" height="684" alt="Screenshot 2025-08-05 171245" src="https://github.com/user-attachments/assets/29750975-9283-4b0a-a506-e9b65be4f93d" /> |

| Before | After |
| --- | --- |
| <img width="1720" height="684" alt="Screenshot 2025-08-05 171326" src="https://github.com/user-attachments/assets/de8432ce-d375-487a-8702-0d844f9fbc05" /> | <img width="1720" height="684" alt="Screenshot 2025-08-05 171458" src="https://github.com/user-attachments/assets/483dff1e-89b7-4c77-a8e7-af260a93cdbd" /> |


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
* Search for any short
* Ensure view count when watching the short or seeing it in history feed matches the count shown when the short appears as a search result (larger number)

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 11, 24H2
- **FreeTube version:** 0.23.5 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
