### PR TITLE
Hide active subscriptions wrapper on mobile display and center bottom SideNav items

### DIFF
--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -200,6 +200,7 @@
       <hr>
       <div
         v-if="!hideActiveSubscriptions"
+        class="mobileHidden"
       >
         <router-link
           v-for="channel in activeSubscriptions"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #8132

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Hide the active subscriptions wrapper on mobile display so an empty active subscriptions container no longer creates a right-side gap
- Adds mobileHidden to the active subscriptions wrapper

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before:
<img width="844" height="301" alt="image" src="https://github.com/user-attachments/assets/bc67ce19-1060-4bcb-9901-f7a108eb384d" />

After:
<img width="629" height="231" alt="Image" src="https://github.com/user-attachments/assets/2bb2f93a-e94c-4eae-aa99-0d1f3106de93" />

More button works fine after:
<img width="433" height="191" alt="image" src="https://github.com/user-attachments/assets/609a309b-7520-43a2-a7a8-5cb84d007372" />

On wide screens is working fine after:
<img width="544" height="556" alt="image" src="https://github.com/user-attachments/assets/7225b7b9-bfb9-4cff-85cf-fd9ccfc293eb" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Switch to mobile display (SideNav is on the bottom)
2. SideNav Items are centered
3. Return to Wide display (SideNav is on the left)
4. Active suscriptions are visible on SideNav if "Hide Active Subscriptions" is disabled and not if enabled

## Desktop
<!-- Please complete the following information-->
- **OS: Fedora Linux**
- **OS Version: 42**
- **FreeTube version: v0.23.11 Beta**

## Additional context
<!-- Add any other context about the pull request here. -->
