### PR TITLE
Fix number of videos to be added to playlist is wrong

### DIFF
--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -373,11 +373,11 @@ function addSelectedToPlaylists() {
   const allPlaylists_ = allPlaylists.value
   const toBeAddedToPlaylistVideoList_ = toBeAddedToPlaylistVideoList.value
 
-  let videosToBeAdded
-
   selectedPlaylistIdList.value.forEach((selectedPlaylistId) => {
     const playlist = allPlaylists_.find((list) => list._id === selectedPlaylistId)
     if (playlist == null) { return }
+
+    let videosToBeAdded
 
     if (!addingDuplicateVideosEnabled.value) {
       const playlistVideoIds = playlist.videos.map((v) => v.videoId)
@@ -397,12 +397,10 @@ function addSelectedToPlaylists() {
 
   let message
   if (addedPlaylistIds.size === 1) {
-    message = t('User Playlists.AddVideoPrompt.Toast.{videoCount} video(s) added to 1 playlist', {
-      videoCount: videosToBeAdded.length,
+    message = t('User Playlists.AddVideoPrompt.Toast.Video(s) added to 1 playlist', {
     }, toBeAddedToPlaylistVideoCount.value)
   } else {
-    message = t('User Playlists.AddVideoPrompt.Toast.{videoCount} video(s) added to {playlistCount} playlists', {
-      videoCount: videosToBeAdded.length,
+    message = t('User Playlists.AddVideoPrompt.Toast.Video(s) added to {playlistCount} playlists', {
       playlistCount: addedPlaylistIds.size,
     }, toBeAddedToPlaylistVideoCount.value)
   }

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -373,11 +373,11 @@ function addSelectedToPlaylists() {
   const allPlaylists_ = allPlaylists.value
   const toBeAddedToPlaylistVideoList_ = toBeAddedToPlaylistVideoList.value
 
+  let videosToBeAdded
+
   selectedPlaylistIdList.value.forEach((selectedPlaylistId) => {
     const playlist = allPlaylists_.find((list) => list._id === selectedPlaylistId)
     if (playlist == null) { return }
-
-    let videosToBeAdded
 
     if (!addingDuplicateVideosEnabled.value) {
       const playlistVideoIds = playlist.videos.map((v) => v.videoId)
@@ -398,11 +398,11 @@ function addSelectedToPlaylists() {
   let message
   if (addedPlaylistIds.size === 1) {
     message = t('User Playlists.AddVideoPrompt.Toast.{videoCount} video(s) added to 1 playlist', {
-      videoCount: toBeAddedToPlaylistVideoCount.value,
+      videoCount: videosToBeAdded.length,
     }, toBeAddedToPlaylistVideoCount.value)
   } else {
     message = t('User Playlists.AddVideoPrompt.Toast.{videoCount} video(s) added to {playlistCount} playlists', {
-      videoCount: toBeAddedToPlaylistVideoCount.value,
+      videoCount: videosToBeAdded.length,
       playlistCount: addedPlaylistIds.size,
     }, toBeAddedToPlaylistVideoCount.value)
   }

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -395,14 +395,9 @@ function addSelectedToPlaylists() {
     addedPlaylistIds.add(playlist._id)
   })
 
-  if (addedPlaylistIds.size === 1) {
-    showToast(t('User Playlists.AddVideoPrompt.Toast.Videos added to 1 playlist', {
-    }, toBeAddedToPlaylistVideoCount.value))
-  } else {
-    showToast(t('User Playlists.AddVideoPrompt.Toast.Videos added to {playlistCount} playlists', {
-      playlistCount: addedPlaylistIds.size,
-    }, toBeAddedToPlaylistVideoCount.value))
-  }
+  showToast(t('User Playlists.AddVideoPrompt.Toast.Video(s) added to {playlistCount} playlists', {
+    playlistCount: addedPlaylistIds.size,
+  }, addedPlaylistIds.value))
 
   hide()
 }

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -397,7 +397,7 @@ function addSelectedToPlaylists() {
 
   showToast(t('User Playlists.AddVideoPrompt.Toast.Video(s) added to {playlistCount} playlists', {
     playlistCount: addedPlaylistIds.size,
-  }, addedPlaylistIds.value))
+  }, addedPlaylistIds.size))
 
   hide()
 }

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -395,17 +395,15 @@ function addSelectedToPlaylists() {
     addedPlaylistIds.add(playlist._id)
   })
 
-  let message
   if (addedPlaylistIds.size === 1) {
-    message = t('User Playlists.AddVideoPrompt.Toast.Video(s) added to 1 playlist', {
-    }, toBeAddedToPlaylistVideoCount.value)
+    showToast(t('User Playlists.AddVideoPrompt.Toast.Videos added to 1 playlist', {
+    }, toBeAddedToPlaylistVideoCount.value))
   } else {
-    message = t('User Playlists.AddVideoPrompt.Toast.Video(s) added to {playlistCount} playlists', {
+    showToast(t('User Playlists.AddVideoPrompt.Toast.Videos added to {playlistCount} playlists', {
       playlistCount: addedPlaylistIds.size,
-    }, toBeAddedToPlaylistVideoCount.value)
+    }, toBeAddedToPlaylistVideoCount.value))
   }
 
-  showToast(message)
   hide()
 }
 

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -233,8 +233,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to 1 playlist": ""
-      "Video(s) added to {playlistCount} playlists": ""
+      "Videos added to 1 playlist": ""
+      "Videos added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -233,7 +233,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -233,7 +233,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -233,8 +233,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Videos added to 1 playlist": ""
-      "Videos added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/af.yaml
+++ b/static/locales/af.yaml
@@ -233,8 +233,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "{videoCount} video(s) added to 1 playlist": ""
-      "{videoCount} video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to 1 playlist": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/am.yaml
+++ b/static/locales/am.yaml
@@ -243,8 +243,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "{videoCount} video(s) added to 1 playlist": ""
-      "{videoCount} video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to 1 playlist": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/am.yaml
+++ b/static/locales/am.yaml
@@ -243,7 +243,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/am.yaml
+++ b/static/locales/am.yaml
@@ -243,8 +243,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Videos added to 1 playlist": ""
-      "Videos added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/am.yaml
+++ b/static/locales/am.yaml
@@ -243,7 +243,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/am.yaml
+++ b/static/locales/am.yaml
@@ -243,8 +243,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to 1 playlist": ""
-      "Video(s) added to {playlistCount} playlists": ""
+      "Videos added to 1 playlist": ""
+      "Videos added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -164,7 +164,7 @@ User Playlists:
     Select a playlist to add your N videos to: حدد قائمة تشغيل لإضافة الفيديو الخاص بك إلى | حدد قائمة تشغيل لإضافة مقاطع الفيديو {videoCount} إليها
     Toast:
       You haven't selected any playlist yet.: لم تقم بتحديد أي قائمة تشغيل حتى الآن.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Save: حفظ
     Search in Playlists: البحث في قوائم التشغيل
     N playlists selected: تم تحديد {playlistCount}

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -164,8 +164,8 @@ User Playlists:
     Select a playlist to add your N videos to: حدد قائمة تشغيل لإضافة الفيديو الخاص بك إلى | حدد قائمة تشغيل لإضافة مقاطع الفيديو {videoCount} إليها
     Toast:
       You haven't selected any playlist yet.: لم تقم بتحديد أي قائمة تشغيل حتى الآن.
-      "Video(s) added to 1 playlist": تمت إضافة فيديو واحد إلى قائمة تشغيل واحدة | تمت إضافة {videoCount} من مقاطع الفيديو إلى قائمة تشغيل واحدة
-      "Video(s) added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة {videoCount} من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
+      "Videos added to 1 playlist": تمت إضافة فيديو واحد إلى قائمة تشغيل واحدة | تمت إضافة من مقاطع الفيديو إلى قائمة تشغيل واحدة
+      "Videos added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
     Save: حفظ
     Search in Playlists: البحث في قوائم التشغيل
     N playlists selected: تم تحديد {playlistCount}

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -164,8 +164,8 @@ User Playlists:
     Select a playlist to add your N videos to: حدد قائمة تشغيل لإضافة الفيديو الخاص بك إلى | حدد قائمة تشغيل لإضافة مقاطع الفيديو {videoCount} إليها
     Toast:
       You haven't selected any playlist yet.: لم تقم بتحديد أي قائمة تشغيل حتى الآن.
-      "{videoCount} video(s) added to 1 playlist": تمت إضافة فيديو واحد إلى قائمة تشغيل واحدة | تمت إضافة {videoCount} من مقاطع الفيديو إلى قائمة تشغيل واحدة
-      "{videoCount} video(s) added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة {videoCount} من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
+      "Video(s) added to 1 playlist": تمت إضافة فيديو واحد إلى قائمة تشغيل واحدة | تمت إضافة {videoCount} من مقاطع الفيديو إلى قائمة تشغيل واحدة
+      "Video(s) added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة {videoCount} من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
     Save: حفظ
     Search in Playlists: البحث في قوائم التشغيل
     N playlists selected: تم تحديد {playlistCount}

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -164,8 +164,7 @@ User Playlists:
     Select a playlist to add your N videos to: حدد قائمة تشغيل لإضافة الفيديو الخاص بك إلى | حدد قائمة تشغيل لإضافة مقاطع الفيديو {videoCount} إليها
     Toast:
       You haven't selected any playlist yet.: لم تقم بتحديد أي قائمة تشغيل حتى الآن.
-      "Videos added to 1 playlist": تمت إضافة فيديو واحد إلى قائمة تشغيل واحدة | تمت إضافة من مقاطع الفيديو إلى قائمة تشغيل واحدة
-      "Videos added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
+      "Video(s) added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
     Save: حفظ
     Search in Playlists: البحث في قوائم التشغيل
     N playlists selected: تم تحديد {playlistCount}

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -164,7 +164,7 @@ User Playlists:
     Select a playlist to add your N videos to: حدد قائمة تشغيل لإضافة الفيديو الخاص بك إلى | حدد قائمة تشغيل لإضافة مقاطع الفيديو {videoCount} إليها
     Toast:
       You haven't selected any playlist yet.: لم تقم بتحديد أي قائمة تشغيل حتى الآن.
-      "Video(s) added to {playlistCount} playlists": تمت إضافة مقطع فيديو واحد إلى قوائم التشغيل {playlistCount} | تمت إضافة من مقاطع الفيديو إلى قوائم التشغيل {playlistCount}
+      "Video(s) added to {playlistCount} playlists":
     Save: حفظ
     Search in Playlists: البحث في قوائم التشغيل
     N playlists selected: تم تحديد {playlistCount}

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -248,8 +248,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to 1 playlist": ""
-      "Video(s) added to {playlistCount} playlists": ""
+      "Videos added to 1 playlist": ""
+      "Videos added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -248,7 +248,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -248,8 +248,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Videos added to 1 playlist": ""
-      "Videos added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -248,8 +248,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "{videoCount} video(s) added to 1 playlist": ""
-      "{videoCount} video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to 1 playlist": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/awa.yaml
+++ b/static/locales/awa.yaml
@@ -248,7 +248,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -170,7 +170,7 @@ User Playlists:
     Added {count} Times: Artıq Əlavə Edilib | {count} dəfə əlavə edildi
     Toast:
       You haven't selected any playlist yet.: Siz hələ heç bir pleylist seçməmisiniz.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Video Artıq Əlavə Edilib'
   Remove Duplicate Videos: Eyni Videoları Sil
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Bu pleylistdən 1 eyni videonu silmək istədiyinizə əminsiniz? Bu geri alına bilməz | {playlistItemCount} eyni videonu bu pleylistdən silmək istədiyinizə əminsiniz? Bu geri alına bilməz.

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -170,8 +170,8 @@ User Playlists:
     Added {count} Times: Artıq Əlavə Edilib | {count} dəfə əlavə edildi
     Toast:
       You haven't selected any playlist yet.: Siz hələ heç bir pleylist seçməmisiniz.
-      "Video(s) added to 1 playlist": 1 video 1 pleylistə əlavə edildi | {videoCount} video 1 pleylistə əlavə edildi
-      "Video(s) added to {playlistCount} playlists": 1 video {playlistCount} pleylistə əlavə edildi | {videoCount} video {playlistCount} pleylistə əlavə edildi
+      "Videos added to 1 playlist": 1 video 1 pleylistə əlavə edildi | video 1 pleylistə əlavə edildi
+      "Videos added to {playlistCount} playlists": video {playlistCount} pleylistə əlavə edildi | video {playlistCount} pleylistə əlavə edildi
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Video Artıq Əlavə Edilib'
   Remove Duplicate Videos: Eyni Videoları Sil
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Bu pleylistdən 1 eyni videonu silmək istədiyinizə əminsiniz? Bu geri alına bilməz | {playlistItemCount} eyni videonu bu pleylistdən silmək istədiyinizə əminsiniz? Bu geri alına bilməz.

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -170,8 +170,8 @@ User Playlists:
     Added {count} Times: Artıq Əlavə Edilib | {count} dəfə əlavə edildi
     Toast:
       You haven't selected any playlist yet.: Siz hələ heç bir pleylist seçməmisiniz.
-      "{videoCount} video(s) added to 1 playlist": 1 video 1 pleylistə əlavə edildi | {videoCount} video 1 pleylistə əlavə edildi
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video {playlistCount} pleylistə əlavə edildi | {videoCount} video {playlistCount} pleylistə əlavə edildi
+      "Video(s) added to 1 playlist": 1 video 1 pleylistə əlavə edildi | {videoCount} video 1 pleylistə əlavə edildi
+      "Video(s) added to {playlistCount} playlists": 1 video {playlistCount} pleylistə əlavə edildi | {videoCount} video {playlistCount} pleylistə əlavə edildi
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Video Artıq Əlavə Edilib'
   Remove Duplicate Videos: Eyni Videoları Sil
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Bu pleylistdən 1 eyni videonu silmək istədiyinizə əminsiniz? Bu geri alına bilməz | {playlistItemCount} eyni videonu bu pleylistdən silmək istədiyinizə əminsiniz? Bu geri alına bilməz.

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -170,7 +170,7 @@ User Playlists:
     Added {count} Times: Artıq Əlavə Edilib | {count} dəfə əlavə edildi
     Toast:
       You haven't selected any playlist yet.: Siz hələ heç bir pleylist seçməmisiniz.
-      "Video(s) added to {playlistCount} playlists": video {playlistCount} pleylistə əlavə edildi | video {playlistCount} pleylistə əlavə edildi
+      "Video(s) added to {playlistCount} playlists":
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Video Artıq Əlavə Edilib'
   Remove Duplicate Videos: Eyni Videoları Sil
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Bu pleylistdən 1 eyni videonu silmək istədiyinizə əminsiniz? Bu geri alına bilməz | {playlistItemCount} eyni videonu bu pleylistdən silmək istədiyinizə əminsiniz? Bu geri alına bilməz.

--- a/static/locales/az.yaml
+++ b/static/locales/az.yaml
@@ -170,8 +170,7 @@ User Playlists:
     Added {count} Times: Artıq Əlavə Edilib | {count} dəfə əlavə edildi
     Toast:
       You haven't selected any playlist yet.: Siz hələ heç bir pleylist seçməmisiniz.
-      "Videos added to 1 playlist": 1 video 1 pleylistə əlavə edildi | video 1 pleylistə əlavə edildi
-      "Videos added to {playlistCount} playlists": video {playlistCount} pleylistə əlavə edildi | video {playlistCount} pleylistə əlavə edildi
+      "Video(s) added to {playlistCount} playlists": video {playlistCount} pleylistə əlavə edildi | video {playlistCount} pleylistə əlavə edildi
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Video Artıq Əlavə Edilib'
   Remove Duplicate Videos: Eyni Videoları Sil
   Are you sure you want to remove {playlistItemCount} duplicate videos from this playlist? This cannot be undone: Bu pleylistdən 1 eyni videonu silmək istədiyinizə əminsiniz? Bu geri alına bilməz | {playlistItemCount} eyni videonu bu pleylistdən silmək istədiyinizə əminsiniz? Bu geri alına bilməz.

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -147,7 +147,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} відэа ўжо дададзена'
     Toast:
       You haven't selected any playlist yet.: Вы яшчэ не выбралі плэй-ліст.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: Выберыце плэй-ліст, каб дадаць сваё відэа | Выберыце плэй-ліст, каб дадаць у яго {videoCount} відэа
     Search in Playlists: Пошук у плэй-лістах
     Added {count} Times: Ужо дададзена | Дададзена {count} разоў

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -147,8 +147,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} відэа ўжо дададзена'
     Toast:
       You haven't selected any playlist yet.: Вы яшчэ не выбралі плэй-ліст.
-      "Video(s) added to {playlistCount} playlists": 1 відэа дададзена ў {playlistCount} плэй-лістоў | {videoCount} відэа дададзены ў {playlistCount} плэй-лістоў
-      "Video(s) added to 1 playlist": 1 відэа дададзена ў 1 плэй-ліст | {videoCount} відэа дададзены ў 1 плэй-ліст
+      "Videos added to {playlistCount} playlists": відэа дададзена ў {playlistCount} плэй-лістоў | відэа дададзены ў {playlistCount} плэй-лістоў
+      "Videos added to 1 playlist": 1 відэа дададзена ў 1 плэй-ліст | відэа дададзены ў 1 плэй-ліст
     Select a playlist to add your N videos to: Выберыце плэй-ліст, каб дадаць сваё відэа | Выберыце плэй-ліст, каб дадаць у яго {videoCount} відэа
     Search in Playlists: Пошук у плэй-лістах
     Added {count} Times: Ужо дададзена | Дададзена {count} разоў

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -147,8 +147,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} відэа ўжо дададзена'
     Toast:
       You haven't selected any playlist yet.: Вы яшчэ не выбралі плэй-ліст.
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 відэа дададзена ў {playlistCount} плэй-лістоў | {videoCount} відэа дададзены ў {playlistCount} плэй-лістоў
-      "{videoCount} video(s) added to 1 playlist": 1 відэа дададзена ў 1 плэй-ліст | {videoCount} відэа дададзены ў 1 плэй-ліст
+      "Video(s) added to {playlistCount} playlists": 1 відэа дададзена ў {playlistCount} плэй-лістоў | {videoCount} відэа дададзены ў {playlistCount} плэй-лістоў
+      "Video(s) added to 1 playlist": 1 відэа дададзена ў 1 плэй-ліст | {videoCount} відэа дададзены ў 1 плэй-ліст
     Select a playlist to add your N videos to: Выберыце плэй-ліст, каб дадаць сваё відэа | Выберыце плэй-ліст, каб дадаць у яго {videoCount} відэа
     Search in Playlists: Пошук у плэй-лістах
     Added {count} Times: Ужо дададзена | Дададзена {count} разоў

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -147,8 +147,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} відэа ўжо дададзена'
     Toast:
       You haven't selected any playlist yet.: Вы яшчэ не выбралі плэй-ліст.
-      "Videos added to {playlistCount} playlists": відэа дададзена ў {playlistCount} плэй-лістоў | відэа дададзены ў {playlistCount} плэй-лістоў
-      "Videos added to 1 playlist": 1 відэа дададзена ў 1 плэй-ліст | відэа дададзены ў 1 плэй-ліст
+      "Video(s) added to {playlistCount} playlists": відэа дададзена ў {playlistCount} плэй-лістоў | відэа дададзены ў {playlistCount} плэй-лістоў
     Select a playlist to add your N videos to: Выберыце плэй-ліст, каб дадаць сваё відэа | Выберыце плэй-ліст, каб дадаць у яго {videoCount} відэа
     Search in Playlists: Пошук у плэй-лістах
     Added {count} Times: Ужо дададзена | Дададзена {count} разоў

--- a/static/locales/be.yaml
+++ b/static/locales/be.yaml
@@ -147,7 +147,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} відэа ўжо дададзена'
     Toast:
       You haven't selected any playlist yet.: Вы яшчэ не выбралі плэй-ліст.
-      "Video(s) added to {playlistCount} playlists": відэа дададзена ў {playlistCount} плэй-лістоў | відэа дададзены ў {playlistCount} плэй-лістоў
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: Выберыце плэй-ліст, каб дадаць сваё відэа | Выберыце плэй-ліст, каб дадаць у яго {videoCount} відэа
     Search in Playlists: Пошук у плэй-лістах
     Added {count} Times: Ужо дададзена | Дададзена {count} разоў

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -173,8 +173,8 @@ User Playlists:
     N playlists selected: '{playlistCount} избрани'
     Toast:
       You haven't selected any playlist yet.: Все още не сте избрали плейлист.
-      "{videoCount} video(s) added to 1 playlist": Добавено 1 видео в 1 плейлист | Добавени {videoCount} видеа в 1 плейлист
-      "{videoCount} video(s) added to {playlistCount} playlists": Добавено 1 видео към {playlistCount} плейлиста | Добавени {videoCount} видеа към {playlistCount} плейлиста
+      "Video(s) added to 1 playlist": Добавено 1 видео в 1 плейлист | Добавени {videoCount} видеа в 1 плейлист
+      "Video(s) added to {playlistCount} playlists": Добавено 1 видео към {playlistCount} плейлиста | Добавени {videoCount} видеа към {playlistCount} плейлиста
     Save: Запазване
     Added {count} Times: Вече е добавено | Добавено {count} пъти
     "{videoCount}/{totalVideoCount} Videos Already Added": Вече са добавени {videoCount}/{totalVideoCount} видеа

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -173,7 +173,7 @@ User Playlists:
     N playlists selected: '{playlistCount} избрани'
     Toast:
       You haven't selected any playlist yet.: Все още не сте избрали плейлист.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Save: Запазване
     Added {count} Times: Вече е добавено | Добавено {count} пъти
     "{videoCount}/{totalVideoCount} Videos Already Added": Вече са добавени {videoCount}/{totalVideoCount} видеа

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -173,8 +173,7 @@ User Playlists:
     N playlists selected: '{playlistCount} избрани'
     Toast:
       You haven't selected any playlist yet.: Все още не сте избрали плейлист.
-      "Videos added to 1 playlist": Добавено 1 видео в 1 плейлист | Добавени видеа в 1 плейлист
-      "Videos added to {playlistCount} playlists": Добавено видео към {playlistCount} плейлиста | Добавени видеа към {playlistCount} плейлиста
+      "Video(s) added to {playlistCount} playlists": Добавено видео към {playlistCount} плейлиста | Добавени видеа към {playlistCount} плейлиста
     Save: Запазване
     Added {count} Times: Вече е добавено | Добавено {count} пъти
     "{videoCount}/{totalVideoCount} Videos Already Added": Вече са добавени {videoCount}/{totalVideoCount} видеа

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -173,8 +173,8 @@ User Playlists:
     N playlists selected: '{playlistCount} избрани'
     Toast:
       You haven't selected any playlist yet.: Все още не сте избрали плейлист.
-      "Video(s) added to 1 playlist": Добавено 1 видео в 1 плейлист | Добавени {videoCount} видеа в 1 плейлист
-      "Video(s) added to {playlistCount} playlists": Добавено 1 видео към {playlistCount} плейлиста | Добавени {videoCount} видеа към {playlistCount} плейлиста
+      "Videos added to 1 playlist": Добавено 1 видео в 1 плейлист | Добавени видеа в 1 плейлист
+      "Videos added to {playlistCount} playlists": Добавено видео към {playlistCount} плейлиста | Добавени видеа към {playlistCount} плейлиста
     Save: Запазване
     Added {count} Times: Вече е добавено | Добавено {count} пъти
     "{videoCount}/{totalVideoCount} Videos Already Added": Вече са добавени {videoCount}/{totalVideoCount} видеа

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -173,7 +173,7 @@ User Playlists:
     N playlists selected: '{playlistCount} избрани'
     Toast:
       You haven't selected any playlist yet.: Все още не сте избрали плейлист.
-      "Video(s) added to {playlistCount} playlists": Добавено видео към {playlistCount} плейлиста | Добавени видеа към {playlistCount} плейлиста
+      "Video(s) added to {playlistCount} playlists":
     Save: Запазване
     Added {count} Times: Вече е добавено | Добавено {count} пъти
     "{videoCount}/{totalVideoCount} Videos Already Added": Вече са добавени {videoCount}/{totalVideoCount} видеа

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -241,8 +241,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'N''ho peus diuzet ur roll-videoioù c''hoazh.'
-      "{videoCount} video(s) added to 1 playlist": "1 video ouzhpennet d'1 roll-videoioù | {videoCount} video ouzhpennet d'1 roll-videoioù"
-      "{videoCount} video(s) added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | {videoCount} video ouzhpennet da  {playlistCount} roll-videoioù"
+      "Video(s) added to 1 playlist": "1 video ouzhpennet d'1 roll-videoioù | {videoCount} video ouzhpennet d'1 roll-videoioù"
+      "Video(s) added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | {videoCount} video ouzhpennet da  {playlistCount} roll-videoioù"
   CreatePlaylistPrompt:
     New Playlist Name: 'Anv nevez ar roll-videoioù'
     Create: 'Krouiñ'

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -241,7 +241,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'N''ho peus diuzet ur roll-videoioù c''hoazh.'
-      "Video(s) added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | video ouzhpennet da  {playlistCount} roll-videoioù"
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: 'Anv nevez ar roll-videoioù'
     Create: 'Krouiñ'

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -241,8 +241,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'N''ho peus diuzet ur roll-videoioù c''hoazh.'
-      "Videos added to 1 playlist": "1 video ouzhpennet d'1 roll-videoioù | video ouzhpennet d'1 roll-videoioù"
-      "Videos added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | video ouzhpennet da  {playlistCount} roll-videoioù"
+      "Video(s) added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | video ouzhpennet da  {playlistCount} roll-videoioù"
   CreatePlaylistPrompt:
     New Playlist Name: 'Anv nevez ar roll-videoioù'
     Create: 'Krouiñ'

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -241,7 +241,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'N''ho peus diuzet ur roll-videoioù c''hoazh.'
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: 'Anv nevez ar roll-videoioù'
     Create: 'Krouiñ'

--- a/static/locales/br.yaml
+++ b/static/locales/br.yaml
@@ -241,8 +241,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'N''ho peus diuzet ur roll-videoioù c''hoazh.'
-      "Video(s) added to 1 playlist": "1 video ouzhpennet d'1 roll-videoioù | {videoCount} video ouzhpennet d'1 roll-videoioù"
-      "Video(s) added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | {videoCount} video ouzhpennet da  {playlistCount} roll-videoioù"
+      "Videos added to 1 playlist": "1 video ouzhpennet d'1 roll-videoioù | video ouzhpennet d'1 roll-videoioù"
+      "Videos added to {playlistCount} playlists": "1 video ouzhpennet da {playlistCount} roll-videoioù | video ouzhpennet da  {playlistCount} roll-videoioù"
   CreatePlaylistPrompt:
     New Playlist Name: 'Anv nevez ar roll-videoioù'
     Create: 'Krouiñ'

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -185,8 +185,8 @@ User Playlists:
     Search in Playlists: گەڕان لەناو پێڕستی لێدانەکان
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ پێڕستێکی لێدانت دیاری نەکردووە.
-      "Video(s) added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | {videoCount} ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
-      "Video(s) added to 1 playlist": ڤیدیۆیەک زیاد کرا بۆ یەک پێڕستی لێدان | {videoCount} ڤیدیۆ زیاد کرا بۆ یەک پێڕستی لێدان
+      "Videos added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
+      "Videos added to 1 playlist": ڤیدیۆیەک زیاد کرا بۆ یەک پێڕستی لێدان | ڤیدیۆ زیاد کرا بۆ یەک پێڕستی لێدان
     Allow Adding Duplicate Video(s): ڕێ بە زیادکردنی ڤیدیۆی دووبارە بدە
     N playlists selected: '{playlistCount} دیاریکراوە'
   CreatePlaylistPrompt:

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -185,8 +185,7 @@ User Playlists:
     Search in Playlists: گەڕان لەناو پێڕستی لێدانەکان
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ پێڕستێکی لێدانت دیاری نەکردووە.
-      "Videos added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
-      "Videos added to 1 playlist": ڤیدیۆیەک زیاد کرا بۆ یەک پێڕستی لێدان | ڤیدیۆ زیاد کرا بۆ یەک پێڕستی لێدان
+      "Video(s) added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
     Allow Adding Duplicate Video(s): ڕێ بە زیادکردنی ڤیدیۆی دووبارە بدە
     N playlists selected: '{playlistCount} دیاریکراوە'
   CreatePlaylistPrompt:

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -185,7 +185,7 @@ User Playlists:
     Search in Playlists: گەڕان لەناو پێڕستی لێدانەکان
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ پێڕستێکی لێدانت دیاری نەکردووە.
-      "Video(s) added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
+      "Video(s) added to {playlistCount} playlists":
     Allow Adding Duplicate Video(s): ڕێ بە زیادکردنی ڤیدیۆی دووبارە بدە
     N playlists selected: '{playlistCount} دیاریکراوە'
   CreatePlaylistPrompt:

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -185,8 +185,8 @@ User Playlists:
     Search in Playlists: گەڕان لەناو پێڕستی لێدانەکان
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ پێڕستێکی لێدانت دیاری نەکردووە.
-      "{videoCount} video(s) added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | {videoCount} ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
-      "{videoCount} video(s) added to 1 playlist": ڤیدیۆیەک زیاد کرا بۆ یەک پێڕستی لێدان | {videoCount} ڤیدیۆ زیاد کرا بۆ یەک پێڕستی لێدان
+      "Video(s) added to {playlistCount} playlists": ڤیدیۆیەک زیاد کرا بۆ {playlistCount} پێڕستی لێدان | {videoCount} ڤیدیۆ زیاد کرا بۆ {playlistCount} پێڕستی لێدان
+      "Video(s) added to 1 playlist": ڤیدیۆیەک زیاد کرا بۆ یەک پێڕستی لێدان | {videoCount} ڤیدیۆ زیاد کرا بۆ یەک پێڕستی لێدان
     Allow Adding Duplicate Video(s): ڕێ بە زیادکردنی ڤیدیۆی دووبارە بدە
     N playlists selected: '{playlistCount} دیاریکراوە'
   CreatePlaylistPrompt:

--- a/static/locales/ckb.yaml
+++ b/static/locales/ckb.yaml
@@ -185,7 +185,7 @@ User Playlists:
     Search in Playlists: گەڕان لەناو پێڕستی لێدانەکان
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ پێڕستێکی لێدانت دیاری نەکردووە.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Allow Adding Duplicate Video(s): ڕێ بە زیادکردنی ڤیدیۆی دووبارە بدە
     N playlists selected: '{playlistCount} دیاریکراوە'
   CreatePlaylistPrompt:

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -124,8 +124,8 @@ User Playlists:
     Search in Playlists: Hledat v playlistech
     Save: Uložit
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video přidáno do {playlistCount} playlistů| {videoCount} videí přidáno do  {playlistCount} playlistů
-      "{videoCount} video(s) added to 1 playlist": 1 video přidáno do playlistu | {videoCount} videí přidáno do playlistu
+      "Video(s) added to {playlistCount} playlists": 1 video přidáno do {playlistCount} playlistů| {videoCount} videí přidáno do  {playlistCount} playlistů
+      "Video(s) added to 1 playlist": 1 video přidáno do playlistu | {videoCount} videí přidáno do playlistu
       You haven't selected any playlist yet.: Zatím jste nevybrali žádný playlist.
     Select a playlist to add your N videos to: Vyberte playlist, do kterého přidat vaše video | Vyberte playlist, do kterého přidat vašich {videoCount} videí
     N playlists selected: Vybráno {playlistCount}

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -124,8 +124,8 @@ User Playlists:
     Search in Playlists: Hledat v playlistech
     Save: Uložit
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 video přidáno do {playlistCount} playlistů| {videoCount} videí přidáno do  {playlistCount} playlistů
-      "Video(s) added to 1 playlist": 1 video přidáno do playlistu | {videoCount} videí přidáno do playlistu
+      "Videos added to {playlistCount} playlists": video přidáno do {playlistCount} playlistů| videí přidáno do  {playlistCount} playlistů
+      "Videos added to 1 playlist": 1 video přidáno do playlistu | videí přidáno do playlistu
       You haven't selected any playlist yet.: Zatím jste nevybrali žádný playlist.
     Select a playlist to add your N videos to: Vyberte playlist, do kterého přidat vaše video | Vyberte playlist, do kterého přidat vašich {videoCount} videí
     N playlists selected: Vybráno {playlistCount}

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -124,7 +124,7 @@ User Playlists:
     Search in Playlists: Hledat v playlistech
     Save: Uložit
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Zatím jste nevybrali žádný playlist.
     Select a playlist to add your N videos to: Vyberte playlist, do kterého přidat vaše video | Vyberte playlist, do kterého přidat vašich {videoCount} videí
     N playlists selected: Vybráno {playlistCount}

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -124,7 +124,7 @@ User Playlists:
     Search in Playlists: Hledat v playlistech
     Save: Uložit
     Toast:
-      "Video(s) added to {playlistCount} playlists": video přidáno do {playlistCount} playlistů| videí přidáno do  {playlistCount} playlistů
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Zatím jste nevybrali žádný playlist.
     Select a playlist to add your N videos to: Vyberte playlist, do kterého přidat vaše video | Vyberte playlist, do kterého přidat vašich {videoCount} videí
     N playlists selected: Vybráno {playlistCount}

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -124,8 +124,7 @@ User Playlists:
     Search in Playlists: Hledat v playlistech
     Save: Uložit
     Toast:
-      "Videos added to {playlistCount} playlists": video přidáno do {playlistCount} playlistů| videí přidáno do  {playlistCount} playlistů
-      "Videos added to 1 playlist": 1 video přidáno do playlistu | videí přidáno do playlistu
+      "Video(s) added to {playlistCount} playlists": video přidáno do {playlistCount} playlistů| videí přidáno do  {playlistCount} playlistů
       You haven't selected any playlist yet.: Zatím jste nevybrali žádný playlist.
     Select a playlist to add your N videos to: Vyberte playlist, do kterého přidat vaše video | Vyberte playlist, do kterého přidat vašich {videoCount} videí
     N playlists selected: Vybráno {playlistCount}

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -147,7 +147,7 @@ User Playlists:
     Added {count} Times: Wedi'u Hychwanegu Eisoes | Ychwanegwyd {count} Gwaith
     Toast:
       You haven't selected any playlist yet.: Nid ydych wedi dewis unrhyw restr chwarae eto.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Allow Adding Duplicate Video(s): Caniatáu Ychwanegu Fideo(s) Dyblyg
     "{videoCount}/{totalVideoCount} Videos Will Be Added": "{videoCount}/{totalVideoCount} Fideo i'w Hychwanegu"
     N playlists selected: "{playlistCount} Wedi'u Dewis"

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -147,7 +147,7 @@ User Playlists:
     Added {count} Times: Wedi'u Hychwanegu Eisoes | Ychwanegwyd {count} Gwaith
     Toast:
       You haven't selected any playlist yet.: Nid ydych wedi dewis unrhyw restr chwarae eto.
-      "Video(s) added to {playlistCount} playlists": fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
+      "Video(s) added to {playlistCount} playlists":
     Allow Adding Duplicate Video(s): Caniatáu Ychwanegu Fideo(s) Dyblyg
     "{videoCount}/{totalVideoCount} Videos Will Be Added": "{videoCount}/{totalVideoCount} Fideo i'w Hychwanegu"
     N playlists selected: "{playlistCount} Wedi'u Dewis"

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -147,8 +147,8 @@ User Playlists:
     Added {count} Times: Wedi'u Hychwanegu Eisoes | Ychwanegwyd {count} Gwaith
     Toast:
       You haven't selected any playlist yet.: Nid ydych wedi dewis unrhyw restr chwarae eto.
-      "{videoCount} video(s) added to 1 playlist": 1 fideo wedi'i ychwanegu at 1 rhestr chwarae | {videoCount} fideo wedi'u hychwanegu at 1 rhestr chwarae
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | {videoCount} fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
+      "Video(s) added to 1 playlist": 1 fideo wedi'i ychwanegu at 1 rhestr chwarae | {videoCount} fideo wedi'u hychwanegu at 1 rhestr chwarae
+      "Video(s) added to {playlistCount} playlists": 1 fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | {videoCount} fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
     Allow Adding Duplicate Video(s): Caniatáu Ychwanegu Fideo(s) Dyblyg
     "{videoCount}/{totalVideoCount} Videos Will Be Added": "{videoCount}/{totalVideoCount} Fideo i'w Hychwanegu"
     N playlists selected: "{playlistCount} Wedi'u Dewis"

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -147,8 +147,8 @@ User Playlists:
     Added {count} Times: Wedi'u Hychwanegu Eisoes | Ychwanegwyd {count} Gwaith
     Toast:
       You haven't selected any playlist yet.: Nid ydych wedi dewis unrhyw restr chwarae eto.
-      "Video(s) added to 1 playlist": 1 fideo wedi'i ychwanegu at 1 rhestr chwarae | {videoCount} fideo wedi'u hychwanegu at 1 rhestr chwarae
-      "Video(s) added to {playlistCount} playlists": 1 fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | {videoCount} fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
+      "Videos added to 1 playlist": 1 fideo wedi'i ychwanegu at 1 rhestr chwarae | fideo wedi'u hychwanegu at 1 rhestr chwarae
+      "Videos added to {playlistCount} playlists": fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
     Allow Adding Duplicate Video(s): Caniatáu Ychwanegu Fideo(s) Dyblyg
     "{videoCount}/{totalVideoCount} Videos Will Be Added": "{videoCount}/{totalVideoCount} Fideo i'w Hychwanegu"
     N playlists selected: "{playlistCount} Wedi'u Dewis"

--- a/static/locales/cy.yaml
+++ b/static/locales/cy.yaml
@@ -147,8 +147,7 @@ User Playlists:
     Added {count} Times: Wedi'u Hychwanegu Eisoes | Ychwanegwyd {count} Gwaith
     Toast:
       You haven't selected any playlist yet.: Nid ydych wedi dewis unrhyw restr chwarae eto.
-      "Videos added to 1 playlist": 1 fideo wedi'i ychwanegu at 1 rhestr chwarae | fideo wedi'u hychwanegu at 1 rhestr chwarae
-      "Videos added to {playlistCount} playlists": fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
+      "Video(s) added to {playlistCount} playlists": fideo wedi'i ychwanegu at {playlistCount} rhestr chwarae | fideo wedi'u hychwanegu at {playlistCount} rhestr chwarae
     Allow Adding Duplicate Video(s): Caniatáu Ychwanegu Fideo(s) Dyblyg
     "{videoCount}/{totalVideoCount} Videos Will Be Added": "{videoCount}/{totalVideoCount} Fideo i'w Hychwanegu"
     N playlists selected: "{playlistCount} Wedi'u Dewis"

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -165,7 +165,7 @@ User Playlists:
     N playlists selected: '{playlistCount} valgt'
     Search in Playlists: Søg i playlister
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Du har ikke valgt nogen playliste endnu.
     Added {count} Times: Allerede tilføjet | Tilføjet {count} gange
     Save: Gem

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -165,9 +165,9 @@ User Playlists:
     N playlists selected: '{playlistCount} valgt'
     Search in Playlists: Søg i playlister
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video føjet til {playlistCount} playlister | {videoCount} videoer føjet til {playlistCount} playlister
+      "Video(s) added to {playlistCount} playlists": 1 video føjet til {playlistCount} playlister | {videoCount} videoer føjet til {playlistCount} playlister
       You haven't selected any playlist yet.: Du har ikke valgt nogen playliste endnu.
-      "{videoCount} video(s) added to 1 playlist": 1 video føjet til 1 playliste | {videoCount} videoer føjet til 1 playliste
+      "Video(s) added to 1 playlist": 1 video føjet til 1 playliste | {videoCount} videoer føjet til 1 playliste
     Added {count} Times: Allerede tilføjet | Tilføjet {count} gange
     Save: Gem
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer tilføjes'

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -165,9 +165,8 @@ User Playlists:
     N playlists selected: '{playlistCount} valgt'
     Search in Playlists: Søg i playlister
     Toast:
-      "Videos added to {playlistCount} playlists": video føjet til {playlistCount} playlister | videoer føjet til {playlistCount} playlister
+      "Video(s) added to {playlistCount} playlists": video føjet til {playlistCount} playlister | videoer føjet til {playlistCount} playlister
       You haven't selected any playlist yet.: Du har ikke valgt nogen playliste endnu.
-      "Videos added to 1 playlist": 1 video føjet til 1 playliste | videoer føjet til 1 playliste
     Added {count} Times: Allerede tilføjet | Tilføjet {count} gange
     Save: Gem
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer tilføjes'

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -165,7 +165,7 @@ User Playlists:
     N playlists selected: '{playlistCount} valgt'
     Search in Playlists: Søg i playlister
     Toast:
-      "Video(s) added to {playlistCount} playlists": video føjet til {playlistCount} playlister | videoer føjet til {playlistCount} playlister
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Du har ikke valgt nogen playliste endnu.
     Added {count} Times: Allerede tilføjet | Tilføjet {count} gange
     Save: Gem

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -165,9 +165,9 @@ User Playlists:
     N playlists selected: '{playlistCount} valgt'
     Search in Playlists: Søg i playlister
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 video føjet til {playlistCount} playlister | {videoCount} videoer føjet til {playlistCount} playlister
+      "Videos added to {playlistCount} playlists": video føjet til {playlistCount} playlister | videoer føjet til {playlistCount} playlister
       You haven't selected any playlist yet.: Du har ikke valgt nogen playliste endnu.
-      "Video(s) added to 1 playlist": 1 video føjet til 1 playliste | {videoCount} videoer føjet til 1 playliste
+      "Videos added to 1 playlist": 1 video føjet til 1 playliste | videoer føjet til 1 playliste
     Added {count} Times: Allerede tilføjet | Tilføjet {count} gange
     Save: Gem
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer tilføjes'

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -164,7 +164,7 @@ User Playlists:
     Save: Speichern
     Toast:
       You haven't selected any playlist yet.: Du hast noch keine Playlist ausgewählt.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: Wähle eine Playlist, der du dein Video hinzufügen möchtest | Wähle eine Playlist, der du deine {videoCount} Videos hinzufügen möchtest
     Added {count} Times: 'Bereits hinzugefügt | {count} Mal hinzugefügt'
     Allow Adding Duplicate Video(s): Hinzufügen doppelter Videos zulassen

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -164,7 +164,7 @@ User Playlists:
     Save: Speichern
     Toast:
       You haven't selected any playlist yet.: Du hast noch keine Playlist ausgewählt.
-      "Video(s) added to {playlistCount} playlists": Video zu {playlistCount} Playlists hinzugefügt | Videos zu {playlistCount} Playlists hinzugefügt
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: Wähle eine Playlist, der du dein Video hinzufügen möchtest | Wähle eine Playlist, der du deine {videoCount} Videos hinzufügen möchtest
     Added {count} Times: 'Bereits hinzugefügt | {count} Mal hinzugefügt'
     Allow Adding Duplicate Video(s): Hinzufügen doppelter Videos zulassen

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -164,8 +164,7 @@ User Playlists:
     Save: Speichern
     Toast:
       You haven't selected any playlist yet.: Du hast noch keine Playlist ausgewählt.
-      "Videos added to 1 playlist": 1 Video zu 1 Playlist hinzugefügt | Videos zu 1 Playlist hinzugefügt
-      "Videos added to {playlistCount} playlists": Video zu {playlistCount} Playlists hinzugefügt | Videos zu {playlistCount} Playlists hinzugefügt
+      "Video(s) added to {playlistCount} playlists": Video zu {playlistCount} Playlists hinzugefügt | Videos zu {playlistCount} Playlists hinzugefügt
     Select a playlist to add your N videos to: Wähle eine Playlist, der du dein Video hinzufügen möchtest | Wähle eine Playlist, der du deine {videoCount} Videos hinzufügen möchtest
     Added {count} Times: 'Bereits hinzugefügt | {count} Mal hinzugefügt'
     Allow Adding Duplicate Video(s): Hinzufügen doppelter Videos zulassen

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -164,8 +164,8 @@ User Playlists:
     Save: Speichern
     Toast:
       You haven't selected any playlist yet.: Du hast noch keine Playlist ausgewählt.
-      "Video(s) added to 1 playlist": 1 Video zu 1 Playlist hinzugefügt | {videoCount} Videos zu 1 Playlist hinzugefügt
-      "Video(s) added to {playlistCount} playlists": 1 Video zu {playlistCount} Playlists hinzugefügt | {videoCount} Videos zu {playlistCount} Playlists hinzugefügt
+      "Videos added to 1 playlist": 1 Video zu 1 Playlist hinzugefügt | Videos zu 1 Playlist hinzugefügt
+      "Videos added to {playlistCount} playlists": Video zu {playlistCount} Playlists hinzugefügt | Videos zu {playlistCount} Playlists hinzugefügt
     Select a playlist to add your N videos to: Wähle eine Playlist, der du dein Video hinzufügen möchtest | Wähle eine Playlist, der du deine {videoCount} Videos hinzufügen möchtest
     Added {count} Times: 'Bereits hinzugefügt | {count} Mal hinzugefügt'
     Allow Adding Duplicate Video(s): Hinzufügen doppelter Videos zulassen

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -164,8 +164,8 @@ User Playlists:
     Save: Speichern
     Toast:
       You haven't selected any playlist yet.: Du hast noch keine Playlist ausgewählt.
-      "{videoCount} video(s) added to 1 playlist": 1 Video zu 1 Playlist hinzugefügt | {videoCount} Videos zu 1 Playlist hinzugefügt
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 Video zu {playlistCount} Playlists hinzugefügt | {videoCount} Videos zu {playlistCount} Playlists hinzugefügt
+      "Video(s) added to 1 playlist": 1 Video zu 1 Playlist hinzugefügt | {videoCount} Videos zu 1 Playlist hinzugefügt
+      "Video(s) added to {playlistCount} playlists": 1 Video zu {playlistCount} Playlists hinzugefügt | {videoCount} Videos zu {playlistCount} Playlists hinzugefügt
     Select a playlist to add your N videos to: Wähle eine Playlist, der du dein Video hinzufügen möchtest | Wähle eine Playlist, der du deine {videoCount} Videos hinzufügen möchtest
     Added {count} Times: 'Bereits hinzugefügt | {count} Mal hinzugefügt'
     Allow Adding Duplicate Video(s): Hinzufügen doppelter Videos zulassen

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -152,8 +152,8 @@ User Playlists:
     Search in Playlists: Αναζήτηση σε λίστες αναπαραγωγής
     Toast:
       You haven't selected any playlist yet.: Δεν έχετε επιλέξει καμία λίστα αναπαραγωγής ακόμα.
-      "Video(s) added to 1 playlist": 1 βίντεο προστέθηκε σε 1 λίστα αναπαραγωγής | {videoCount} βίντεο που προστέθηκαν σε 1 λίστα αναπαραγωγής
-      "Video(s) added to {playlistCount} playlists": 1 βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | {videoCount} βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
+      "Videos added to 1 playlist": 1 βίντεο προστέθηκε σε 1 λίστα αναπαραγωγής | βίντεο που προστέθηκαν σε 1 λίστα αναπαραγωγής
+      "Videos added to {playlistCount} playlists": βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
     Allow Adding Duplicate Video(s): Επίτρεψε την προσθήκη διπλών βίντεο( ών)
     Added {count} Times: Προστέθηκε ήδη | Προστέθηκε {count} Φορές
     Save: Αποθήκευση

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -152,8 +152,8 @@ User Playlists:
     Search in Playlists: Αναζήτηση σε λίστες αναπαραγωγής
     Toast:
       You haven't selected any playlist yet.: Δεν έχετε επιλέξει καμία λίστα αναπαραγωγής ακόμα.
-      "{videoCount} video(s) added to 1 playlist": 1 βίντεο προστέθηκε σε 1 λίστα αναπαραγωγής | {videoCount} βίντεο που προστέθηκαν σε 1 λίστα αναπαραγωγής
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | {videoCount} βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
+      "Video(s) added to 1 playlist": 1 βίντεο προστέθηκε σε 1 λίστα αναπαραγωγής | {videoCount} βίντεο που προστέθηκαν σε 1 λίστα αναπαραγωγής
+      "Video(s) added to {playlistCount} playlists": 1 βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | {videoCount} βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
     Allow Adding Duplicate Video(s): Επίτρεψε την προσθήκη διπλών βίντεο( ών)
     Added {count} Times: Προστέθηκε ήδη | Προστέθηκε {count} Φορές
     Save: Αποθήκευση

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -152,7 +152,7 @@ User Playlists:
     Search in Playlists: Αναζήτηση σε λίστες αναπαραγωγής
     Toast:
       You haven't selected any playlist yet.: Δεν έχετε επιλέξει καμία λίστα αναπαραγωγής ακόμα.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Allow Adding Duplicate Video(s): Επίτρεψε την προσθήκη διπλών βίντεο( ών)
     Added {count} Times: Προστέθηκε ήδη | Προστέθηκε {count} Φορές
     Save: Αποθήκευση

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -152,7 +152,7 @@ User Playlists:
     Search in Playlists: Αναζήτηση σε λίστες αναπαραγωγής
     Toast:
       You haven't selected any playlist yet.: Δεν έχετε επιλέξει καμία λίστα αναπαραγωγής ακόμα.
-      "Video(s) added to {playlistCount} playlists": βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
+      "Video(s) added to {playlistCount} playlists":
     Allow Adding Duplicate Video(s): Επίτρεψε την προσθήκη διπλών βίντεο( ών)
     Added {count} Times: Προστέθηκε ήδη | Προστέθηκε {count} Φορές
     Save: Αποθήκευση

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -152,8 +152,7 @@ User Playlists:
     Search in Playlists: Αναζήτηση σε λίστες αναπαραγωγής
     Toast:
       You haven't selected any playlist yet.: Δεν έχετε επιλέξει καμία λίστα αναπαραγωγής ακόμα.
-      "Videos added to 1 playlist": 1 βίντεο προστέθηκε σε 1 λίστα αναπαραγωγής | βίντεο που προστέθηκαν σε 1 λίστα αναπαραγωγής
-      "Videos added to {playlistCount} playlists": βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
+      "Video(s) added to {playlistCount} playlists": βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount} | βίντεο προστέθηκε στις λίστες αναπαραγωγής {playlistCount}
     Allow Adding Duplicate Video(s): Επίτρεψε την προσθήκη διπλών βίντεο( ών)
     Added {count} Times: Προστέθηκε ήδη | Προστέθηκε {count} Φορές
     Save: Αποθήκευση

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -167,7 +167,7 @@ User Playlists:
     Save: Save
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "Video(s) added to {playlistCount} playlists": Video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists
+      "Video(s) added to {playlistCount} playlists": Video(s) added to 1 playlist | Video(s) added to  {playlistCount} playlists
     Select a playlist to add your N videos to: Select a playlist to add your video to | Select a playlist to add your {videoCount} videos to
     Added {count} Times: Already Added | Added {count} times
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videos will be added'

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -166,9 +166,8 @@ User Playlists:
     Search in Playlists: Search in playlists
     Save: Save
     Toast:
-      "Videos added to 1 playlist": Video added to 1 playlist | Videos added to 1 playlist
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "Videos added to {playlistCount} playlists": Video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists
+      "Video(s) added to {playlistCount} playlists": Video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists
     Select a playlist to add your N videos to: Select a playlist to add your video to | Select a playlist to add your {videoCount} videos to
     Added {count} Times: Already Added | Added {count} times
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videos will be added'

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -166,9 +166,9 @@ User Playlists:
     Search in Playlists: Search in playlists
     Save: Save
     Toast:
-      "Video(s) added to 1 playlist": 1 video added to 1 playlist | {videoCount} videos added to 1 playlist
+      "Videos added to 1 playlist": Video added to 1 playlist | Videos added to 1 playlist
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "Video(s) added to {playlistCount} playlists": 1 video added to {playlistCount} playlists | {videoCount} videos added to  {playlistCount} playlists
+      "Videos added to {playlistCount} playlists": Video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists
     Select a playlist to add your N videos to: Select a playlist to add your video to | Select a playlist to add your {videoCount} videos to
     Added {count} Times: Already Added | Added {count} times
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videos will be added'

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -167,7 +167,7 @@ User Playlists:
     Save: Save
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "Video(s) added to {playlistCount} playlists": Video(s) added to 1 playlist | Video(s) added to  {playlistCount} playlists
+      "Video(s) added to {playlistCount} playlists": "Video(s) added to 1 playlist | Video(s) added to {playlistCount} playlists"
     Select a playlist to add your N videos to: Select a playlist to add your video to | Select a playlist to add your {videoCount} videos to
     Added {count} Times: Already Added | Added {count} times
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videos will be added'

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -166,9 +166,9 @@ User Playlists:
     Search in Playlists: Search in playlists
     Save: Save
     Toast:
-      "{videoCount} video(s) added to 1 playlist": 1 video added to 1 playlist | {videoCount} videos added to 1 playlist
+      "Video(s) added to 1 playlist": 1 video added to 1 playlist | {videoCount} videos added to 1 playlist
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video added to {playlistCount} playlists | {videoCount} videos added to  {playlistCount} playlists
+      "Video(s) added to {playlistCount} playlists": 1 video added to {playlistCount} playlists | {videoCount} videos added to  {playlistCount} playlists
     Select a playlist to add your N videos to: Select a playlist to add your video to | Select a playlist to add your {videoCount} videos to
     Added {count} Times: Already Added | Added {count} times
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videos will be added'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -246,8 +246,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "Video(s) added to 1 playlist": "1 video added to 1 playlist | Videos added to 1 playlist"
-      "Video(s) added to {playlistCount} playlists": "1 video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists"
+      "Videos added to 1 playlist": "Video added to 1 playlist | Videos added to 1 playlist"
+      "Videos added to {playlistCount} playlists": "Video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists"
   CreatePlaylistPrompt:
     New Playlist Name: New Playlist Name
     Create: Create

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -246,8 +246,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "Videos added to 1 playlist": "Video added to 1 playlist | Videos added to 1 playlist"
-      "Videos added to {playlistCount} playlists": "Video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists"
+      "Video(s) added to {playlistCount} playlists": "Video(s) added to 1 playlist | Video(s) added to {playlistCount} playlists"
   CreatePlaylistPrompt:
     New Playlist Name: New Playlist Name
     Create: Create

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -246,8 +246,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: You haven't selected any playlist yet.
-      "{videoCount} video(s) added to 1 playlist": "1 video added to 1 playlist | {videoCount} videos added to 1 playlist"
-      "{videoCount} video(s) added to {playlistCount} playlists": "1 video added to {playlistCount} playlists | {videoCount} videos added to  {playlistCount} playlists"
+      "Video(s) added to 1 playlist": "1 video added to 1 playlist | Videos added to 1 playlist"
+      "Video(s) added to {playlistCount} playlists": "1 video added to {playlistCount} playlists | Videos added to  {playlistCount} playlists"
   CreatePlaylistPrompt:
     New Playlist Name: New Playlist Name
     Create: Create

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -164,7 +164,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videos ya agregados'
     Toast:
       You haven't selected any playlist yet.: Todavía no seleccionaste ninguna lista de reproducción.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: Nombre de la nueva lista de reproducción
     Toast:

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -164,8 +164,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videos ya agregados'
     Toast:
       You haven't selected any playlist yet.: Todavía no seleccionaste ninguna lista de reproducción.
-      "Video(s) added to 1 playlist": 1 video agregado a 1 lista de reproducción | {videoCount} videos agregados a 1 lista de reproducción
-      "Video(s) added to {playlistCount} playlists": 1 video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
+      "Videos added to 1 playlist": 1 video agregado a 1 lista de reproducción | videos agregados a 1 lista de reproducción
+      "Videos added to {playlistCount} playlists": video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
   CreatePlaylistPrompt:
     New Playlist Name: Nombre de la nueva lista de reproducción
     Toast:

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -164,7 +164,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videos ya agregados'
     Toast:
       You haven't selected any playlist yet.: Todavía no seleccionaste ninguna lista de reproducción.
-      "Video(s) added to {playlistCount} playlists": video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: Nombre de la nueva lista de reproducción
     Toast:

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -164,8 +164,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videos ya agregados'
     Toast:
       You haven't selected any playlist yet.: Todavía no seleccionaste ninguna lista de reproducción.
-      "Videos added to 1 playlist": 1 video agregado a 1 lista de reproducción | videos agregados a 1 lista de reproducción
-      "Videos added to {playlistCount} playlists": video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
+      "Video(s) added to {playlistCount} playlists": video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
   CreatePlaylistPrompt:
     New Playlist Name: Nombre de la nueva lista de reproducción
     Toast:

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -164,8 +164,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videos ya agregados'
     Toast:
       You haven't selected any playlist yet.: Todavía no seleccionaste ninguna lista de reproducción.
-      "{videoCount} video(s) added to 1 playlist": 1 video agregado a 1 lista de reproducción | {videoCount} videos agregados a 1 lista de reproducción
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
+      "Video(s) added to 1 playlist": 1 video agregado a 1 lista de reproducción | {videoCount} videos agregados a 1 lista de reproducción
+      "Video(s) added to {playlistCount} playlists": 1 video agregado a {playlistCount} listas de reproducción |{videoCount} videos agregados a {playlistCount} listas de reproducción
   CreatePlaylistPrompt:
     New Playlist Name: Nombre de la nueva lista de reproducción
     Toast:

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -166,9 +166,9 @@ User Playlists:
   Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: ¿Estás seguro de que deseas eliminar 1 video visto de esta lista de reproducción? Esto no se puede deshacer.
   AddVideoPrompt:
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
+      "Video(s) added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna playlist.
-      "{videoCount} video(s) added to 1 playlist": 1 video agregado a 1 playlist
+      "Video(s) added to 1 playlist": 1 video agregado a 1 playlist
     Save: Guardar
     Allow Adding Duplicate Video(s): Permitir agregar videos duplicados
     Added {count} Times: Ya agregado | Agregado {count} veces

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -166,9 +166,9 @@ User Playlists:
   Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: ¿Estás seguro de que deseas eliminar 1 video visto de esta lista de reproducción? Esto no se puede deshacer.
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
+      "Videos added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna playlist.
-      "Video(s) added to 1 playlist": 1 video agregado a 1 playlist
+      "Videos added to 1 playlist": 1 video agregado a 1 playlist
     Save: Guardar
     Allow Adding Duplicate Video(s): Permitir agregar videos duplicados
     Added {count} Times: Ya agregado | Agregado {count} veces

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -166,7 +166,7 @@ User Playlists:
   Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: ¿Estás seguro de que deseas eliminar 1 video visto de esta lista de reproducción? Esto no se puede deshacer.
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna playlist.
     Save: Guardar
     Allow Adding Duplicate Video(s): Permitir agregar videos duplicados

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -166,7 +166,7 @@ User Playlists:
   Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: ¿Estás seguro de que deseas eliminar 1 video visto de esta lista de reproducción? Esto no se puede deshacer.
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna playlist.
     Save: Guardar
     Allow Adding Duplicate Video(s): Permitir agregar videos duplicados

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -166,9 +166,8 @@ User Playlists:
   Are you sure you want to remove {playlistItemCount} watched videos from this playlist? This cannot be undone: ¿Estás seguro de que deseas eliminar 1 video visto de esta lista de reproducción? Esto no se puede deshacer.
   AddVideoPrompt:
     Toast:
-      "Videos added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
+      "Video(s) added to {playlistCount} playlists": '{videoCount} videos agregados a {playlistCount} playlists'
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna playlist.
-      "Videos added to 1 playlist": 1 video agregado a 1 playlist
     Save: Guardar
     Allow Adding Duplicate Video(s): Permitir agregar videos duplicados
     Added {count} Times: Ya agregado | Agregado {count} veces

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -120,7 +120,7 @@ User Playlists:
     Search in Playlists: Buscar en listas de reproducción
     Save: Guardar
     Toast:
-      "Video(s) added to {playlistCount} playlists": vídeo añadido a {playlistCount} listas de reproducción | vídeos añadidos a {playlistCount} listas de reproducción
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna lista de reproducción.
     Select a playlist to add your N videos to: Seleccione una lista de reproducción a la que añadir su vídeo | Seleccione una lista de reproducción a la que añadir sus {videoCount} vídeos
     N playlists selected: '{playlistCount} seleccionada'

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -120,8 +120,7 @@ User Playlists:
     Search in Playlists: Buscar en listas de reproducción
     Save: Guardar
     Toast:
-      "Videos added to {playlistCount} playlists": vídeo añadido a {playlistCount} listas de reproducción | vídeos añadidos a {playlistCount} listas de reproducción
-      "Videos added to 1 playlist": 1 vídeo añadido a 1 lista de reproducción | vídeos añadidos a 1 lista de reproducción
+      "Video(s) added to {playlistCount} playlists": vídeo añadido a {playlistCount} listas de reproducción | vídeos añadidos a {playlistCount} listas de reproducción
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna lista de reproducción.
     Select a playlist to add your N videos to: Seleccione una lista de reproducción a la que añadir su vídeo | Seleccione una lista de reproducción a la que añadir sus {videoCount} vídeos
     N playlists selected: '{playlistCount} seleccionada'

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -120,7 +120,7 @@ User Playlists:
     Search in Playlists: Buscar en listas de reproducción
     Save: Guardar
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna lista de reproducción.
     Select a playlist to add your N videos to: Seleccione una lista de reproducción a la que añadir su vídeo | Seleccione una lista de reproducción a la que añadir sus {videoCount} vídeos
     N playlists selected: '{playlistCount} seleccionada'

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -120,8 +120,8 @@ User Playlists:
     Search in Playlists: Buscar en listas de reproducción
     Save: Guardar
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 vídeo añadido a {playlistCount} listas de reproducción | {videoCount} vídeos añadidos a {playlistCount} listas de reproducción
-      "{videoCount} video(s) added to 1 playlist": 1 vídeo añadido a 1 lista de reproducción | {videoCount} vídeos añadidos a 1 lista de reproducción
+      "Video(s) added to {playlistCount} playlists": 1 vídeo añadido a {playlistCount} listas de reproducción | {videoCount} vídeos añadidos a {playlistCount} listas de reproducción
+      "Video(s) added to 1 playlist": 1 vídeo añadido a 1 lista de reproducción | {videoCount} vídeos añadidos a 1 lista de reproducción
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna lista de reproducción.
     Select a playlist to add your N videos to: Seleccione una lista de reproducción a la que añadir su vídeo | Seleccione una lista de reproducción a la que añadir sus {videoCount} vídeos
     N playlists selected: '{playlistCount} seleccionada'

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -120,8 +120,8 @@ User Playlists:
     Search in Playlists: Buscar en listas de reproducción
     Save: Guardar
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 vídeo añadido a {playlistCount} listas de reproducción | {videoCount} vídeos añadidos a {playlistCount} listas de reproducción
-      "Video(s) added to 1 playlist": 1 vídeo añadido a 1 lista de reproducción | {videoCount} vídeos añadidos a 1 lista de reproducción
+      "Videos added to {playlistCount} playlists": vídeo añadido a {playlistCount} listas de reproducción | vídeos añadidos a {playlistCount} listas de reproducción
+      "Videos added to 1 playlist": 1 vídeo añadido a 1 lista de reproducción | vídeos añadidos a 1 lista de reproducción
       You haven't selected any playlist yet.: Aún no has seleccionado ninguna lista de reproducción.
     Select a playlist to add your N videos to: Seleccione una lista de reproducción a la que añadir su vídeo | Seleccione una lista de reproducción a la que añadir sus {videoCount} vídeos
     N playlists selected: '{playlistCount} seleccionada'

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -139,8 +139,8 @@ User Playlists:
     Search in Playlists: Otsi esindusloenditest
     Save: Salvesta
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video on lisatud {playlistCount} esitusloendisse | {videoCount} videot on lisatud {playlistCount} esitusloendisse
-      "{videoCount} video(s) added to 1 playlist": 1 video on lisatud 1'te esitusloendisse | {videoCount} videot on lisatud 1'te esitusloendisse
+      "Video(s) added to {playlistCount} playlists": 1 video on lisatud {playlistCount} esitusloendisse | {videoCount} videot on lisatud {playlistCount} esitusloendisse
+      "Video(s) added to 1 playlist": 1 video on lisatud 1'te esitusloendisse | {videoCount} videot on lisatud 1'te esitusloendisse
       You haven't selected any playlist yet.: Sa pole veel ühtegi esitusloendit valinud.
     Select a playlist to add your N videos to: Vali esitusloend, kuhu soovid oma video lisada | Vali esitusloend, kuhu soovid oma {videoCount} videot lisada
     N playlists selected: '{playlistCount} valitud'

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -139,8 +139,7 @@ User Playlists:
     Search in Playlists: Otsi esindusloenditest
     Save: Salvesta
     Toast:
-      "Videos added to {playlistCount} playlists": video on lisatud {playlistCount} esitusloendisse | videot on lisatud {playlistCount} esitusloendisse
-      "Videos added to 1 playlist": 1 video on lisatud 1'te esitusloendisse | videot on lisatud 1'te esitusloendisse
+      "Video(s) added to {playlistCount} playlists": video on lisatud {playlistCount} esitusloendisse | videot on lisatud {playlistCount} esitusloendisse
       You haven't selected any playlist yet.: Sa pole veel ühtegi esitusloendit valinud.
     Select a playlist to add your N videos to: Vali esitusloend, kuhu soovid oma video lisada | Vali esitusloend, kuhu soovid oma {videoCount} videot lisada
     N playlists selected: '{playlistCount} valitud'

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -139,8 +139,8 @@ User Playlists:
     Search in Playlists: Otsi esindusloenditest
     Save: Salvesta
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 video on lisatud {playlistCount} esitusloendisse | {videoCount} videot on lisatud {playlistCount} esitusloendisse
-      "Video(s) added to 1 playlist": 1 video on lisatud 1'te esitusloendisse | {videoCount} videot on lisatud 1'te esitusloendisse
+      "Videos added to {playlistCount} playlists": video on lisatud {playlistCount} esitusloendisse | videot on lisatud {playlistCount} esitusloendisse
+      "Videos added to 1 playlist": 1 video on lisatud 1'te esitusloendisse | videot on lisatud 1'te esitusloendisse
       You haven't selected any playlist yet.: Sa pole veel ühtegi esitusloendit valinud.
     Select a playlist to add your N videos to: Vali esitusloend, kuhu soovid oma video lisada | Vali esitusloend, kuhu soovid oma {videoCount} videot lisada
     N playlists selected: '{playlistCount} valitud'

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -139,7 +139,7 @@ User Playlists:
     Search in Playlists: Otsi esindusloenditest
     Save: Salvesta
     Toast:
-      "Video(s) added to {playlistCount} playlists": video on lisatud {playlistCount} esitusloendisse | videot on lisatud {playlistCount} esitusloendisse
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Sa pole veel ühtegi esitusloendit valinud.
     Select a playlist to add your N videos to: Vali esitusloend, kuhu soovid oma video lisada | Vali esitusloend, kuhu soovid oma {videoCount} videot lisada
     N playlists selected: '{playlistCount} valitud'

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -139,7 +139,7 @@ User Playlists:
     Search in Playlists: Otsi esindusloenditest
     Save: Salvesta
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Sa pole veel ühtegi esitusloendit valinud.
     Select a playlist to add your N videos to: Vali esitusloend, kuhu soovid oma video lisada | Vali esitusloend, kuhu soovid oma {videoCount} videot lisada
     N playlists selected: '{playlistCount} valitud'

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -182,7 +182,7 @@ User Playlists:
     Added {count} Times: Gehitu da | {count} aldiz gehitu da
     Toast:
       You haven't selected any playlist yet.: Oraindik ez duzu erreprodukzio zerrendarik hautatu.
-      "Video(s) added to {playlistCount} playlists": Bideo gehitu da {playlistCount} erreprodukzio zerrendetan | bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: Hautatu erreprodukzio-zerrenda zure bideoa -ra gehitzeko | Hautatu erreprodukzio-zerrenda zure {videoCount} bideoak gehitzeko
     N playlists selected: '{playlistCount} hautatuta'
     Search in Playlists: Bilatu erreprodukzio-zerrendetan

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -182,7 +182,7 @@ User Playlists:
     Added {count} Times: Gehitu da | {count} aldiz gehitu da
     Toast:
       You haven't selected any playlist yet.: Oraindik ez duzu erreprodukzio zerrendarik hautatu.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: Hautatu erreprodukzio-zerrenda zure bideoa -ra gehitzeko | Hautatu erreprodukzio-zerrenda zure {videoCount} bideoak gehitzeko
     N playlists selected: '{playlistCount} hautatuta'
     Search in Playlists: Bilatu erreprodukzio-zerrendetan

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -181,9 +181,9 @@ User Playlists:
   AddVideoPrompt:
     Added {count} Times: Gehitu da | {count} aldiz gehitu da
     Toast:
-      "Video(s) added to 1 playlist": Bideo 1 gehitu da erreprodukzio-zerrenda batera | {videoCount} bideo gehitu dira erreprodukzio-zerrenda batera
+      "Videos added to 1 playlist": Bideo 1 gehitu da erreprodukzio-zerrenda batera | bideo gehitu dira erreprodukzio-zerrenda batera
       You haven't selected any playlist yet.: Oraindik ez duzu erreprodukzio zerrendarik hautatu.
-      "Video(s) added to {playlistCount} playlists": Bideo 1 gehitu da {playlistCount} erreprodukzio zerrendetan | {videoCount} bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
+      "Videos added to {playlistCount} playlists": Bideo gehitu da {playlistCount} erreprodukzio zerrendetan | bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
     Select a playlist to add your N videos to: Hautatu erreprodukzio-zerrenda zure bideoa -ra gehitzeko | Hautatu erreprodukzio-zerrenda zure {videoCount} bideoak gehitzeko
     N playlists selected: '{playlistCount} hautatuta'
     Search in Playlists: Bilatu erreprodukzio-zerrendetan

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -181,9 +181,9 @@ User Playlists:
   AddVideoPrompt:
     Added {count} Times: Gehitu da | {count} aldiz gehitu da
     Toast:
-      "{videoCount} video(s) added to 1 playlist": Bideo 1 gehitu da erreprodukzio-zerrenda batera | {videoCount} bideo gehitu dira erreprodukzio-zerrenda batera
+      "Video(s) added to 1 playlist": Bideo 1 gehitu da erreprodukzio-zerrenda batera | {videoCount} bideo gehitu dira erreprodukzio-zerrenda batera
       You haven't selected any playlist yet.: Oraindik ez duzu erreprodukzio zerrendarik hautatu.
-      "{videoCount} video(s) added to {playlistCount} playlists": Bideo 1 gehitu da {playlistCount} erreprodukzio zerrendetan | {videoCount} bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
+      "Video(s) added to {playlistCount} playlists": Bideo 1 gehitu da {playlistCount} erreprodukzio zerrendetan | {videoCount} bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
     Select a playlist to add your N videos to: Hautatu erreprodukzio-zerrenda zure bideoa -ra gehitzeko | Hautatu erreprodukzio-zerrenda zure {videoCount} bideoak gehitzeko
     N playlists selected: '{playlistCount} hautatuta'
     Search in Playlists: Bilatu erreprodukzio-zerrendetan

--- a/static/locales/eu.yaml
+++ b/static/locales/eu.yaml
@@ -181,9 +181,8 @@ User Playlists:
   AddVideoPrompt:
     Added {count} Times: Gehitu da | {count} aldiz gehitu da
     Toast:
-      "Videos added to 1 playlist": Bideo 1 gehitu da erreprodukzio-zerrenda batera | bideo gehitu dira erreprodukzio-zerrenda batera
       You haven't selected any playlist yet.: Oraindik ez duzu erreprodukzio zerrendarik hautatu.
-      "Videos added to {playlistCount} playlists": Bideo gehitu da {playlistCount} erreprodukzio zerrendetan | bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
+      "Video(s) added to {playlistCount} playlists": Bideo gehitu da {playlistCount} erreprodukzio zerrendetan | bideo gehitu dira {playlistCount} erreprodukzio-zerrendetan
     Select a playlist to add your N videos to: Hautatu erreprodukzio-zerrenda zure bideoa -ra gehitzeko | Hautatu erreprodukzio-zerrenda zure {videoCount} bideoak gehitzeko
     N playlists selected: '{playlistCount} hautatuta'
     Search in Playlists: Bilatu erreprodukzio-zerrendetan

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -122,9 +122,9 @@ User Playlists:
     Search in Playlists: جستجو در لیست‌های پخش
     Allow Adding Duplicate Video(s): اجازه افزودن ویدیو(های) تکراری
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 ویدیو به {playlistCount} لیست پخش اضافه شد | {videoCount} ویدیو به {playlistCount} لیست پخش اضافه شد
+      "Videos added to {playlistCount} playlists": ویدیو به {playlistCount} لیست پخش اضافه شد | ویدیو به {playlistCount} لیست پخش اضافه شد
       You haven't selected any playlist yet.: هنوز هیچ لیست پخشی را انتخاب نکرده‌اید.
-      "Video(s) added to 1 playlist": 1 ویدیو به 1 لیست پخش اضافه شد | {videoCount} ویدیو به 1 لیست پخش اضافه شد
+      "Videos added to 1 playlist": 1 ویدیو به 1 لیست پخش اضافه شد | ویدیو به 1 لیست پخش اضافه شد
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ویدیو از قبل اضافه شده'
     N playlists selected: '{playlistCount} انتخاب شد'
     Added {count} Times: قبلا اضافه شده | {count} بار اضافه شد

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -122,9 +122,8 @@ User Playlists:
     Search in Playlists: جستجو در لیست‌های پخش
     Allow Adding Duplicate Video(s): اجازه افزودن ویدیو(های) تکراری
     Toast:
-      "Videos added to {playlistCount} playlists": ویدیو به {playlistCount} لیست پخش اضافه شد | ویدیو به {playlistCount} لیست پخش اضافه شد
+      "Video(s) added to {playlistCount} playlists": ویدیو به {playlistCount} لیست پخش اضافه شد | ویدیو به {playlistCount} لیست پخش اضافه شد
       You haven't selected any playlist yet.: هنوز هیچ لیست پخشی را انتخاب نکرده‌اید.
-      "Videos added to 1 playlist": 1 ویدیو به 1 لیست پخش اضافه شد | ویدیو به 1 لیست پخش اضافه شد
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ویدیو از قبل اضافه شده'
     N playlists selected: '{playlistCount} انتخاب شد'
     Added {count} Times: قبلا اضافه شده | {count} بار اضافه شد

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -122,7 +122,7 @@ User Playlists:
     Search in Playlists: جستجو در لیست‌های پخش
     Allow Adding Duplicate Video(s): اجازه افزودن ویدیو(های) تکراری
     Toast:
-      "Video(s) added to {playlistCount} playlists": ویدیو به {playlistCount} لیست پخش اضافه شد | ویدیو به {playlistCount} لیست پخش اضافه شد
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: هنوز هیچ لیست پخشی را انتخاب نکرده‌اید.
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ویدیو از قبل اضافه شده'
     N playlists selected: '{playlistCount} انتخاب شد'

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -122,7 +122,7 @@ User Playlists:
     Search in Playlists: جستجو در لیست‌های پخش
     Allow Adding Duplicate Video(s): اجازه افزودن ویدیو(های) تکراری
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: هنوز هیچ لیست پخشی را انتخاب نکرده‌اید.
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ویدیو از قبل اضافه شده'
     N playlists selected: '{playlistCount} انتخاب شد'

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -122,9 +122,9 @@ User Playlists:
     Search in Playlists: جستجو در لیست‌های پخش
     Allow Adding Duplicate Video(s): اجازه افزودن ویدیو(های) تکراری
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 ویدیو به {playlistCount} لیست پخش اضافه شد | {videoCount} ویدیو به {playlistCount} لیست پخش اضافه شد
+      "Video(s) added to {playlistCount} playlists": 1 ویدیو به {playlistCount} لیست پخش اضافه شد | {videoCount} ویدیو به {playlistCount} لیست پخش اضافه شد
       You haven't selected any playlist yet.: هنوز هیچ لیست پخشی را انتخاب نکرده‌اید.
-      "{videoCount} video(s) added to 1 playlist": 1 ویدیو به 1 لیست پخش اضافه شد | {videoCount} ویدیو به 1 لیست پخش اضافه شد
+      "Video(s) added to 1 playlist": 1 ویدیو به 1 لیست پخش اضافه شد | {videoCount} ویدیو به 1 لیست پخش اضافه شد
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ویدیو از قبل اضافه شده'
     N playlists selected: '{playlistCount} انتخاب شد'
     Added {count} Times: قبلا اضافه شده | {count} بار اضافه شد

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -163,8 +163,8 @@ User Playlists:
     Save: Tallenna
     Toast:
       You haven't selected any playlist yet.: Et ole valinnut yhtäkään soittolistaa.
-      "{videoCount} video(s) added to 1 playlist": 1 video lisätty 1 soittolistaan | {videoCount} videoita lisätty 1 soittolistaan
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video lisätty {playlistCount}-soittolistoihin | {videoCount} videot lisätty {playlistCount}-soittolistoihin
+      "Video(s) added to 1 playlist": 1 video lisätty 1 soittolistaan | {videoCount} videoita lisätty 1 soittolistaan
+      "Video(s) added to {playlistCount} playlists": 1 video lisätty {playlistCount}-soittolistoihin | {videoCount} videot lisätty {playlistCount}-soittolistoihin
     Added {count} Times: Jo lisätty | Lisätty {count} kertaa
     Search in Playlists: Haku soittolistoista
     Select a playlist to add your N videos to: Valitse soittoluettelo, johon haluat lisätä videosi | Valitse soittoluettelo, johon haluat lisätä {videoCount}-videot

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -163,8 +163,7 @@ User Playlists:
     Save: Tallenna
     Toast:
       You haven't selected any playlist yet.: Et ole valinnut yhtäkään soittolistaa.
-      "Videos added to 1 playlist": 1 video lisätty 1 soittolistaan | videoita lisätty 1 soittolistaan
-      "Videos added to {playlistCount} playlists": video lisätty {playlistCount}-soittolistoihin | videot lisätty {playlistCount}-soittolistoihin
+      "Video(s) added to {playlistCount} playlists": video lisätty {playlistCount}-soittolistoihin | videot lisätty {playlistCount}-soittolistoihin
     Added {count} Times: Jo lisätty | Lisätty {count} kertaa
     Search in Playlists: Haku soittolistoista
     Select a playlist to add your N videos to: Valitse soittoluettelo, johon haluat lisätä videosi | Valitse soittoluettelo, johon haluat lisätä {videoCount}-videot

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -163,7 +163,7 @@ User Playlists:
     Save: Tallenna
     Toast:
       You haven't selected any playlist yet.: Et ole valinnut yhtäkään soittolistaa.
-      "Video(s) added to {playlistCount} playlists": video lisätty {playlistCount}-soittolistoihin | videot lisätty {playlistCount}-soittolistoihin
+      "Video(s) added to {playlistCount} playlists":
     Added {count} Times: Jo lisätty | Lisätty {count} kertaa
     Search in Playlists: Haku soittolistoista
     Select a playlist to add your N videos to: Valitse soittoluettelo, johon haluat lisätä videosi | Valitse soittoluettelo, johon haluat lisätä {videoCount}-videot

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -163,8 +163,8 @@ User Playlists:
     Save: Tallenna
     Toast:
       You haven't selected any playlist yet.: Et ole valinnut yhtäkään soittolistaa.
-      "Video(s) added to 1 playlist": 1 video lisätty 1 soittolistaan | {videoCount} videoita lisätty 1 soittolistaan
-      "Video(s) added to {playlistCount} playlists": 1 video lisätty {playlistCount}-soittolistoihin | {videoCount} videot lisätty {playlistCount}-soittolistoihin
+      "Videos added to 1 playlist": 1 video lisätty 1 soittolistaan | videoita lisätty 1 soittolistaan
+      "Videos added to {playlistCount} playlists": video lisätty {playlistCount}-soittolistoihin | videot lisätty {playlistCount}-soittolistoihin
     Added {count} Times: Jo lisätty | Lisätty {count} kertaa
     Search in Playlists: Haku soittolistoista
     Select a playlist to add your N videos to: Valitse soittoluettelo, johon haluat lisätä videosi | Valitse soittoluettelo, johon haluat lisätä {videoCount}-videot

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -163,7 +163,7 @@ User Playlists:
     Save: Tallenna
     Toast:
       You haven't selected any playlist yet.: Et ole valinnut yhtäkään soittolistaa.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Added {count} Times: Jo lisätty | Lisätty {count} kertaa
     Search in Playlists: Haku soittolistoista
     Select a playlist to add your N videos to: Valitse soittoluettelo, johon haluat lisätä videosi | Valitse soittoluettelo, johon haluat lisätä {videoCount}-videot

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -118,9 +118,9 @@ User Playlists:
     Save: Sauvegarder
     Select a playlist to add your N videos to: Sélectionnez une liste de lecture à laquelle ajouter votre vidéo | Sélectionnez une liste de lecture à laquelle ajouter vos {videoCount} vidéos
     Toast:
-      "{videoCount} video(s) added to 1 playlist": 1 vidéo ajoutée à 1 liste de lecture | {videoCount} vidéos ajoutées à 1 liste de lecture
+      "Video(s) added to 1 playlist": 1 vidéo ajoutée à 1 liste de lecture | {videoCount} vidéos ajoutées à 1 liste de lecture
       You haven't selected any playlist yet.: Vous n'avez pas encore sélectionné de liste de lecture.
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 vidéo ajoutée à {playlistCount} listes de lecture | {videoCount} vidéos ajoutées à {playlistCount} listes de lecture
+      "Video(s) added to {playlistCount} playlists": 1 vidéo ajoutée à {playlistCount} listes de lecture | {videoCount} vidéos ajoutées à {playlistCount} listes de lecture
     N playlists selected: '{playlistCount} Sélectionnée(s)'
     Added {count} Times: Déjà ajouté | Ajouté {count} fois
     Allow Adding Duplicate Video(s): Autoriser l'ajout de vidéos en double

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -119,7 +119,7 @@ User Playlists:
     Select a playlist to add your N videos to: Sélectionnez une liste de lecture à laquelle ajouter votre vidéo | Sélectionnez une liste de lecture à laquelle ajouter vos {videoCount} vidéos
     Toast:
       You haven't selected any playlist yet.: Vous n'avez pas encore sélectionné de liste de lecture.
-      "Video(s) added to {playlistCount} playlists": vidéo ajoutée à {playlistCount} listes de lecture | vidéos ajoutées à {playlistCount} listes de lecture
+      "Video(s) added to {playlistCount} playlists":
     N playlists selected: '{playlistCount} Sélectionnée(s)'
     Added {count} Times: Déjà ajouté | Ajouté {count} fois
     Allow Adding Duplicate Video(s): Autoriser l'ajout de vidéos en double

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -118,9 +118,9 @@ User Playlists:
     Save: Sauvegarder
     Select a playlist to add your N videos to: Sélectionnez une liste de lecture à laquelle ajouter votre vidéo | Sélectionnez une liste de lecture à laquelle ajouter vos {videoCount} vidéos
     Toast:
-      "Video(s) added to 1 playlist": 1 vidéo ajoutée à 1 liste de lecture | {videoCount} vidéos ajoutées à 1 liste de lecture
+      "Videos added to 1 playlist": 1 vidéo ajoutée à 1 liste de lecture | vidéos ajoutées à 1 liste de lecture
       You haven't selected any playlist yet.: Vous n'avez pas encore sélectionné de liste de lecture.
-      "Video(s) added to {playlistCount} playlists": 1 vidéo ajoutée à {playlistCount} listes de lecture | {videoCount} vidéos ajoutées à {playlistCount} listes de lecture
+      "Videos added to {playlistCount} playlists": vidéo ajoutée à {playlistCount} listes de lecture | vidéos ajoutées à {playlistCount} listes de lecture
     N playlists selected: '{playlistCount} Sélectionnée(s)'
     Added {count} Times: Déjà ajouté | Ajouté {count} fois
     Allow Adding Duplicate Video(s): Autoriser l'ajout de vidéos en double

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -119,7 +119,7 @@ User Playlists:
     Select a playlist to add your N videos to: Sélectionnez une liste de lecture à laquelle ajouter votre vidéo | Sélectionnez une liste de lecture à laquelle ajouter vos {videoCount} vidéos
     Toast:
       You haven't selected any playlist yet.: Vous n'avez pas encore sélectionné de liste de lecture.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     N playlists selected: '{playlistCount} Sélectionnée(s)'
     Added {count} Times: Déjà ajouté | Ajouté {count} fois
     Allow Adding Duplicate Video(s): Autoriser l'ajout de vidéos en double

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -118,9 +118,8 @@ User Playlists:
     Save: Sauvegarder
     Select a playlist to add your N videos to: Sélectionnez une liste de lecture à laquelle ajouter votre vidéo | Sélectionnez une liste de lecture à laquelle ajouter vos {videoCount} vidéos
     Toast:
-      "Videos added to 1 playlist": 1 vidéo ajoutée à 1 liste de lecture | vidéos ajoutées à 1 liste de lecture
       You haven't selected any playlist yet.: Vous n'avez pas encore sélectionné de liste de lecture.
-      "Videos added to {playlistCount} playlists": vidéo ajoutée à {playlistCount} listes de lecture | vidéos ajoutées à {playlistCount} listes de lecture
+      "Video(s) added to {playlistCount} playlists": vidéo ajoutée à {playlistCount} listes de lecture | vidéos ajoutées à {playlistCount} listes de lecture
     N playlists selected: '{playlistCount} Sélectionnée(s)'
     Added {count} Times: Déjà ajouté | Ajouté {count} fois
     Allow Adding Duplicate Video(s): Autoriser l'ajout de vidéos en double

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -175,8 +175,8 @@ User Playlists:
     Select a playlist to add your N videos to: בחר רשימת שידורים להוספת הסרטון שלך | בחר רשימת שידורים להוספת {videoCount} הסרטונים שלך
     Toast:
       You haven't selected any playlist yet.: עדיין לא נבחרה רשימת שידורים.
-      "{videoCount} video(s) added to 1 playlist": סרטון נוסף לרשימת השמעה | {videoCount} סרטונים נוספו לרשימת השמעה
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 סרטון הוסף ל{playlistCount} רשימות שידורים | {videoCount} סרטונים הוספו ל{playlistCount} רשימות שידורים
+      "Video(s) added to 1 playlist": סרטון נוסף לרשימת השמעה | {videoCount} סרטונים נוספו לרשימת השמעה
+      "Video(s) added to {playlistCount} playlists": 1 סרטון הוסף ל{playlistCount} רשימות שידורים | {videoCount} סרטונים הוספו ל{playlistCount} רשימות שידורים
   CreatePlaylistPrompt:
     Create: יצירה
     New Playlist Name: שם חדש לרשימת נגינה

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -175,7 +175,7 @@ User Playlists:
     Select a playlist to add your N videos to: בחר רשימת שידורים להוספת הסרטון שלך | בחר רשימת שידורים להוספת {videoCount} הסרטונים שלך
     Toast:
       You haven't selected any playlist yet.: עדיין לא נבחרה רשימת שידורים.
-      "Video(s) added to {playlistCount} playlists": סרטון הוסף ל{playlistCount} רשימות שידורים | סרטונים הוספו ל{playlistCount} רשימות שידורים
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     Create: יצירה
     New Playlist Name: שם חדש לרשימת נגינה

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -175,7 +175,7 @@ User Playlists:
     Select a playlist to add your N videos to: בחר רשימת שידורים להוספת הסרטון שלך | בחר רשימת שידורים להוספת {videoCount} הסרטונים שלך
     Toast:
       You haven't selected any playlist yet.: עדיין לא נבחרה רשימת שידורים.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     Create: יצירה
     New Playlist Name: שם חדש לרשימת נגינה

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -175,8 +175,7 @@ User Playlists:
     Select a playlist to add your N videos to: בחר רשימת שידורים להוספת הסרטון שלך | בחר רשימת שידורים להוספת {videoCount} הסרטונים שלך
     Toast:
       You haven't selected any playlist yet.: עדיין לא נבחרה רשימת שידורים.
-      "Videos added to 1 playlist": סרטון נוסף לרשימת השמעה | סרטונים נוספו לרשימת השמעה
-      "Videos added to {playlistCount} playlists": סרטון הוסף ל{playlistCount} רשימות שידורים | סרטונים הוספו ל{playlistCount} רשימות שידורים
+      "Video(s) added to {playlistCount} playlists": סרטון הוסף ל{playlistCount} רשימות שידורים | סרטונים הוספו ל{playlistCount} רשימות שידורים
   CreatePlaylistPrompt:
     Create: יצירה
     New Playlist Name: שם חדש לרשימת נגינה

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -175,8 +175,8 @@ User Playlists:
     Select a playlist to add your N videos to: בחר רשימת שידורים להוספת הסרטון שלך | בחר רשימת שידורים להוספת {videoCount} הסרטונים שלך
     Toast:
       You haven't selected any playlist yet.: עדיין לא נבחרה רשימת שידורים.
-      "Video(s) added to 1 playlist": סרטון נוסף לרשימת השמעה | {videoCount} סרטונים נוספו לרשימת השמעה
-      "Video(s) added to {playlistCount} playlists": 1 סרטון הוסף ל{playlistCount} רשימות שידורים | {videoCount} סרטונים הוספו ל{playlistCount} רשימות שידורים
+      "Videos added to 1 playlist": סרטון נוסף לרשימת השמעה | סרטונים נוספו לרשימת השמעה
+      "Videos added to {playlistCount} playlists": סרטון הוסף ל{playlistCount} רשימות שידורים | סרטונים הוספו ל{playlistCount} רשימות שידורים
   CreatePlaylistPrompt:
     Create: יצירה
     New Playlist Name: שם חדש לרשימת נגינה

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -169,8 +169,8 @@ User Playlists:
     Save: Spremi
     Toast:
       You haven't selected any playlist yet.: Još nisi odabrao/la nijednu zbirku.
-      "Video(s) added to {playlistCount} playlists": 1 video dodan u {playlistCount} zbirke | {videoCount} videa dodana u {playlistCount} zbirke
-      "Video(s) added to 1 playlist": 1 video dodan u 1 zbirku | {videoCount} videa dodana u 1 zbirku
+      "Videos added to {playlistCount} playlists": video dodan u {playlistCount} zbirke | videa dodana u {playlistCount} zbirke
+      "Videos added to 1 playlist": 1 video dodan u 1 zbirku | videa dodana u 1 zbirku
     Select a playlist to add your N videos to: Odaberi zbirku za dodavanje tvog videa | Odaberi zbirku za dodavanje tvojih {videoCount} videa
     Added {count} Times: Već dodano | Dodano {count} puta
     Allow Adding Duplicate Video(s): Dozvoli dodavanje duplih videa

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -169,7 +169,7 @@ User Playlists:
     Save: Spremi
     Toast:
       You haven't selected any playlist yet.: Još nisi odabrao/la nijednu zbirku.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: Odaberi zbirku za dodavanje tvog videa | Odaberi zbirku za dodavanje tvojih {videoCount} videa
     Added {count} Times: Već dodano | Dodano {count} puta
     Allow Adding Duplicate Video(s): Dozvoli dodavanje duplih videa

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -169,8 +169,8 @@ User Playlists:
     Save: Spremi
     Toast:
       You haven't selected any playlist yet.: Još nisi odabrao/la nijednu zbirku.
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video dodan u {playlistCount} zbirke | {videoCount} videa dodana u {playlistCount} zbirke
-      "{videoCount} video(s) added to 1 playlist": 1 video dodan u 1 zbirku | {videoCount} videa dodana u 1 zbirku
+      "Video(s) added to {playlistCount} playlists": 1 video dodan u {playlistCount} zbirke | {videoCount} videa dodana u {playlistCount} zbirke
+      "Video(s) added to 1 playlist": 1 video dodan u 1 zbirku | {videoCount} videa dodana u 1 zbirku
     Select a playlist to add your N videos to: Odaberi zbirku za dodavanje tvog videa | Odaberi zbirku za dodavanje tvojih {videoCount} videa
     Added {count} Times: Već dodano | Dodano {count} puta
     Allow Adding Duplicate Video(s): Dozvoli dodavanje duplih videa

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -169,7 +169,7 @@ User Playlists:
     Save: Spremi
     Toast:
       You haven't selected any playlist yet.: Još nisi odabrao/la nijednu zbirku.
-      "Video(s) added to {playlistCount} playlists": video dodan u {playlistCount} zbirke | videa dodana u {playlistCount} zbirke
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: Odaberi zbirku za dodavanje tvog videa | Odaberi zbirku za dodavanje tvojih {videoCount} videa
     Added {count} Times: Već dodano | Dodano {count} puta
     Allow Adding Duplicate Video(s): Dozvoli dodavanje duplih videa

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -169,8 +169,7 @@ User Playlists:
     Save: Spremi
     Toast:
       You haven't selected any playlist yet.: Još nisi odabrao/la nijednu zbirku.
-      "Videos added to {playlistCount} playlists": video dodan u {playlistCount} zbirke | videa dodana u {playlistCount} zbirke
-      "Videos added to 1 playlist": 1 video dodan u 1 zbirku | videa dodana u 1 zbirku
+      "Video(s) added to {playlistCount} playlists": video dodan u {playlistCount} zbirke | videa dodana u {playlistCount} zbirke
     Select a playlist to add your N videos to: Odaberi zbirku za dodavanje tvog videa | Odaberi zbirku za dodavanje tvojih {videoCount} videa
     Added {count} Times: Već dodano | Dodano {count} puta
     Allow Adding Duplicate Video(s): Dozvoli dodavanje duplih videa

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -124,8 +124,8 @@ User Playlists:
     Search in Playlists: Keresés a lejátszási listában
     Save: Mentés
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 videó hozzáadva a {playlistCount} lejátszási listákhoz | {videoCount} videó hozzáadása a {playlistCount} lejátszási listákhoz
-      "{videoCount} video(s) added to 1 playlist": 1 videó hozzáadva 1 lejátszási listához | {videoCount} videó hozzáadása 1 lejátszási listához
+      "Video(s) added to {playlistCount} playlists": 1 videó hozzáadva a {playlistCount} lejátszási listákhoz | {videoCount} videó hozzáadása a {playlistCount} lejátszási listákhoz
+      "Video(s) added to 1 playlist": 1 videó hozzáadva 1 lejátszási listához | {videoCount} videó hozzáadása 1 lejátszási listához
       You haven't selected any playlist yet.: Még nem választott ki egyetlen lejátszási listát sem.
     Select a playlist to add your N videos to: Válasszon ki egy lejátszási listát a videó hozzáadásához | Válasszon ki egy lejátszási listát a {videoCount} videó hozzáadásához
     N playlists selected: '{playlistCount} kiválasztva'

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -124,7 +124,7 @@ User Playlists:
     Search in Playlists: Keresés a lejátszási listában
     Save: Mentés
     Toast:
-      "Video(s) added to {playlistCount} playlists": videó hozzáadva a {playlistCount} lejátszási listákhoz | videó hozzáadása a {playlistCount} lejátszási listákhoz
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Még nem választott ki egyetlen lejátszási listát sem.
     Select a playlist to add your N videos to: Válasszon ki egy lejátszási listát a videó hozzáadásához | Válasszon ki egy lejátszási listát a {videoCount} videó hozzáadásához
     N playlists selected: '{playlistCount} kiválasztva'

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -124,8 +124,8 @@ User Playlists:
     Search in Playlists: Keresés a lejátszási listában
     Save: Mentés
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 videó hozzáadva a {playlistCount} lejátszási listákhoz | {videoCount} videó hozzáadása a {playlistCount} lejátszási listákhoz
-      "Video(s) added to 1 playlist": 1 videó hozzáadva 1 lejátszási listához | {videoCount} videó hozzáadása 1 lejátszási listához
+      "Videos added to {playlistCount} playlists": videó hozzáadva a {playlistCount} lejátszási listákhoz | videó hozzáadása a {playlistCount} lejátszási listákhoz
+      "Videos added to 1 playlist": 1 videó hozzáadva 1 lejátszási listához | videó hozzáadása 1 lejátszási listához
       You haven't selected any playlist yet.: Még nem választott ki egyetlen lejátszási listát sem.
     Select a playlist to add your N videos to: Válasszon ki egy lejátszási listát a videó hozzáadásához | Válasszon ki egy lejátszási listát a {videoCount} videó hozzáadásához
     N playlists selected: '{playlistCount} kiválasztva'

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -124,7 +124,7 @@ User Playlists:
     Search in Playlists: Keresés a lejátszási listában
     Save: Mentés
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Még nem választott ki egyetlen lejátszási listát sem.
     Select a playlist to add your N videos to: Válasszon ki egy lejátszási listát a videó hozzáadásához | Válasszon ki egy lejátszási listát a {videoCount} videó hozzáadásához
     N playlists selected: '{playlistCount} kiválasztva'

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -124,8 +124,7 @@ User Playlists:
     Search in Playlists: Keresés a lejátszási listában
     Save: Mentés
     Toast:
-      "Videos added to {playlistCount} playlists": videó hozzáadva a {playlistCount} lejátszási listákhoz | videó hozzáadása a {playlistCount} lejátszási listákhoz
-      "Videos added to 1 playlist": 1 videó hozzáadva 1 lejátszási listához | videó hozzáadása 1 lejátszási listához
+      "Video(s) added to {playlistCount} playlists": videó hozzáadva a {playlistCount} lejátszási listákhoz | videó hozzáadása a {playlistCount} lejátszási listákhoz
       You haven't selected any playlist yet.: Még nem választott ki egyetlen lejátszási listát sem.
     Select a playlist to add your N videos to: Válasszon ki egy lejátszási listát a videó hozzáadásához | Válasszon ki egy lejátszási listát a {videoCount} videó hozzáadásához
     N playlists selected: '{playlistCount} kiválasztva'

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -169,7 +169,7 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: Anda belum memilih daftar putar apa pun.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     N playlists selected: '{playlistCount} Dipilih'
     Search in Playlists: Cari di Daftar Putar
     Save: Simpan

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -169,8 +169,7 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: Anda belum memilih daftar putar apa pun.
-      "Videos added to {playlistCount} playlists": video ditambahkan ke {playlistCount} daftar putar | video ditambahkan ke {playlistCount} daftar putar
-      "Videos added to 1 playlist": 1 video ditambahkan ke 1 daftar putar | video ditambahkan ke 1 daftar putar
+      "Video(s) added to {playlistCount} playlists": video ditambahkan ke {playlistCount} daftar putar | video ditambahkan ke {playlistCount} daftar putar
     N playlists selected: '{playlistCount} Dipilih'
     Search in Playlists: Cari di Daftar Putar
     Save: Simpan

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -169,8 +169,8 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: Anda belum memilih daftar putar apa pun.
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video ditambahkan ke {playlistCount} daftar putar | {videoCount} video ditambahkan ke {playlistCount} daftar putar
-      "{videoCount} video(s) added to 1 playlist": 1 video ditambahkan ke 1 daftar putar | {videoCount} video ditambahkan ke 1 daftar putar
+      "Video(s) added to {playlistCount} playlists": 1 video ditambahkan ke {playlistCount} daftar putar | {videoCount} video ditambahkan ke {playlistCount} daftar putar
+      "Video(s) added to 1 playlist": 1 video ditambahkan ke 1 daftar putar | {videoCount} video ditambahkan ke 1 daftar putar
     N playlists selected: '{playlistCount} Dipilih'
     Search in Playlists: Cari di Daftar Putar
     Save: Simpan

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -169,7 +169,7 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: Anda belum memilih daftar putar apa pun.
-      "Video(s) added to {playlistCount} playlists": video ditambahkan ke {playlistCount} daftar putar | video ditambahkan ke {playlistCount} daftar putar
+      "Video(s) added to {playlistCount} playlists":
     N playlists selected: '{playlistCount} Dipilih'
     Search in Playlists: Cari di Daftar Putar
     Save: Simpan

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -169,8 +169,8 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: Anda belum memilih daftar putar apa pun.
-      "Video(s) added to {playlistCount} playlists": 1 video ditambahkan ke {playlistCount} daftar putar | {videoCount} video ditambahkan ke {playlistCount} daftar putar
-      "Video(s) added to 1 playlist": 1 video ditambahkan ke 1 daftar putar | {videoCount} video ditambahkan ke 1 daftar putar
+      "Videos added to {playlistCount} playlists": video ditambahkan ke {playlistCount} daftar putar | video ditambahkan ke {playlistCount} daftar putar
+      "Videos added to 1 playlist": 1 video ditambahkan ke 1 daftar putar | video ditambahkan ke 1 daftar putar
     N playlists selected: '{playlistCount} Dipilih'
     Search in Playlists: Cari di Daftar Putar
     Save: Simpan

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -165,9 +165,9 @@ User Playlists:
     Search in Playlists: Leita í spilunarlistum
     Save: Vista
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 myndskeiði bætt við  {playlistCount} spilunarlista | {videoCount} myndskeiðum bætt við {playlistCount} spilunarlista
+      "Video(s) added to {playlistCount} playlists": 1 myndskeiði bætt við  {playlistCount} spilunarlista | {videoCount} myndskeiðum bætt við {playlistCount} spilunarlista
       You haven't selected any playlist yet.: Þú hefur enn ekki valið neina spilunarlista.
-      "{videoCount} video(s) added to 1 playlist": 1 myndskeiði bætt við 1 spilunarlista | {videoCount} myndskeiðum bætt við 1 spilunarlista
+      "Video(s) added to 1 playlist": 1 myndskeiði bætt við 1 spilunarlista | {videoCount} myndskeiðum bætt við 1 spilunarlista
     Select a playlist to add your N videos to: Veldu spilunarlista til að bæta myndskeiðinu þínu á | Veldu spilunarlista til að bæta {videoCount}̣ myndskeiðunum þínum á
     Added {count} Times: Þegar bætt við | Bætt við {count} sinnum
     Allow Adding Duplicate Video(s): Leyfa að tvíteknum myndskeiðum sé bætt við

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -165,9 +165,9 @@ User Playlists:
     Search in Playlists: Leita í spilunarlistum
     Save: Vista
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 myndskeiði bætt við  {playlistCount} spilunarlista | {videoCount} myndskeiðum bætt við {playlistCount} spilunarlista
+      "Videos added to {playlistCount} playlists": myndskeiði bætt við  {playlistCount} spilunarlista | myndskeiðum bætt við {playlistCount} spilunarlista
       You haven't selected any playlist yet.: Þú hefur enn ekki valið neina spilunarlista.
-      "Video(s) added to 1 playlist": 1 myndskeiði bætt við 1 spilunarlista | {videoCount} myndskeiðum bætt við 1 spilunarlista
+      "Videos added to 1 playlist": 1 myndskeiði bætt við 1 spilunarlista | myndskeiðum bætt við 1 spilunarlista
     Select a playlist to add your N videos to: Veldu spilunarlista til að bæta myndskeiðinu þínu á | Veldu spilunarlista til að bæta {videoCount}̣ myndskeiðunum þínum á
     Added {count} Times: Þegar bætt við | Bætt við {count} sinnum
     Allow Adding Duplicate Video(s): Leyfa að tvíteknum myndskeiðum sé bætt við

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -165,7 +165,7 @@ User Playlists:
     Search in Playlists: Leita í spilunarlistum
     Save: Vista
     Toast:
-      "Video(s) added to {playlistCount} playlists": myndskeiði bætt við  {playlistCount} spilunarlista | myndskeiðum bætt við {playlistCount} spilunarlista
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Þú hefur enn ekki valið neina spilunarlista.
     Select a playlist to add your N videos to: Veldu spilunarlista til að bæta myndskeiðinu þínu á | Veldu spilunarlista til að bæta {videoCount}̣ myndskeiðunum þínum á
     Added {count} Times: Þegar bætt við | Bætt við {count} sinnum

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -165,9 +165,8 @@ User Playlists:
     Search in Playlists: Leita í spilunarlistum
     Save: Vista
     Toast:
-      "Videos added to {playlistCount} playlists": myndskeiði bætt við  {playlistCount} spilunarlista | myndskeiðum bætt við {playlistCount} spilunarlista
+      "Video(s) added to {playlistCount} playlists": myndskeiði bætt við  {playlistCount} spilunarlista | myndskeiðum bætt við {playlistCount} spilunarlista
       You haven't selected any playlist yet.: Þú hefur enn ekki valið neina spilunarlista.
-      "Videos added to 1 playlist": 1 myndskeiði bætt við 1 spilunarlista | myndskeiðum bætt við 1 spilunarlista
     Select a playlist to add your N videos to: Veldu spilunarlista til að bæta myndskeiðinu þínu á | Veldu spilunarlista til að bæta {videoCount}̣ myndskeiðunum þínum á
     Added {count} Times: Þegar bætt við | Bætt við {count} sinnum
     Allow Adding Duplicate Video(s): Leyfa að tvíteknum myndskeiðum sé bætt við

--- a/static/locales/is.yaml
+++ b/static/locales/is.yaml
@@ -165,7 +165,7 @@ User Playlists:
     Search in Playlists: Leita í spilunarlistum
     Save: Vista
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Þú hefur enn ekki valið neina spilunarlista.
     Select a playlist to add your N videos to: Veldu spilunarlista til að bæta myndskeiðinu þínu á | Veldu spilunarlista til að bæta {videoCount}̣ myndskeiðunum þínum á
     Added {count} Times: Þegar bætt við | Bætt við {count} sinnum

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -120,7 +120,7 @@ User Playlists:
     Search in Playlists: Ricerca nelle playlist
     Save: Salva
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Non hai ancora selezionato nessuna playlist.
     Select a playlist to add your N videos to: Seleziona una playlist a cui aggiungere il tuo video | Seleziona una playlist a cui aggiungere i tuoi {videoCount} video
     N playlists selected: '{playlistCount} selezionate'

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -120,8 +120,8 @@ User Playlists:
     Search in Playlists: Ricerca nelle playlist
     Save: Salva
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video aggiunto a {playlistCount} playlist | {videoCount} video aggiunti a {playlistCount} playlist
-      "{videoCount} video(s) added to 1 playlist": 1 video aggiunto a 1 playlist | {videoCount} video aggiunti a 1 playlist
+      "Video(s) added to {playlistCount} playlists": 1 video aggiunto a {playlistCount} playlist | {videoCount} video aggiunti a {playlistCount} playlist
+      "Video(s) added to 1 playlist": 1 video aggiunto a 1 playlist | {videoCount} video aggiunti a 1 playlist
       You haven't selected any playlist yet.: Non hai ancora selezionato nessuna playlist.
     Select a playlist to add your N videos to: Seleziona una playlist a cui aggiungere il tuo video | Seleziona una playlist a cui aggiungere i tuoi {videoCount} video
     N playlists selected: '{playlistCount} selezionate'

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -120,8 +120,7 @@ User Playlists:
     Search in Playlists: Ricerca nelle playlist
     Save: Salva
     Toast:
-      "Videos added to {playlistCount} playlists": video aggiunto a {playlistCount} playlist | video aggiunti a {playlistCount} playlist
-      "Videos added to 1 playlist": 1 video aggiunto a 1 playlist | video aggiunti a 1 playlist
+      "Video(s) added to {playlistCount} playlists": video aggiunto a {playlistCount} playlist | video aggiunti a {playlistCount} playlist
       You haven't selected any playlist yet.: Non hai ancora selezionato nessuna playlist.
     Select a playlist to add your N videos to: Seleziona una playlist a cui aggiungere il tuo video | Seleziona una playlist a cui aggiungere i tuoi {videoCount} video
     N playlists selected: '{playlistCount} selezionate'

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -120,7 +120,7 @@ User Playlists:
     Search in Playlists: Ricerca nelle playlist
     Save: Salva
     Toast:
-      "Video(s) added to {playlistCount} playlists": video aggiunto a {playlistCount} playlist | video aggiunti a {playlistCount} playlist
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Non hai ancora selezionato nessuna playlist.
     Select a playlist to add your N videos to: Seleziona una playlist a cui aggiungere il tuo video | Seleziona una playlist a cui aggiungere i tuoi {videoCount} video
     N playlists selected: '{playlistCount} selezionate'

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -120,8 +120,8 @@ User Playlists:
     Search in Playlists: Ricerca nelle playlist
     Save: Salva
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 video aggiunto a {playlistCount} playlist | {videoCount} video aggiunti a {playlistCount} playlist
-      "Video(s) added to 1 playlist": 1 video aggiunto a 1 playlist | {videoCount} video aggiunti a 1 playlist
+      "Videos added to {playlistCount} playlists": video aggiunto a {playlistCount} playlist | video aggiunti a {playlistCount} playlist
+      "Videos added to 1 playlist": 1 video aggiunto a 1 playlist | video aggiunti a 1 playlist
       You haven't selected any playlist yet.: Non hai ancora selezionato nessuna playlist.
     Select a playlist to add your N videos to: Seleziona una playlist a cui aggiungere il tuo video | Seleziona una playlist a cui aggiungere i tuoi {videoCount} video
     N playlists selected: '{playlistCount} selezionate'

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -170,7 +170,7 @@ User Playlists:
     Allow Adding Duplicate Video(s): 重複した動画の追加を許可する
     Toast:
       You haven't selected any playlist yet.: まだ再生リストを選択していません。
-      "Video(s) added to {playlistCount} playlists": 本の動画が {playlistCount} 個の再生リストに追加されました | 本の動画が {playlistCount} 個の再生リストに追加されました
+      "Video(s) added to {playlistCount} playlists":
     Search in Playlists: 再生リストで検索
     N playlists selected: '{playlistCount} 選択中'
     Save: 保存

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -170,8 +170,8 @@ User Playlists:
     Allow Adding Duplicate Video(s): 重複した動画の追加を許可する
     Toast:
       You haven't selected any playlist yet.: まだ再生リストを選択していません。
-      "Video(s) added to 1 playlist": 1本の動画が1個の再生リストに追加されました | {videoCount} 本の動画が1個の再生リストに追加されました
-      "Video(s) added to {playlistCount} playlists": 1本の動画が {playlistCount} 個の再生リストに追加されました | {videoCount} 本の動画が {playlistCount} 個の再生リストに追加されました
+      "Videos added to 1 playlist": 1本の動画が1個の再生リストに追加されました | 本の動画が1個の再生リストに追加されました
+      "Videos added to {playlistCount} playlists":本の動画が {playlistCount} 個の再生リストに追加されました | 本の動画が {playlistCount} 個の再生リストに追加されました
     Search in Playlists: 再生リストで検索
     N playlists selected: '{playlistCount} 選択中'
     Save: 保存

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -171,7 +171,7 @@ User Playlists:
     Toast:
       You haven't selected any playlist yet.: まだ再生リストを選択していません。
       "Videos added to 1 playlist": 1本の動画が1個の再生リストに追加されました | 本の動画が1個の再生リストに追加されました
-      "Videos added to {playlistCount} playlists":本の動画が {playlistCount} 個の再生リストに追加されました | 本の動画が {playlistCount} 個の再生リストに追加されました
+      "Videos added to {playlistCount} playlists": 本の動画が {playlistCount} 個の再生リストに追加されました | 本の動画が {playlistCount} 個の再生リストに追加されました
     Search in Playlists: 再生リストで検索
     N playlists selected: '{playlistCount} 選択中'
     Save: 保存

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -170,7 +170,7 @@ User Playlists:
     Allow Adding Duplicate Video(s): 重複した動画の追加を許可する
     Toast:
       You haven't selected any playlist yet.: まだ再生リストを選択していません。
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Search in Playlists: 再生リストで検索
     N playlists selected: '{playlistCount} 選択中'
     Save: 保存

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -170,8 +170,7 @@ User Playlists:
     Allow Adding Duplicate Video(s): 重複した動画の追加を許可する
     Toast:
       You haven't selected any playlist yet.: まだ再生リストを選択していません。
-      "Videos added to 1 playlist": 1本の動画が1個の再生リストに追加されました | 本の動画が1個の再生リストに追加されました
-      "Videos added to {playlistCount} playlists": 本の動画が {playlistCount} 個の再生リストに追加されました | 本の動画が {playlistCount} 個の再生リストに追加されました
+      "Video(s) added to {playlistCount} playlists": 本の動画が {playlistCount} 個の再生リストに追加されました | 本の動画が {playlistCount} 個の再生リストに追加されました
     Search in Playlists: 再生リストで検索
     N playlists selected: '{playlistCount} 選択中'
     Save: 保存

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -170,8 +170,8 @@ User Playlists:
     Allow Adding Duplicate Video(s): 重複した動画の追加を許可する
     Toast:
       You haven't selected any playlist yet.: まだ再生リストを選択していません。
-      "{videoCount} video(s) added to 1 playlist": 1本の動画が1個の再生リストに追加されました | {videoCount} 本の動画が1個の再生リストに追加されました
-      "{videoCount} video(s) added to {playlistCount} playlists": 1本の動画が {playlistCount} 個の再生リストに追加されました | {videoCount} 本の動画が {playlistCount} 個の再生リストに追加されました
+      "Video(s) added to 1 playlist": 1本の動画が1個の再生リストに追加されました | {videoCount} 本の動画が1個の再生リストに追加されました
+      "Video(s) added to {playlistCount} playlists": 1本の動画が {playlistCount} 個の再生リストに追加されました | {videoCount} 本の動画が {playlistCount} 個の再生リストに追加されました
     Search in Playlists: 再生リストで検索
     N playlists selected: '{playlistCount} 選択中'
     Save: 保存

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -118,7 +118,7 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ لیستێکی پەخشکردنت دیاری نەکردووە.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکەت بۆ | لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکانی {videoCount} بۆی
     Allow Adding Duplicate Video(s): ڕێگە بدە بە زیادکردنی ڤیدیۆ(ەکان)ی دووبارە
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ڤیدیۆکان پێشتر زیادکراون'

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -118,8 +118,7 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ لیستێکی پەخشکردنت دیاری نەکردووە.
-      "Videos added to 1 playlist": 1 ڤیدیۆ زیادکرا بۆ 1 لیستی پەخشکردن | ڤیدیۆکان زیادکران بۆ 1 لیستی پەخشکردن
-      "Videos added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی زیادکراون بۆ لیستەکانی پلەی {playlistCount}
+      "Video(s) added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی زیادکراون بۆ لیستەکانی پلەی {playlistCount}
     Select a playlist to add your N videos to: لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکەت بۆ | لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکانی {videoCount} بۆی
     Allow Adding Duplicate Video(s): ڕێگە بدە بە زیادکردنی ڤیدیۆ(ەکان)ی دووبارە
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ڤیدیۆکان پێشتر زیادکراون'

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -118,8 +118,8 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ لیستێکی پەخشکردنت دیاری نەکردووە.
-      "{videoCount} video(s) added to 1 playlist": 1 ڤیدیۆ زیادکرا بۆ 1 لیستی پەخشکردن | {videoCount} ڤیدیۆکان زیادکران بۆ 1 لیستی پەخشکردن
-      "{videoCount} video(s) added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی {videoCount} زیادکراون بۆ لیستەکانی پلەی {playlistCount}
+      "Video(s) added to 1 playlist": 1 ڤیدیۆ زیادکرا بۆ 1 لیستی پەخشکردن | {videoCount} ڤیدیۆکان زیادکران بۆ 1 لیستی پەخشکردن
+      "Video(s) added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی {videoCount} زیادکراون بۆ لیستەکانی پلەی {playlistCount}
     Select a playlist to add your N videos to: لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکەت بۆ | لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکانی {videoCount} بۆی
     Allow Adding Duplicate Video(s): ڕێگە بدە بە زیادکردنی ڤیدیۆ(ەکان)ی دووبارە
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ڤیدیۆکان پێشتر زیادکراون'

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -118,7 +118,7 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ لیستێکی پەخشکردنت دیاری نەکردووە.
-      "Video(s) added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی زیادکراون بۆ لیستەکانی پلەی {playlistCount}
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکەت بۆ | لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکانی {videoCount} بۆی
     Allow Adding Duplicate Video(s): ڕێگە بدە بە زیادکردنی ڤیدیۆ(ەکان)ی دووبارە
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ڤیدیۆکان پێشتر زیادکراون'

--- a/static/locales/ku.yaml
+++ b/static/locales/ku.yaml
@@ -118,8 +118,8 @@ User Playlists:
   AddVideoPrompt:
     Toast:
       You haven't selected any playlist yet.: هێشتا هیچ لیستێکی پەخشکردنت دیاری نەکردووە.
-      "Video(s) added to 1 playlist": 1 ڤیدیۆ زیادکرا بۆ 1 لیستی پەخشکردن | {videoCount} ڤیدیۆکان زیادکران بۆ 1 لیستی پەخشکردن
-      "Video(s) added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی {videoCount} زیادکراون بۆ لیستەکانی پلەی {playlistCount}
+      "Videos added to 1 playlist": 1 ڤیدیۆ زیادکرا بۆ 1 لیستی پەخشکردن | ڤیدیۆکان زیادکران بۆ 1 لیستی پەخشکردن
+      "Videos added to {playlistCount} playlists": v$1 ڤیدیۆ زیادکرا بۆ {playlistCount} پلەی لیستەکان | ڤیدیۆکانی زیادکراون بۆ لیستەکانی پلەی {playlistCount}
     Select a playlist to add your N videos to: لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکەت بۆ | لیستێکی پەخشکردن دەسنیشان بکە بۆ زیادکردنی ڤیدیۆکانی {videoCount} بۆی
     Allow Adding Duplicate Video(s): ڕێگە بدە بە زیادکردنی ڤیدیۆ(ەکان)ی دووبارە
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} ڤیدیۆکان پێشتر زیادکراون'

