### PR TITLE
Remove n argument in sed

### DIFF
--- a/.github/workflows/updateSite.yml
+++ b/.github/workflows/updateSite.yml
@@ -52,7 +52,7 @@ jobs:
         git checkout master
     - name: Update index.php
       run: |
-        sed -in 's/${{ steps.previous.outputs.result  }}/${{ steps.current.outputs.result }}/' src/index.php
+        sed -i 's/${{ steps.previous.outputs.result  }}/${{ steps.current.outputs.result }}/' src/index.php
     - name: Commit Files
       uses: stefanzweifel/git-auto-commit-action@v6
       with:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTubeApp.io/commit/fc8429129da74069e8132b0641679270bd049440#diff-51d6bfb8792aec023c93824fd8db464a816a4971f89acc4360e5d5cdbe33d95f

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The `-in` part of the sed command is likely incorrect but i couldn't test this to verify it. The `-i` option is used for in-place editing, and it should be followed by the file extension you want to create (e.g., -i.bak to create a .bak file as a backup).
`-in` could be interpreted as trying to create a backup with the .n extension, which might be why we're seeing a file like index.phpn.