### PR TITLE
Handle lockup views with no published text or views

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1538,13 +1538,13 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
             lengthSeconds = Utils.timeToSeconds(durationBadge.text)
           }
 
-          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts.find(part => part.text?.text?.endsWith('ago'))?.text?.text
+          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
         }
       }
 
       let viewCount = null
 
-      const viewsText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts.find(part => {
+      const viewsText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => {
         return part.text?.text && VIEWS_OR_WATCHING_REGEX.test(part.text.text)
       })?.text?.text
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #8155

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Users were unable to watch videos if the recommended section had videos in them that had no published text or views

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before watch page blanks out:
<img width="1813" height="885" alt="FreeTube_rHmeSuUyHD" src="https://github.com/user-attachments/assets/60340dbb-725c-46e8-9ae2-e82582e16046" />

After users are able to view videos and videos in the recommended section:
<img width="370" height="321" alt="VirtualBoxVM_IOMqYlFVa1" src="https://github.com/user-attachments/assets/339b54b9-1274-4577-89fe-7ca3fa1ed127" />

How it looks on YT:
<img width="600" height="394" alt="firefox_5HEhu10ojP" src="https://github.com/user-attachments/assets/3067dd3e-7dd9-49c7-877c-ef9dc7b9bd5a" />


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to one of the following videos: 
* https://youtu.be/z-cEVMBOcOA
* https://youtu.be/5o3tyID4EbM
* https://youtu.be/d9DgIXRyxhE
2. Verify that videos play again and recommended section is filled with videos

## Desktop
<!-- Please complete the following information-->
- **OS: Windows 11**
- **OS Version: 24H2**

## Additional context
<!-- Add any other context about the pull request here. -->
I could only reproduce these errors after i vpned to usa otherwise videos played normally
