### PR TITLE
Make appimage updateable if project sets up `latest` tag [UNTESTED]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,7 @@ jobs:
         chmod +x ./"$appimage" ./appimagetool.AppImage
         ./"$appimage" --appimage-extract && rm -f ./"$appimage"
         ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+          -u "gh-releases-zsync|FreeTubeApp|FreeTube|latest|*.AppImage.zsync" \
           -n ./squashfs-root ./"$appimage"
         rm -rf ./squashfs-root ./appimagetool.AppImage
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
         chmod +x ./"$appimage" ./appimagetool.AppImage
         ./"$appimage" --appimage-extract && rm -f ./"$appimage"
         ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+          -u "gh-releases-zsync|FreeTubeApp|FreeTube|latest|*.AppImage.zsync" \
           -n ./squashfs-root ./"$appimage"
         rm -rf ./squashfs-root ./appimagetool.AppImage
 


### PR DESCRIPTION
Seems this is all it needs, according to some quick research..
https://github.com/search?q=appimage+updateable&type=pullrequests

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
This adds a line to the build and release gh workflows for supporting appimage updates.

## Testing
It is referring to a `latest` tag that doesn't exist yet, so that would have to be created.
