### PR TITLE
Fix: Quick bookmark button not updating UI/persisting on Your Playlist page (#7793)

### DIFF
--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -114,7 +114,7 @@ const props = defineProps({
 
 const { t } = useI18n()
 
-let playlistId = ''
+const playlistId = computed(() => isUserPlaylist.value ? props.data._id : props.data.playlistId)
 let title = ''
 /** @type {string} */
 let thumbnail = thumbnailPlaceholder
@@ -152,7 +152,7 @@ const isUserPlaylist = computed(() => props.data._id != null)
 
 // For `router-link` attribute `to`
 const playlistPageLinkTo = computed(() => ({
-  path: `/playlist/${playlistId}`,
+  path: `/playlist/${playlistId.value}`,
   query: {
     playlistType: isUserPlaylist.value ? 'user' : '',
     searchQueryText: props.searchQueryText,
@@ -182,7 +182,7 @@ function parseInvidiousData() {
 
   channelName = props.data.author
   channelId = props.data.authorId
-  playlistId = props.data.playlistId
+  // playlistId is now computed, do not assign
   videoCount = props.data.videoCount
 
   if (props.data.proxyThumbnail === false) {
@@ -197,7 +197,7 @@ function parseLocalData() {
 
   channelName = props.data.channelName
   channelId = props.data.channelId
-  playlistId = props.data.playlistId
+  // playlistId is now computed, do not assign
   videoCount = props.data.videoCount
 }
 
@@ -214,7 +214,7 @@ function parseUserData() {
 
   channelName = ''
   channelId = ''
-  playlistId = props.data._id
+  // playlistId is now computed, do not assign
   videoCount = props.data.videos.length
 }
 
@@ -223,9 +223,9 @@ const quickBookmarkPlaylistId = computed(() => store.getters.getQuickBookmarkTar
 
 const markedAsQuickBookmarkTarget = computed(() => {
   // Only user playlists can be target
-  return playlistId != null &&
+  return playlistId.value != null &&
     quickBookmarkPlaylistId.value != null &&
-    quickBookmarkPlaylistId.value === playlistId
+    quickBookmarkPlaylistId.value === playlistId.value
 })
 
 function handleQuickBookmarkEnabledDisabledClick() {
@@ -235,7 +235,7 @@ function handleQuickBookmarkEnabledDisabledClick() {
 async function enableQuickBookmarkForThisPlaylist() {
   const currentQuickBookmarkTargetPlaylist = store.getters.getQuickBookmarkPlaylist
 
-  store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistId.value)
+  await store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistId.value)
 
   if (currentQuickBookmarkTargetPlaylist != null) {
     showToast(
@@ -243,8 +243,8 @@ async function enableQuickBookmarkForThisPlaylist() {
         oldPlaylistName: currentQuickBookmarkTargetPlaylist.playlistName,
       }),
       5000,
-      () => {
-        store.dispatch('updateQuickBookmarkTargetPlaylistId', currentQuickBookmarkTargetPlaylist._id)
+      async () => {
+        await store.dispatch('updateQuickBookmarkTargetPlaylistId', currentQuickBookmarkTargetPlaylist._id)
         showToast(
           t('User Playlists.SinglePlaylistView.Toast["Reverted to use {oldPlaylistName} for quick bookmark"]', {
             oldPlaylistName: currentQuickBookmarkTargetPlaylist.playlistName,


### PR DESCRIPTION
…t page (#7793)

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #7793

## Description
Fixes the bug where the quick bookmark button on the "Your Playlist" page did not update the UI or persist the change.

- Refactored `playlistId` in [FtListPlaylist.vue](cci:7://file:///f:/Open%20source/New%20folder/FreeTube/src/renderer/components/FtListPlaylist/FtListPlaylist.vue:0:0-0:0) to be a computed property for correct Vue reactivity.
- Removed all assignments to `playlistId` in parsing functions.
- Updated all usages to reference `playlistId.value`.
- Ensured the quick bookmark button now updates state, UI, and persists as expected.
- Undo toast works and restores previous bookmark.
- No impact to other components or global state.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Before:

<img width="1366" height="732" alt="Screenshot (1571)" src="https://github.com/user-attachments/assets/d158be2b-7e14-4677-8883-66b7b181509f" />
<img width="1366" height="725" alt="Screenshot (1572)" src="https://github.com/user-attachments/assets/70194ff1-b8c4-4a12-ae31-8ddd8e516926" />


After:


<img width="1366" height="725" alt="Screenshot (1566)" src="https://github.com/user-attachments/assets/0e87f0e1-e6a1-4e5e-ad5f-24aa93c4daaa" />
<img width="1366" height="722" alt="Screenshot (1567)" src="https://github.com/user-attachments/assets/95c267a8-f7e6-4111-b578-a9bfec0bd4fa" />
<img width="1366" height="723" alt="Screenshot (1568)" src="https://github.com/user-attachments/assets/cc7ebf2c-7050-4ce9-a927-62d44c8eca28" />
<img width="1366" height="724" alt="Screenshot (1569)" src="https://github.com/user-attachments/assets/bcd77651-b3c3-4483-bf8b-97049ea5c337" />
<img width="1366" height="723" alt="Screenshot (1570)" src="https://github.com/user-attachments/assets/ae61e8ed-0863-4e60-997e-b5a77ccbb7e7" />


## Testing
- Marked different playlists as quick bookmark; UI updated instantly.
- Verified that the indicator and button behave correctly for all playlists.
- Reloaded the page to confirm persistence.
- Used the undo toast to revert the bookmark and confirmed correct behavior.
- No runtime errors or UI glitches observed.

## Desktop
OS: Windows
OS Version: 10
FreeTube version: 0.23.5

## Additional context

