### PR TITLE
Make MWEB return the original audio track

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -230,7 +230,18 @@ export async function getLocalVideoInfo(id) {
 
   const info = await webInnertube.getInfo(id, { po_token: contentPoToken })
 
-  // temporary workaround for SABR-only responses
+  // #region temporary workaround for SABR-only responses
+
+  // MWEB doesn't have an audio track selector so it picks the audio track on the server based on the request language.
+
+  const originalAudioTrackFormat = info.streaming_data?.adaptive_formats.find(format => {
+    return format.has_audio && format.is_original && format.language
+  })
+
+  if (originalAudioTrackFormat) {
+    webInnertube.session.context.client.hl = originalAudioTrackFormat.language
+  }
+
   const mwebInfo = await webInnertube.getBasicInfo(id, { client: 'MWEB', po_token: contentPoToken })
 
   if (mwebInfo.playability_status.status === 'OK' && mwebInfo.streaming_data) {
@@ -239,6 +250,8 @@ export async function getLocalVideoInfo(id) {
 
     clientName = 'MWEB'
   }
+
+  // #endregion temporary workaround for SABR-only responses
 
   let hasTrailer = info.has_trailer
   let trailerIsAgeRestricted = info.getTrailerInfo() === null


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

too many to link...

## Description

YouTube's mobile website doesn't have an audio track selector so they try to be helpful and pick an audio track based on your display language. Which is a nice idea although in practice that means it frequently picks an AI-generated dubbing. As FreeTube has to parse many language specific strings to extract information such as published dates and view counts, it requests everything in American English (en-US), however as we only need the streaming data from the MWEB request we are not limited to just English.

This pull request finds the original audio track in the WEB response (we can't currently use it for playback because of SABR) and uses its language as the request language for the MWEB /player request, which makes it a lot more likely that YouTube will pick the original audio track as the audio track to include in the response.

## Testing

Example taken from the FreeTube General Matrix chat: https://youtu.be/j8aDCBODy3A

## Desktop

- **OS:** Windows
- **OS Version:** 10