--- a/static/locales/mr.yaml
+++ b/static/locales/mr.yaml
@@ -243,8 +243,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "{videoCount} video(s) added to 1 playlist": ""
-      "{videoCount} video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to 1 playlist": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/mr.yaml
+++ b/static/locales/mr.yaml
@@ -243,7 +243,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/mr.yaml
+++ b/static/locales/mr.yaml
@@ -243,8 +243,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Videos added to 1 playlist": ""
-      "Videos added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/mr.yaml
+++ b/static/locales/mr.yaml
@@ -243,7 +243,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/mr.yaml
+++ b/static/locales/mr.yaml
@@ -243,8 +243,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to 1 playlist": ""
-      "Video(s) added to {playlistCount} playlists": ""
+      "Videos added to 1 playlist": ""
+      "Videos added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -236,8 +236,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to 1 playlist": ""
-      "Video(s) added to {playlistCount} playlists": ""
+      "Videos added to 1 playlist": ""
+      "Videos added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -236,8 +236,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Videos added to 1 playlist": ""
-      "Videos added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -236,8 +236,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "{videoCount} video(s) added to 1 playlist": ""
-      "{videoCount} video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to 1 playlist": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -236,7 +236,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/my.yaml
+++ b/static/locales/my.yaml
@@ -236,7 +236,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -146,7 +146,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer vil bli lagt til'
     Toast:
       You haven't selected any playlist yet.: Du har ikke valgt noen spillelister enda.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videoer allerede lagt til'
     Added {count} Times: Allerede lagt til | Lagt til {count} ganger
     Select a playlist to add your N videos to: Velg en spilleliste å legge videoen til | Velg en spilleliste å legge dine {videoCount} videoer til

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -146,8 +146,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer vil bli lagt til'
     Toast:
       You haven't selected any playlist yet.: Du har ikke valgt noen spillelister enda.
