### PR TITLE
Respect watch history setting when opening in an external player

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -391,8 +391,8 @@ export default defineComponent({
     watchedProgressSavingEnabled: function () {
       return ['auto', 'semi-auto'].includes(this.$store.getters.getWatchedProgressSavingMode)
     },
-    autosaveWatchedProgress: function () {
-      return this.$store.getters.getWatchedProgressSavingMode === 'auto'
+    rememberHistory: function () {
+      return this.$store.getters.getRememberHistory
     },
 
     saveVideoHistoryWithLastViewedPlaylist: function () {
@@ -642,7 +642,9 @@ export default defineComponent({
       }
       this.openInExternalPlayer(payload)
 
-      this.markAsWatched()
+      if (this.rememberHistory) {
+        this.markAsWatched()
+      }
     },
 
     handleOptionsClick: function (option) {

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -160,6 +160,10 @@ export default defineComponent({
       return this.$store.getters.getWatchedProgressSavingMode === 'semi-auto'
     },
 
+    rememberHistory() {
+      return this.$store.getters.getRememberHistory
+    },
+
     downloadBehavior: function () {
       return this.$store.getters.getDownloadBehavior
     },
@@ -334,26 +338,28 @@ export default defineComponent({
 
       this.openInExternalPlayer(payload)
 
-      // Marking as watched
-      const videoData = {
-        videoId: this.id,
-        title: this.title,
-        author: this.channelName,
-        authorId: this.channelId,
-        published: this.published,
-        description: this.description,
-        viewCount: this.viewCount,
-        lengthSeconds: this.lengthSeconds,
-        watchProgress: 0,
-        timeWatched: Date.now(),
-        isLive: false,
-        type: 'video'
-      }
+      if (this.rememberHistory) {
+        // Marking as watched
+        const videoData = {
+          videoId: this.id,
+          title: this.title,
+          author: this.channelName,
+          authorId: this.channelId,
+          published: this.published,
+          description: this.description,
+          viewCount: this.viewCount,
+          lengthSeconds: this.lengthSeconds,
+          watchProgress: 0,
+          timeWatched: Date.now(),
+          isLive: false,
+          type: 'video'
+        }
 
-      this.updateHistory(videoData)
+        this.updateHistory(videoData)
 
-      if (!this.historyEntryExists) {
-        showToast(this.$t('Video.Video has been marked as watched'))
+        if (!this.historyEntryExists) {
+          showToast(this.$t('Video.Video has been marked as watched'))
+        }
       }
     },
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

Introduced by: #7707

## Description

When the feature to mark the videos as watched when they are opened in an external player was introduced, we forgot to check whether saving the watch history is actually enabled, this pull request rectifies that.

## Testing

Please test opening a video in an external player in the following situations:

1. From a video list e.g. subscriptions while remember watch history is turned OFF -> watch history should NOT be updated
2. From a video list e.g. subscriptions while remember watch history is turned ON -> watch history should be updated
3. From the watch page while remember watch history is turned OFF -> watch history should NOT be updated
4. From the watch page while remember watch history is turned ON -> watch history should be updated

## Desktop

- **OS:** Windows
- **OS Version:** 10