### PR TITLE
Move Loop to Overflow menu

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -829,7 +829,6 @@ export default defineComponent({
       } else {
         uiConfig.controlPanelElements.push(
           'ft_screenshot',
-          'loop',
           'ft_autoplay_toggle',
           'overflow_menu',
           'picture_in_picture',
@@ -843,6 +842,7 @@ export default defineComponent({
           'captions',
           'playback_rate',
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
+          'loop',
           'recenter_vr',
           'toggle_stereoscopic',
         )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Move?

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
#7919 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The recent shaka player update moved controls into the Overflow menu. After using FT for a while im confident that Loop also belongs in that menu as its something that the users sets once