-      "{videoCount} video(s) added to 1 playlist": 1 video lagt til 1 spilleliste | {videoCount} videoer lagt til 1 spilleliste
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video lagt til {playlistCount} spillelister | {videoCount} videoer lagt til  {playlistCount} spillelister
+      "Video(s) added to 1 playlist": 1 video lagt til 1 spilleliste | {videoCount} videoer lagt til 1 spilleliste
+      "Video(s) added to {playlistCount} playlists": 1 video lagt til {playlistCount} spillelister | {videoCount} videoer lagt til  {playlistCount} spillelister
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videoer allerede lagt til'
     Added {count} Times: Allerede lagt til | Lagt til {count} ganger
     Select a playlist to add your N videos to: Velg en spilleliste å legge videoen til | Velg en spilleliste å legge dine {videoCount} videoer til

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -146,7 +146,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer vil bli lagt til'
     Toast:
       You haven't selected any playlist yet.: Du har ikke valgt noen spillelister enda.
-      "Video(s) added to {playlistCount} playlists": video lagt til {playlistCount} spillelister | videoer lagt til  {playlistCount} spillelister
+      "Video(s) added to {playlistCount} playlists":
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videoer allerede lagt til'
     Added {count} Times: Allerede lagt til | Lagt til {count} ganger
     Select a playlist to add your N videos to: Velg en spilleliste å legge videoen til | Velg en spilleliste å legge dine {videoCount} videoer til

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -146,8 +146,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer vil bli lagt til'
     Toast:
       You haven't selected any playlist yet.: Du har ikke valgt noen spillelister enda.
