### PR TITLE
Work around the back button not updating the window title

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ const IpcChannels = {
   NATIVE_THEME_UPDATE: 'native-theme-update',
   APP_READY: 'app-ready',
   RELAUNCH_REQUEST: 'relaunch-request',
+  SET_WINDOW_TITLE: 'set-window-title',
 
   SEARCH_INPUT_HANDLING_READY: 'search-input-handling-ready',
   UPDATE_SEARCH_INPUT_TEXT: 'update-search-input-text',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1190,6 +1190,12 @@ function runApp() {
     }
   })
 
+  ipcMain.on(IpcChannels.SET_WINDOW_TITLE, (event, title) => {
+    if (isFreeTubeUrl(event.senderFrame.url) && typeof title === 'string') {
+      BrowserWindow.fromWebContents(event.sender)?.setTitle(title)
+    }
+  })
+
   function relaunch() {
     if (process.env.NODE_ENV === 'development') {
       app.exit(parseInt(process.env.FREETUBE_RELAUNCH_EXIT_CODE))

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -9,6 +9,17 @@ ipcRenderer.on(IpcChannels.NATIVE_THEME_UPDATE, (_, shouldUseDarkColors) => {
   document.body.dataset.systemTheme = shouldUseDarkColors ? 'dark' : 'light'
 })
 
+// Force update the window title whenever the page title changes
+// as Electron doesn't do it when the back button is pressed, probably a bug.
+// It doesn't even fire the `page-title-updated` in the main process.
+
+const titleMutationObserver = new MutationObserver((mutations) => {
+  ipcRenderer.send(IpcChannels.SET_WINDOW_TITLE, mutations[0].addedNodes[0].textContent)
+})
+document.addEventListener('DOMContentLoaded', () => {
+  titleMutationObserver.observe(document.querySelector('title'), { childList: true })
+}, { once: true })
+
 let currentUpdateSearchInputTextListener
 
 export default {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #7398

## Description

This pull request works around Electron not updating the window title when the page title changes as a result of the back button being pressed. This was caused by https://github.com/electron/electron/pull/45981 but I have yet to create a minimal reproduction of the issue outside of FreeTube to report the bug on the Electron repo and as there was a pretty simple workaround I decided to open this pull request in the mean time.

## Testing

1. Open FreeTube
2. Click on a video and wait for it to load
3. Click the back button
4. The window title should match the current page, instead of still showing the video title.

## Desktop

- **OS:** Windows
- **OS Version:** 11