### PR TITLE
Add missing IS_ELECTRON and SUPPORTS_LOCAL_API checks

### DIFF
--- a/src/renderer/components/general-settings/general-settings.js
+++ b/src/renderer/components/general-settings/general-settings.js
@@ -24,6 +24,7 @@ export default defineComponent({
   data: function () {
     return {
       usingElectron: process.env.IS_ELECTRON,
+      supportsLocalAPI: process.env.SUPPORTS_LOCAL_API,
       backendValues: process.env.SUPPORTS_LOCAL_API
         ? [
             'invidious',

--- a/src/renderer/components/general-settings/general-settings.vue
+++ b/src/renderer/components/general-settings/general-settings.vue
@@ -11,6 +11,7 @@
           @change="updateCheckForUpdates"
         />
         <ft-toggle-switch
+          v-if="supportsLocalAPI"
           :label="$t('Settings.General Settings.Fallback to Non-Preferred Backend on Failure')"
           :default-value="backendFallback"
           :compact="true"
@@ -46,6 +47,7 @@
           @change="updateEnableSearchSuggestions"
         />
         <ft-toggle-switch
+          v-if="usingElectron"
           :label="$t('Settings.General Settings.Open Deep Links In New Window')"
           :default-value="openDeepLinksInNewWindow"
           :compact="true"

--- a/src/renderer/components/watch-video-info/watch-video-info.js
+++ b/src/renderer/components/watch-video-info/watch-video-info.js
@@ -127,6 +127,11 @@ export default defineComponent({
     'scroll-to-info-area',
     'save-watched-progress',
   ],
+  data: function () {
+    return {
+      usingElectron: process.env.IS_ELECTRON
+    }
+  },
   computed: {
     hideSharingActions: function() {
       return this.$store.getters.getHideSharingActions

--- a/src/renderer/components/watch-video-info/watch-video-info.vue
+++ b/src/renderer/components/watch-video-info/watch-video-info.vue
@@ -119,7 +119,7 @@
         </span>
         <span class="videoOptionsMobileRow">
           <ft-icon-button
-            v-if="externalPlayer !== ''"
+            v-if="usingElectron && externalPlayer !== ''"
             :title="$t('Video.External Player.OpenInTemplate', { externalPlayer })"
             :icon="['fas', 'external-link-alt']"
             theme="secondary"


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

I noticed these missing IS_ELECTRON and SUPPORTS_LOCAL_API checks were added in the FreeTubeAndroid code base, so we might as well add them here, so they don't have to be maintained downstream.

## Desktop

- **OS:** Windows
- **OS Version:** 11