-      "Video(s) added to 1 playlist": 1 video lagt til 1 spilleliste | {videoCount} videoer lagt til 1 spilleliste
-      "Video(s) added to {playlistCount} playlists": 1 video lagt til {playlistCount} spillelister | {videoCount} videoer lagt til  {playlistCount} spillelister
+      "Videos added to 1 playlist": 1 video lagt til 1 spilleliste | videoer lagt til 1 spilleliste
+      "Videos added to {playlistCount} playlists": video lagt til {playlistCount} spillelister | videoer lagt til  {playlistCount} spillelister
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videoer allerede lagt til'
     Added {count} Times: Allerede lagt til | Lagt til {count} ganger
     Select a playlist to add your N videos to: Velg en spilleliste å legge videoen til | Velg en spilleliste å legge dine {videoCount} videoer til

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -146,8 +146,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} videoer vil bli lagt til'
     Toast:
       You haven't selected any playlist yet.: Du har ikke valgt noen spillelister enda.
-      "Videos added to 1 playlist": 1 video lagt til 1 spilleliste | videoer lagt til 1 spilleliste
-      "Videos added to {playlistCount} playlists": video lagt til {playlistCount} spillelister | videoer lagt til  {playlistCount} spillelister
+      "Video(s) added to {playlistCount} playlists": video lagt til {playlistCount} spillelister | videoer lagt til  {playlistCount} spillelister
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} videoer allerede lagt til'
     Added {count} Times: Allerede lagt til | Lagt til {count} ganger
     Select a playlist to add your N videos to: Velg en spilleliste å legge videoen til | Velg en spilleliste å legge dine {videoCount} videoer til

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -142,8 +142,7 @@ User Playlists:
     Search in Playlists: Zoeken in afspeellijsten
     Toast:
       You haven't selected any playlist yet.: U heeft nog geen afspeellijst geselecteerd.
