### PR TITLE
Fix selecting a new quick bookmark playlist

### DIFF
--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -235,7 +235,7 @@ function handleQuickBookmarkEnabledDisabledClick() {
 async function enableQuickBookmarkForThisPlaylist() {
   const currentQuickBookmarkTargetPlaylist = store.getters.getQuickBookmarkPlaylist
 
-  store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistId.value)
+  store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistId)
 
   if (currentQuickBookmarkTargetPlaylist != null) {
     showToast(


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

closes #7793
Introduced in #7667 (FtListPlaylist composition API migration)

## Description

This pull request fixes a bug where the quick bookmark playlist would be set to `undefined` when trying to select a new one, that was introduced in the FtListPlaylist composition API migration.

## Testing

Ensure you have multiple playlists and select different ones as the quick bookmark playlist on the User Playlists page.

## Desktop

- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:** b533536d58f6f62ed8b9b08932376dcf349ac409