### PR TITLE
Fix dropdownShown error on the watch page for live streams

### DIFF
--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -429,17 +429,20 @@ onMounted(() => {
     })
   }
 
-  downloadDropdownWatcher = watch(() => downloadButton.value.dropdownShown, (dropdownShown) => {
-    emit('set-info-area-sticky', !dropdownShown)
+  // live and post-live DVR don't have a download button
+  if (downloadButton.value) {
+    downloadDropdownWatcher = watch(() => downloadButton.value.dropdownShown, (dropdownShown) => {
+      emit('set-info-area-sticky', !dropdownShown)
 
-    if (dropdownShown && window.innerWidth >= 901) {
-      // adds a slight delay so we know that the dropdown has shown up
-      // and won't mess up our scrolling
-      nextTick(() => {
-        emit('scroll-to-info-area')
-      })
-    }
-  })
+      if (dropdownShown && window.innerWidth >= 901) {
+        // adds a slight delay so we know that the dropdown has shown up
+        // and won't mess up our scrolling
+        nextTick(() => {
+          emit('scroll-to-info-area')
+        })
+      }
+    })
+  }
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8330

## Description

This pull request fixes a bug introduced by the composition API migration of the WatchVideoInfo component, by checking if the download button actually exists before attaching a watcher to its dropdown.

## Testing

1. Open a live stream and check that the error in the linked issues is gone.

## Desktop

- **OS:** Windows
- **OS Version:** 11