### PR TITLE
Fix video playback by using video ID bound poToken

### DIFF
--- a/src/botGuardScript.js
+++ b/src/botGuardScript.js
@@ -6,10 +6,9 @@ import { BG, buildURL, GOOG_API_KEY } from 'bgutils-js'
 /**
  * Based on: https://github.com/LuanRT/BgUtils/blob/main/examples/node/innertube-challenge-fetcher-example.ts
  * @param {string} videoId
- * @param {string} visitorData
  * @param {import('youtubei.js').Session['context']} context
  */
-export default async function (videoId, visitorData, context) {
+export default async function (videoId, context) {
   const requestKey = 'O43z0dpjhgX20SCx4KAo'
 
   const challengeResponse = await fetch(
@@ -19,7 +18,7 @@ export default async function (videoId, visitorData, context) {
       headers: {
         Accept: '*/*',
         'Content-Type': 'application/json',
-        'X-Goog-Visitor-Id': visitorData,
+        'X-Goog-Visitor-Id': context.client.visitorData,
         'X-Youtube-Client-Version': context.client.clientVersion,
         'X-Youtube-Client-Name': '1'
       },
@@ -83,8 +82,5 @@ export default async function (videoId, visitorData, context) {
 
   const integrityTokenBasedMinter = await BG.WebPoMinter.create({ integrityToken: response[0] }, webPoSignalOutput)
 
-  const contentPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(videoId)
-  const sessionPoToken = await integrityTokenBasedMinter.mintAsWebsafeString(visitorData)
-
-  return { contentPoToken, sessionPoToken }
+  return await integrityTokenBasedMinter.mintAsWebsafeString(videoId)
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -40,7 +40,7 @@ const IpcChannels = {
 
   SET_INVIDIOUS_AUTHORIZATION: 'set-invidious-authorization',
 
-  GENERATE_PO_TOKENS: 'generate-po-tokens',
+  GENERATE_PO_TOKEN: 'generate-po-token',
 
   GET_SCREENSHOT_FALLBACK_FOLDER: 'get-screenshot-fallback-folder',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1196,8 +1196,8 @@ function runApp() {
     })
   })
 
-  ipcMain.handle(IpcChannels.GENERATE_PO_TOKENS, (_, videoId, visitorData, context) => {
-    return generatePoToken(videoId, visitorData, context, proxyUrl)
+  ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (_, videoId, context) => {
+    return generatePoToken(videoId, context, proxyUrl)
   })
 
   ipcMain.on(IpcChannels.ENABLE_PROXY, (_, url) => {

--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -3,19 +3,18 @@ import { readFile } from 'fs/promises'
 import { join } from 'path'
 
 /**
- * Generates a poToken (proof of origin token) using `bgutils-js`.
+ * Generates a content-bound poToken (proof of origin token) using `bgutils-js`.
  * The script to generate it is `src/botGuardScript.js`
  *
  * This is intentionally split out into it's own thing, with it's own temporary in-memory session,
  * as the BotGuard stuff accesses the global `document` and `window` objects and also requires making some requests.
  * So we definitely don't want it running in the same places as the rest of the FreeTube code with the user data.
  * @param {string} videoId
- * @param {string} visitorData
  * @param {string} context
  * @param {string|undefined} proxyUrl
- * @returns {Promise<{ contentPoToken: string, sessionPoToken: string }>}
+ * @returns {Promise<string>}
  */
-export async function generatePoToken(videoId, visitorData, context, proxyUrl) {
+export async function generatePoToken(videoId, context, proxyUrl) {
   const sessionUuid = crypto.randomUUID()
 
   const theSession = session.fromPartition(`potoken-${sessionUuid}`, { cache: false })
@@ -97,7 +96,7 @@ export async function generatePoToken(videoId, visitorData, context, proxyUrl) {
     }
   })
 
-  const script = await getScript(videoId, visitorData, context)
+  const script = await getScript(videoId, context)
 
   const response = await webContentsView.webContents.executeJavaScript(script)
 
@@ -111,10 +110,9 @@ let cachedScript
 
 /**
  * @param {string} videoId
- * @param {string} visitorData
  * @param {string} context
  */
-async function getScript(videoId, visitorData, context) {
+async function getScript(videoId, context) {
   if (!cachedScript) {
     const pathToScript = process.env.NODE_ENV === 'development'
       ? join(__dirname, '../../dist/botGuardScript.js')
@@ -129,5 +127,5 @@ async function getScript(videoId, visitorData, context) {
     cachedScript = content.replace(match[0], `;${functionName}(FT_PARAMS)`)
   }
 
-  return cachedScript.replace('FT_PARAMS', `"${videoId}","${visitorData}",${context}`)
+  return cachedScript.replace('FT_PARAMS', `"${videoId}",${context}`)
 }

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -100,12 +100,11 @@ export default {
 
   /**
    * @param {string} videoId
-   * @param {string} visitorData
    * @param {string} context
-   * @returns {Promise<{ contentPoToken: string, sessionPoToken: string }>}
+   * @returns {Promise<string>}
    */
-  generatePoTokens: (videoId, visitorData, context) => {
-    return ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKENS, videoId, visitorData, context)
+  generatePoToken: (videoId, context) => {
+    return ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKEN, videoId, context)
   },
 
   /**

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -424,16 +424,15 @@ export async function getLocalSearchContinuation(continuationData) {
 export async function getLocalVideoInfo(id) {
   const webInnertube = await createInnertube({ withPlayer: true, generateSessionLocally: false })
 
-  // based on the videoId (added to the body of the /player request and to caption URLs)
+  // based on the videoId
   let contentPoToken
 
   if (process.env.IS_ELECTRON) {
     try {
-      ({ contentPoToken } = await window.ftElectron.generatePoTokens(
+      contentPoToken = await window.ftElectron.generatePoToken(
         id,
-        webInnertube.session.context.client.visitorData,
         JSON.stringify(webInnertube.session.context)
-      ))
+      )
 
       webInnertube.session.player.po_token = contentPoToken
     } catch (error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
It seem 403 occurs again due to YT switching to video bound poToken (instead of visitorData bound poToken)
This PR just makes local API use former for all stuff now (the latter is no longer used)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- Play videos, lives, shorts

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
