### PR TITLE
Support exporting single playlists as a list of video URLs

### DIFF
--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -32,6 +32,7 @@
         :description="playlistDescription"
         :video-count="shownVideoCount"
         :videos="shownPlaylistItems"
+        :sorted-videos="sortedPlaylistItems"
         :view-count="viewCount"
         :total-playlist-duration="totalPlaylistDuration"
         :is-duration-approximate="isDurationApproximate"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -186,6 +186,7 @@ User Playlists:
   Enable Quick Bookmark With This Playlist: Enable Quick Bookmark With This Playlist
   Quick Bookmark Enabled: Quick Bookmark Enabled
   Export Playlist: Export This Playlist
+  Export list of URLs: Export list of URLs
   The playlist has been successfully exported: The playlist has been successfully exported
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Are you sure you want to remove 1 duplicate video from this playlist? This cannot be undone. | Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone.
   Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: Are you sure you want to remove 1 watched video from this playlist? This cannot be undone. | Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone.


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

A user in the FreeTube Matrix chat was asking about passing a FreeTube playlist to yt-dlp and I had to give a rather unsatisfactory answer that they would need to transform the FreeTube playlist database format into something that yt-dlp could understand. To address that this pull request expands the single playlist export options to include an option to export the playlist as a list of YouTube URLs in a text file, the list is sorted in the same order as shown on screen. That list can be passed to yt-dlp with the `--batch-file` flag or be used for interfacing with other programs that don't support the FreeTube specific playlist database format.

## Testing

1. Create a user playlist and add some videos to it if you don't already have one.
2. Click the export playlist button.
3. Export as a list of URLs (check the file in a text editor to check it is correct).
4. Export as a FreeTube database (regression test).

## Desktop

- **OS:** Windows
- **OS Version:** 11