### PR TITLE
Fix scroll to current chapter on expand

### DIFF
--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -177,7 +177,7 @@ function chaptersToggled(event) {
 
 function scrollToCurrentChapter() {
   const container = chaptersWrapper.value
-  const currentItem = container ? Array.from(chaptersWrapper.value.children)[currentIndex.value] : null
+  const currentItem = container ? Array.from(container.children)[currentIndex.value] : null
 
   if (currentItem != null) {
     container.scrollTop = currentItem.offsetTop - container.offsetTop


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I found that chapter does not scroll to current element on expand / scroll into view and this PR fixes it
Only reproducible on production builds = not dev (I found this issue using my custom builds)

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Must use production builds
- https://github.com/PikachuEXE/FreeTube/actions/runs/19187288644 (this is the custom build I use before submitting this PR)
- https://github.com/PikachuEXE/FreeTube/actions/runs/19190251207 (build based on PR branch

Steps
- Find video with chapter (e.g. https://youtu.be/fFtk9gJLnfk?t=904
- Scroll to chapter and expand it and ensure scrolled to current chapter (can scroll up and re-expand to confirm)
- Scroll up while expanded, scroll down to comments until out of view and scroll back and confirm it's scrolled to current chapter


## Desktop
<!-- Please complete the following information-->
- **OS:** Windows
- **OS Version:** 10
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
