### PR TITLE
Add support for exporting watch history in YouTube's JSON format

### DIFF
--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -36,7 +36,7 @@
       />
       <FtButton
         :label="$t('Settings.Data Settings.Export History')"
-        @click="exportWatchHistory"
+        @click="showExportWatchHistoryPrompt = true"
       />
     </FtFlexBox>
     <h4 class="groupTitle">
@@ -62,7 +62,7 @@
       />
       <FtButton
         :label="t('Settings.Data Settings.Export search history')"
-        @click="showSearchExportHistoryPrompt = true"
+        @click="showExportSearchHistoryPrompt = true"
       />
     </FtFlexBox>
     <FtPrompt
@@ -73,10 +73,17 @@
       @click="exportSubscriptions"
     />
     <FtPrompt
-      v-if="showSearchExportHistoryPrompt"
+      v-if="showExportWatchHistoryPrompt"
       :label="t('Settings.Data Settings.Select Export Type')"
-      :option-names="exportSearchHistoryPromptNames"
-      :option-values="SEARCH_HISTORY_PROMPT_VALUES"
+      :option-names="exportWatchSearchHistoryPromptNames"
+      :option-values="WATCH_SEARCH_HISTORY_PROMPT_VALUES"
+      @click="exportWatchHistory"
+    />
+    <FtPrompt
+      v-if="showExportSearchHistoryPrompt"
+      :label="t('Settings.Data Settings.Select Export Type')"
+      :option-names="exportWatchSearchHistoryPromptNames"
+      :option-values="WATCH_SEARCH_HISTORY_PROMPT_VALUES"
       @click="exportSearchHistory"
     />
   </FtSettingsSection>
@@ -752,6 +759,17 @@ async function exportNewPipeSubscriptions() {
 
 // #endregion subscriptions export
 
+const WATCH_SEARCH_HISTORY_PROMPT_VALUES = [
+  'freetube',
+  'youtube'
+]
+
+const exportWatchSearchHistoryPromptNames = computed(() => [
+  `${t('Settings.Data Settings.Export FreeTube')} (.db)`,
+  `${t('Settings.Data Settings.Export YouTube')} (.json)`,
+  t('Close')
+])
+
 // #region watch history
 
 const historyCacheById = computed(() => {
@@ -952,7 +970,25 @@ async function importYouTubeWatchHistory(historyData) {
   showToast(t('Settings.Data Settings.All watched history has been successfully imported'))
 }
 
-async function exportWatchHistory() {
+const showExportWatchHistoryPrompt = ref(false)
+
+/**
+ * @param {'freetube' | 'youtube' | null} option
+ */
+async function exportWatchHistory(option) {
+  showExportWatchHistoryPrompt.value = false
+
+  switch (option) {
+    case 'freetube':
+      exportFreeTubeWatchHistory()
+      break
+    case 'youtube':
+      exportYouTubeWatchHistory()
+      break
+  }
+}
+
+async function exportFreeTubeWatchHistory() {
   const historyDb = historyCacheSorted.value.map((historyEntry) => {
     return JSON.stringify(historyEntry)
   }).join('\n') + '\n'
@@ -965,6 +1001,39 @@ async function exportWatchHistory() {
     t('Settings.Data Settings.History File'),
     'application/x-freetube-db',
     '.db',
+    t('Settings.Data Settings.All watched history has been successfully exported')
+  )
+}
+
+async function exportYouTubeWatchHistory() {
+  const historyData = historyCacheSorted.value.map((entry) => {
+    return {
+      header: 'YouTube',
+      title: `Watched ${entry.title}`,
+      titleUrl: `https://www.youtube.com/watch?v=${entry.videoId}`,
+      subtitles: [{
+        name: entry.author,
+        url: `https://www.youtube.com/channel/${entry.authorId}`
+      }],
+      time: new Date(entry.timeWatched).toISOString(),
+      products: [
+        'YouTube'
+      ],
+      activityControls: [
+        'YouTube watch history'
+      ]
+    }
+  })
+
+  const dateStr = getTodayDateStrLocalTimezone()
+  const exportFileName = 'youtube-watch-history-' + dateStr + '.json'
+
+  await promptAndWriteToFile(
+    exportFileName,
+    JSON.stringify(historyData),
+    t('Settings.Data Settings.History File'),
+    'application/json',
+    '.json',
     t('Settings.Data Settings.All watched history has been successfully exported')
   )
 }
@@ -1326,24 +1395,13 @@ async function importYouTubeSearchHistory(historyData) {
   showToast(t('Settings.Data Settings.All search history has been successfully imported'))
 }
 
-const SEARCH_HISTORY_PROMPT_VALUES = [
-  'freetube',
-  'youtube'
-]
-
-const exportSearchHistoryPromptNames = computed(() => [
-  `${t('Settings.Data Settings.Export FreeTube')} (.db)`,
-  `${t('Settings.Data Settings.Export YouTube')} (.json)`,
-  t('Close')
-])
-
-const showSearchExportHistoryPrompt = ref(false)
+const showExportSearchHistoryPrompt = ref(false)
 
 /**
  * @param {'freetube' | 'youtube' | null} option
  */
 async function exportSearchHistory(option) {
-  showSearchExportHistoryPrompt.value = false
+  showExportSearchHistoryPrompt.value = false
 
   switch (option) {
     case 'freetube':


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

- https://github.com/FreeTubeApp/FreeTube/pull/8237

## Description

This pull request adds support for exporting watch history in the JSON format used by Google Takeout.

## Testing

1. Backup your watch history (YouTube's format stores less data than FreeTube's so you'll want to back it up in FreeTube's format to avoid losing data)
2. Export your watch history and select "YouTube (.json)" in the prompt.
3. Remove your watch history in the privacy settings
4. Import the watch history JSON file that you created with the export before
5. Success?

You can get your watch history back with all data by removing your watch history in the privacy settings and restoring the FreeTube database format backup that you created in step 1

## Desktop

- **OS:** Windows
- **OS Version:** 11