### PR TITLE
Fix: Large fast forward/rewind value popup on player

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1966,7 +1966,8 @@ export default defineComponent({
         const popUpLayout = seconds > 0
           ? { icon: 'arrow-right', invertContentOrder: true }
           : { icon: 'arrow-left', invertContentOrder: false }
-        const formattedSeconds = Math.abs(seconds).toFixed(2)
+        // `+value` converts string back to float
+        const formattedSeconds = +Math.abs(seconds).toFixed(2)
         showValueChange(`${formattedSeconds}s`, popUpLayout.icon, popUpLayout.invertContentOrder)
       }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #8230 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Rounds `formattedSeconds` to two decimal places to avoid a very long displayed value

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Go to Player settings
Set Video Playback Rate Interval to 0.1
Set Fast-Forward / Rewind Interval to 13s
Set the playback speed to 1.8x
Watch a video
Use ←, →, J and L
See playback rate popup showing rounded number