### PR TITLE
Fix channel thumbnail on hearted community post comments

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -2023,10 +2023,18 @@ function parseLocalCommunityPost(post) {
     replyCount = parseLocalSubscriberCount(post?.action_buttons.reply_button.text)
   }
 
+  const authorThumbnails = post.author.thumbnails
+
+  authorThumbnails.forEach((thumbnail) => {
+    if (thumbnail.url.startsWith('//')) {
+      thumbnail.url = 'https:' + thumbnail.url
+    }
+  })
+
   return {
     postText: post.content.isEmpty() ? '' : Autolinker.link(parseLocalTextRuns(post.content.runs, 16)),
     postId: post.id,
-    authorThumbnails: post.author.thumbnails,
+    authorThumbnails,
     publishedTime: calculatePublishedDate(post.published.text),
     // YouTube hides the vote/like count on posts when it is zero
     voteCount: post.vote_count ? parseLocalSubscriberCount(post.vote_count.text) : 0,


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8268

## Description

This pull request fixes the channel thumbnail next to hearted comments being broken on the local API. Hearted comments get the thumbnail of the video or post uploader passed down from the video or post respectively, we were already correcting the thumbnail link for the post itself but not the one we passed to the comments.

This pull request only fixes the issue during parsing, so community posts cached on the subscription page from before this change will still have the issue but that can be easily fixed by visiting the channel in question or refreshing the subscriptions, additionally viewing the comments on posts with the local API isn't in a release build yet so it won't affect normal users.

## Testing

1. Make sure you are using the local API
2. Open https://www.youtube.com/post/UgkxBR17mS798vtpQ3d5pm9gPWPkf0arjSah
3. Load the comments
4. Inspect the channel thumbnail next to the comment heart with the dev tools
5. Check that the link starts with `https://` instead of `//`

## Desktop

- **OS:** Windows
- **OS Version:** 11