### PR TITLE
Properly fix CORS in PO token web views

### DIFF
--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -52,15 +52,31 @@ export async function generatePoToken(videoId, context, proxyUrl) {
     callback({ requestHeaders })
   })
 
+  theSession.webRequest.onHeadersReceived({ urls: ['https://*/*'] }, ({ responseHeaders }, callback) => {
+    if (responseHeaders) {
+      callback({
+        responseHeaders: {
+          ...responseHeaders,
+          'Access-Control-Allow-Origin': ['*'],
+          'Access-Control-Allow-Methods': ['GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH']
+        }
+      })
+    }
+  })
+
+  theSession.webRequest.onBeforeRequest({ urls: ['<all_urls>'], types: ['cspReport', 'ping'] }, (details, callback) => {
+    callback({ cancel: true })
+  })
+
   const webContentsView = new WebContentsView({
     webPreferences: {
       backgroundThrottling: false,
       safeDialogs: true,
       sandbox: true,
+      contextIsolation: true,
       v8CacheOptions: 'none',
       session: theSession,
       offscreen: true,
-      webSecurity: false,
       disableBlinkFeatures: 'ElectronCSSCornerSmoothing'
     }
   })


### PR DESCRIPTION
## Pull Request Type

- [x] Security improvement

## Description

Currently we set the webSecurity option to false in the PO token web views, which as the name implies disables various security features, this pull request switches to using the `webRequest.onHeadersReceived` callback to override the CORS headers, so we no longer need to set webSecurity to false.

## Testing

Open a video and check that it plays.

## Desktop

- **OS:** Windows
- **OS Version:** 11