### PR TITLE
Fix watch page playlist component not scrolled to current video on load

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -218,12 +218,12 @@ export default defineComponent({
       this.prevVideoBeforeDeletion = null
     },
     watchViewLoading: function (newVal, oldVal) {
-      // This component is loaded/rendered before watch view loaded
+      // If watch view is loaded after this component loaded
       if (oldVal && !newVal) {
         // Scroll after watch view loaded, otherwise doesn't work
         // Mainly for Local API
-        // nextTick(() => this.scrollToCurrentVideo())
-        this.scrollToCurrentVideo()
+        // `nextTick` is required (tested via reloading)
+        nextTick(() => this.scrollToCurrentVideo())
       }
     },
     isLoading: function (newVal, oldVal) {


### PR DESCRIPTION

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Maybe https://github.com/FreeTubeApp/FreeTube/pull/7782

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
On watch page playlist component no longer scroll to current video on load
This fixes it

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy and you should test

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Find random video playlist (long enough to have scrolling), play last video to ensure it scroll to bottom on load
e.g. https://youtu.be/X5OIucMnw7M?list=PL8mG-RkN2uTxRRAvbc1C3yyP1ny4zE9K8

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
