### PR TITLE
Use Array#find directly when parsing the chapters

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -507,7 +507,9 @@ export default defineComponent({
 
         let chapters = []
         if (!this.hideChapters) {
-          const rawChapters = result.player_overlays?.decorated_player_bar?.player_bar?.markers_map?.get({ marker_key: 'DESCRIPTION_CHAPTERS' })?.value.chapters
+          const rawChapters = result.player_overlays?.decorated_player_bar?.player_bar?.markers_map
+            ?.find(marker => marker.marker_key === 'DESCRIPTION_CHAPTERS')?.value.chapters
+
           if (rawChapters) {
             for (const chapter of rawChapters) {
               const start = chapter.time_range_start_millis / 1000


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

YouTube.js' ObservableArray#get is a wrapper around Array#find but with object comparisions, so using Array#find directly is faster.

## Testing

Check that chapters still appear in the chapters box on a video with chapters such as https://youtu.be/jNQXAC9IVRw.

## Desktop

- **OS:** Windows
- **OS Version:** 10