### PR TITLE
Hide more Invidious specific functionality when backend fallback is disabled

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -59,14 +59,18 @@ class Settings {
   // Unique Electron main process handlers
   static _findAppReadyRelatedSettings() {
     return db.settings.findAsync({
-      $or: [
-        { _id: 'disableSmoothScrolling' },
-        { _id: 'useProxy' },
-        { _id: 'proxyProtocol' },
-        { _id: 'proxyHostname' },
-        { _id: 'proxyPort' },
-        { _id: 'hideToTrayOnMinimize' }
-      ]
+      _id: {
+        $in: [
+          'disableSmoothScrolling',
+          'useProxy',
+          'proxyProtocol',
+          'proxyHostname',
+          'proxyPort',
+          'backendFallback',
+          'backendPreference',
+          'hideToTrayOnMinimize'
+        ]
+      }
     })
   }
 
@@ -78,8 +82,6 @@ class Settings {
     return {
       hideTrendingVideos: db.settings.findOneAsync({ _id: 'hideTrendingVideos' }),
       hidePopularVideos: db.settings.findOneAsync({ _id: 'hidePopularVideos' }),
-      backendFallback: db.settings.findOneAsync({ _id: 'backendFallback' }),
-      backendPreference: db.settings.findOneAsync({ _id: 'backendPreference' }),
       hidePlaylists: db.settings.findOneAsync({ _id: 'hidePlaylists' }),
     }
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -77,6 +77,9 @@ function runApp() {
 
   const ROOT_APP_URL = process.env.NODE_ENV === 'development' ? 'http://localhost:9080' : 'app://bundle/index.html'
 
+  let backendPreference = 'local'
+  let backendFallback = true
+
   contextMenu({
     showSearchWithGoogle: false,
     showSaveImageAs: true,
@@ -221,7 +224,7 @@ function runApp() {
         },
         {
           label: 'Copy Invidious Link',
-          visible: visible && isInAppUrl,
+          visible: visible && isInAppUrl && (backendPreference === 'invidious' || backendFallback),
           click: () => {
             copy(transformURL(false))
           }
@@ -473,6 +476,12 @@ function runApp() {
             break
           case 'proxyPort':
             proxyPort = doc.value
+            break
+          case 'backendFallback':
+            backendFallback = doc.value
+            break
+          case 'backendPreference':
+            backendPreference = doc.value
             break
           case 'hideToTrayOnMinimize':
             if (process.platform !== 'darwin') {
@@ -1482,10 +1491,16 @@ function runApp() {
           )
           switch (data._id) {
             // Update app menu on related setting update
+            case 'backendFallback':
+              backendFallback = data.value
+              await setMenu()
+              break
+            case 'backendPreference':
+              backendPreference = data.value
+              await setMenu()
+              break
             case 'hideTrendingVideos':
             case 'hidePopularVideos':
-            case 'backendFallback':
-            case 'backendPreference':
             case 'hidePlaylists':
               await setMenu()
               break
@@ -2064,8 +2079,6 @@ function runApp() {
     const sidenavSettings = baseHandlers.settings._findSidenavSettings()
     const hideTrendingVideos = (await sidenavSettings.hideTrendingVideos)?.value
     const hidePopularVideos = (await sidenavSettings.hidePopularVideos)?.value
-    const backendFallback = (await sidenavSettings.backendFallback)?.value
-    const backendPreference = (await sidenavSettings.backendPreference)?.value
     const hidePlaylists = (await sidenavSettings.hidePlaylists)?.value
 
     const template = [

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -104,7 +104,8 @@
         <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide Popular Videos')"
           :compact="true"
-          :default-value="hidePopularVideos"
+          :disabled="disableHidePopularVideos"
+          :default-value="disableHidePopularVideos || hidePopularVideos"
           @change="updateHidePopularVideos"
         />
       </div>
@@ -299,10 +300,15 @@ const { t } = useI18n()
 
 const channelHiderDisabled = ref(false)
 
-/** @type {import('vue').ComputedRef<{ preference: 'local' | 'invidious', fallback: boolean }>} */
+/** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
+const backendPreference = computed(() => store.getters.getBackendPreference)
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const backendFallback = computed(() => store.getters.getBackendFallback)
+
 const backendOptions = computed(() => ({
-  preference: store.getters.getBackendPreference,
-  fallback: store.getters.getBackendFallback
+  preference: backendPreference.value,
+  fallback: backendFallback.value
 }))
 
 /** @type {import('vue').ComputedRef<boolean>} */
@@ -371,6 +377,8 @@ function updateHideTrendingVideos(value) {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hidePopularVideos = computed(() => store.getters.getHidePopularVideos)
+
+const disableHidePopularVideos = computed(() => backendPreference.value !== 'invidious' && !backendFallback.value)
 
 /**
  * @param {boolean} value

--- a/src/renderer/components/FtShareButton/FtShareButton.vue
+++ b/src/renderer/components/FtShareButton/FtShareButton.vue
@@ -69,53 +69,55 @@
         </FtButton>
       </div>
 
-      <div class="divider" />
+      <template v-if="showInvidiousOptions">
+        <div class="divider" />
 
-      <div
-        id="invidiousShare"
-        class="header invidious"
-      >
-        <span class="invidiousLogo" /> Invidious
-      </div>
+        <div
+          id="invidiousShare"
+          class="header invidious"
+        >
+          <span class="invidiousLogo" /> Invidious
+        </div>
 
-      <div class="buttons">
-        <FtButton
-          aria-describedby="invidiousShare"
-          class="action"
-          @click="copyInvidious"
-        >
-          <FontAwesomeIcon :icon="['fas', 'copy']" />
-          {{ $t("Share.Copy Link") }}
-        </FtButton>
-        <FtButton
-          aria-describedby="invidiousShare"
-          class="action"
-          @click="openInvidious"
-        >
-          <FontAwesomeIcon :icon="['fas', 'globe']" />
-          {{ $t("Share.Open Link") }}
-        </FtButton>
-        <FtButton
-          v-if="isVideo || isPlaylist"
-          aria-describedby="invidiousShare"
-          class="action"
-          background-color="var(--accent-color-active)"
-          @click="copyInvidiousEmbed"
-        >
-          <FontAwesomeIcon :icon="['fas', 'copy']" />
-          {{ $t("Share.Copy Embed") }}
-        </FtButton>
-        <FtButton
-          v-if="isVideo || isPlaylist"
-          aria-describedby="invidiousShare"
-          class="action"
-          background-color="var(--accent-color-active)"
-          @click="openInvidiousEmbed"
-        >
-          <FontAwesomeIcon :icon="['fas', 'globe']" />
-          {{ $t("Share.Open Embed") }}
-        </FtButton>
-      </div>
+        <div class="buttons">
+          <FtButton
+            aria-describedby="invidiousShare"
+            class="action"
+            @click="copyInvidious"
+          >
+            <FontAwesomeIcon :icon="['fas', 'copy']" />
+            {{ $t("Share.Copy Link") }}
+          </FtButton>
+          <FtButton
+            aria-describedby="invidiousShare"
+            class="action"
+            @click="openInvidious"
+          >
+            <FontAwesomeIcon :icon="['fas', 'globe']" />
+            {{ $t("Share.Open Link") }}
+          </FtButton>
+          <FtButton
+            v-if="isVideo || isPlaylist"
+            aria-describedby="invidiousShare"
+            class="action"
+            background-color="var(--accent-color-active)"
+            @click="copyInvidiousEmbed"
+          >
+            <FontAwesomeIcon :icon="['fas', 'copy']" />
+            {{ $t("Share.Copy Embed") }}
+          </FtButton>
+          <FtButton
+            v-if="isVideo || isPlaylist"
+            aria-describedby="invidiousShare"
+            class="action"
+            background-color="var(--accent-color-active)"
+            @click="openInvidiousEmbed"
+          >
+            <FontAwesomeIcon :icon="['fas', 'globe']" />
+            {{ $t("Share.Open Embed") }}
+          </FtButton>
+        </div>
+      </template>
     </div>
   </FtIconButton>
 </template>
@@ -189,6 +191,10 @@ const shareTitle = computed(() => {
 
 const currentInvidiousInstanceUrl = computed(() => {
   return store.getters.getCurrentInvidiousInstanceUrl
+})
+
+const showInvidiousOptions = computed(() => {
+  return store.getters.getBackendPreference === 'invidious' || store.getters.getBackendFallback
 })
 
 const selectedUserPlaylist = computed(() => {

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -242,6 +242,10 @@ export default defineComponent({
       return this.$store.getters.getHideSharingActions
     },
 
+    showInvidiousShareOptions: function () {
+      return this.backendPreference === 'invidious' || this.$store.getters.getBackendFallback
+    },
+
     dropdownOptions: function () {
       const options = [
         {
@@ -264,10 +268,12 @@ export default defineComponent({
             label: this.$t('Video.Copy YouTube Embedded Player Link'),
             value: 'copyYoutubeEmbed'
           },
-          {
-            label: this.$t('Video.Copy Invidious Link'),
-            value: 'copyInvidious'
-          },
+          ...this.showInvidiousShareOptions
+            ? [{
+                label: this.$t('Video.Copy Invidious Link'),
+                value: 'copyInvidious'
+              }]
+            : [],
           {
             type: 'divider'
           },
@@ -279,10 +285,12 @@ export default defineComponent({
             label: this.$t('Video.Open YouTube Embedded Player'),
             value: 'openYoutubeEmbed'
           },
-          {
-            label: this.$t('Video.Open in Invidious'),
-            value: 'openInvidious'
-          }
+          ...this.showInvidiousShareOptions
+            ? [{
+                label: this.$t('Video.Open in Invidious'),
+                value: 'openInvidious'
+              }]
+            : [],
         )
         if (this.channelId !== null) {
           options.push(
@@ -293,10 +301,12 @@ export default defineComponent({
               label: this.$t('Video.Copy YouTube Channel Link'),
               value: 'copyYoutubeChannel'
             },
-            {
-              label: this.$t('Video.Copy Invidious Channel Link'),
-              value: 'copyInvidiousChannel'
-            },
+            ...this.showInvidiousShareOptions
+              ? [{
+                  label: this.$t('Video.Copy Invidious Channel Link'),
+                  value: 'copyInvidiousChannel'
+                }]
+              : [],
             {
               type: 'divider'
             },
@@ -304,10 +314,12 @@ export default defineComponent({
               label: this.$t('Video.Open Channel in YouTube'),
               value: 'openYoutubeChannel'
             },
-            {
-              label: this.$t('Video.Open Channel in Invidious'),
-              value: 'openInvidiousChannel'
-            }
+            ...this.showInvidiousShareOptions
+              ? [{
+                  label: this.$t('Video.Open Channel in Invidious'),
+                  value: 'openInvidiousChannel'
+                }]
+              : [],
           )
         }
       }


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

- closes #7476
- related to #7954

## Description

This pull request hides the Invidious options in the video list kebab menu, the share menu and the context menu, as well as disabling the Hide Popular Videos setting when the local API is selected and backend fallback is disabled.

The YouTube options are still shown when the backend is set to Invidious as people may want to share normal YouTube links to other people e.g. if you are using a private Invidious instance that you haven't shared with the person that you want to send the link too.

I recommend enabling the Hide Whitespace changes option on GitHub while doing the code review.

## Screenshots

<img width="221" height="261" alt="Invidious options hidden in the video list kebab menu" src="https://github.com/user-attachments/assets/5b141caf-2594-4681-9383-2c7968895a5e" />

<img width="168" height="146" alt="Copy as Invidious Link hidden in the context menu" src="https://github.com/user-attachments/assets/d14501b1-8b23-4fcf-a8ba-77f2784a630a" />

<img width="185" height="278" alt="Invidious share options hidden in the share menu" src="https://github.com/user-attachments/assets/6ff89a11-c249-453b-ac12-92dd442aa566" />

<img width="544" height="125" alt="Hide Popular Videos settings force enabled in the distraction free settings" src="https://github.com/user-attachments/assets/02d5de6b-dd91-40bd-8a16-34ad9a865140" />

## Testing

Set the backend to the local API and disable backend fallback and check that the Invidious options are correctly hidden in the specified locations but that they are still visible if backend fallback is enabled.

## Desktop

- **OS:** Windows
- **OS Version:** 10