### PR TITLE
Upgrade FontAwesome to version 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "ci": "yarn install --silent --frozen-lockfile --network-concurrency 1"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.7.2",
-    "@fortawesome/free-brands-svg-icons": "^6.7.2",
-    "@fortawesome/free-regular-svg-icons": "^6.7.2",
-    "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "@fortawesome/vue-fontawesome": "^3.0.8",
+    "@fortawesome/fontawesome-svg-core": "^7.1.0",
+    "@fortawesome/free-brands-svg-icons": "^7.1.0",
+    "@fortawesome/free-regular-svg-icons": "^7.1.0",
+    "@fortawesome/free-solid-svg-icons": "^7.1.0",
+    "@fortawesome/vue-fontawesome": "^3.1.2",
     "@seald-io/nedb": "^4.1.2",
     "autolinker": "^4.1.5",
     "bgutils-js": "^3.2.0",

--- a/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
+++ b/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
@@ -15,7 +15,6 @@
       v-else
       :icon="['fas', 'circle-user']"
       class="bubble"
-      fixed-width
     />
     <div
       :id="id"

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.vue
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.vue
@@ -6,7 +6,6 @@
       <FontAwesomeIcon
         :icon="['fas', 'sliders-h']"
         class="headingIcon"
-        fixed-width
       />
       {{ $t('Settings.Settings') }}
     </h2>

--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -10,7 +10,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'circle-exclamation']"
           class="warning-icon"
-          fixed-width
         />
         {{ $t('Settings.Proxy Settings.Proxy Warning') }}
       </p>

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -21,7 +21,6 @@
             :icon="['fas', 'rss']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -44,7 +43,6 @@
             :icon="['fas', 'user-check']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -68,7 +66,6 @@
             :icon="['fas', 'fire']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -92,7 +89,6 @@
             :icon="['fas', 'users']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -116,7 +112,6 @@
             :icon="['fas', 'bookmark']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -140,7 +135,6 @@
             :icon="['fas', 'history']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -164,7 +158,6 @@
             :icon="['fas', 'sliders-h']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p
@@ -187,7 +180,6 @@
             :icon="['fas', 'info-circle']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -44,7 +44,6 @@
             :icon="['fas', 'user-check']"
             class="navIcon"
             :class="applyNavIconExpand"
-            fixed-width
           />
         </div>
         <p

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -93,7 +93,6 @@
       class="offlineWrapper"
     >
       <font-awesome-layers
-        fixed-width
         class="offlineIcon"
         aria-hidden="true"
       >

--- a/src/renderer/views/About/About.vue
+++ b/src/renderer/views/About/About.vue
@@ -5,7 +5,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'info-circle']"
           class="headingIcon"
-          fixed-width
         />
         {{ $t("About.About") }}
       </h2>

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -13,7 +13,6 @@
           :icon="['fas', 'hashtag']"
           aria-hidden="false"
           class="headingIcon"
-          fixed-width
         />
         {{ hashtag }}
       </h2>

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -7,7 +7,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'history']"
           class="headingIcon"
-          fixed-width
         />
         {{ t('History.History') }}
       </h2>

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -12,7 +12,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'users']"
           class="headingIcon"
-          fixed-width
         />
         {{ $t("Most Popular") }}
       </h2>

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -12,7 +12,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'search']"
           class="headingIcon"
-          fixed-width
         />
         {{ t("Search Filters.Search Results") }}
       </h2>

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -5,7 +5,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'user-check']"
           class="headingIcon"
-          fixed-width
         />
         {{ $t('Channels.Title') }}
       </h2>

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -5,7 +5,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'rss']"
           class="subscriptionIcon"
-          fixed-width
         />
         {{ $t("Subscriptions.Subscriptions") }}
       </h2>
@@ -31,7 +30,6 @@
           <FontAwesomeIcon
             :icon="['fa', 'video']"
             class="subscriptionIcon"
-            fixed-width
           />
           {{ $t("Global.Videos") }}
         </div>
@@ -52,7 +50,6 @@
           <FontAwesomeIcon
             :icon="['fa', 'clapperboard']"
             class="subscriptionIcon"
-            fixed-width
           />
           {{ $t("Global.Shorts") }}
         </div>
@@ -73,7 +70,6 @@
           <FontAwesomeIcon
             :icon="['fa', 'tower-broadcast']"
             class="subscriptionIcon"
-            fixed-width
           />
           {{ $t("Global.Live") }}
         </div>
@@ -94,7 +90,6 @@
           <FontAwesomeIcon
             :icon="['fa', 'message']"
             class="subscriptionIcon"
-            fixed-width
           />
           {{ $t("Global.Posts") }}
         </div>

