### PR TITLE
Fix show added items not working for hide videos from channels

### DIFF
--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -621,7 +621,7 @@ function updateShowDistractionFreeTitles(value) {
 const showAddedChannelsHidden = computed(() => store.getters.getShowAddedChannelsHidden)
 
 function handleAddedChannelsHidden() {
-  store.dispatch('updateShowAddedChannelsHidden', showAddedChannelsHidden.value)
+  store.dispatch('updateShowAddedChannelsHidden', !showAddedChannelsHidden.value)
 }
 
 /** @type {import('vue').ComputedRef<any[]>} */


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

Introduced by #7807

## Description

Typo during the migration :/

## Testing

Toggle the show added items check box on the Hide Videos From Channels setting.

## Desktop

- **OS:** Windows
- **OS Version:** 10