### PR TITLE
Handle lockup view videos without a view count

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1284,6 +1284,8 @@ export function parseLocalListVideo(item, channelId, channelName) {
   }
 }
 
+const VIEWS_OR_WATCHING_REGEX = /views?|watching/i
+
 /**
  * @param {import('youtubei.js').YTNodes.LockupView} lockupView
  * @param {string | undefined} channelId
@@ -1349,13 +1351,15 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
             lengthSeconds = Utils.timeToSeconds(durationBadge.text)
           }
 
-          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.[1].text?.text
+          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts.find(part => part.text?.text?.endsWith('ago'))?.text?.text
         }
       }
 
       let viewCount = null
 
-      const viewsText = lockupView.metadata.metadata?.metadata_rows[1]?.metadata_parts?.[0].text?.text
+      const viewsText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts.find(part => {
+        return part.text?.text && VIEWS_OR_WATCHING_REGEX.test(part.text.text)
+      })?.text?.text
 
       if (viewsText) {
         const views = parseLocalSubscriberCount(viewsText)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

closes #8055

## Description

YouTube doesn't provide the view count for age-restricted videos that appear in the recommended videos section, this pull request fixes the error caused by that. 

## Testing

Check that the video provided in the bug report https://youtu.be/-IF61N6AegU opens without throwing any errors and that the video `Sideswiped - Ep 2 "Baby Steps"` is shown correctly in the recommended videos section apart from not having a view count.

## Desktop

- **OS:** Windows
- **OS Version:** 11