### PR TITLE
Refactor/cleanup tray related code after PR merged

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -274,7 +274,7 @@ function runApp() {
   let mainWindow
   let startupUrl
   let tray = null
-  let trayOnMinimize
+  let trayOnMinimize = false
   let trayWindows = []
   const trayMaximizedWindows = {}
 
@@ -333,7 +333,7 @@ function runApp() {
         if (!openDeepLinksInNewWindow) {
           // Just focus the main window (instead of starting a new instance)
           if (mainWindow.isMinimized()) {
-            if (trayOnMinimize) {
+            if (process.platform !== 'darwin' && trayOnMinimize) {
               trayClick(mainWindow)
             } else {
               mainWindow.restore()
@@ -475,7 +475,9 @@ function runApp() {
             proxyPort = doc.value
             break
           case 'hideToTrayOnMinimize':
-            trayOnMinimize = (process.platform !== 'darwin') ? doc.value : false
+            if (process.platform !== 'darwin') {
+              trayOnMinimize = doc.value
+            }
             break
         }
       })
@@ -691,35 +693,6 @@ function runApp() {
       mainWindow.webContents.openDevTools()
     }
   })
-
-  function manageTray(window, removeWindow = false) {
-    if (tray) {
-      if (!removeWindow) {
-        trayWindows.push(window)
-        createTrayContextMenu()
-      } else if (trayWindows.some(item => item.id === window.id)) {
-        trayClick(window)
-      }
-    } else {
-      const icon = process.env.NODE_ENV === 'development'
-        ? path.join(__dirname, '..', '..', '_icons', 'iconColor.png')
-        : path.join(__dirname, '..', '_icons', 'iconColor.png')
-
-      tray = new Tray(icon)
-
-      tray.setIgnoreDoubleClickEvents(true)
-      tray.setToolTip('FreeTube')
-
-      trayWindows = [window]
-      createTrayContextMenu()
-
-      if (process.platform !== 'linux') {
-        tray.on('click', (event) => {
-          if (trayWindows.length === 1) { trayClick(trayWindows[0]) }
-        })
-      }
-    }
-  }
 
   function trayClick(window, close = false) {
     if (!close) {
@@ -983,20 +956,51 @@ function runApp() {
 
     // endregion Ensure child windows use same options since electron 14
 
-    newWindow.on('minimize', () => {
-      if (trayOnMinimize) {
-        newWindow.hide()
-        manageTray(newWindow)
+    if (process.platform !== 'darwin') {
+      function manageTray(window, removeWindow = false) {
+        if (tray) {
+          if (!removeWindow) {
+            trayWindows.push(window)
+            createTrayContextMenu()
+          } else if (trayWindows.some(item => item.id === window.id)) {
+            trayClick(window)
+          }
+        } else {
+          const icon = process.env.NODE_ENV === 'development'
+            ? path.join(__dirname, '..', '..', '_icons', 'iconColor.png')
+            : path.join(__dirname, '..', '_icons', 'iconColor.png')
+
+          tray = new Tray(icon)
+
+          tray.setIgnoreDoubleClickEvents(true)
+          tray.setToolTip('FreeTube')
+
+          trayWindows = [window]
+          createTrayContextMenu()
+
+          if (process.platform !== 'linux') {
+            tray.on('click', (event) => {
+              if (trayWindows.length === 1) { trayClick(trayWindows[0]) }
+            })
+          }
+        }
       }
-    })
 
-    newWindow.on('maximize', () => {
-      if (trayOnMinimize) { trayMaximizedWindows[newWindow.id] = true }
-    })
+      newWindow.on('minimize', () => {
+        if (trayOnMinimize) {
+          newWindow.hide()
+          manageTray(newWindow)
+        }
+      })
 
-    newWindow.on('unmaximize', () => {
-      if (trayOnMinimize) { delete trayMaximizedWindows[newWindow.id] }
-    })
+      newWindow.on('maximize', () => {
+        if (trayOnMinimize) { trayMaximizedWindows[newWindow.id] = true }
+      })
+
+      newWindow.on('unmaximize', () => {
+        if (trayOnMinimize) { delete trayMaximizedWindows[newWindow.id] }
+      })
+    }
 
     if (replaceMainWindow) {
       mainWindow = newWindow
@@ -1062,7 +1066,7 @@ function runApp() {
         return
       }
 
-      if (trayOnMinimize && trayWindows.length > 0) {
+      if (process.platform !== 'darwin' && trayOnMinimize && trayWindows.length > 0) {
         trayClick(newWindow)
       } else {
         newWindow.show()
@@ -1486,8 +1490,10 @@ function runApp() {
               await setMenu()
               break
             case 'hideToTrayOnMinimize':
-              trayOnMinimize = data.value
-              if (!trayOnMinimize) { showHiddenWindows() }
+              if (process.platform !== 'darwin') {
+                trayOnMinimize = data.value
+                if (!trayOnMinimize) { showHiddenWindows() }
+              }
               break
 
             default:
@@ -1913,9 +1919,11 @@ function runApp() {
     })
   }
 
-  app.on('before-quit', () => {
-    if (tray) { tray.destroy() }
-  })
+  if (process.platform !== 'darwin') {
+    app.on('before-quit', () => {
+      if (tray) { tray.destroy() }
+    })
+  }
 
   function handleQuit() {
     cleanUpResources().finally(() => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/6915

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Cleanup per https://github.com/FreeTubeApp/FreeTube/pull/6915#pullrequestreview-3125848598
Addressed stuff:
- Commented code
- Using `.length` as boolean -> `.length === 0 / > 0`
- If (!something) else -> if (something) else
- Move tray related code in main process to be behind `process.platform !== 'darwin'` so they should be removed on build time

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Nope

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Same as https://github.com/FreeTubeApp/FreeTube/pull/6915

- Update `_scripts/webpack.main.config.js` from `'process.platform': `'${process.platform}'`,` to `'process.platform': '\'darwin\'',` (replace `darwin with other values later
- `yarn run pack && npx prettier@2.8.8 --write --no-config dist/main.js`
- open `dist/main.js`
- Check `setIgnoreDoubleClickEvents` absent with `darwin`, present with other values

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
