### PR TITLE
Skip Electron binary download in CI as we do not run it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
     - run: yarn run ci
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     - run: yarn run lint
     - name: Get Version Number
       id: getPackageInfo

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,6 +24,8 @@ jobs:
         node-version: 22.x
         cache: "yarn"
     - run: yarn run ci
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     - run: yarn run lint
     # let's verify that webpack is able to package the project
     - run: yarn run pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
     - run: yarn run ci
+      env:
+        ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     - run: yarn run lint
 
     - name: Get Version Number


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

The electron npm package downloads the Electron binary in a post-install script, but as we don't run Electron in our linter, build or release workflows and electron-builder downloads its own copy for packaging, we can tell that postinstall script to skip downloading the binary.

https://github.com/electron/electron/blob/f62d7254c4c4c865e40da8056aee73644aa37bd7/npm/install.js#L14-L16