### PR TITLE
Serialize search and playlist continuations in the store

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -5,6 +5,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtListVideoNumbered from '../FtListVideoNumbered/FtListVideoNumbered.vue'
 import { copyToClipboard, showToast } from '../../helpers/utils'
 import {
+  getLocalCachedFeedContinuation,
   getLocalPlaylist,
   parseLocalPlaylistVideo,
   untilEndOfLocalPlayList,
@@ -398,7 +399,11 @@ export default defineComponent({
         this.playlistItems = cachedPlaylist.items
       } else {
         const videos = cachedPlaylist.items
-        await untilEndOfLocalPlayList(cachedPlaylist.continuationData, (p) => {
+
+        const continuationData = await getLocalCachedFeedContinuation('playlist', cachedPlaylist.continuationData)
+        videos.push(...continuationData.items.map(parseLocalPlaylistVideo))
+
+        await untilEndOfLocalPlayList(continuationData, (p) => {
           videos.push(...p.items.map(parseLocalPlaylistVideo))
         }, { runCallbackOnceFirst: false })
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -175,6 +175,7 @@ import FtAutoLoadNextPageWrapper from '../../components/FtAutoLoadNextPageWrappe
 import store from '../../store/index'
 
 import {
+  extractLocalCacheablePlaylistContinuation,
   getLocalPlaylist,
   getLocalPlaylistContinuation,
   parseLocalPlaylistVideo,
@@ -887,7 +888,9 @@ onBeforeRouteLeave((to, from, next) => {
       channelName: channelName.value,
       channelId: channelId.value,
       items: sortedPlaylistItems.value,
-      continuationData: continuationData.value,
+      continuationData: continuationData.value
+        ? extractLocalCacheablePlaylistContinuation(continuationData.value)
+        : null,
     })
   }
 

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -56,7 +56,11 @@ import {
   searchFiltersMatch,
   showToast,
 } from '../../helpers/utils'
-import { getLocalSearchContinuation, getLocalSearchResults } from '../../helpers/api/local'
+import {
+  extractLocalCacheableSearchContinuation,
+  getLocalSearchContinuation,
+  getLocalSearchResults
+} from '../../helpers/api/local'
 import { getInvidiousSearchResults } from '../../helpers/api/invidious'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
@@ -67,7 +71,7 @@ const isLoading = ref(false)
 const apiUsed = ref('local')
 const searchSettings = ref({})
 const searchPage = ref(1)
-/** @type {import('vue').ShallowRef<import('youtubei.js').YT.Search | null>} */
+/** @type {import('vue').ShallowRef<import('youtubei.js').YT.Search | string | null>} */
 const nextPageRef = shallowRef(null)
 const shownResults = shallowRef([])
 
@@ -207,7 +211,7 @@ async function performSearchLocal(payload) {
       query: payload.query,
       data: shownResults.value,
       searchSettings: searchSettings.value,
-      nextPageRef: nextPageRef.value,
+      nextPageRef: nextPageRef.value ? extractLocalCacheableSearchContinuation(nextPageRef.value) : null,
       apiUsed: apiUsed.value
     }
 
@@ -248,7 +252,7 @@ async function getNextpageLocal(payload) {
       query: payload.query,
       data: shownResults.value,
       searchSettings: searchSettings.value,
-      nextPageRef: nextPageRef.value,
+      nextPageRef: nextPageRef.value ? extractLocalCacheableSearchContinuation(nextPageRef.value) : null,
       apiUsed: apiUsed.value
     }
 
@@ -356,7 +360,7 @@ function replaceShownResults(history) {
   searchSettings.value = history.searchSettings
   apiUsed.value = history.apiUsed
 
-  if (typeof (history.nextPageRef) !== 'undefined') {
+  if (history.nextPageRef != null) {
     nextPageRef.value = history.nextPageRef
   }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Vue 3 migration

## Description

One of the issues with upgrading to Vue 3 is that the reactivity system switched from using getters and setters to using [proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) and proxies break private properties, which means they break YouTube.js' classes that use private properties. In most cases we've been able to workaround this by using [shallow reactivity](https://vuejs.org/api/reactivity-advanced.html#shallowref) which allows the reading and setting of the variables to be reactive but the classes themselves are not touched, but for the search cache and for passing the playlist continuation from the Playlist page to the Watch page, where we use the store, we cannot avoid the reactivity without migrating to Pinia and we should probably finish migrating to Vue 3 first before we start another big migration. To avoid storing YouTube.js objects in the store this pull request extracts the session data and continuation data from the YouTube.js objects, serialising them to a string and stores the string in the store, then when it gets read from the store we create a new Innertube object, overwrite the stored session data and make a request with the stored continuation.

It isn't pretty and duplicates code from YouTube.js but this is only intended to be a temporary solution until we migrate to Pinia.

## Testing

### Playlists
1. Open a YouTube playlist that has more than 100 videos with the local API
2. Click on the first video
3. On the watch page you should see the full playlist without any playlist related errors appearing in the console (playback issues are unrelated).

### Search
1. Search for anything in the same window
2. Press the back arrow
3. Press the forward arrow
4. Scroll down and load the next page of data.
5. More data should load without triggering any errors.

## Desktop

- **OS:** Windows
- **OS Version:** 11