### PR TITLE
Fix top nav cannot search in new window

### DIFF
--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -497,7 +497,8 @@ function goToSearch(queryText, { event }) {
             time: searchSettings.value.time,
             type: searchSettings.value.type,
             duration: searchSettings.value.duration,
-            features: searchSettings.value.features,
+            // Array proxy cannot be cloned during IPC call
+            features: [...searchSettings.value.features],
           },
           doCreateNewWindow,
           searchQueryText: queryText,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/8248#pullrequestreview-3440187179
https://github.com/FreeTubeApp/FreeTube/pull/8094

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Top nav cannot search in new window after vue 3 migration and this PR fixes it
Proxed array is returned now for `features` and must be converted before passing it to IPC call

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Type something in top nav and shift enter / shift click icon and ensure new window opened with search result

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