-      "Videos added to 1 playlist": 1 video toegevoegd aan 1 afspeellijst | video's toegevoegd aan 1 afspeellijst
-      "Videos added to {playlistCount} playlists": video toegevoegd aan {playlistCount} afspeellijsten | video's toegevoegd aan {playlistCount} afspeellijsten
+      "Video(s) added to {playlistCount} playlists": video toegevoegd aan {playlistCount} afspeellijsten | video's toegevoegd aan {playlistCount} afspeellijsten
     Select a playlist to add your N videos to: Selecteer een afspeellijst om je video aan toe te voegen | Selecteer een afspeellijst om je {videoCount} video's aan toe te voegen
     Added {count} Times: 'Video is al toegevoegd | {count} keer toegevoegd'
     Allow Adding Duplicate Video(s): Toevoegen van dubbele video's toestaan

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -142,7 +142,7 @@ User Playlists:
     Search in Playlists: Zoeken in afspeellijsten
     Toast:
       You haven't selected any playlist yet.: U heeft nog geen afspeellijst geselecteerd.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: Selecteer een afspeellijst om je video aan toe te voegen | Selecteer een afspeellijst om je {videoCount} video's aan toe te voegen
     Added {count} Times: 'Video is al toegevoegd | {count} keer toegevoegd'
     Allow Adding Duplicate Video(s): Toevoegen van dubbele video's toestaan

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -142,8 +142,8 @@ User Playlists:
     Search in Playlists: Zoeken in afspeellijsten
     Toast:
       You haven't selected any playlist yet.: U heeft nog geen afspeellijst geselecteerd.
