### PR TITLE
Hide webpack-dev-server error overlay for application errors

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -174,6 +174,11 @@ function startRenderer(callback) {
   })
 
   const server = new WebpackDevServer({
+    client: {
+      overlay: {
+        runtimeErrors: false
+      }
+    },
     static: [
       {
         directory: path.resolve(__dirname, '..', 'static'),


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue

https://github.com/FreeTubeApp/FreeTube/pull/7919#pullrequestreview-3173856975

## Description

This pull request disables webpack-dev-servers's error overlay for application level errors, anything important already gets logged to the devtools console tab, which we open automatically in dev mode. It still keeps the overlay for build errors.

## Desktop

- **OS:** Windows
- **OS Version:** 11