### PR TITLE
Fix: External player arguments cant be hidden

### DIFF
--- a/src/renderer/components/ExternalPlayerSettings.vue
+++ b/src/renderer/components/ExternalPlayerSettings.vue
@@ -52,7 +52,9 @@
         :tag-name-placeholder="$t('Settings.External Player Settings.Custom External Player Arguments')"
         :tag-list="externalPlayerCustomArgs"
         :tooltip="externalPlayerCustomArgsTooltip"
+        :show-tags="showAddedExternalPlayerCustomArgs"
         @change="handleExternalPlayerCustomArgs"
+        @toggle-show-tags="handleAddedExternalPayerCustomArgs"
       />
     </FtFlexBox>
   </FtSettingsSection>
@@ -149,5 +151,12 @@ function updateExternalPlayerExecutable(value) {
  */
 function handleExternalPlayerCustomArgs(args) {
   store.dispatch('updateExternalPlayerCustomArgs', JSON.stringify(args))
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const showAddedExternalPlayerCustomArgs = computed(() => store.getters.getShowAddedExternalPlayerCustomArgs)
+
+function handleAddedExternalPayerCustomArgs() {
+  store.dispatch('updateShowAddedExternalPlayerCustomArgs', !showAddedExternalPlayerCustomArgs.value)
 }
 </script>

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -179,6 +179,7 @@ const state = {
   externalPlayerIgnoreWarnings: false,
   externalPlayerIgnoreDefaultArgs: false,
   externalPlayerCustomArgs: '[]',
+  showAddedExternalPlayerCustomArgs: true,
   expandSideBar: false,
   hideActiveSubscriptions: false,
   hideChannelCommunity: false,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #8229

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fixes "Show Added Items" checkbox under "Custom External Player Arguments" to show/hide items by correctly setting `show-tags`

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Go to Settings -> External Player -> Custom External Player Arguments
Add some arguments
Toggle the "Show Added Items" checkbox on/off to see correct show/hide behavior