### PR TITLE
Replace vue-portal dependency with Vue's built-in <Teleport> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "bgutils-js": "^3.2.0",
     "electron-context-menu": "^4.1.1",
     "marked": "^16.4.1",
-    "portal-vue": "^3.0.0",
     "process": "^0.11.10",
     "shaka-player": "^4.16.6",
     "swiper": "^12.0.3",

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -44,7 +44,6 @@ export default defineComponent({
       latestBlogUrl: '',
       updateChangelog: '',
       changeLogTitle: '',
-      isPromptOpen: false,
       lastExternalLinkToBeOpened: '',
       showExternalLinkOpeningPrompt: false,
       externalLinkOpeningPromptValues: [
@@ -154,6 +153,10 @@ export default defineComponent({
     appTitle: function () {
       return this.$store.getters.getAppTitle
     },
+
+    isAnyPromptOpen: function () {
+      return this.$store.getters.isAnyPromptOpen
+    }
   },
   watch: {
     windowTitle: 'setWindowTitle',
@@ -328,10 +331,6 @@ export default defineComponent({
       }
 
       this.showBlogBanner = false
-    },
-
-    handlePromptPortalUpdate: function(data) {
-      this.isPromptOpen = data.hasContent
     },
 
     openDownloadsPage: function () {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -9,11 +9,6 @@
       hideLabelsSideBar: hideLabelsSideBar && !isSideNavOpen
     }"
   >
-    <portal-target
-      name="promptPortal"
-      multiple
-      @change="handlePromptPortalUpdate"
-    />
     <ft-prompt
       v-if="showReleaseNotes"
       theme="readable-width"
@@ -70,16 +65,16 @@
       v-if="showProgressBar"
     />
     <top-nav
-      :inert="isPromptOpen"
+      :inert="isAnyPromptOpen"
     />
     <side-nav
       ref="sideNav"
-      :inert="isPromptOpen"
+      :inert="isAnyPromptOpen"
     />
     <ft-flex-box
       class="flexBox routerView"
       role="main"
-      :inert="isPromptOpen"
+      :inert="isAnyPromptOpen"
     >
       <div
         v-if="showUpdatesBanner || showBlogBanner"

--- a/src/renderer/components/FtPrompt/FtPrompt.vue
+++ b/src/renderer/components/FtPrompt/FtPrompt.vue
@@ -1,5 +1,5 @@
 <template>
-  <portal to="promptPortal">
+  <Teleport to=".app">
     <div
       class="prompt"
       tabindex="-1"
@@ -52,7 +52,7 @@
         </slot>
       </FtCard>
     </div>
-  </portal>
+  </Teleport>
 </template>
 
 <script setup>
@@ -111,6 +111,7 @@ let lastActiveElement = null
 onMounted(() => {
   lastActiveElement = document.activeElement
   document.addEventListener('keydown', handleEscape, true)
+  store.commit('addOpenPrompt', id)
 
   nextTick(() => {
     promptButtons = Array.from(promptCard.value.$el.querySelectorAll('.btn.ripple, .iconButton'))
@@ -120,6 +121,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleEscape, true)
+  store.commit('removeOpenPrompt', id)
   nextTick(() => lastActiveElement?.focus())
 })
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -131,7 +131,6 @@ import {
   faMastodon,
 } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon, FontAwesomeLayers } from '@fortawesome/vue-fontawesome'
-import PortalVue from 'portal-vue'
 
 // Please keep the list of constants sorted by name
 // to avoid code conflict and duplicate entries
@@ -269,7 +268,6 @@ app
   .use(router)
   .use(store)
   .use(i18n)
-  .use(PortalVue)
 
 router.isReady().then(() => {
   app.mount('#app')

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -60,7 +60,8 @@ const state = {
     shorts: false,
     posts: false,
   },
-  appTitle: ''
+  appTitle: '',
+  openPrompts: new Set()
 }
 
 const getters = {
@@ -182,6 +183,9 @@ const getters = {
   },
   getAppTitle (state) {
     return state.appTitle
+  },
+  isAnyPromptOpen(state) {
+    return state.openPrompts.size > 0
   }
 }
 
@@ -980,6 +984,14 @@ const mutations = {
   // Use this to set the app title / document.title
   setAppTitle (state, value) {
     state.appTitle = value
+  },
+
+  addOpenPrompt(state, id) {
+    state.openPrompts.add(id)
+  },
+
+  removeOpenPrompt(state, id) {
+    state.openPrompts.delete(id)
   },
 
   setSubscriptionForVideosFirstAutoFetchRun (state) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6731,11 +6731,6 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
-portal-vue@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/portal-vue/-/portal-vue-3.0.0.tgz#0f60fe3540e479d18f998d32d415c50c8e17c9a9"
-  integrity sha512-9eprMxNURLx6ijbcgkWjYNcTWJYu/H8QF8nyAeBzOmk9lKCea01BW1hYBeLkgz+AestmPOvznAEOFmNuO4Adjw==
-
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

Now that we are using Vue 3 we can switch to using Vue's built-in <Teleport> component instead of the third-party vue-portal dependency that hasn't received updates since the update that added Vue 3 support.

## Testing

Please test that prompts show up and are styled correctly and that you cannot <kbd>TAB</kbd> outside of them. Additionally please check that multiple prompts shown at the same time work correctly e.g. add to playlist -> create new playlist.

## Desktop

- **OS:** Windows
- **OS Version:** 11