### PR TITLE
Fix importing and exporting data after the Electron 38.2.0 update

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -425,23 +425,43 @@ function runApp() {
     // FreeTube needs the following permissions:
     // - "fullscreen": So that the video player can enter full screen
     // - "clipboard-sanitized-write": To allow the user to copy video URLs and error messages
+    // - "fileSystem" Needed for the Web File System API (e.g. importing and exporting data)
 
-    session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
+    session.defaultSession.setPermissionCheckHandler((webContents, permission, requestingOrigin, details) => {
       if (!isFreeTubeUrl(requestingOrigin)) {
         return false
       }
 
-      return permission === 'fullscreen' || permission === 'clipboard-sanitized-write'
+      return (
+        permission === 'fullscreen' ||
+        permission === 'clipboard-sanitized-write' ||
+        (permission === 'fileSystem' && !details.isDirectory)
+      )
     })
 
-    session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
+    session.defaultSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
       if (!isFreeTubeUrl(webContents.getURL())) {
         // eslint-disable-next-line n/no-callback-literal
         callback(false)
         return
       }
 
-      callback(permission === 'fullscreen' || permission === 'clipboard-sanitized-write')
+      callback(
+        permission === 'fullscreen' ||
+        permission === 'clipboard-sanitized-write' ||
+        (permission === 'fileSystem' && !details.isDirectory)
+      )
+    })
+
+    session.defaultSession.on('file-system-access-restricted', (event, details, callback) => {
+      if (!isFreeTubeUrl(details.origin)) {
+        // eslint-disable-next-line n/no-callback-literal
+        callback('deny')
+        return
+      }
+
+      // eslint-disable-next-line n/no-callback-literal
+      callback(details.isDirectory ? 'deny' : 'allow')
     })
 
     let docArray
@@ -839,7 +859,7 @@ function runApp() {
     if (process.env.NODE_ENV === 'development') {
       return url_ !== null && url_.protocol === 'http:' && url_.host === 'localhost:9080' && (url_.pathname === '/' || url_.pathname === '/index.html')
     } else {
-      return url_ !== null && url_.protocol === 'app:' && url_.host === 'bundle' && url_.pathname === '/index.html'
+      return url_ !== null && url_.protocol === 'app:' && url_.host === 'bundle' && (url_.pathname === '/' || url_.pathname === '/index.html')
     }
   }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8101

## Description

Electron 38.2 started checking permissions for the Web File System API, so we need to explicitly allow it now and Electron also started passing `app://bundle/` as the requesting origin instead of `app://bundle/index.html` so it was failing the URL checks too.

## Testing

1. Open the data settings
2. Click on export for one of the data types
3. Select a save location
4. The save should complete without permission errors.

## Desktop

- **OS:** Windows
- **OS Version:** 11