### PR TITLE
Update playlist lastUpdatedAt in same step as adding/removing videos

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -182,18 +182,24 @@ class Playlists {
     return db.playlists.updateAsync({ _id: playlist._id }, { $set: playlist }, { upsert: true })
   }
 
-  static upsertVideoByPlaylistId(_id, videoData) {
+  static upsertVideoByPlaylistId(_id, lastUpdatedAt, videoData) {
     return db.playlists.updateAsync(
       { _id },
-      { $push: { videos: videoData } },
+      {
+        $push: { videos: videoData },
+        $set: { lastUpdatedAt }
+      },
       { upsert: true }
     )
   }
 
-  static upsertVideosByPlaylistId(_id, videos) {
+  static upsertVideosByPlaylistId(_id, lastUpdatedAt, videos) {
     return db.playlists.updateAsync(
       { _id },
-      { $push: { videos: { $each: videos } } },
+      {
+        $push: { videos: { $each: videos } },
+        $set: { lastUpdatedAt }
+      },
       { upsert: true }
     )
   }
@@ -202,17 +208,23 @@ class Playlists {
     return db.playlists.removeAsync({ _id, protected: { $ne: true } })
   }
 
-  static deleteVideoIdByPlaylistId(_id, videoId, playlistItemId) {
+  static deleteVideoIdByPlaylistId(_id, lastUpdatedAt, videoId, playlistItemId) {
     if (playlistItemId != null) {
       return db.playlists.updateAsync(
         { _id },
-        { $pull: { videos: { playlistItemId } } },
+        {
+          $pull: { videos: { playlistItemId } },
+          $set: { lastUpdatedAt }
+        },
         { upsert: true }
       )
     } else if (videoId != null) {
       return db.playlists.updateAsync(
         { _id },
-        { $pull: { videos: { videoId } } },
+        {
+          $pull: { videos: { videoId } },
+          $set: { lastUpdatedAt }
+        },
         { upsert: true }
       )
     } else {
@@ -220,10 +232,13 @@ class Playlists {
     }
   }
 
-  static deleteVideoIdsByPlaylistId(_id, playlistItemIds) {
+  static deleteVideoIdsByPlaylistId(_id, lastUpdatedAt, playlistItemIds) {
     return db.playlists.updateAsync(
       { _id },
-      { $pull: { videos: { playlistItemId: { $in: playlistItemIds } } } },
+      {
+        $pull: { videos: { playlistItemId: { $in: playlistItemIds } } },
+        $set: { lastUpdatedAt }
+      },
       { upsert: true }
     )
   }

--- a/src/datastores/handlers/electron.js
+++ b/src/datastores/handlers/electron.js
@@ -85,29 +85,35 @@ class Playlists {
     return window.ftElectron.dbPlaylists(DBActions.GENERAL.UPSERT, playlist)
   }
 
-  static upsertVideoByPlaylistId(_id, videoData) {
-    return window.ftElectron.dbPlaylists(DBActions.PLAYLISTS.UPSERT_VIDEO, { _id, videoData })
+  static upsertVideoByPlaylistId(_id, lastUpdatedAt, videoData) {
+    return window.ftElectron.dbPlaylists(
+      DBActions.PLAYLISTS.UPSERT_VIDEO,
+      { _id, lastUpdatedAt, videoData }
+    )
   }
 
-  static upsertVideosByPlaylistId(_id, videos) {
-    return window.ftElectron.dbPlaylists(DBActions.PLAYLISTS.UPSERT_VIDEOS, { _id, videos })
+  static upsertVideosByPlaylistId(_id, lastUpdatedAt, videos) {
+    return window.ftElectron.dbPlaylists(
+      DBActions.PLAYLISTS.UPSERT_VIDEOS,
+      { _id, lastUpdatedAt, videos }
+    )
   }
 
   static delete(_id) {
     return window.ftElectron.dbPlaylists(DBActions.GENERAL.DELETE, _id)
   }
 
-  static deleteVideoIdByPlaylistId(_id, videoId, playlistItemId) {
+  static deleteVideoIdByPlaylistId(_id, lastUpdatedAt, videoId, playlistItemId) {
     return window.ftElectron.dbPlaylists(
       DBActions.PLAYLISTS.DELETE_VIDEO_ID,
-      { _id, videoId, playlistItemId }
+      { _id, lastUpdatedAt, videoId, playlistItemId }
     )
   }
 
-  static deleteVideoIdsByPlaylistId(_id, playlistItemIds) {
+  static deleteVideoIdsByPlaylistId(_id, lastUpdatedAt, playlistItemIds) {
     return window.ftElectron.dbPlaylists(
       DBActions.PLAYLISTS.DELETE_VIDEO_IDS,
-      { _id, playlistItemIds }
+      { _id, lastUpdatedAt, playlistItemIds }
     )
   }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1522,7 +1522,7 @@ function runApp() {
           return null
 
         case DBActions.PLAYLISTS.UPSERT_VIDEO:
-          await baseHandlers.playlists.upsertVideoByPlaylistId(data._id, data.videoData)
+          await baseHandlers.playlists.upsertVideoByPlaylistId(data._id, data.lastUpdatedAt, data.videoData)
           syncOtherWindows(
             IpcChannels.SYNC_PLAYLISTS,
             event,
@@ -1531,7 +1531,7 @@ function runApp() {
           return null
 
         case DBActions.PLAYLISTS.UPSERT_VIDEOS:
-          await baseHandlers.playlists.upsertVideosByPlaylistId(data._id, data.videos)
+          await baseHandlers.playlists.upsertVideosByPlaylistId(data._id, data.lastUpdatedAt, data.videos)
           syncOtherWindows(
             IpcChannels.SYNC_PLAYLISTS,
             event,
@@ -1549,7 +1549,7 @@ function runApp() {
           return null
 
         case DBActions.PLAYLISTS.DELETE_VIDEO_ID:
-          await baseHandlers.playlists.deleteVideoIdByPlaylistId(data._id, data.videoId, data.playlistItemId)
+          await baseHandlers.playlists.deleteVideoIdByPlaylistId(data._id, data.lastUpdatedAt, data.videoId, data.playlistItemId)
           syncOtherWindows(
             IpcChannels.SYNC_PLAYLISTS,
             event,
@@ -1558,7 +1558,7 @@ function runApp() {
           return null
 
         case DBActions.PLAYLISTS.DELETE_VIDEO_IDS:
-          await baseHandlers.playlists.deleteVideoIdsByPlaylistId(data._id, data.playlistItemIds)
+          await baseHandlers.playlists.deleteVideoIdsByPlaylistId(data._id, data.lastUpdatedAt, data.playlistItemIds)
           syncOtherWindows(
             IpcChannels.SYNC_PLAYLISTS,
             event,

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -393,9 +393,6 @@ function addSelectedToPlaylists() {
     })
 
     addedPlaylistIds.add(playlist._id)
-
-    // Update playlist's `lastUpdatedAt`
-    store.dispatch('updatePlaylist', { _id: playlist._id })
   })
 
   let message

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -850,8 +850,6 @@ export default defineComponent({
         _id: this.quickBookmarkPlaylist._id,
         videoData,
       })
-      // Update playlist's `lastUpdatedAt`
-      this.updatePlaylist({ _id: this.quickBookmarkPlaylist._id })
 
       // TODO: Maybe show playlist name
       showToast(this.$t('Video.Video has been saved'))
@@ -862,8 +860,6 @@ export default defineComponent({
         // Remove all playlist items with same videoId
         videoId: this.id,
       })
-      // Update playlist's `lastUpdatedAt`
-      this.updatePlaylist({ _id: this.quickBookmarkPlaylist._id })
 
       // TODO: Maybe show playlist name
       showToast(this.$t('Video.Video has been removed from your saved list'))
@@ -887,7 +883,6 @@ export default defineComponent({
       'updateChannelsHidden',
       'showAddToPlaylistPromptForManyVideos',
       'addVideo',
-      'updatePlaylist',
       'removeVideo',
     ])
   }

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -424,8 +424,6 @@ export default defineComponent({
         _id: this.quickBookmarkPlaylist._id,
         videoData,
       })
-      // Update playlist's `lastUpdatedAt`
-      this.updatePlaylist({ _id: this.quickBookmarkPlaylist._id })
 
       // TODO: Maybe show playlist name
       showToast(this.$t('Video.Video has been saved'))
@@ -436,8 +434,6 @@ export default defineComponent({
         // Remove all playlist items with same videoId
         videoId: this.id,
       })
-      // Update playlist's `lastUpdatedAt`
-      this.updatePlaylist({ _id: this.quickBookmarkPlaylist._id })
 
       // TODO: Maybe show playlist name
       showToast(this.$t('Video.Video has been removed from your saved list'))
@@ -456,7 +452,6 @@ export default defineComponent({
       'downloadMedia',
       'showAddToPlaylistPromptForManyVideos',
       'addVideo',
-      'updatePlaylist',
       'updateHistory',
       'removeVideo',
     ])


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

Currently adding or removing videos and updating the `lastUpdatedAt` field are done in two separate steps, this means we are doing two of everything, including disk writes (if you watch the `playlists.db` file while adding a video to a playlist, you'll notice that nedb appends two lines). As nedb lets us perform multiple operations in a single `updateAsync()` call, this pull request merges the two steps together, which also means it only has to do one disk write.

## Testing

Check that adding and removing videos to a playlist still works correctly and that it still updates the last updated at timestamp on the playlist (sorting by last updated on the user playlists page is one way to see that).

## Desktop

- **OS:** Windows
- **OS Version:** 10