--- a/src/renderer/views/Trending/Trending.vue
+++ b/src/renderer/views/Trending/Trending.vue
@@ -7,7 +7,6 @@
         <FontAwesomeIcon
           :icon="['fas', 'fire']"
           class="trendingIcon"
-          fixed-width
         />
         {{ $t("Trending.Trending") }}
       </h2>
@@ -33,7 +32,6 @@
           <FontAwesomeIcon
             :icon="['fas', 'gamepad']"
             class="trendingIcon"
-            fixed-width
           />
           {{ $t("Trending.Gaming") }}
         </div>
@@ -54,7 +52,6 @@
           <FontAwesomeIcon
             :icon="['fas', 'trophy']"
             class="trendingIcon"
-            fixed-width
           />
           {{ t("Trending.Sports") }}
         </div>
@@ -75,7 +72,6 @@
           <FontAwesomeIcon
             :icon="['fas', 'podcast']"
             class="trendingIcon"
-            fixed-width
           />
           {{ t("Channel.Podcasts.Podcasts") }}
         </div>

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -8,7 +8,6 @@
           <FontAwesomeIcon
             :icon="['fas', 'bookmark']"
             class="headingIcon"
-            fixed-width
           />
           {{ $t("User Playlists.Your Playlists") }}
         </h2>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,43 +1088,43 @@
     "@eslint/core" "^0.17.0"
     levn "^0.4.1"
 
-"@fortawesome/fontawesome-common-types@6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz#7123d74b0c1e726794aed1184795dbce12186470"
-  integrity sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==
+"@fortawesome/fontawesome-common-types@7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz#a4e0b7e40073d5fdef41182da1bc216a05875659"
+  integrity sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==
 
-"@fortawesome/fontawesome-svg-core@^6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz#0ac6013724d5cc327c1eb81335b91300a4fce2f2"
-  integrity sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==
+"@fortawesome/fontawesome-svg-core@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz#b0a45363a4e95ec985130393c0b1b95717ef0760"
+  integrity sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.7.2"
+    "@fortawesome/fontawesome-common-types" "7.1.0"
 
-"@fortawesome/free-brands-svg-icons@^6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz#4ebee8098f31da5446dda81edc344025eb59b27e"
-  integrity sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==
+"@fortawesome/free-brands-svg-icons@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz#68e08b05a99566782cff8e5a62b1cb69bdec2d35"
+  integrity sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.7.2"
+    "@fortawesome/fontawesome-common-types" "7.1.0"
 
-"@fortawesome/free-regular-svg-icons@^6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz#f1651e55e6651a15589b0569516208f9c65f96db"
-  integrity sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==
+"@fortawesome/free-regular-svg-icons@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.1.0.tgz#e57c5eb63e6a30bb4fe2276aba851e3470452680"
+  integrity sha512-0e2fdEyB4AR+e6kU4yxwA/MonnYcw/CsMEP9lH82ORFi9svA6/RhDyhxIv5mlJaldmaHLLYVTb+3iEr+PDSZuQ==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.7.2"
+    "@fortawesome/fontawesome-common-types" "7.1.0"
 
-"@fortawesome/free-solid-svg-icons@^6.7.2":
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz#fe25883b5eb8464a82918599950d283c465b57f6"
-  integrity sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==
+"@fortawesome/free-solid-svg-icons@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.1.0.tgz#cb9d149cefd3419a7a3fd041106e3a2315463e3e"
+  integrity sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "6.7.2"
+    "@fortawesome/fontawesome-common-types" "7.1.0"
 
-"@fortawesome/vue-fontawesome@^3.0.8":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.8.tgz#1e8032df151173d8174ac9f5a28da3c0f5a495e4"
-  integrity sha512-yyHHAj4G8pQIDfaIsMvQpwKMboIZtcHTUvPqXjOHyldh1O1vZfH4W03VDPv5RvI9P6DLTzJQlmVgj9wCf7c2Fw==
+"@fortawesome/vue-fontawesome@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.1.2.tgz#a61d44522bc0be3283ccd9811ed5a2de282c168a"
+  integrity sha512-mhYnBIuuW8OIMHf31kOjaBmyE7BMrwBorhrOHVud6vTTu+7IPQNWB+DWaHoE75v10dRF5s/dFtcrgE7vKSEWwQ==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

This pull request upgrades FontAwesome to version 7. As far as I can tell from reading [the changelog](https://docs.fontawesome.com/upgrade/whats-changed), the only two differences that affect us is that icons are hidden from screen readers by default, which was already address by prior pull requests that wrapped the icons in `<button>`s and the fact that fixed width is the default, most icons seem to look alright at a fixed width but if it is an issue we can always override it by setting the `--fa-width` CSS variable.

## Testing

Check the icons throughout FreeTube, especially if the layouts still look alright.

## Desktop

- **OS:** Windows
- **OS Version:** 11