### PR TITLE
Fix weblate parsing error

### DIFF
--- a/static/locales/mr.yaml
+++ b/static/locales/mr.yaml
@@ -123,8 +123,7 @@ Subscriptions:
   Subscriptions: ''
   # channels that were likely deleted
   Error Channels: ''
-  This profile has a large number of subscriptions. Forcing RSS to avoid rate 
-    limiting: ''
+  This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting: ''
   'Your Subscription list is currently empty. Start adding subscriptions to see them here.': ''
   Disabled Automatic Fetching: ''
   Empty Channels: ''
@@ -155,8 +154,7 @@ Feed:
 Playlists: ''
 User Playlists:
   Your Playlists: ''
-  You have no playlists. Click on the create new playlist button to create a new 
-    one.: ''
+  You have no playlists. Click on the create new playlist button to create a new one.: ''
   Empty Search Message: ''
   Search bar placeholder: ''
   Playlists with Matching Videos: ''
@@ -187,10 +185,8 @@ User Playlists:
   Export Playlist: ''
   Export list of URLs: ''
   The playlist has been successfully exported: ''
-  Are you sure you want to remove {playlistItemCount} duplicate videos from this 
-    playlist? This cannot be undone: ''
-  Are you sure you want to remove {playlistItemCount} watched videos from this 
-    playlist? This cannot be undone: ''
+  Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: ''
+  Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: ''
   Delete Playlist: ''
   Cannot delete the quick bookmark target playlist.: ''
   Are you sure you want to delete this playlist? This cannot be undone: ''
@@ -221,8 +217,7 @@ User Playlists:
 
       This playlist is already being used for quick bookmark.: ''
       This playlist is now used for quick bookmark: ''
-      This playlist is now used for quick bookmark instead of {oldPlaylistName}. 
-        Click here to undo: ''
+      This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo: ''
       Reverted to use {oldPlaylistName} for quick bookmark: ''
 
       Some videos in the playlist are not loaded yet. Click here to copy anyway.: ''
@@ -520,8 +515,7 @@ Settings:
     Are you sure you want to remove your entire watch history?: ''
     Watch history has been cleared: ''
     Remove All Subscriptions / Profiles: ''
-    Are you sure you want to remove all subscriptions and profiles?  This cannot 
-      be undone.: ''
+    Are you sure you want to remove all subscriptions and profiles?  This cannot be undone.: ''
     Remove All Playlists: ''
     All playlists have been removed: ''
     Are you sure you want to remove all your playlists?: ''
@@ -738,8 +732,7 @@ Profile:
     channels?  The same channels will be deleted in any profile they are found 
     in.
   : ''
-  Are you sure you want to delete the selected channels?  This will not delete 
-    the channel from any other profile.: ''
+  Are you sure you want to delete the selected channels?  This will not delete the channel from any other profile.: ''
   Close Profile Dropdown: ''
   Open Profile Dropdown: ''
 #On Channel Page
@@ -1042,8 +1035,7 @@ Local API Error (Click to copy): ''
 Invidious API Error (Click to copy): ''
 Falling back to Invidious API: ''
 Falling back to Local API: ''
-This video is unavailable because of missing formats. This can happen due to 
-  country unavailability.: ''
+This video is unavailable because of missing formats. This can happen due to country unavailability.: ''
 Unknown YouTube url type, cannot be opened in app: ''
 Loop is now disabled: ''
 Loop is now enabled: ''


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

Weblate submitted a commit with broken YAML syntax and started showing an error message that it can't parse the file.

> Could not parse translation files.
> Weblate could not parse the translation files while updating the translations.
> 
> The following occurrences were found:
> 
> Filename: static/locales/mr.yaml
> Error: 'could not find expected \':\' in "<unicode string>", line 127, column 13:\n limiting: \'\'\n ^ (line: 127)'

## Testing

We won't fully know that it works until the error goes away on weblate.