### PR TITLE
Invidious API: Fix published dates on recommended videos

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -883,6 +883,15 @@ export default defineComponent({
           this.videoPublished = result.published * 1000
           this.videoDescriptionHtml = result.descriptionHtml
           const recommendedVideos = result.recommendedVideos
+
+          // The recommended videos currently use yyyy-mm-ddThh:mm:ss for the published timestamp
+          // whereas the rest of the API uses unix timestamps, correct that here
+          recommendedVideos.forEach((video) => {
+            if (typeof video.published === 'string') {
+              video.published = Date.parse(video.published)
+            }
+          })
+
           // place watched recommended videos last
           this.recommendedVideos = [
             ...recommendedVideos.filter((video) => !this.isRecommendedVideoWatched(video.videoId)),


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

Invidious uses a different timestamp format for the published property in the recommended videos than they do for the rest of the API. This pull request works around that by converting it to the format that FreeTube expects.

## Testing

1. Open a video with the Invidious API enabled
2. Notice that the published dates are shown on recommended videos

## Desktop

- **OS:** Windows
- **OS Version:** 11