### PR TITLE
Validate sender in all IPC event handlers

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -351,9 +351,19 @@ function runApp() {
           replaceMainWindow: false,
           showWindowNow: true,
         })
-        ipcMain.once(IpcChannels.APP_READY, () => {
-          newWindow.webContents.send(IpcChannels.OPEN_URL, newStartupUrl)
-        })
+
+        /**
+         * @param {import('electron').IpcMainEvent} event
+         */
+        const readyHandler = (event) => {
+          if (isFreeTubeUrl(event.senderFrame.url)) {
+            newWindow.webContents.ipc.off(IpcChannels.APP_READY, readyHandler)
+
+            event.reply(IpcChannels.OPEN_URL, newStartupUrl)
+          }
+        }
+
+        newWindow.webContents.ipc.on(IpcChannels.APP_READY, readyHandler)
       }
     })
   }
@@ -1100,9 +1110,18 @@ function runApp() {
     }
 
     if (typeof searchQueryText === 'string' && searchQueryText.length > 0) {
-      ipcMain.once(IpcChannels.SEARCH_INPUT_HANDLING_READY, () => {
-        newWindow.webContents.send(IpcChannels.UPDATE_SEARCH_INPUT_TEXT, searchQueryText)
-      })
+      /**
+       * @param {import('electron').IpcMainEvent} event
+       */
+      const searchInputReadyHandler = (event) => {
+        if (isFreeTubeUrl(event.senderFrame.url)) {
+          newWindow.webContents.ipc.off(IpcChannels.SEARCH_INPUT_HANDLING_READY, searchInputReadyHandler)
+
+          event.reply(IpcChannels.UPDATE_SEARCH_INPUT_TEXT, searchQueryText)
+        }
+      }
+
+      newWindow.webContents.ipc.on(IpcChannels.SEARCH_INPUT_HANDLING_READY, searchInputReadyHandler)
     }
 
     // Show when loaded
@@ -1155,11 +1174,13 @@ function runApp() {
     return newWindow
   }
 
