### PR TITLE
Fix behavior of skip frame shortcuts

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2287,16 +2287,18 @@ export default defineComponent({
         }
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LAST_FRAME:
           // `⌘+,` is for settings in MacOS
-          if (!event.metaKey) {
+          if (!event.metaKey && video_.paused) {
             event.preventDefault()
             // Return to previous frame
             frameByFrame(-1)
           }
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.NEXT_FRAME:
-          event.preventDefault()
-          // Advance to next frame
-          frameByFrame(1)
+          if (video_.paused) {
+            event.preventDefault()
+            // Advance to next frame
+            frameByFrame(1)
+          }
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.STATS:
           // Toggle stats display


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
From https://docs.freetubeapp.io/usage/keyboard-shortcuts/ and shortcuts modal
> , or .  While the video is paused, skip to the previous / next frame.
> Previous frame (while paused)	,
> Next frame (while paused)	.

Currently it also works when video is playing. When user pressing those keys the video will pause which is undesired. 

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Watch a video
2. Use shortcuts when video is playing
3. Verify that it doesnt do anything
4. Pause video
5. Use shortcuts
6. Verify that it skips frame(s)

## Desktop
<!-- Please complete the following information-->
- **OS:  Windows 11**
- **OS Version: 24H2**
