### PR TITLE
Configure nedb to always clean up corrupted data

### DIFF
--- a/src/datastores/index.js
+++ b/src/datastores/index.js
@@ -22,9 +22,21 @@ if (process.env.IS_ELECTRON_MAIN) {
   dbPath = (dbName) => `${dbName}.db`
 }
 
-export const settings = new Datastore({ filename: dbPath('settings'), autoload: !process.env.IS_ELECTRON_MAIN })
-export const profiles = new Datastore({ filename: dbPath('profiles'), autoload: !process.env.IS_ELECTRON_MAIN })
-export const playlists = new Datastore({ filename: dbPath('playlists'), autoload: !process.env.IS_ELECTRON_MAIN })
-export const history = new Datastore({ filename: dbPath('history'), autoload: !process.env.IS_ELECTRON_MAIN })
-export const searchHistory = new Datastore({ filename: dbPath('search-history'), autoload: !process.env.IS_ELECTRON_MAIN })
-export const subscriptionCache = new Datastore({ filename: dbPath('subscription-cache'), autoload: !process.env.IS_ELECTRON_MAIN })
+/**
+ * @param {string} name
+ */
+function createDatastore(name) {
+  return new Datastore({
+    filename: dbPath(name),
+    autoload: !process.env.IS_ELECTRON_MAIN,
+    // Automatically clean up corrupted data, instead of crashing
+    corruptAlertThreshold: 1
+  })
+}
+
+export const settings = createDatastore('settings')
+export const profiles = createDatastore('profiles')
+export const playlists = createDatastore('playlists')
+export const history = createDatastore('history')
+export const searchHistory = createDatastore('search-history')
+export const subscriptionCache = createDatastore('subscription-cache')


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

## Description

If the FreeTube databases get corrupted by a sudden computer shutdown e.g. a power outage, nedb will refuse to open the database if 10% or more is corrupted, below that threshold it cleans up the corrupted data and continues as if it were never there. In those situations we currently tell users to manually edit the database files and remove the corrupted parts. This pull request changes nedb's `corruptAlertThreshold` configuration from 0.1 (the default) to 1, so it will always clean up corrupted data, this saves users having to manually edit the databases.

As the nedb new Datastore() lines were getting quite long and most of the parameters are the same for all databases, I decided to move it to a function that takes the database name.

## Testing

1. Make sure FreeTube isn't running
2. Back up your FreeTube databases from the data location (https://docs.freetubeapp.io/usage/data-location/)
3. Delete parts from various entries/lines in one of the databases in a text editor
4. Start FreeTube
5. It should start normally, just missing the corrupted records

## Desktop

- **OS:** Windows
- **OS Version:** 11