-      "Video(s) added to 1 playlist": 1 video toegevoegd aan 1 afspeellijst | {videoCount} video's toegevoegd aan 1 afspeellijst
-      "Video(s) added to {playlistCount} playlists": 1 video toegevoegd aan {playlistCount} afspeellijsten | {videoCount} video's toegevoegd aan {playlistCount} afspeellijsten
+      "Videos added to 1 playlist": 1 video toegevoegd aan 1 afspeellijst | video's toegevoegd aan 1 afspeellijst
+      "Videos added to {playlistCount} playlists": video toegevoegd aan {playlistCount} afspeellijsten | video's toegevoegd aan {playlistCount} afspeellijsten
     Select a playlist to add your N videos to: Selecteer een afspeellijst om je video aan toe te voegen | Selecteer een afspeellijst om je {videoCount} video's aan toe te voegen
     Added {count} Times: 'Video is al toegevoegd | {count} keer toegevoegd'
     Allow Adding Duplicate Video(s): Toevoegen van dubbele video's toestaan

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -142,7 +142,7 @@ User Playlists:
     Search in Playlists: Zoeken in afspeellijsten
     Toast:
       You haven't selected any playlist yet.: U heeft nog geen afspeellijst geselecteerd.
-      "Video(s) added to {playlistCount} playlists": video toegevoegd aan {playlistCount} afspeellijsten | video's toegevoegd aan {playlistCount} afspeellijsten
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: Selecteer een afspeellijst om je video aan toe te voegen | Selecteer een afspeellijst om je {videoCount} video's aan toe te voegen
     Added {count} Times: 'Video is al toegevoegd | {count} keer toegevoegd'
     Allow Adding Duplicate Video(s): Toevoegen van dubbele video's toestaan

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -142,8 +142,8 @@ User Playlists:
     Search in Playlists: Zoeken in afspeellijsten
     Toast:
       You haven't selected any playlist yet.: U heeft nog geen afspeellijst geselecteerd.
-      "{videoCount} video(s) added to 1 playlist": 1 video toegevoegd aan 1 afspeellijst | {videoCount} video's toegevoegd aan 1 afspeellijst
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video toegevoegd aan {playlistCount} afspeellijsten | {videoCount} video's toegevoegd aan {playlistCount} afspeellijsten
+      "Video(s) added to 1 playlist": 1 video toegevoegd aan 1 afspeellijst | {videoCount} video's toegevoegd aan 1 afspeellijst
+      "Video(s) added to {playlistCount} playlists": 1 video toegevoegd aan {playlistCount} afspeellijsten | {videoCount} video's toegevoegd aan {playlistCount} afspeellijsten
     Select a playlist to add your N videos to: Selecteer een afspeellijst om je video aan toe te voegen | Selecteer een afspeellijst om je {videoCount} video's aan toe te voegen
     Added {count} Times: 'Video is al toegevoegd | {count} keer toegevoegd'
     Allow Adding Duplicate Video(s): Toevoegen van dubbele video's toestaan

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -117,8 +117,7 @@ User Playlists:
     Search in Playlists: Szukaj w playlistach
     Save: Zapisz
     Toast:
-      "Videos added to {playlistCount} playlists": film dodano do {playlistCount} playlist | film(y/ów) dodano do {playlistCount} playlist
-      "Videos added to 1 playlist": 1 film dodano do 1 playlisty | Do 1 playlisty dodano film(y/ów)
+      "Video(s) added to {playlistCount} playlists": film dodano do {playlistCount} playlist | film(y/ów) dodano do {playlistCount} playlist
       You haven't selected any playlist yet.: Nie wybrano jeszcze żadnych playlist.
     Select a playlist to add your N videos to: Wybierz playlistę, do której chcesz dodać swój film | Wybierz playlistę, do której chcesz dodać swoje {videoCount} film(y/ów)
     N playlists selected: Zaznaczono {playlistCount}

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -117,8 +117,8 @@ User Playlists:
     Search in Playlists: Szukaj w playlistach
     Save: Zapisz
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 film dodano do {playlistCount} playlist | {videoCount} film(y/ów) dodano do {playlistCount} playlist
-      "{videoCount} video(s) added to 1 playlist": 1 film dodano do 1 playlisty | Do 1 playlisty dodano {videoCount} film(y/ów)
+      "Video(s) added to {playlistCount} playlists": 1 film dodano do {playlistCount} playlist | {videoCount} film(y/ów) dodano do {playlistCount} playlist
+      "Video(s) added to 1 playlist": 1 film dodano do 1 playlisty | Do 1 playlisty dodano {videoCount} film(y/ów)
       You haven't selected any playlist yet.: Nie wybrano jeszcze żadnych playlist.
     Select a playlist to add your N videos to: Wybierz playlistę, do której chcesz dodać swój film | Wybierz playlistę, do której chcesz dodać swoje {videoCount} film(y/ów)
     N playlists selected: Zaznaczono {playlistCount}

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -117,7 +117,7 @@ User Playlists:
     Search in Playlists: Szukaj w playlistach
     Save: Zapisz
     Toast:
-      "Video(s) added to {playlistCount} playlists": film dodano do {playlistCount} playlist | film(y/ów) dodano do {playlistCount} playlist
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Nie wybrano jeszcze żadnych playlist.
     Select a playlist to add your N videos to: Wybierz playlistę, do której chcesz dodać swój film | Wybierz playlistę, do której chcesz dodać swoje {videoCount} film(y/ów)
     N playlists selected: Zaznaczono {playlistCount}

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -117,8 +117,8 @@ User Playlists:
     Search in Playlists: Szukaj w playlistach
     Save: Zapisz
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 film dodano do {playlistCount} playlist | {videoCount} film(y/ów) dodano do {playlistCount} playlist
-      "Video(s) added to 1 playlist": 1 film dodano do 1 playlisty | Do 1 playlisty dodano {videoCount} film(y/ów)
+      "Videos added to {playlistCount} playlists": film dodano do {playlistCount} playlist | film(y/ów) dodano do {playlistCount} playlist
+      "Videos added to 1 playlist": 1 film dodano do 1 playlisty | Do 1 playlisty dodano film(y/ów)
       You haven't selected any playlist yet.: Nie wybrano jeszcze żadnych playlist.
     Select a playlist to add your N videos to: Wybierz playlistę, do której chcesz dodać swój film | Wybierz playlistę, do której chcesz dodać swoje {videoCount} film(y/ów)
     N playlists selected: Zaznaczono {playlistCount}

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -117,7 +117,7 @@ User Playlists:
     Search in Playlists: Szukaj w playlistach
     Save: Zapisz
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Nie wybrano jeszcze żadnych playlist.
     Select a playlist to add your N videos to: Wybierz playlistę, do której chcesz dodać swój film | Wybierz playlistę, do której chcesz dodać swoje {videoCount} film(y/ów)
     N playlists selected: Zaznaczono {playlistCount}

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -171,7 +171,7 @@ User Playlists:
     Search for Videos: Buscar vídeos
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists": vídeo adicionado a {playlistCount} playlists | vídeos adicionados a {playlistCount} playlists
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Você ainda não selecionou nenhuma playlist.
     Select a playlist to add your N videos to: Selecione uma playlist para adicionar seu vídeo | Selecione uma playlist para adicionar seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionada(s)'

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -171,8 +171,8 @@ User Playlists:
     Search for Videos: Buscar vídeos
   AddVideoPrompt:
     Toast:
-      "Video(s) added to 1 playlist": 1 vídeo adicionado a 1 playlist | {videoCount} vídeos adicionados a 1 playlist
-      "Video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} playlists | {videoCount} vídeos adicionados a {playlistCount} playlists
+      "Videos added to 1 playlist": 1 vídeo adicionado a 1 playlist | vídeos adicionados a 1 playlist
+      "Videos added to {playlistCount} playlists": vídeo adicionado a {playlistCount} playlists | vídeos adicionados a {playlistCount} playlists
       You haven't selected any playlist yet.: Você ainda não selecionou nenhuma playlist.
     Select a playlist to add your N videos to: Selecione uma playlist para adicionar seu vídeo | Selecione uma playlist para adicionar seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionada(s)'

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -171,7 +171,7 @@ User Playlists:
     Search for Videos: Buscar vídeos
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Você ainda não selecionou nenhuma playlist.
     Select a playlist to add your N videos to: Selecione uma playlist para adicionar seu vídeo | Selecione uma playlist para adicionar seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionada(s)'

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -171,8 +171,7 @@ User Playlists:
     Search for Videos: Buscar vídeos
   AddVideoPrompt:
     Toast:
-      "Videos added to 1 playlist": 1 vídeo adicionado a 1 playlist | vídeos adicionados a 1 playlist
-      "Videos added to {playlistCount} playlists": vídeo adicionado a {playlistCount} playlists | vídeos adicionados a {playlistCount} playlists
+      "Video(s) added to {playlistCount} playlists": vídeo adicionado a {playlistCount} playlists | vídeos adicionados a {playlistCount} playlists
       You haven't selected any playlist yet.: Você ainda não selecionou nenhuma playlist.
     Select a playlist to add your N videos to: Selecione uma playlist para adicionar seu vídeo | Selecione uma playlist para adicionar seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionada(s)'

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -171,8 +171,8 @@ User Playlists:
     Search for Videos: Buscar vídeos
   AddVideoPrompt:
     Toast:
-      "{videoCount} video(s) added to 1 playlist": 1 vídeo adicionado a 1 playlist | {videoCount} vídeos adicionados a 1 playlist
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} playlists | {videoCount} vídeos adicionados a {playlistCount} playlists
+      "Video(s) added to 1 playlist": 1 vídeo adicionado a 1 playlist | {videoCount} vídeos adicionados a 1 playlist
+      "Video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} playlists | {videoCount} vídeos adicionados a {playlistCount} playlists
       You haven't selected any playlist yet.: Você ainda não selecionou nenhuma playlist.
     Select a playlist to add your N videos to: Selecione uma playlist para adicionar seu vídeo | Selecione uma playlist para adicionar seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionada(s)'

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -169,7 +169,7 @@ User Playlists:
   Playlist Description: Descrição da lista de reprodução
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -169,8 +169,8 @@ User Playlists:
   Playlist Description: Descrição da lista de reprodução
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} listas de reprodução | {videoCount} vídeos adicionados a {playlistCount} listas de reprodução
-      "Video(s) added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | {videoCount} vídeos adicionados a 1 lista de reprodução
+      "Videos added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
+      "Videos added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | vídeos adicionados a 1 lista de reprodução
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -169,8 +169,7 @@ User Playlists:
   Playlist Description: Descrição da lista de reprodução
   AddVideoPrompt:
     Toast:
-      "Videos added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
-      "Videos added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | vídeos adicionados a 1 lista de reprodução
+      "Video(s) added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -169,7 +169,7 @@ User Playlists:
   Playlist Description: Descrição da lista de reprodução
   AddVideoPrompt:
     Toast:
-      "Video(s) added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -169,8 +169,8 @@ User Playlists:
   Playlist Description: Descrição da lista de reprodução
   AddVideoPrompt:
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} listas de reprodução | {videoCount} vídeos adicionados a {playlistCount} listas de reprodução
-      "{videoCount} video(s) added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | {videoCount} vídeos adicionados a 1 lista de reprodução
+      "Video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} listas de reprodução | {videoCount} vídeos adicionados a {playlistCount} listas de reprodução
+      "Video(s) added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | {videoCount} vídeos adicionados a 1 lista de reprodução
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -166,9 +166,9 @@ User Playlists:
     Search in Playlists: Procurar nas listas de reprodução
     Save: Guardar
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} listas de reprodução | {videoCount} vídeos adicionados a {playlistCount} listas de reprodução
+      "Videos added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
-      "Video(s) added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | {videoCount} vídeos adicionados a 1 lista de reprodução
+      "Videos added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | vídeos adicionados a 1 lista de reprodução
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'
     Added {count} Times: Já adicionado | Adicionado {count} vezes

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -166,7 +166,7 @@ User Playlists:
     Search in Playlists: Procurar nas listas de reprodução
     Save: Guardar
     Toast:
-      "Video(s) added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -166,9 +166,8 @@ User Playlists:
     Search in Playlists: Procurar nas listas de reprodução
     Save: Guardar
     Toast:
-      "Videos added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
+      "Video(s) added to {playlistCount} playlists": vídeo adicionado a {playlistCount} listas de reprodução | vídeos adicionados a {playlistCount} listas de reprodução
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
-      "Videos added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | vídeos adicionados a 1 lista de reprodução
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'
     Added {count} Times: Já adicionado | Adicionado {count} vezes

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -166,7 +166,7 @@ User Playlists:
     Search in Playlists: Procurar nas listas de reprodução
     Save: Guardar
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -166,9 +166,9 @@ User Playlists:
     Search in Playlists: Procurar nas listas de reprodução
     Save: Guardar
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} listas de reprodução | {videoCount} vídeos adicionados a {playlistCount} listas de reprodução
+      "Video(s) added to {playlistCount} playlists": 1 vídeo adicionado a {playlistCount} listas de reprodução | {videoCount} vídeos adicionados a {playlistCount} listas de reprodução
       You haven't selected any playlist yet.: Ainda não selecionou uma lista de reprodução.
