### PR TITLE
Fix the spacing between playlist metadata entries

### DIFF
--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -68,13 +68,13 @@
         </h2>
         <p>
           {{ t('Global.Counts.Video Count', { count: parsedVideoCount }, videoCount) }}
-          <span v-if="!hideViews && !isUserPlaylist">
+          <template v-if="!hideViews && !isUserPlaylist">
             - {{ t('Global.Counts.View Count', { count: parsedViewCount }, viewCount) }}
-          </span>
-          <span>- </span>
-          <span v-if="infoSource !== 'local'">
+          </template>
+          -
+          <template v-if="infoSource !== 'local'">
             {{ $t("Playlist.Last Updated On") }}
-          </span>
+          </template>
           {{ lastUpdated }}
           <template v-if="durationFormatted !== ''">
             <br>


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8227
  (1 and two were solved in #8292)

## Description

This pull request fixes the spacing between the dividers and the metadata entries in the playlist information section.

## Screenshots

See the linked issue for a screenshot of the previous appearance.

After:

<img width="296" height="423" alt="playlist metadata with fixed spacing" src="https://github.com/user-attachments/assets/7e2689d2-ca09-40e4-869e-a06afff3bc70" />

## Testing

Open a playlist and check the spacing between the dividers in the metadata.

## Desktop

- **OS:** Windows
- **OS Version:** 11