### PR TITLE
Simplify the NATIVE_THEME_UPDATE event handler

### DIFF
--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -6,7 +6,7 @@ import { IpcChannels } from '../constants.js'
  * all systems running the electron app.
  */
 ipcRenderer.on(IpcChannels.NATIVE_THEME_UPDATE, (_, shouldUseDarkColors) => {
-  webFrame.executeJavaScript(`document.body.dataset.systemTheme = "${shouldUseDarkColors ? 'dark' : 'light'}"`).catch()
+  document.body.dataset.systemTheme = shouldUseDarkColors ? 'dark' : 'light'
 })
 
 let currentUpdateSearchInputTextListener


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue

## Description

When I originally implemented the event handler I wasn't aware that Electron's preload isolatd world shares the DOM with the main world, just like a browser extension, so we can do the DOM manipulation directly instead of using `execuateJavaScript()`.

## Testing

1. Set the theme to system default
2. Change between dark and light mode in the settings at the operating sytem level
3. FreeTube should still adapt to the system theme changes.

## Desktop

- **OS:** Windows
- **OS Version:** 11