### PR TITLE
Clean up defunct shaka-player types patching

### DIFF
--- a/_scripts/patchShaka.mjs
+++ b/_scripts/patchShaka.mjs
@@ -1,59 +1,11 @@
-// This script fixes shaka not exporting its type definitions and referencing the Roboto font on google fonts in its CSS
-// by adding an export line to the type definitions and updating the CSS to point to the local Roboto font
+// This script fixes shaka-player referencing the Roboto font on google fonts in its CSS
+// by updating the CSS to point to the local Roboto font
 // this script only makes changes if they are needed, so running it multiple times doesn't cause any problems
 
-import { appendFileSync, closeSync, ftruncateSync, openSync, readFileSync, writeSync } from 'fs'
+import { closeSync, ftruncateSync, openSync, readFileSync, writeSync } from 'fs'
 import { resolve } from 'path'
 
 const SHAKA_DIST_DIR = resolve(import.meta.dirname, '../node_modules/shaka-player/dist')
-
-function fixTypes() {
-  let fixedTypes = false
-
-  let fileHandleNormal
-  try {
-    fileHandleNormal = openSync(`${SHAKA_DIST_DIR}/shaka-player.ui.d.ts`, 'a+')
-
-    const contents = readFileSync(fileHandleNormal, 'utf-8')
-
-    // This script is run after every `yarn install`, even if shaka-player wasn't updated
-    // So we want to check first, if we actually need to make any changes
-    // or if the ones from the previous run are still intact
-    if (!contents.includes('export default shaka')) {
-      appendFileSync(fileHandleNormal, 'export default shaka;\n')
-
-      fixedTypes = true
-    }
-  } finally {
-    if (typeof fileHandleNormal !== 'undefined') {
-      closeSync(fileHandleNormal)
-    }
-  }
-
-  let fileHandleDebug
-  try {
-    fileHandleDebug = openSync(`${SHAKA_DIST_DIR}/shaka-player.ui.debug.d.ts`, 'a+')
-
-    const contents = readFileSync(fileHandleDebug, 'utf-8')
-
-    // This script is run after every `yarn install`, even if shaka-player wasn't updated
-    // So we want to check first, if we actually need to make any changes
-    // or if the ones from the previous run are still intact
-    if (!contents.includes('export default shaka')) {
-      appendFileSync(fileHandleDebug, 'export default shaka;\n')
-
-      fixedTypes = true
-    }
-  } finally {
-    if (typeof fileHandleDebug !== 'undefined') {
-      closeSync(fileHandleDebug)
-    }
-  }
-
-  if (fixedTypes) {
-    console.log('Fixed shaka-player types')
-  }
-}
 
 function removeRobotoFont() {
   let cssFileHandle
@@ -72,11 +24,10 @@ function removeRobotoFont() {
       console.log('Removed shaka-player Roboto font, so it uses ours')
     }
   } finally {
-    if (typeof cssFileHandle !== 'undefined') {
+    if (cssFileHandle !== undefined) {
       closeSync(cssFileHandle)
     }
   }
 }
 
-fixTypes()
 removeRobotoFont()


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue

- #8223

## Description

With version 4.16.7 shaka-player started shipping with the TypeScript types exported by default, which means we no longer need that part of our patching script.

## Testing

N/A

## Desktop

- **OS:** Windows
- **OS Version:** 11