### PR TITLE
Fix FtSelect validation warning in the player settings

### DIFF
--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -103,7 +103,7 @@
       />
       <FtSelect
         :placeholder="t('Settings.Player Settings.Video Playback Rate Interval')"
-        :value="videoPlaybackRateInterval"
+        :value="videoPlaybackRateIntervalString"
         :select-names="PLAYBACK_RATE_INTERVAL_VALUES"
         :select-values="PLAYBACK_RATE_INTERVAL_VALUES"
         :icon="['fas', 'gauge']"
@@ -492,6 +492,9 @@ const PLAYBACK_RATE_INTERVAL_VALUES = ['0.1', '0.25', '0.5', '1']
 
 /** @type {import('vue').ComputedRef<number>} */
 const videoPlaybackRateInterval = computed(() => store.getters.getVideoPlaybackRateInterval)
+
+/** @type {import('vue').ComputedRef<string>} */
+const videoPlaybackRateIntervalString = computed(() => store.getters.getVideoPlaybackRateInterval.toString())
 
 /**
  * @param {string} value


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

In the FtSelect composition API migration pull request I corrected the type of the `value` property in the `FtSelect` component from `String` and `Number` to just `String`, as the native `<select>` element coerces the value to a string and allowing numbers gives the false impression that you will also get one back in the change event.
That resulted in a warning being issues by Vue in this case. As we still need the original number (used by the default playback rate slider) I introduced a second computed ref.

## Testing

Open the player settings and you shouldn't see any property validation warnings from the player settings anymore.

## Desktop

- **OS:** Windows
- **OS Version:** 10