### PR TITLE
Fix view count with RSS feeds

### DIFF
--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -99,6 +99,18 @@ export async function parseYouTubeRSSFeed(rssString, channelId) {
 async function parseRSSEntry(entry, channelId, channelName) {
   // doesn't need to be asynchronous, but doing it allows us to do the relatively slow DOM querying in parallel
 
+  const rawViewCount = entry.getElementsByTagName('media:statistics')[0]?.getAttribute('views')
+
+  let viewCount = null
+
+  if (rawViewCount) {
+    const parsedViewCount = parseInt(rawViewCount)
+
+    if (!isNaN(parsedViewCount)) {
+      viewCount = parsedViewCount
+    }
+  }
+
   return {
     authorId: channelId,
     author: channelName,
@@ -106,7 +118,7 @@ async function parseRSSEntry(entry, channelId, channelName) {
     videoId: entry.getElementsByTagName('yt:videoId')[0].textContent,
     title: entry.querySelector('title').textContent,
     published: Date.parse(entry.querySelector('published').textContent),
-    viewCount: entry.getElementsByTagName('media:statistics')[0]?.getAttribute('views') || null,
+    viewCount,
     type: 'video',
     lengthSeconds: '0:00',
     isRSS: true


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8326

## Description

We were not parsing the view count in the RSS responses to a number and vue-i18n 8 used to use `Math.abs()` which [internally coorces parameters to numbers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs#coercion_of_parameter) but the newer Vue 3 compatible versions of vue-i18n no longer do that magic casting and instead end up using the first choice aka "1 view". This pull request fixes that by parsing the view count to a number.

The linked issue mentions that it started yesterday but they probably only upgraded their nightly build yesterday as this first crops up in the merge of the Vue 3 upgrade.

## Testing

1. Turn on Fetch Feeds from RSS
2. Refresh your subscriptions
3. Most videos should not have a view count of 1 (of course videos that only have one view will still say 1 view).

## Desktop

- **OS:** Windows
- **OS Version:** 11