### PR TITLE
Fix the icon colors for SponsorBlock categories

### DIFF
--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
@@ -14,7 +14,7 @@
       :select-values="COLOR_VALUES"
       :icon="['fas', 'palette']"
       :class="'sec' + sponsorBlockValues.color"
-      icon-color="var(--accent-color)"
+      icon-color="rgb(var(--accent-color-rgb))"
       @change="updateColor"
     />
     <FtSelect

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -1486,21 +1486,8 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --text-with-accent-color: #f8f8f2;
 }
 
-.secDraculaCyan,
-.secDraculaGreen,
-.secDraculaOrange,
-.secDraculaPink,
-.secDraculaPurple,
-.secDraculaRed,
-.secDraculaYellow {
-  --accent-color-opacity1: rgb(98 114 164 / 4%);
-  --accent-color-opacity2: rgb(98 114 164 / 12%);
-  --accent-color-opacity3: rgb(98 114 164 / 16%);
-  --accent-color-opacity4: rgb(98 114 164 / 24%);
-}
-
 .secDraculaCyan {
-  --accent-color: #8be9fd;
+  --accent-color-rgb: 139 233 253;
   --accent-color-hover: #97ebfd;
   --accent-color-active: #7dd2e4;
   --accent-color-light: #a2edfd;
@@ -1509,7 +1496,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .secDraculaGreen {
-  --accent-color: #50fa7b;
+  --accent-color-rgb: 80 250 123;
   --accent-color-hover: #62fb88;
   --accent-color-active: #48e16f;
   --accent-color-light: #73fb95;
@@ -1517,7 +1504,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .secDraculaOrange {
-  --accent-color: #ffb86c;
+  --accent-color-rgb: 255 184 108;
   --accent-color-hover: #ffbf7b;
   --accent-color-active: #e6a661;
   --accent-color-light: #ffc689;
@@ -1525,7 +1512,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .secDraculaPink {
-  --accent-color: #ff79c6;
+  --accent-color-rgb: 255 121 198;
   --accent-color-hover: #ff86cc;
   --accent-color-active: #e66db2;
   --accent-color-light: #ff94d1;
@@ -1533,7 +1520,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .secDraculaPurple {
-  --accent-color: #bd93f9;
+  --accent-color-rgb: 189 147 249;
   --accent-color-hover: #c49efa;
   --accent-color-active: #aa84e0;
   --accent-color-light: #caa9fa;
@@ -1541,7 +1528,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .secDraculaRed {
-  --accent-color: #f55;
+  --accent-color-rgb: 255 85 85;
   --accent-color-hover: #f66;
   --accent-color-active: #e64d4d;
   --accent-color-light: #f77;
@@ -1549,7 +1536,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 }
 
 .secDraculaYellow {
-  --accent-color: #f1fa8c;
+  --accent-color-rgb: 241 250 140;
   --accent-color-hover: #f2fb98;
   --accent-color-active: #d9e17e;
   --accent-color-light: #f4fba3;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/6505

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The icon colors for SponsorBlock categories weren’t updating correctly, except for the Dracula colors, which were overlooked in the previous PR 

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before:
<img width="1195" height="503" alt="FreeTube_6Hj7R3Kcpy" src="https://github.com/user-attachments/assets/a7dd5997-4ee6-49aa-acd2-59b93081d287" />

After:
<img width="903" height="398" alt="VirtualBoxVM_xGvbymeKpv" src="https://github.com/user-attachments/assets/14496252-bad8-4519-945d-45fe775f882e" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to the SponsorBlock settings
2. Change a color of a category
3. See icon change color