-  ipcMain.on(IpcChannels.APP_READY, () => {
-    if (startupUrl) {
-      mainWindow.webContents.send(IpcChannels.OPEN_URL, startupUrl)
+  ipcMain.on(IpcChannels.APP_READY, (event) => {
+    if (isFreeTubeUrl(event.senderFrame.url)) {
+      if (startupUrl) {
+        mainWindow.webContents.send(IpcChannels.OPEN_URL, startupUrl)
+      }
+      startupUrl = null
     }
-    startupUrl = null
   })
 
   function relaunch() {
@@ -1203,15 +1224,23 @@ function runApp() {
     const allWindows = BrowserWindow.getAllWindows()
 
     allWindows.forEach((window) => {
-      window.webContents.send(IpcChannels.NATIVE_THEME_UPDATE, nativeTheme.shouldUseDarkColors)
+      if (isFreeTubeUrl(window.webContents.getURL())) {
+        window.webContents.send(IpcChannels.NATIVE_THEME_UPDATE, nativeTheme.shouldUseDarkColors)
+      }
     })
   })
 
-  ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (_, videoId, context) => {
-    return generatePoToken(videoId, context, proxyUrl)
+  ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (event, videoId, context) => {
+    if (isFreeTubeUrl(event.senderFrame.url)) {
+      return generatePoToken(videoId, context, proxyUrl)
+    }
   })
 
-  ipcMain.on(IpcChannels.ENABLE_PROXY, (_, url) => {
+  ipcMain.on(IpcChannels.ENABLE_PROXY, (event, url) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     session.defaultSession.setProxy({
       proxyRules: url
     })
@@ -1219,7 +1248,11 @@ function runApp() {
     session.defaultSession.closeAllConnections()
   })
 
-  ipcMain.on(IpcChannels.DISABLE_PROXY, () => {
+  ipcMain.on(IpcChannels.DISABLE_PROXY, (event) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     session.defaultSession.setProxy({})
     proxyUrl = undefined
     session.defaultSession.closeAllConnections()
@@ -1231,7 +1264,11 @@ function runApp() {
   // Math.trunc but with a bitwise OR so that it can be calcuated at build time and the number inlined
   const HALF_OF_NAV_HISTORY_DISPLAY_LIMIT = (NAV_HISTORY_DISPLAY_LIMIT / 2) | 0
 
-  ipcMain.handle(IpcChannels.GET_NAVIGATION_HISTORY, ({ sender }) => {
+  ipcMain.handle(IpcChannels.GET_NAVIGATION_HISTORY, ({ senderFrame, sender }) => {
+    if (!isFreeTubeUrl(senderFrame.url)) {
+      return
+    }
+
     const activeIndex = sender.navigationHistory.getActiveIndex()
     const length = sender.navigationHistory.length()
 
@@ -1262,17 +1299,17 @@ function runApp() {
 
   // #endregion navigation history
 
-  ipcMain.handle(IpcChannels.GET_SYSTEM_LOCALE, () => {
-    // we should switch to getPreferredSystemLanguages at some point and iterate through until we find a supported locale
-    return app.getSystemLocale()
+  ipcMain.handle(IpcChannels.GET_SYSTEM_LOCALE, (event) => {
+    if (isFreeTubeUrl(event.senderFrame.url)) {
+      // we should switch to getPreferredSystemLanguages at some point and iterate through until we find a supported locale
+      return app.getSystemLocale()
+    }
   })
 
   ipcMain.handle(IpcChannels.GET_SCREENSHOT_FALLBACK_FOLDER, (event) => {
-    if (!isFreeTubeUrl(event.senderFrame.url)) {
-      return
+    if (isFreeTubeUrl(event.senderFrame.url)) {
+      return path.join(app.getPath('pictures'), 'Freetube')
     }
-
-    return path.join(app.getPath('pictures'), 'Freetube')
   })
 
   ipcMain.on(IpcChannels.CHOOSE_DEFAULT_FOLDER, async (event, kind) => {
@@ -1317,7 +1354,9 @@ function runApp() {
     }
 
     BrowserWindow.getAllWindows().forEach((window) => {
-      window.webContents.send(IpcChannels.SYNC_SETTINGS, syncPayload)
+      if (isFreeTubeUrl(window.webContents.getURL())) {
+        window.webContents.send(IpcChannels.SYNC_SETTINGS, syncPayload)
+      }
     })
   })
 
@@ -1434,16 +1473,24 @@ function runApp() {
     })
   })
 
-  ipcMain.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, (_, executable, args) => {
-    const child = cp.spawn(executable, args, { detached: true, stdio: 'ignore' })
-    child.unref()
+  ipcMain.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, (event, executable, args) => {
+    if (isFreeTubeUrl(event.senderFrame.url)) {
+      const child = cp.spawn(executable, args, { detached: true, stdio: 'ignore' })
+      child.unref()
+    }
   })
 
-  ipcMain.handle(IpcChannels.GET_REPLACE_HTTP_CACHE, () => {
-    return replaceHttpCache
+  ipcMain.handle(IpcChannels.GET_REPLACE_HTTP_CACHE, (event) => {
+    if (isFreeTubeUrl(event.senderFrame.url)) {
+      return replaceHttpCache
+    }
   })
 
-  ipcMain.once(IpcChannels.TOGGLE_REPLACE_HTTP_CACHE, async () => {
+  ipcMain.once(IpcChannels.TOGGLE_REPLACE_HTTP_CACHE, async (event) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     if (replaceHttpCache) {
       await asyncFs.rm(REPLACE_HTTP_CACHE_PATH)
     } else {
@@ -1464,7 +1511,11 @@ function runApp() {
     return path.join(PLAYER_CACHE_PATH, sanitizedKey)
   }
 
-  ipcMain.handle(IpcChannels.PLAYER_CACHE_GET, async (_, key) => {
+  ipcMain.handle(IpcChannels.PLAYER_CACHE_GET, async (event, key) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     const filePath = playerCachePathForKey(key)
 
     try {
@@ -1482,7 +1533,11 @@ function runApp() {
     }
   })
 
-  ipcMain.handle(IpcChannels.PLAYER_CACHE_SET, async (_, key, value) => {
+  ipcMain.handle(IpcChannels.PLAYER_CACHE_SET, async (event, key, value) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     const filePath = playerCachePathForKey(key)
 
     await asyncFs.mkdir(PLAYER_CACHE_PATH, { recursive: true })
@@ -1511,6 +1566,10 @@ function runApp() {
 
   // Settings
   ipcMain.handle(IpcChannels.DB_SETTINGS, async (event, { action, data }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     try {
       switch (action) {
         case DBActions.GENERAL.FIND:
@@ -1569,6 +1628,10 @@ function runApp() {
   // *********** //
   // History
   ipcMain.handle(IpcChannels.DB_HISTORY, async (event, { action, data }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     try {
       switch (action) {
         case DBActions.GENERAL.FIND:
@@ -1641,6 +1704,10 @@ function runApp() {
   // *********** //
   // Profiles
   ipcMain.handle(IpcChannels.DB_PROFILES, async (event, { action, data }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     try {
       switch (action) {
         case DBActions.GENERAL.CREATE: {
@@ -1709,6 +1776,10 @@ function runApp() {
   // The remaining should have it implemented only when playlists
   // get fully implemented into the app
   ipcMain.handle(IpcChannels.DB_PLAYLISTS, async (event, { action, data }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     try {
       switch (action) {
         case DBActions.GENERAL.CREATE:
@@ -1810,6 +1881,10 @@ function runApp() {
   // ************** //
   // Search History
   ipcMain.handle(IpcChannels.DB_SEARCH_HISTORY, async (event, { action, data }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     try {
       switch (action) {
         case DBActions.GENERAL.FIND:
@@ -1855,6 +1930,10 @@ function runApp() {
   // *********** //
   // Profiles
   ipcMain.handle(IpcChannels.DB_SUBSCRIPTION_CACHE, async (event, { action, data }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return
+    }
+
     try {
       switch (action) {
         case DBActions.GENERAL.FIND:
@@ -1937,7 +2016,7 @@ function runApp() {
 
   function syncOtherWindows(channel, event, payload) {
     const otherWindows = BrowserWindow.getAllWindows().filter((window) => {
-      return window.webContents.id !== event.sender.id
+      return window.webContents.id !== event.sender.id && isFreeTubeUrl(window.webContents.getURL())
     })
 
     for (const window of otherWindows) {
@@ -2047,9 +2126,19 @@ function runApp() {
       replaceMainWindow: false,
       showWindowNow: true,
     })
-    ipcMain.once(IpcChannels.APP_READY, () => {
-      newWindow.webContents.send(IpcChannels.OPEN_URL, newStartupUrl)
-    })
+
+    /**
+     * @param {import('electron').IpcMainEvent} event
+     */
+    const readyHandler = (event) => {
+      if (isFreeTubeUrl(event.senderFrame.url)) {
+        newWindow.webContents.ipc.off(IpcChannels.APP_READY, readyHandler)
+
+        event.reply(IpcChannels.OPEN_URL, newStartupUrl)
+      }
+    }
+
+    newWindow.webContents.ipc.on(IpcChannels.APP_READY, readyHandler)
   })
 
   app.on('web-contents-created', (_, webContents) => {
@@ -2108,7 +2197,7 @@ function runApp() {
    */
 
   function navigateTo(path, browserWindow) {
-    if (browserWindow == null) {
+    if (browserWindow == null || !isFreeTubeUrl(browserWindow.webContents.getURL())) {
       return
     }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Security improvement

## Description

At the moment we only validate that the sender of the IPC event was actually the FreeTube page in a few event handlers, this pull request adds the checks to the remaining ones.

## Testing

Test a few things that use IPC calls e.g. turning on and off the experimental HTTP cache or having multiple windows open and changing some data in one window and check that it is synced to the other window.

## Desktop

- **OS:** Windows
- **OS Version:** 11