### PR TITLE
Fix comment section auto-scroll glitch on initial load

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -620,7 +620,7 @@ async function getCommentDataLocal(more = false) {
 
     if (!more) {
       nextTick(() => {
-        commentsTitle.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        commentsTitle.value?.scrollIntoView({ behavior: 'smooth', block: 'center' })
       })
     }
   } catch (err) {
@@ -732,7 +732,7 @@ async function getCommentDataInvidious() {
 
     if (isInitialLoad) {
       nextTick(() => {
-        commentsTitle.value?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        commentsTitle.value?.scrollIntoView({ behavior: 'smooth', block: 'center' })
       })
     }
   } catch (err) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
- closes #8307

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fixes an unwanted auto-scroll behavior when loading comments. Previously, when a user expanded the video description, scrolled to the bottom, and then clicked "Load Comments," the page would automatically scroll down too far, causing the user to miss the first few comments.



## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Before : 

https://github.com/user-attachments/assets/449bc032-75ed-49fb-8cc9-226c84b70d48

After:

https://github.com/user-attachments/assets/32a9f983-fb37-42c6-b272-d0c7d4b9082c

Before 2nd example: 

https://github.com/user-attachments/assets/da52f1ec-a94f-4a8a-9153-f55ee683702f

After 2nd example: 

https://github.com/user-attachments/assets/ac09c8bb-1be6-4a03-af7c-cc504a628c52



## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- Go to a video e.g. https://youtu.be/g3FkuZNSGkw
- Expand description
- Scroll description to the bottom
- Load comments
- Check if the comment section starts from the 1st comment or not 


- 2nd -> check if community post comments are loading properly or not. 


## Desktop
<!-- Please complete the following information-->
- **OS: Windows 11**
- **OS Version: Windows 11 24H2 (OS Build 26100.7171)**
- **FreeTube version: 0.23.12**

## Additional context
<!-- Add any other context about the pull request here. -->
- Nothing special just I have tested it on multiple videos including community posts comment section for edge cases and I think the issue is resolved. 