### PR TITLE
Show more information on long playlists.

### DIFF
--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -382,7 +382,11 @@ const durationFormatted = computed(() => {
     seconds: total % 60,
   }
 
-  return new Intl.DurationFormat([locale.value, 'en'], { style: 'short' }).format(duration)
+  let formatted = new Intl.DurationFormat([locale.value, 'en'], { style: 'short' }).format(duration)
+  if (props.moreVideoDataAvailable) {
+    formatted += '+'
+  }
+  return formatted
 })
 
 /** @type {import('vue').ComputedRef<boolean>} */


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

Closes #7473 

## Description

When a playlist still does not have all videos loaded, a "+" is added to the end of the displayed duration.

## Screenshots

<img width="589" height="199" alt="b" src="https://github.com/user-attachments/assets/d57c1e80-819e-4045-aab5-ea0a785f6cce" />

## Testing

1. Open a long playlist. (https://youtube.com/playlist?list=PL8mG-RkN2uTw7PhlnAr4pZZz2QubIbujH)
2. See that there is a + at the end of its duration.
3. Scroll down and load all videos.
4. Duration is updated. No "+" is shown.

## "What about the ~ for playlists with shorts?"

The original issue also suggested showing an approximate duration for playlists with YouTube Shorts and adding a ~ to it. However, I wasn't able to replicate the bug where Shorts caused the duration to disappear.

I tested a few playlists, including the one from issue #7007 and the duration was displayed correctly, so this may have been fixed (?).

Example of playlist with shorts and a duration: 

<img width="747" height="693" alt="a" src="https://github.com/user-attachments/assets/69ba9e6c-8cc6-45c5-aa66-dc2912275733" />

## Desktop

- **OS:** Linux
- **OS Version:** Ubuntu 24
- **FreeTube version:** 0.23.6 Beta