-      "{videoCount} video(s) added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | {videoCount} vídeos adicionados a 1 lista de reprodução
+      "Video(s) added to 1 playlist": 1 vídeo adicionado a 1 lista de reprodução | {videoCount} vídeos adicionados a 1 lista de reprodução
     Select a playlist to add your N videos to: Selecione uma lista de reprodução à qual adicionar o seu vídeo | Selecione uma lista de reprodução à qual adicionar os seus {videoCount} vídeos
     N playlists selected: '{playlistCount} selecionados'
     Added {count} Times: Já adicionado | Adicionado {count} vezes

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -141,8 +141,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videoclipuri vor fi adăugate'
     Toast:
       You haven't selected any playlist yet.: Nu ați selectat încă nicio listă de redare.
-      "Video(s) added to 1 playlist": 1 videoclip adăugat la 1 listă de redare | {videoCount} videoclipuri adăugate la 1 listă de redare
-      "Video(s) added to {playlistCount} playlists": 1 videoclip adăugat la {playlistCount} liste de redare | {videoCount} videoclipuri adăugate la {playlistCount} liste de redare
+      "Videos added to 1 playlist": 1 videoclip adăugat la 1 listă de redare | videoclipuri adăugate la 1 listă de redare
+      "Videos added to {playlistCount} playlists": videoclip adăugat la {playlistCount} liste de redare | videoclipuri adăugate la {playlistCount} liste de redare
     N playlists selected: '{playlistCount} Selectat'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videoclipuri deja adăugate'
     Search in Playlists: Caută in listele de redare

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -141,7 +141,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videoclipuri vor fi adăugate'
     Toast:
       You haven't selected any playlist yet.: Nu ați selectat încă nicio listă de redare.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     N playlists selected: '{playlistCount} Selectat'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videoclipuri deja adăugate'
     Search in Playlists: Caută in listele de redare

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -141,8 +141,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videoclipuri vor fi adăugate'
     Toast:
       You haven't selected any playlist yet.: Nu ați selectat încă nicio listă de redare.
-      "{videoCount} video(s) added to 1 playlist": 1 videoclip adăugat la 1 listă de redare | {videoCount} videoclipuri adăugate la 1 listă de redare
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 videoclip adăugat la {playlistCount} liste de redare | {videoCount} videoclipuri adăugate la {playlistCount} liste de redare
+      "Video(s) added to 1 playlist": 1 videoclip adăugat la 1 listă de redare | {videoCount} videoclipuri adăugate la 1 listă de redare
+      "Video(s) added to {playlistCount} playlists": 1 videoclip adăugat la {playlistCount} liste de redare | {videoCount} videoclipuri adăugate la {playlistCount} liste de redare
     N playlists selected: '{playlistCount} Selectat'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videoclipuri deja adăugate'
     Search in Playlists: Caută in listele de redare

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -141,8 +141,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videoclipuri vor fi adăugate'
     Toast:
       You haven't selected any playlist yet.: Nu ați selectat încă nicio listă de redare.
-      "Videos added to 1 playlist": 1 videoclip adăugat la 1 listă de redare | videoclipuri adăugate la 1 listă de redare
-      "Videos added to {playlistCount} playlists": videoclip adăugat la {playlistCount} liste de redare | videoclipuri adăugate la {playlistCount} liste de redare
+      "Video(s) added to {playlistCount} playlists": videoclip adăugat la {playlistCount} liste de redare | videoclipuri adăugate la {playlistCount} liste de redare
     N playlists selected: '{playlistCount} Selectat'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videoclipuri deja adăugate'
     Search in Playlists: Caută in listele de redare

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -141,7 +141,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videoclipuri vor fi adăugate'
     Toast:
       You haven't selected any playlist yet.: Nu ați selectat încă nicio listă de redare.
-      "Video(s) added to {playlistCount} playlists": videoclip adăugat la {playlistCount} liste de redare | videoclipuri adăugate la {playlistCount} liste de redare
+      "Video(s) added to {playlistCount} playlists":
     N playlists selected: '{playlistCount} Selectat'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videoclipuri deja adăugate'
     Search in Playlists: Caută in listele de redare

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -159,7 +159,7 @@ User Playlists:
     Save: Сохранить
     Toast:
       You haven't selected any playlist yet.: Вы не выбрали ни одного плейлиста.
-      "Video(s) added to {playlistCount} playlists": видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в плейлистов
+      "Video(s) added to {playlistCount} playlists":
     Select a playlist to add your N videos to: Выберите плейлист для добавления видео | Выберите плейлист для добавления {videoCount} видео
     Added {count} Times: Уже добавлено | Добавлено {count} раз
     Allow Adding Duplicate Video(s): Разрешить добавление дубликатов видео

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -159,8 +159,8 @@ User Playlists:
     Save: Сохранить
     Toast:
       You haven't selected any playlist yet.: Вы не выбрали ни одного плейлиста.
-      "{videoCount} video(s) added to 1 playlist": 1 видео добавлено в 1 плейлист| {videoCount} видео добавлено в 1 плейлист
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в {videoCount} плейлистов
+      "Video(s) added to 1 playlist": 1 видео добавлено в 1 плейлист| {videoCount} видео добавлено в 1 плейлист
+      "Video(s) added to {playlistCount} playlists": 1 видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в {videoCount} плейлистов
     Select a playlist to add your N videos to: Выберите плейлист для добавления видео | Выберите плейлист для добавления {videoCount} видео
     Added {count} Times: Уже добавлено | Добавлено {count} раз
     Allow Adding Duplicate Video(s): Разрешить добавление дубликатов видео

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -159,8 +159,8 @@ User Playlists:
     Save: Сохранить
     Toast:
       You haven't selected any playlist yet.: Вы не выбрали ни одного плейлиста.
-      "Video(s) added to 1 playlist": 1 видео добавлено в 1 плейлист| {videoCount} видео добавлено в 1 плейлист
-      "Video(s) added to {playlistCount} playlists": 1 видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в {videoCount} плейлистов
+      "Videos added to 1 playlist": 1 видео добавлено в 1 плейлист| видео добавлено в 1 плейлист
+      "Videos added to {playlistCount} playlists": видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в плейлистов
     Select a playlist to add your N videos to: Выберите плейлист для добавления видео | Выберите плейлист для добавления {videoCount} видео
     Added {count} Times: Уже добавлено | Добавлено {count} раз
     Allow Adding Duplicate Video(s): Разрешить добавление дубликатов видео

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -159,8 +159,7 @@ User Playlists:
     Save: Сохранить
     Toast:
       You haven't selected any playlist yet.: Вы не выбрали ни одного плейлиста.
-      "Videos added to 1 playlist": 1 видео добавлено в 1 плейлист| видео добавлено в 1 плейлист
-      "Videos added to {playlistCount} playlists": видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в плейлистов
+      "Video(s) added to {playlistCount} playlists": видео добавлено в {videoCount} плейлистов | {playlistCount} видео добавлено в плейлистов
     Select a playlist to add your N videos to: Выберите плейлист для добавления видео | Выберите плейлист для добавления {videoCount} видео
     Added {count} Times: Уже добавлено | Добавлено {count} раз
     Allow Adding Duplicate Video(s): Разрешить добавление дубликатов видео

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -159,7 +159,7 @@ User Playlists:
     Save: Сохранить
     Toast:
       You haven't selected any playlist yet.: Вы не выбрали ни одного плейлиста.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Select a playlist to add your N videos to: Выберите плейлист для добавления видео | Выберите плейлист для добавления {videoCount} видео
     Added {count} Times: Уже добавлено | Добавлено {count} раз
     Allow Adding Duplicate Video(s): Разрешить добавление дубликатов видео

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -175,9 +175,9 @@ User Playlists:
     Select a playlist to add your N videos to: Vyberte zoznam videí, do ktorého chcete pridať svoje video | Vyberte zoznam videí, do ktorého chcete pridať svoje {videoCount} videá
     "{videoCount}/{totalVideoCount} Videos Already Added": 'Počet už pridaných videí: {videoCount}/{totalVideoCount}'
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 video pridané do {playlistCount} zoznamov skladieb | {videoCount} videí pridaných do {playlistCount} zoznamov skladieb
+      "Videos added to {playlistCount} playlists": video pridané do {playlistCount} zoznamov skladieb | videí pridaných do {playlistCount} zoznamov skladieb
       You haven't selected any playlist yet.: Zatiaľ ste nevybrali žiadny zoznam skladieb.
-      "Video(s) added to 1 playlist": 1 video pridané do 1 zoznamu videí | {videoCount} videí pridaných do 1 zoznamu videí
+      "Videos added to 1 playlist": 1 video pridané do 1 zoznamu videí | videí pridaných do 1 zoznamu videí
     Save: uložiť
     "{videoCount}/{totalVideoCount} Videos Will Be Added": Budú pridané videá ({videoCount}/{totalVideoCount})
   Quick Bookmark Enabled: Rýchle záložky povolené

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -175,9 +175,9 @@ User Playlists:
     Select a playlist to add your N videos to: Vyberte zoznam videí, do ktorého chcete pridať svoje video | Vyberte zoznam videí, do ktorého chcete pridať svoje {videoCount} videá
     "{videoCount}/{totalVideoCount} Videos Already Added": 'Počet už pridaných videí: {videoCount}/{totalVideoCount}'
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video pridané do {playlistCount} zoznamov skladieb | {videoCount} videí pridaných do {playlistCount} zoznamov skladieb
+      "Video(s) added to {playlistCount} playlists": 1 video pridané do {playlistCount} zoznamov skladieb | {videoCount} videí pridaných do {playlistCount} zoznamov skladieb
       You haven't selected any playlist yet.: Zatiaľ ste nevybrali žiadny zoznam skladieb.
-      "{videoCount} video(s) added to 1 playlist": 1 video pridané do 1 zoznamu videí | {videoCount} videí pridaných do 1 zoznamu videí
+      "Video(s) added to 1 playlist": 1 video pridané do 1 zoznamu videí | {videoCount} videí pridaných do 1 zoznamu videí
     Save: uložiť
     "{videoCount}/{totalVideoCount} Videos Will Be Added": Budú pridané videá ({videoCount}/{totalVideoCount})
   Quick Bookmark Enabled: Rýchle záložky povolené

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -175,7 +175,7 @@ User Playlists:
     Select a playlist to add your N videos to: Vyberte zoznam videí, do ktorého chcete pridať svoje video | Vyberte zoznam videí, do ktorého chcete pridať svoje {videoCount} videá
     "{videoCount}/{totalVideoCount} Videos Already Added": 'Počet už pridaných videí: {videoCount}/{totalVideoCount}'
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Zatiaľ ste nevybrali žiadny zoznam skladieb.
     Save: uložiť
     "{videoCount}/{totalVideoCount} Videos Will Be Added": Budú pridané videá ({videoCount}/{totalVideoCount})

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -175,9 +175,8 @@ User Playlists:
     Select a playlist to add your N videos to: Vyberte zoznam videí, do ktorého chcete pridať svoje video | Vyberte zoznam videí, do ktorého chcete pridať svoje {videoCount} videá
     "{videoCount}/{totalVideoCount} Videos Already Added": 'Počet už pridaných videí: {videoCount}/{totalVideoCount}'
     Toast:
-      "Videos added to {playlistCount} playlists": video pridané do {playlistCount} zoznamov skladieb | videí pridaných do {playlistCount} zoznamov skladieb
+      "Video(s) added to {playlistCount} playlists": video pridané do {playlistCount} zoznamov skladieb | videí pridaných do {playlistCount} zoznamov skladieb
       You haven't selected any playlist yet.: Zatiaľ ste nevybrali žiadny zoznam skladieb.
-      "Videos added to 1 playlist": 1 video pridané do 1 zoznamu videí | videí pridaných do 1 zoznamu videí
     Save: uložiť
     "{videoCount}/{totalVideoCount} Videos Will Be Added": Budú pridané videá ({videoCount}/{totalVideoCount})
   Quick Bookmark Enabled: Rýchle záložky povolené

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -175,7 +175,7 @@ User Playlists:
     Select a playlist to add your N videos to: Vyberte zoznam videí, do ktorého chcete pridať svoje video | Vyberte zoznam videí, do ktorého chcete pridať svoje {videoCount} videá
     "{videoCount}/{totalVideoCount} Videos Already Added": 'Počet už pridaných videí: {videoCount}/{totalVideoCount}'
     Toast:
-      "Video(s) added to {playlistCount} playlists": video pridané do {playlistCount} zoznamov skladieb | videí pridaných do {playlistCount} zoznamov skladieb
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Zatiaľ ste nevybrali žiadny zoznam skladieb.
     Save: uložiť
     "{videoCount}/{totalVideoCount} Videos Will Be Added": Budú pridané videá ({videoCount}/{totalVideoCount})

--- a/static/locales/sq.yaml
+++ b/static/locales/sq.yaml
@@ -242,8 +242,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'Nuk ke zgjedhur akoma asnjë playlist.'
-      "{videoCount} video(s) added to 1 playlist": "1 video shtuar në 1 playlist | {videoCount} video shtuar në 1 playlist"
-      "{videoCount} video(s) added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | {videoCount} video shtuar në {playlistCount} playlist"
+      "Video(s) added to 1 playlist": "1 video shtuar në 1 playlist | {videoCount} video shtuar në 1 playlist"
+      "Video(s) added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | {videoCount} video shtuar në {playlistCount} playlist"
   CreatePlaylistPrompt:
     New Playlist Name: 'Emri i playlist'
     Create: 'Krijo'

--- a/static/locales/sq.yaml
+++ b/static/locales/sq.yaml
@@ -242,8 +242,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'Nuk ke zgjedhur akoma asnjë playlist.'
-      "Video(s) added to 1 playlist": "1 video shtuar në 1 playlist | {videoCount} video shtuar në 1 playlist"
-      "Video(s) added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | {videoCount} video shtuar në {playlistCount} playlist"
+      "Videos added to 1 playlist": "1 video shtuar në 1 playlist | video shtuar në 1 playlist"
+      "Videos added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | video shtuar në {playlistCount} playlist"
   CreatePlaylistPrompt:
     New Playlist Name: 'Emri i playlist'
     Create: 'Krijo'

--- a/static/locales/sq.yaml
+++ b/static/locales/sq.yaml
@@ -242,8 +242,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'Nuk ke zgjedhur akoma asnjë playlist.'
-      "Videos added to 1 playlist": "1 video shtuar në 1 playlist | video shtuar në 1 playlist"
-      "Videos added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | video shtuar në {playlistCount} playlist"
+      "Video(s) added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | video shtuar në {playlistCount} playlist"
   CreatePlaylistPrompt:
     New Playlist Name: 'Emri i playlist'
     Create: 'Krijo'

--- a/static/locales/sq.yaml
+++ b/static/locales/sq.yaml
@@ -242,7 +242,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'Nuk ke zgjedhur akoma asnjë playlist.'
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: 'Emri i playlist'
     Create: 'Krijo'

--- a/static/locales/sq.yaml
+++ b/static/locales/sq.yaml
@@ -242,7 +242,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'Nuk ke zgjedhur akoma asnjë playlist.'
-      "Video(s) added to {playlistCount} playlists": "1 video shtuar në {playlistCount} playlist | video shtuar në {playlistCount} playlist"
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: 'Emri i playlist'
     Create: 'Krijo'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -125,8 +125,8 @@ User Playlists:
     Search in Playlists: Претрага у плејлистама
     Save: Сачувај
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 видео снимак додат је на {playlistCount} плејлисте | {videoCount} видео снимака додато је на {playlistCount} плејлисте
-      "{videoCount} video(s) added to 1 playlist": 1 видео снимак додат је на 1 плејлисту | {videoCount} видео снимака додато је на 1 плејлисту
+      "Video(s) added to {playlistCount} playlists": 1 видео снимак додат је на {playlistCount} плејлисте | {videoCount} видео снимака додато је на {playlistCount} плејлисте
+      "Video(s) added to 1 playlist": 1 видео снимак додат је на 1 плејлисту | {videoCount} видео снимака додато је на 1 плејлисту
       You haven't selected any playlist yet.: Још увек нисте изабрали ниједну плејлисту.
     Select a playlist to add your N videos to: Изаберите плејлисту на коју желите да додате видео снимак | Изаберите плејлисту на коју желите да додате {videoCount} видео снимака
     N playlists selected: 'Изабрано: {playlistCount}'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -125,8 +125,8 @@ User Playlists:
     Search in Playlists: Претрага у плејлистама
     Save: Сачувај
     Toast:
-      "Video(s) added to {playlistCount} playlists": 1 видео снимак додат је на {playlistCount} плејлисте | {videoCount} видео снимака додато је на {playlistCount} плејлисте
-      "Video(s) added to 1 playlist": 1 видео снимак додат је на 1 плејлисту | {videoCount} видео снимака додато је на 1 плејлисту
+      "Videos added to {playlistCount} playlists": видео снимак додат је на {playlistCount} плејлисте | видео снимака додато је на {playlistCount} плејлисте
+      "Videos added to 1 playlist": 1 видео снимак додат је на 1 плејлисту | видео снимака додато је на 1 плејлисту
       You haven't selected any playlist yet.: Још увек нисте изабрали ниједну плејлисту.
     Select a playlist to add your N videos to: Изаберите плејлисту на коју желите да додате видео снимак | Изаберите плејлисту на коју желите да додате {videoCount} видео снимака
     N playlists selected: 'Изабрано: {playlistCount}'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -125,8 +125,7 @@ User Playlists:
     Search in Playlists: Претрага у плејлистама
     Save: Сачувај
     Toast:
-      "Videos added to {playlistCount} playlists": видео снимак додат је на {playlistCount} плејлисте | видео снимака додато је на {playlistCount} плејлисте
-      "Videos added to 1 playlist": 1 видео снимак додат је на 1 плејлисту | видео снимака додато је на 1 плејлисту
+      "Video(s) added to {playlistCount} playlists": видео снимак додат је на {playlistCount} плејлисте | видео снимака додато је на {playlistCount} плејлисте
       You haven't selected any playlist yet.: Још увек нисте изабрали ниједну плејлисту.
     Select a playlist to add your N videos to: Изаберите плејлисту на коју желите да додате видео снимак | Изаберите плејлисту на коју желите да додате {videoCount} видео снимака
     N playlists selected: 'Изабрано: {playlistCount}'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -125,7 +125,7 @@ User Playlists:
     Search in Playlists: Претрага у плејлистама
     Save: Сачувај
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Још увек нисте изабрали ниједну плејлисту.
     Select a playlist to add your N videos to: Изаберите плејлисту на коју желите да додате видео снимак | Изаберите плејлисту на коју желите да додате {videoCount} видео снимака
     N playlists selected: 'Изабрано: {playlistCount}'

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -125,7 +125,7 @@ User Playlists:
     Search in Playlists: Претрага у плејлистама
     Save: Сачувај
     Toast:
-      "Video(s) added to {playlistCount} playlists": видео снимак додат је на {playlistCount} плејлисте | видео снимака додато је на {playlistCount} плејлисте
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Још увек нисте изабрали ниједну плејлисту.
     Select a playlist to add your N videos to: Изаберите плејлисту на коју желите да додате видео снимак | Изаберите плејлисту на коју желите да додате {videoCount} видео снимака
     N playlists selected: 'Изабрано: {playlistCount}'

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -154,8 +154,8 @@ User Playlists:
     N playlists selected: '{playlistCount} valda'
     Toast:
       You haven't selected any playlist yet.: Du har inte valt någon spellista ännu.
-      "Video(s) added to 1 playlist": 1 video tillagd i 1 spellista | {videoCount} videor tillagda i 1 spellista
-      "Video(s) added to {playlistCount} playlists": 1 video tillagd i {playlistCount} spellistor | {videoCount} videor tillagda i {playlistCount} spellistor
+      "Videos added to 1 playlist": 1 video tillagd i 1 spellista | videor tillagda i 1 spellista
+      "Videos added to {playlistCount} playlists": video tillagd i {playlistCount} spellistor | videor tillagda i {playlistCount} spellistor
     Allow Adding Duplicate Video(s): Tillåt tilläggning av dubblettvideo(n)
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videor Kommer Att Läggas Till'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videor Redan Tillagda'

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -154,8 +154,7 @@ User Playlists:
     N playlists selected: '{playlistCount} valda'
     Toast:
       You haven't selected any playlist yet.: Du har inte valt någon spellista ännu.
-      "Videos added to 1 playlist": 1 video tillagd i 1 spellista | videor tillagda i 1 spellista
-      "Videos added to {playlistCount} playlists": video tillagd i {playlistCount} spellistor | videor tillagda i {playlistCount} spellistor
+      "Video(s) added to {playlistCount} playlists": video tillagd i {playlistCount} spellistor | videor tillagda i {playlistCount} spellistor
     Allow Adding Duplicate Video(s): Tillåt tilläggning av dubblettvideo(n)
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videor Kommer Att Läggas Till'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videor Redan Tillagda'

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -154,7 +154,7 @@ User Playlists:
     N playlists selected: '{playlistCount} valda'
     Toast:
       You haven't selected any playlist yet.: Du har inte valt någon spellista ännu.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Allow Adding Duplicate Video(s): Tillåt tilläggning av dubblettvideo(n)
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videor Kommer Att Läggas Till'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videor Redan Tillagda'

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -154,7 +154,7 @@ User Playlists:
     N playlists selected: '{playlistCount} valda'
     Toast:
       You haven't selected any playlist yet.: Du har inte valt någon spellista ännu.
-      "Video(s) added to {playlistCount} playlists": video tillagd i {playlistCount} spellistor | videor tillagda i {playlistCount} spellistor
+      "Video(s) added to {playlistCount} playlists":
     Allow Adding Duplicate Video(s): Tillåt tilläggning av dubblettvideo(n)
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videor Kommer Att Läggas Till'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videor Redan Tillagda'

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -154,8 +154,8 @@ User Playlists:
     N playlists selected: '{playlistCount} valda'
     Toast:
       You haven't selected any playlist yet.: Du har inte valt någon spellista ännu.
