### PR TITLE
Fix subtitles being in the top right corner

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -323,6 +323,10 @@ export async function getLocalVideoInfo(id) {
       url.searchParams.set('pot', contentPoToken)
       url.searchParams.set('c', clientName)
 
+      // Remove &xosf=1 as it adds `position:63% line:0%` to the subtitle lines
+      // placing them in the top right corner
+      url.searchParams.delete('xosf')
+
       captionTrack.base_url = url.toString()
     }
   }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- https://github.com/FreeTubeApp/FreeTube/discussions/7800#discussioncomment-14059495

## Description

This pull request fixes the recent issue with uploader provided subtitles being positioned in the top right corner of the video player.

## Screenshots

Before: _see screenshots in the linked thread_
After: the way it used to be, so I hopefully don't need to take a screenshot of it for you.

## Testing

Test that uploader provided subtitles are in their correct position in the bottom middle of the video player.
E.g. "English" on this video https://youtu.be/nMfYXqXt8mE

## Desktop

- **OS:** Windows
- **OS Version:** 10