### PR TITLE
Change Freetube Logo App text color for dark and black themes

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -68,6 +68,13 @@ body:not(.hotPink, .pastelPink) {
   --logo-tertiary-color: #000;
 }
 
+/* Text "app" should be visible but retain FreeTube color logo */
+.system[data-system-theme*='dark'],
+.dark,
+.black {
+  --logo-tertiary-color: #fff;
+}
+
 /* Given that the Hot Pink theme does not need link underlining due to meeting
 WCAG 2 Level AA (https://webaim.org/resources/linkcontrastchecker/?fcolor=FFFFFF&bcolor=DE1C85&lcolor=000000),
 it can be safely elided. This looks quite pleasant on this theme. */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #8283

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Overrides the color of "app" text in Freetube logo for dark and black themes so that it's white and visible

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before
<img width="904" height="305" alt="2025-11-14_20-47-31" src="https://github.com/user-attachments/assets/b62c882e-2a8a-47f8-8314-bc1f7a8167b8" />
<img width="792" height="305" alt="2025-11-14_20-45-31" src="https://github.com/user-attachments/assets/78ab6e92-cd9a-4cf5-9f4a-3675920743c1" />

After
<img width="826" height="294" alt="2025-11-15_19-20-04" src="https://github.com/user-attachments/assets/36987893-b22c-450d-a391-f927126436b9" />
<img width="900" height="302" alt="2025-11-15_19-19-54" src="https://github.com/user-attachments/assets/f03f1f7b-45cc-4052-8eda-4d1668d6c7ef" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Change theme to either Dark or Black
Go to Settings
See that "App" text of the Freetube logo is white and visible