### PR TITLE
Fix playlist video view counts on the local API

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1292,27 +1292,12 @@ export function parseLocalPlaylistVideo(video) {
 
     let viewCount = null
 
-    // the accessiblity label contains the full view count
-    // the video info only contains the short view count
-    if (video_.accessibility_label) {
-      // the `.*\s+` at the start of the regex, ensures we match the last occurence
-      // just in case the video title also contains that pattern
-      const match = video_.accessibility_label.match(/.*\s+([\d,.]+|no)\s+views?/)
+    const viewsText = video_.video_info.runs?.find(run => VIEWS_OR_WATCHING_REGEX.test(run.text))?.text
 
-      if (match) {
-        const count = match[1]
-
-        // as it's rare that a video has no views,
-        // checking the length allows us to avoid running toLowerCase unless we have to
-        if (count.length === 2 && count === 'no') {
-          viewCount = 0
-        } else {
-          const views = extractNumberFromString(count)
-
-          if (!isNaN(views)) {
-            viewCount = views
-          }
-        }
+    if (viewsText) {
+      const views = parseLocalSubscriberCount(viewsText)
+      if (!isNaN(views)) {
+        viewCount = views
       }
     }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

In the past we scraped the view count for playlist videos from the accessibility text as YouTube returned the full view count in there, but they are no longer doing that so we weren't showing any view count. This pull request switches to extracting the compact number view count, as a less accurate view count is still better than none.

## Screenshots

Before:
<img width="976" height="721" alt="before" src="https://github.com/user-attachments/assets/4fef3e6b-0ceb-4d42-8baf-34e5fb7006f3" />

After:
<img width="977" height="723" alt="after" src="https://github.com/user-attachments/assets/a0a17e65-e064-498d-8dc4-b01d1a48476e" />

## Testing

Open a few playlists and check that the view count shows up on videos. Please note that the view count still won't be shown for all videos but it will be missing for the same ones that it is missing in the playlist view on YouTube's website.

## Desktop

- **OS:** Windows
- **OS Version:** 11