### PR TITLE
Improve playlist import performance

### DIFF
--- a/src/renderer/helpers/playlists.js
+++ b/src/renderer/helpers/playlists.js
@@ -84,3 +84,25 @@ function compareTwoPlaylistItems(a, b, sortOrder, collator) {
       return 0
   }
 }
+
+export const generateRandomUniqueId = crypto.randomUUID
+  ? crypto.randomUUID
+  : () => `id-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+
+/**
+ * @param {any} videoData
+ */
+export function processToBeAddedPlaylistVideo(videoData) {
+  if (videoData.timeAdded == null) {
+    videoData.timeAdded = Date.now()
+  }
+
+  if (videoData.playlistItemId == null) {
+    videoData.playlistItemId = generateRandomUniqueId()
+  }
+
+  // For backward compatibility
+  if (videoData.type == null) {
+    videoData.type = 'video'
+  }
+}


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Related issue

[FreeTubeAndroid#505](https://github.com/MarmadileManteater/FreeTubeAndroid/issues/505)

## Description

This pull request improves the performance of playlist imports by reducing the number of store and database updates, along with a few other minor performance improvements. Previously we would add each new playlist to the store and database individually, now they are added in one go. If a playlist already exists we used to add each new video to the playlist individually and then an extra update at the end to update the playlist metadata, now we do one single store and database update for the entire playlist.
That means if the import contains more than one new playlist or one of the existing playlists receives at least one new video, there will be less store and database updates, which should be the case for most imports (I suspect that importing a completely identical playlist database is a very rare occurence).

## Testing

Test that importing playlist databases still works correctly. If you want to verify that it does less updates to the database you can add some logging to the `Playlists` class in `src/datastores/handlers/base.js`.

## Desktop

- **OS:** Windows
- **OS Version:** 11