### PR TITLE
Fix application icon on Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "freetube",
   "productName": "FreeTube",
+  "desktopName": "freetube",
   "description": "A private YouTube client",
   "version": "0.23.11",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
On Wayland application id must match installed `.desktop` entry, otherwise compositor won't show application icon. 
## Screenshots 
**Before:** 
![freetube-before](https://github.com/user-attachments/assets/c72caa67-bb0a-4bad-907a-cda722532649)
**After:**
![freetube-after](https://github.com/user-attachments/assets/4db7d50d-23cc-44de-a8b9-329a52bc74a1)


## Testing

1. Run FreeTube with next command `freetube --ozone-platform=wayland` on KDE Wayland session
2. Look at the application icon

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling Release
- **FreeTube version:** 0.23.10-beta