### PR TITLE
Pass button icon and label through props in FtShareButton

### DIFF
--- a/src/renderer/components/FtShareButton/FtShareButton.vue
+++ b/src/renderer/components/FtShareButton/FtShareButton.vue
@@ -13,7 +13,7 @@
     <FtFlexBox>
       <FtToggleSwitch
         v-if="isVideo"
-        :label="$t('Share.Include Timestamp')"
+        :label="t('Share.Include Timestamp')"
         :compact="true"
         :default-value="includeTimestamp"
         @change="updateIncludeTimestamp"
@@ -35,39 +35,35 @@
         <FtButton
           class="action"
           aria-describedby="youtubeShareImage"
+          :icon="['fas', 'copy']"
+          :label="t('Share.Copy Link')"
           @click="copyYoutube"
-        >
-          <FontAwesomeIcon :icon="['fas', 'copy']" />
-          {{ $t("Share.Copy Link") }}
-        </FtButton>
+        />
         <FtButton
           class="action"
           aria-describedby="youtubeShareImage"
+          :icon="['fas', 'globe']"
+          :label="t('Share.Open Link')"
           @click="openYoutube"
-        >
-          <FontAwesomeIcon :icon="['fas', 'globe']" />
-          {{ $t("Share.Open Link") }}
-        </FtButton>
+        />
         <FtButton
           v-if="isVideo || isPlaylist"
           class="action"
           aria-describedby="youtubeShareImage"
           background-color="var(--accent-color-active)"
+          :icon="['fas', 'copy']"
+          :label="t('Share.Copy Embed')"
           @click="copyYoutubeEmbed"
-        >
-          <FontAwesomeIcon :icon="['fas', 'copy']" />
-          {{ $t("Share.Copy Embed") }}
-        </FtButton>
+        />
         <FtButton
           v-if="isVideo || isPlaylist"
           class="action"
           aria-describedby="youtubeShareImage"
           background-color="var(--accent-color-active)"
+          :icon="['fas', 'globe']"
+          :label="t('Share.Open Embed')"
           @click="openYoutubeEmbed"
-        >
-          <FontAwesomeIcon :icon="['fas', 'globe']" />
-          {{ $t("Share.Open Embed") }}
-        </FtButton>
+        />
       </div>
 
       <template v-if="showInvidiousOptions">
@@ -84,39 +80,35 @@
           <FtButton
             aria-describedby="invidiousShare"
             class="action"
+            :icon="['fas', 'copy']"
+            :label="t('Share.Copy Link')"
             @click="copyInvidious"
-          >
-            <FontAwesomeIcon :icon="['fas', 'copy']" />
-            {{ $t("Share.Copy Link") }}
-          </FtButton>
+          />
           <FtButton
             aria-describedby="invidiousShare"
             class="action"
+            :icon="['fas', 'globe']"
+            :label="t('Share.Open Link')"
             @click="openInvidious"
-          >
-            <FontAwesomeIcon :icon="['fas', 'globe']" />
-            {{ $t("Share.Open Link") }}
-          </FtButton>
+          />
           <FtButton
             v-if="isVideo || isPlaylist"
             aria-describedby="invidiousShare"
             class="action"
             background-color="var(--accent-color-active)"
+            :icon="['fas', 'copy']"
+            :label="t('Share.Copy Embed')"
             @click="copyInvidiousEmbed"
-          >
-            <FontAwesomeIcon :icon="['fas', 'copy']" />
-            {{ $t("Share.Copy Embed") }}
-          </FtButton>
+          />
           <FtButton
             v-if="isVideo || isPlaylist"
             aria-describedby="invidiousShare"
             class="action"
             background-color="var(--accent-color-active)"
+            :icon="['fas', 'globe']"
+            :label="t('Share.Open Embed')"
             @click="openInvidiousEmbed"
-          >
-            <FontAwesomeIcon :icon="['fas', 'globe']" />
-            {{ $t("Share.Open Embed") }}
-          </FtButton>
+          />
         </div>
       </template>
     </div>
@@ -124,7 +116,6 @@
 </template>
 
 <script setup>
-import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, ref, useTemplateRef } from 'vue'
 import { copyToClipboard, openExternalLink } from '../../helpers/utils'
 import { useI18n } from '../../composables/use-i18n-polyfill'


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

The buttons in the `FtShareButton` component had icons before the `icon` property was added to the `FtButton` component and various other buttons in FreeTube received icons. Now that that property does exist and the rest of FreeTube is using it, it makes sense to switch to that property in the `FtShareButton` component too. Apart from improving the consistency across the codebase it also means we can remove the FontAwesomeIcon import in the `FtShareButton` component.

We can't remove the `<slot>` in the FtButton component as the subscribe button still uses an icon-only button for the profile dropdown.

## Testing

Check that the labels and icons still appear on the buttons in the share button drop down.

## Desktop

- **OS:** Windows
- **OS Version:** 11