-      "{videoCount} video(s) added to 1 playlist": 1 video tillagd i 1 spellista | {videoCount} videor tillagda i 1 spellista
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video tillagd i {playlistCount} spellistor | {videoCount} videor tillagda i {playlistCount} spellistor
+      "Video(s) added to 1 playlist": 1 video tillagd i 1 spellista | {videoCount} videor tillagda i 1 spellista
+      "Video(s) added to {playlistCount} playlists": 1 video tillagd i {playlistCount} spellistor | {videoCount} videor tillagda i {playlistCount} spellistor
     Allow Adding Duplicate Video(s): Tillåt tilläggning av dubblettvideo(n)
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Videor Kommer Att Läggas Till'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Videor Redan Tillagda'

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -239,8 +239,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'நீங்கள் இதுவரை எந்த பிளேலிச்ட்டையும் தேர்வு செய்யவில்லை.'
-      "Video(s) added to 1 playlist": "1 பிளேலிச்ட்டில் 1 வீடியோ சேர்க்கப்பட்டது | {videoCount} வீடியோக்கள் 1 பிளேலிச்ட்டில் சேர்க்கப்பட்டன"
-      "Video(s) added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் 1 வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் {videoCount} பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
+      "Videos added to 1 playlist": "1 பிளேலிச்ட்டில் 1 வீடியோ சேர்க்கப்பட்டது | வீடியோக்கள் 1 பிளேலிச்ட்டில் சேர்க்கப்பட்டன"
+      "Videos added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
   CreatePlaylistPrompt:
     New Playlist Name: 'புதிய பிளேலிச்ட் பெயர்'
     Create: 'உருவாக்கு'

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -239,7 +239,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'நீங்கள் இதுவரை எந்த பிளேலிச்ட்டையும் தேர்வு செய்யவில்லை.'
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: 'புதிய பிளேலிச்ட் பெயர்'
     Create: 'உருவாக்கு'

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -239,8 +239,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'நீங்கள் இதுவரை எந்த பிளேலிச்ட்டையும் தேர்வு செய்யவில்லை.'
-      "Videos added to 1 playlist": "1 பிளேலிச்ட்டில் 1 வீடியோ சேர்க்கப்பட்டது | வீடியோக்கள் 1 பிளேலிச்ட்டில் சேர்க்கப்பட்டன"
-      "Videos added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
+      "Video(s) added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
   CreatePlaylistPrompt:
     New Playlist Name: 'புதிய பிளேலிச்ட் பெயர்'
     Create: 'உருவாக்கு'

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -239,7 +239,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'நீங்கள் இதுவரை எந்த பிளேலிச்ட்டையும் தேர்வு செய்யவில்லை.'
-      "Video(s) added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: 'புதிய பிளேலிச்ட் பெயர்'
     Create: 'உருவாக்கு'

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -239,8 +239,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: 'நீங்கள் இதுவரை எந்த பிளேலிச்ட்டையும் தேர்வு செய்யவில்லை.'
-      "{videoCount} video(s) added to 1 playlist": "1 பிளேலிச்ட்டில் 1 வீடியோ சேர்க்கப்பட்டது | {videoCount} வீடியோக்கள் 1 பிளேலிச்ட்டில் சேர்க்கப்பட்டன"
-      "{videoCount} video(s) added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் 1 வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் {videoCount} பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
+      "Video(s) added to 1 playlist": "1 பிளேலிச்ட்டில் 1 வீடியோ சேர்க்கப்பட்டது | {videoCount} வீடியோக்கள் 1 பிளேலிச்ட்டில் சேர்க்கப்பட்டன"
+      "Video(s) added to {playlistCount} playlists": "1 பிளேலிச்ட்கவுண்ட்} பிளேலிச்ட்களில் 1 வீடியோ சேர்க்கப்பட்டது {playlistCount} வீடியோக்கள் {videoCount} பிளேலிச்ட்களில் சேர்க்கப்பட்டன"
   CreatePlaylistPrompt:
     New Playlist Name: 'புதிய பிளேலிச்ட் பெயர்'
     Create: 'உருவாக்கு'

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -163,8 +163,7 @@ User Playlists:
     Save: Kaydet
     Toast:
       You haven't selected any playlist yet.: Henüz bir oynatma listesi seçmediniz.
-      "Videos added to {playlistCount} playlists": video {playlistCount} oynatma listesine eklendi | video {playlistCount} oynatma listesine eklendi
-      "Videos added to 1 playlist": 1 video 1 oynatma listesine eklendi | video 1 oynatma listesine eklendi
+      "Video(s) added to {playlistCount} playlists": video {playlistCount} oynatma listesine eklendi | video {playlistCount} oynatma listesine eklendi
     N playlists selected: '{playlistCount} Seçildi'
     Search in Playlists: Oynatma Listelerinde Ara
     Added {count} Times: 'Zaten Eklendi | {count} Defa Eklendi'

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -163,8 +163,8 @@ User Playlists:
     Save: Kaydet
     Toast:
       You haven't selected any playlist yet.: Henüz bir oynatma listesi seçmediniz.
-      "Video(s) added to {playlistCount} playlists": 1 video {playlistCount} oynatma listesine eklendi | {videoCount} video {playlistCount} oynatma listesine eklendi
-      "Video(s) added to 1 playlist": 1 video 1 oynatma listesine eklendi | {videoCount} video 1 oynatma listesine eklendi
+      "Videos added to {playlistCount} playlists": video {playlistCount} oynatma listesine eklendi | video {playlistCount} oynatma listesine eklendi
+      "Videos added to 1 playlist": 1 video 1 oynatma listesine eklendi | video 1 oynatma listesine eklendi
     N playlists selected: '{playlistCount} Seçildi'
     Search in Playlists: Oynatma Listelerinde Ara
     Added {count} Times: 'Zaten Eklendi | {count} Defa Eklendi'

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -163,7 +163,7 @@ User Playlists:
     Save: Kaydet
     Toast:
       You haven't selected any playlist yet.: Henüz bir oynatma listesi seçmediniz.
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     N playlists selected: '{playlistCount} Seçildi'
     Search in Playlists: Oynatma Listelerinde Ara
     Added {count} Times: 'Zaten Eklendi | {count} Defa Eklendi'

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -163,8 +163,8 @@ User Playlists:
     Save: Kaydet
     Toast:
       You haven't selected any playlist yet.: Henüz bir oynatma listesi seçmediniz.
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 video {playlistCount} oynatma listesine eklendi | {videoCount} video {playlistCount} oynatma listesine eklendi
-      "{videoCount} video(s) added to 1 playlist": 1 video 1 oynatma listesine eklendi | {videoCount} video 1 oynatma listesine eklendi
+      "Video(s) added to {playlistCount} playlists": 1 video {playlistCount} oynatma listesine eklendi | {videoCount} video {playlistCount} oynatma listesine eklendi
+      "Video(s) added to 1 playlist": 1 video 1 oynatma listesine eklendi | {videoCount} video 1 oynatma listesine eklendi
     N playlists selected: '{playlistCount} Seçildi'
     Search in Playlists: Oynatma Listelerinde Ara
     Added {count} Times: 'Zaten Eklendi | {count} Defa Eklendi'

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -163,7 +163,7 @@ User Playlists:
     Save: Kaydet
     Toast:
       You haven't selected any playlist yet.: Henüz bir oynatma listesi seçmediniz.
-      "Video(s) added to {playlistCount} playlists": video {playlistCount} oynatma listesine eklendi | video {playlistCount} oynatma listesine eklendi
+      "Video(s) added to {playlistCount} playlists":
     N playlists selected: '{playlistCount} Seçildi'
     Search in Playlists: Oynatma Listelerinde Ara
     Added {count} Times: 'Zaten Eklendi | {count} Defa Eklendi'

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -186,7 +186,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Відео буде додано'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Відео вже додано'
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Ви ще не вибрали жодної добірки.
     N playlists selected: '{playlistCount} вибрано'
     Select a playlist to add your N videos to: Виберіть добірку, до якої ви хочете додати своє відео | Виберіть добірку, до якої ви хочете додати свої {videoCount} відео

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -186,8 +186,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Відео буде додано'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Відео вже додано'
     Toast:
-      "{videoCount} video(s) added to 1 playlist": 1 відео додано до 1 добірки | {videoCount} відео додано до 1 добірки
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 відео додано до {playlistCount} добірок | {videoCount} відео додано до {playlistCount} добірок
+      "Video(s) added to 1 playlist": 1 відео додано до 1 добірки | {videoCount} відео додано до 1 добірки
+      "Video(s) added to {playlistCount} playlists": 1 відео додано до {playlistCount} добірок | {videoCount} відео додано до {playlistCount} добірок
       You haven't selected any playlist yet.: Ви ще не вибрали жодної добірки.
     N playlists selected: '{playlistCount} вибрано'
     Select a playlist to add your N videos to: Виберіть добірку, до якої ви хочете додати своє відео | Виберіть добірку, до якої ви хочете додати свої {videoCount} відео

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -186,7 +186,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Відео буде додано'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Відео вже додано'
     Toast:
-      "Video(s) added to {playlistCount} playlists": відео додано до {playlistCount} добірок | відео додано до {playlistCount} добірок
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Ви ще не вибрали жодної добірки.
     N playlists selected: '{playlistCount} вибрано'
     Select a playlist to add your N videos to: Виберіть добірку, до якої ви хочете додати своє відео | Виберіть добірку, до якої ви хочете додати свої {videoCount} відео

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -186,8 +186,8 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Відео буде додано'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Відео вже додано'
     Toast:
-      "Video(s) added to 1 playlist": 1 відео додано до 1 добірки | {videoCount} відео додано до 1 добірки
-      "Video(s) added to {playlistCount} playlists": 1 відео додано до {playlistCount} добірок | {videoCount} відео додано до {playlistCount} добірок
+      "Videos added to 1 playlist": 1 відео додано до 1 добірки | відео додано до 1 добірки
+      "Videos added to {playlistCount} playlists": відео додано до {playlistCount} добірок | відео додано до {playlistCount} добірок
       You haven't selected any playlist yet.: Ви ще не вибрали жодної добірки.
     N playlists selected: '{playlistCount} вибрано'
     Select a playlist to add your N videos to: Виберіть добірку, до якої ви хочете додати своє відео | Виберіть добірку, до якої ви хочете додати свої {videoCount} відео

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -186,8 +186,7 @@ User Playlists:
     "{videoCount}/{totalVideoCount} Videos Will Be Added": '{videoCount}/{totalVideoCount} Відео буде додано'
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} Відео вже додано'
     Toast:
-      "Videos added to 1 playlist": 1 відео додано до 1 добірки | відео додано до 1 добірки
-      "Videos added to {playlistCount} playlists": відео додано до {playlistCount} добірок | відео додано до {playlistCount} добірок
+      "Video(s) added to {playlistCount} playlists": відео додано до {playlistCount} добірок | відео додано до {playlistCount} добірок
       You haven't selected any playlist yet.: Ви ще не вибрали жодної добірки.
     N playlists selected: '{playlistCount} вибрано'
     Select a playlist to add your N videos to: Виберіть добірку, до якої ви хочете додати своє відео | Виберіть добірку, до якої ви хочете додати свої {videoCount} відео

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -166,9 +166,9 @@ User Playlists:
     N playlists selected: Đã chọn {playlistCount}
     Search in Playlists: Tìm trong danh sách phát
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": Đã thêm 1 video vào {playlistCount} danh sách phát | Đã thêm {videoCount} video vào {playlistCount} danh sách phát
+      "Video(s) added to {playlistCount} playlists": Đã thêm 1 video vào {playlistCount} danh sách phát | Đã thêm {videoCount} video vào {playlistCount} danh sách phát
       You haven't selected any playlist yet.: Bạn đang chưa chọn danh sách phát nào.
-      "{videoCount} video(s) added to 1 playlist": Đã thêm 1 video vào 1 danh sách phát | Đã thêm {videoCount} vào 1 danh sách phát
+      "Video(s) added to 1 playlist": Đã thêm 1 video vào 1 danh sách phát | Đã thêm {videoCount} vào 1 danh sách phát
     Save: Lưu
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} đã có trong danh sách phát'
     Added {count} Times: Đã được thêm | Đã được thêm {count} lần

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -166,7 +166,7 @@ User Playlists:
     N playlists selected: Đã chọn {playlistCount}
     Search in Playlists: Tìm trong danh sách phát
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: Bạn đang chưa chọn danh sách phát nào.
     Save: Lưu
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} đã có trong danh sách phát'

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -166,9 +166,8 @@ User Playlists:
     N playlists selected: Đã chọn {playlistCount}
     Search in Playlists: Tìm trong danh sách phát
     Toast:
-      "Videos added to {playlistCount} playlists": Đã thêm video vào {playlistCount} danh sách phát | Đã thêm video vào {playlistCount} danh sách phát
+      "Video(s) added to {playlistCount} playlists": Đã thêm video vào {playlistCount} danh sách phát | Đã thêm video vào {playlistCount} danh sách phát
       You haven't selected any playlist yet.: Bạn đang chưa chọn danh sách phát nào.
-      "Videos added to 1 playlist": Đã thêm 1 video vào 1 danh sách phát | Đã thêm vào 1 danh sách phát
     Save: Lưu
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} đã có trong danh sách phát'
     Added {count} Times: Đã được thêm | Đã được thêm {count} lần

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -166,9 +166,9 @@ User Playlists:
     N playlists selected: Đã chọn {playlistCount}
     Search in Playlists: Tìm trong danh sách phát
     Toast:
-      "Video(s) added to {playlistCount} playlists": Đã thêm 1 video vào {playlistCount} danh sách phát | Đã thêm {videoCount} video vào {playlistCount} danh sách phát
+      "Videos added to {playlistCount} playlists": Đã thêm video vào {playlistCount} danh sách phát | Đã thêm video vào {playlistCount} danh sách phát
       You haven't selected any playlist yet.: Bạn đang chưa chọn danh sách phát nào.
-      "Video(s) added to 1 playlist": Đã thêm 1 video vào 1 danh sách phát | Đã thêm {videoCount} vào 1 danh sách phát
+      "Videos added to 1 playlist": Đã thêm 1 video vào 1 danh sách phát | Đã thêm vào 1 danh sách phát
     Save: Lưu
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} đã có trong danh sách phát'
     Added {count} Times: Đã được thêm | Đã được thêm {count} lần

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -166,7 +166,7 @@ User Playlists:
     N playlists selected: Đã chọn {playlistCount}
     Search in Playlists: Tìm trong danh sách phát
     Toast:
-      "Video(s) added to {playlistCount} playlists": Đã thêm video vào {playlistCount} danh sách phát | Đã thêm video vào {playlistCount} danh sách phát
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: Bạn đang chưa chọn danh sách phát nào.
     Save: Lưu
     "{videoCount}/{totalVideoCount} Videos Already Added": '{videoCount}/{totalVideoCount} đã có trong danh sách phát'

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -233,8 +233,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to 1 playlist": ""
-      "Video(s) added to {playlistCount} playlists": ""
+      "Videos added to 1 playlist": ""
+      "Videos added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -233,7 +233,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists":
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -233,7 +233,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -233,8 +233,7 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "Videos added to 1 playlist": ""
-      "Videos added to {playlistCount} playlists": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/vls.yaml
+++ b/static/locales/vls.yaml
@@ -233,8 +233,8 @@ User Playlists:
 
     Toast:
       You haven't selected any playlist yet.: ''
-      "{videoCount} video(s) added to 1 playlist": ""
-      "{videoCount} video(s) added to {playlistCount} playlists": ""
+      "Video(s) added to 1 playlist": ""
+      "Video(s) added to {playlistCount} playlists": ""
   CreatePlaylistPrompt:
     New Playlist Name: ''
     Create: ''

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -117,7 +117,7 @@ User Playlists:
     Search in Playlists: 在播放列表中搜索
     Save: 保存
     Toast:
-      "Video(s) added to {playlistCount} playlists": 添加了 则视频到 {playlistCount} 个播放列表 | 添加了 则视频到 {playlistCount} 个播放列表
+      "Video(s) added to {playlistCount} playlists":
       You haven't selected any playlist yet.: 你尚未选中任何播放列表。
     Select a playlist to add your N videos to: 选择一个播放列表来添加你的视频 | 选择一个播放列表来添加你的 {videoCount} 个视频
     N playlists selected: 选中了 {playlistCount} 个播放列表

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -117,7 +117,7 @@ User Playlists:
     Search in Playlists: 在播放列表中搜索
     Save: 保存
     Toast:
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
       You haven't selected any playlist yet.: 你尚未选中任何播放列表。
     Select a playlist to add your N videos to: 选择一个播放列表来添加你的视频 | 选择一个播放列表来添加你的 {videoCount} 个视频
     N playlists selected: 选中了 {playlistCount} 个播放列表

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -117,8 +117,8 @@ User Playlists:
     Search in Playlists: 在播放列表中搜索
     Save: 保存
     Toast:
-      "{videoCount} video(s) added to {playlistCount} playlists": 添加了 1 则视频到 {playlistCount} 个播放列表 | 添加了 {videoCount} 则视频到 {playlistCount} 个播放列表
-      "{videoCount} video(s) added to 1 playlist": 添加了1 则视频到 1 个播放列表 | 添加了 {videoCount} 则视频到 1 个播放列表
+      "Video(s) added to {playlistCount} playlists": 添加了 1 则视频到 {playlistCount} 个播放列表 | 添加了 {videoCount} 则视频到 {playlistCount} 个播放列表
+      "Video(s) added to 1 playlist": 添加了1 则视频到 1 个播放列表 | 添加了 {videoCount} 则视频到 1 个播放列表
       You haven't selected any playlist yet.: 你尚未选中任何播放列表。
     Select a playlist to add your N videos to: 选择一个播放列表来添加你的视频 | 选择一个播放列表来添加你的 {videoCount} 个视频
     N playlists selected: 选中了 {playlistCount} 个播放列表

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -117,8 +117,7 @@ User Playlists:
     Search in Playlists: 在播放列表中搜索
     Save: 保存
     Toast:
-      "Videos added to {playlistCount} playlists": 添加了 则视频到 {playlistCount} 个播放列表 | 添加了 则视频到 {playlistCount} 个播放列表
-      "Videos added to 1 playlist": 添加了1 则视频到 1 个播放列表 | 添加了 则视频到 1 个播放列表
+      "Video(s) added to {playlistCount} playlists": 添加了 则视频到 {playlistCount} 个播放列表 | 添加了 则视频到 {playlistCount} 个播放列表
       You haven't selected any playlist yet.: 你尚未选中任何播放列表。
     Select a playlist to add your N videos to: 选择一个播放列表来添加你的视频 | 选择一个播放列表来添加你的 {videoCount} 个视频
     N playlists selected: 选中了 {playlistCount} 个播放列表

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -117,8 +117,8 @@ User Playlists:
     Search in Playlists: 在播放列表中搜索
     Save: 保存
     Toast:
-      "Video(s) added to {playlistCount} playlists": 添加了 1 则视频到 {playlistCount} 个播放列表 | 添加了 {videoCount} 则视频到 {playlistCount} 个播放列表
-      "Video(s) added to 1 playlist": 添加了1 则视频到 1 个播放列表 | 添加了 {videoCount} 则视频到 1 个播放列表
+      "Videos added to {playlistCount} playlists": 添加了 则视频到 {playlistCount} 个播放列表 | 添加了 则视频到 {playlistCount} 个播放列表
+      "Videos added to 1 playlist": 添加了1 则视频到 1 个播放列表 | 添加了 则视频到 1 个播放列表
       You haven't selected any playlist yet.: 你尚未选中任何播放列表。
     Select a playlist to add your N videos to: 选择一个播放列表来添加你的视频 | 选择一个播放列表来添加你的 {videoCount} 个视频
     N playlists selected: 选中了 {playlistCount} 个播放列表

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -164,7 +164,7 @@ User Playlists:
     Save: 儲存
     Toast:
       You haven't selected any playlist yet.: 您尚未選取任何播放清單。
-      "Video(s) added to {playlistCount} playlists":
+      "Video(s) added to {playlistCount} playlists": ""
     Added {count} Times: 已新增 | 新增了 {count} 次
     Allow Adding Duplicate Video(s): 允許新增重複影片
     "{videoCount}/{totalVideoCount} Videos Already Added": 已新增 {videoCount}/{totalVideoCount} 部影片

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -164,7 +164,7 @@ User Playlists:
     Save: 儲存
     Toast:
       You haven't selected any playlist yet.: 您尚未選取任何播放清單。
-      "Video(s) added to {playlistCount} playlists": 部影片新增至 {playlistCount} 個播放清單 | 部影片新增至 {playlistCount} 個播放清單
+      "Video(s) added to {playlistCount} playlists":
     Added {count} Times: 已新增 | 新增了 {count} 次
     Allow Adding Duplicate Video(s): 允許新增重複影片
     "{videoCount}/{totalVideoCount} Videos Already Added": 已新增 {videoCount}/{totalVideoCount} 部影片

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -164,8 +164,8 @@ User Playlists:
     Save: 儲存
     Toast:
       You haven't selected any playlist yet.: 您尚未選取任何播放清單。
-      "{videoCount} video(s) added to 1 playlist": 1 部影片新增至 1 個播放清單 | {videoCount} 部影片新增至 1 個播放清單
-      "{videoCount} video(s) added to {playlistCount} playlists": 1 部影片新增至 {playlistCount} 個播放清單 | {videoCount} 部影片新增至 {playlistCount} 個播放清單
+      "Video(s) added to 1 playlist": 1 部影片新增至 1 個播放清單 | {videoCount} 部影片新增至 1 個播放清單
+      "Video(s) added to {playlistCount} playlists": 1 部影片新增至 {playlistCount} 個播放清單 | {videoCount} 部影片新增至 {playlistCount} 個播放清單
     Added {count} Times: 已新增 | 新增了 {count} 次
     Allow Adding Duplicate Video(s): 允許新增重複影片
     "{videoCount}/{totalVideoCount} Videos Already Added": 已新增 {videoCount}/{totalVideoCount} 部影片

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -164,8 +164,7 @@ User Playlists:
     Save: 儲存
     Toast:
       You haven't selected any playlist yet.: 您尚未選取任何播放清單。
-      "Videos added to 1 playlist": 1 部影片新增至 1 個播放清單 | 部影片新增至 1 個播放清單
-      "Videos added to {playlistCount} playlists": 部影片新增至 {playlistCount} 個播放清單 | 部影片新增至 {playlistCount} 個播放清單
+      "Video(s) added to {playlistCount} playlists": 部影片新增至 {playlistCount} 個播放清單 | 部影片新增至 {playlistCount} 個播放清單
     Added {count} Times: 已新增 | 新增了 {count} 次
     Allow Adding Duplicate Video(s): 允許新增重複影片
     "{videoCount}/{totalVideoCount} Videos Already Added": 已新增 {videoCount}/{totalVideoCount} 部影片

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -164,8 +164,8 @@ User Playlists:
     Save: 儲存
     Toast:
       You haven't selected any playlist yet.: 您尚未選取任何播放清單。
-      "Video(s) added to 1 playlist": 1 部影片新增至 1 個播放清單 | {videoCount} 部影片新增至 1 個播放清單
-      "Video(s) added to {playlistCount} playlists": 1 部影片新增至 {playlistCount} 個播放清單 | {videoCount} 部影片新增至 {playlistCount} 個播放清單
+      "Videos added to 1 playlist": 1 部影片新增至 1 個播放清單 | 部影片新增至 1 個播放清單
+      "Videos added to {playlistCount} playlists": 部影片新增至 {playlistCount} 個播放清單 | 部影片新增至 {playlistCount} 個播放清單
     Added {count} Times: 已新增 | 新增了 {count} 次
     Allow Adding Duplicate Video(s): 允許新增重複影片
     "{videoCount}/{totalVideoCount} Videos Already Added": 已新增 {videoCount}/{totalVideoCount} 部影片


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #8231

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Changes the video count in toast message when adding videos to a playlist

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

Go to https://youtube.com/playlist?list=PL8mG-RkN2uTw7PhlnAr4pZZz2QubIbujH
Add the first 100 videos to new playlist
Load more videos in the playlist
Click on the add to playlist button
Add the videos to the playlist
See the toast message is correct for both adding to one playlist or multiple playlists