### PR TITLE
Fix toast with timeout 0 will be displayed for default 3s

### DIFF
--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -41,9 +41,6 @@ const toasts = shallowReactive([])
  * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null }>} event
  */
 function open({ detail: { message, time, action, abortSignal } }) {
-  // Sometimes caller just pass user setting based value in and it can be zero
-  if (time === 0) { return }
-
   /** @type {Toast} */
   const toast = {
     message,

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -169,6 +169,12 @@ export const ToastEventBus = new EventTarget()
  * @param {AbortSignal} abortSignal
  */
 export function showToast(message, time = null, action = null, abortSignal = null) {
+  // Sometimes caller just pass user setting based value in and it can be zero
+  if (time === 0) {
+    console.warn('showToast called with time: 0', { message, time, action, abortSignal })
+    return
+  }
+
   ToastEventBus.dispatchEvent(new CustomEvent('toast-open', {
     detail: {
       message,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1367,15 +1367,18 @@ export default defineComponent({
         this.playNextTimeout = null
       }, nextVideoInterval * 1000)
 
-      showToast(
-        ({ remainingMs }) => {
-          const countDownTimeLeftInSecond = remainingMs / 1000
-          return this.$tc('Playing Next Video Interval', countDownTimeLeftInSecond, { nextVideoInterval: countDownTimeLeftInSecond })
-        },
-        // So that we don't see last countdown text like 0/N
-        nextVideoInterval * 1000,
-        this.abortAutoplayCountdown,
-      )
+      if (nextVideoInterval > 0) {
+        // No countdown for 0s interval
+        showToast(
+          ({ remainingMs }) => {
+            const countDownTimeLeftInSecond = remainingMs / 1000
+            return this.$tc('Playing Next Video Interval', countDownTimeLeftInSecond, { nextVideoInterval: countDownTimeLeftInSecond })
+          },
+          // So that we don't see last countdown text like 0/N
+          nextVideoInterval * 1000,
+          this.abortAutoplayCountdown,
+        )
+      }
     },
 
     // Skip to the next video if in a playlist


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Reported in https://github.com/FreeTubeApp/FreeTube/pull/8103#issuecomment-3422567662

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Toast shown with default timeout 3s when 0 is passed in
This PR just make `showToast` with `0` timeout passed in to do nothing

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- Update player autoplay countdown to 0s
- Play any playlist
- Ensure no countdown seen

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
