### PR TITLE
Fix long playlist strings breaking viewport

### DIFF
--- a/src/renderer/components/ChannelHome/ChannelHome.css
+++ b/src/renderer/components/ChannelHome/ChannelHome.css
@@ -1,6 +1,11 @@
+.shelfContainer {
+  max-inline-size: 85vw;
+}
+
 .shelfTitle {
   font-size: 24px;
   cursor: pointer;
+  overflow-wrap: break-word;
 }
 
 .shelfTitle::marker {

--- a/src/renderer/components/ChannelHome/ChannelHome.vue
+++ b/src/renderer/components/ChannelHome/ChannelHome.vue
@@ -3,6 +3,7 @@
     <div
       v-for="(shelf, index) in filteredShelves"
       :key="index"
+      class="shelfContainer"
     >
       <details
         open

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.scss
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.scss
@@ -27,6 +27,7 @@
 
 .playlistTitle {
   margin-block-end: 0.1em;
+  overflow-wrap: break-word;
 }
 
 .playlistDescription {

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -85,6 +85,10 @@
       padding: 10px;
     }
   }
+
+  .playlistPage {
+    inline-size: 85vw;
+  }
 }
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #7104

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Long strings inside Playlists break the Channel Home and Playlists viewport and push content down. This PR wraps them correctly.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Channel Home Before
<img width="1918" height="1040" alt="2025-11-12_21-50-14" src="https://github.com/user-attachments/assets/89376c6d-b27c-4e42-8774-773f62a4870d" />

Channel Home After
<img width="1918" height="1040" alt="2025-11-12_21-50-54" src="https://github.com/user-attachments/assets/e3ea2fd2-01d0-4c87-982c-8254bf544587" />

Playlist Before
<img width="1918" height="1040" alt="2025-11-12_21-49-10" src="https://github.com/user-attachments/assets/fbfab778-8478-4ffd-8721-2cb3d5016536" />

Playlist After
<img width="1918" height="1040" alt="2025-11-12_22-01-29" src="https://github.com/user-attachments/assets/565bef63-61cb-45dc-98d2-d3f239cc0d6a" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Go to a channel with very long playlist name (for example: [mai_dq](https://www.youtube.com/@mai_dq))
See that channel home page is not "pushed down" in the viewport
Scroll down to see that long playlist string is wrapped correctly
Click on View Playlist
See that long playlist string is wrapped correctly in playlist view