### PR TITLE
Add support for parsing premiere video LockupViews

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1278,6 +1278,8 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       let publishedText
       let lengthSeconds = ''
       let liveNow = false
+      let isUpcoming = false
+      let premiereDate
 
       /** @type {YTNodes.ThumbnailOverlayBadgeView | undefined} */
       const thumbnailOverlayBadgeView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailOverlayBadgeView)
@@ -1285,6 +1287,12 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       if (thumbnailOverlayBadgeView) {
         if (thumbnailOverlayBadgeView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
           liveNow = true
+        } else if (thumbnailOverlayBadgeView.badges.some(badge => badge.text.toLowerCase() === 'upcoming')) {
+          isUpcoming = true
+
+          if (lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.[1].text?.text) {
+            premiereDate = new Date(lockupView.metadata.metadata.metadata_rows[1].metadata_parts[1].text.text)
+          }
         } else {
           const durationBadge = thumbnailOverlayBadgeView.badges.find(badge => /^[\d:]+$/.test(badge.text))
 
@@ -1315,9 +1323,11 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         author: lockupView.metadata.metadata?.metadata_rows[0].metadata_parts?.[0].text?.text,
         authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId,
         viewCount,
-        published: calculatePublishedDate(publishedText, liveNow),
+        published: calculatePublishedDate(publishedText, liveNow, isUpcoming, premiereDate),
         lengthSeconds,
-        liveNow
+        liveNow,
+        isUpcoming,
+        premiereDate
       }
     }
     default:


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

This pull request adds support for parsing premiere video lockup views in the up next feed. As they rarely appear there, I wasn't able to find one until now, thanks to https://github.com/TeamNewPipe/NewPipeExtractor/pull/1361.

## Screenshots

<img width="326" height="328" alt="Recommended videos with an upcoming video" src="https://github.com/user-attachments/assets/ace77fac-99a4-49f9-aec9-a85f30466b55" />

## Testing

At the time of writing a premiere shows up in the up next feed on this video: https://youtu.be/bEn2C36vjkw

## Desktop

- **OS:** Windows
- **OS Version:** 10