### PR TITLE
Added chapter preview over timeline

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -258,7 +258,7 @@
   position: absolute;
   bottom: 104px; /* Positioned just above the frame of timeline */
   transform: translateX(-50%);
-  background-color: rgb(89 89 89 / 78%);
+  background-color: rgb(27 27 27 / 67%);
   border-radius: 999px; /* shape of the background colour */
   color: #fff;
   font-size: 13px;
@@ -275,7 +275,7 @@
 }
 
 .ftVideoPlayer:fullscreen :deep(.ft-chapter-preview) {
-  bottom: 125px;
+  bottom: 160px;
 }
 
 /* stylelint-enable liberty/use-logical-spec */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1014,7 +1014,14 @@ export default defineComponent({
         if (chapterPreview.style.display !== 'block') {
           chapterPreview.style.display = 'block'
         }
-        chapterPreview.style.left = `${percentage * 100}%`
+
+        const previewWidth = chapterPreview.offsetWidth
+        const minX = previewWidth / 2
+        const maxX = rect.width - (previewWidth / 2)
+        const targetX = percentage * rect.width
+        const clampedX = Math.max(minX, Math.min(maxX, targetX))
+
+        chapterPreview.style.left = `${clampedX}px`
       } else {
         if (chapterPreview.style.display !== 'none') {
           chapterPreview.style.display = 'none'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Feature Implementation


## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
- closes #2829


## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR implements a chapter preview feature that displays the chapter title when hovering over the video timeline. When users move their cursor along the seekbar, a text (chapter label) appears above the timeline showing the title of the chapter at that position.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

- Before:

https://github.com/user-attachments/assets/e881f4f3-b0c3-43f3-b87d-3491167134d3


- After:

https://github.com/user-attachments/assets/eb094aa6-9882-484f-8f47-0b9a89ab7eb6



## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1) Visiting Youtube videos having chapters: example: 
- https://www.youtube.com/watch?v=TiMoSDztAhw
- https://www.youtube.com/watch?v=V_xro1bcAuA&t=7102s

2) move their cursor along the seekbar and see if the text appears above the video frame 

3) Go full screen and test for the same.

## Desktop
<!-- Please complete the following information-->
- **OS: Windows 11**
- **OS Version: Windows 11 24H2 (OS Build 26100.7171)**
- **FreeTube version: 0.23.12**

## Additional context
<!-- Add any other context about the pull request here. -->
1) Important Edge case fixed: 

https://github.com/user-attachments/assets/51b1ba16-89fe-4698-9fc8-94d5f9391db5

- As you can see from the video, the chapter label text does not break when the seekbar is at the extreme ends. 
