### PR TITLE
Add <bdi>, <bdo> and dir="auto" to text that may not match the display language

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -18,12 +18,14 @@
         <h1
           :id="labelId"
           class="changeLogTitle"
+          dir="ltr"
         >
           {{ changeLogTitle }}
         </h1>
       </template>
-      <span
+      <bdo
         class="changeLogText"
+        dir="ltr"
         lang="en"
         v-html="updateChangelog"
       />

--- a/src/renderer/components/ChannelAbout/ChannelAbout.vue
+++ b/src/renderer/components/ChannelAbout/ChannelAbout.vue
@@ -8,6 +8,7 @@
       <h2>{{ $t("Channel.About.Channel Description") }}</h2>
       <div
         class="aboutInfo"
+        dir="auto"
         v-html="description"
       />
     </template>
@@ -56,7 +57,11 @@
           >
             {{ $t('Channel.About.Location') }}
           </th>
-          <td>{{ location }}</td>
+          <td
+            dir="auto"
+          >
+            {{ location }}
+          </td>
         </tr>
       </table>
     </template>
@@ -71,6 +76,7 @@
           v-for="tag in tags"
           :key="tag"
           class="aboutTag"
+          dir="auto"
         >
           <router-link
             v-if="!hideSearchBar"

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -34,6 +34,7 @@
           >
             <h1
               class="name"
+              dir="auto"
             >
               {{ name }}
             </h1>

--- a/src/renderer/components/ChannelHome/ChannelHome.vue
+++ b/src/renderer/components/ChannelHome/ChannelHome.vue
@@ -11,7 +11,9 @@
         <summary
           class="shelfTitle"
         >
-          {{ shelf.title }}
+          <bdi>
+            {{ shelf.title }}
+          </bdi>
           <span
             v-if="shelf.playlistId"
             class="playAllSpan"
@@ -34,6 +36,7 @@
         <p
           v-if="shelf.subtitle"
           class="shelfSubtitle"
+          dir="auto"
         >
           {{ shelf.subtitle }}
         </p>

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -93,10 +93,18 @@
 .commentText {
   white-space: pre-wrap;
   font-size: 14px;
-  margin-block-start: -10px;
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  margin-left: -10px;
   margin-inline-start: 70px;
   overflow-wrap: break-word;
 }
+
+/* stylelint-disable liberty/use-logical-spec */
+:global(body[dir='rtl'] .commentText) {
+  margin-left: initial;
+  margin-right: -10px;
+}
+/* stylelint-enable liberty/use-logical-spec */
 
 .commentPinned {
   font-weight: normal;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -67,6 +67,7 @@
           <div
             v-if="hideCommentPhotos && !comment.isOwner"
             class="commentThumbnailHidden"
+            dir="auto"
           >
             {{ comment.author.substring(1, 2) }}
           </div>
@@ -84,13 +85,14 @@
           <FontAwesomeIcon
             :icon="['fas', 'thumbtack']"
           />
-          {{ $t("Comments.Pinned by") }} {{ channelName }}
+          {{ $t("Comments.Pinned by") }} <bdi>{{ channelName }}</bdi>
         </p>
         <p
           class="commentAuthorWrapper"
         >
           <router-link
             class="commentAuthor"
+            dir="auto"
             :class="{
               commentOwner: comment.isOwner
             }"
@@ -183,6 +185,7 @@
               <div
                 v-if="hideCommentPhotos && !reply.isOwner"
                 class="commentThumbnailHidden"
+                dir="auto"
               >
                 {{ reply.author.substring(1, 2) }}
               </div>
@@ -196,6 +199,7 @@
             <p class="commentAuthorWrapper">
               <router-link
                 class="commentAuthor"
+                dir="auto"
                 :class="{
                   commentOwner: reply.isOwner
                 }"

--- a/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
+++ b/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
@@ -19,6 +19,7 @@
     <div
       :id="id"
       class="channelName"
+      dir="auto"
     >
       {{ channelName }}
     </div>
@@ -50,6 +51,7 @@
     <div
       :id="id"
       class="channelName"
+      dir="auto"
     >
       {{ channelName }}
     </div>

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
@@ -20,6 +20,7 @@
         </span>
         <div
           class="option-text"
+          dir="auto"
         >
           {{ choice.text }}
         </div>
@@ -34,7 +35,10 @@
           :src="findSmallestPollImage(choice.image)"
           alt=""
         >
-        <div class="option-text">
+        <div
+          class="option-text"
+          dir="auto"
+        >
           {{ choice.text }}
         </div>
       </div>

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -31,6 +31,7 @@
       </template>
       <p
         class="authorName"
+        dir="auto"
       >
         <router-link
           v-if="authorId"
@@ -53,6 +54,7 @@
     </div>
     <p
       class="postText"
+      dir="auto"
       v-html="postText"
     />
     <swiper-container

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -96,7 +96,7 @@
               :icon="['fas', dataListProperties[index].iconName]"
               class="searchResultIcon"
             />
-            <span>{{ entry }}</span>
+            <bdi>{{ entry }}</bdi>
           </div>
           <a
             v-if="dataListProperties[index]?.isRemoveable"

--- a/src/renderer/components/FtInputTags/FtInputTags.vue
+++ b/src/renderer/components/FtInputTags/FtInputTags.vue
@@ -59,9 +59,9 @@
                 loading="lazy"
               >
             </RouterLink>
-            <span>{{ (tag.preferredName) ? tag.preferredName : tag.name }}</span>
+            <bdi>{{ (tag.preferredName) ? tag.preferredName : tag.name }}</bdi>
           </template>
-          <span v-else>{{ tag }}</span>
+          <bdi v-else>{{ tag }}</bdi>
           <button
             v-if="!disabled"
             class="removeTagButton"

--- a/src/renderer/components/FtListChannel/FtListChannel.vue
+++ b/src/renderer/components/FtListChannel/FtListChannel.vue
@@ -27,7 +27,10 @@
           class="title"
           :to="`/channel/${id}`"
         >
-          <h3 class="h3Title">
+          <h3
+            class="h3Title"
+            dir="auto"
+          >
             {{ name }}
           </h3>
         </router-link>
@@ -35,6 +38,7 @@
           <router-link
             v-if="handle !== null"
             class="handle"
+            dir="auto"
             :to="`/channel/${id}`"
           >
             {{ handle }}
@@ -57,6 +61,7 @@
         <p
           v-if="listType !== 'grid'"
           class="description"
+          dir="auto"
           v-html="description"
         />
       </div>

--- a/src/renderer/components/FtListHashtag/FtListHashtag.vue
+++ b/src/renderer/components/FtListHashtag/FtListHashtag.vue
@@ -25,7 +25,10 @@
         class="title"
         :to="url"
       >
-        <h3 class="h3Title">
+        <h3
+          class="h3Title"
+          dir="auto"
+        >
           {{ title }}
         </h3>
       </router-link>

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -38,7 +38,10 @@
         class="title"
         :to="playlistPageLinkTo"
       >
-        <h3 class="h3Title">
+        <h3
+          class="h3Title"
+          dir="auto"
+        >
           {{ titleForDisplay }}
         </h3>
       </RouterLink>
@@ -46,16 +49,17 @@
         <RouterLink
           v-if="channelId"
           class="channelName"
+          dir="auto"
           :to="`/channel/${channelId}`"
         >
           {{ channelName }}
         </RouterLink>
-        <span
+        <bdi
           v-else
           class="channelName"
         >
           {{ channelName }}
-        </span>
+        </bdi>
       </div>
       <FtIconButton
         v-if="externalPlayer !== '' && !isUserPlaylist"

--- a/src/renderer/components/FtPlaylistSelector/FtPlaylistSelector.vue
+++ b/src/renderer/components/FtPlaylistSelector/FtPlaylistSelector.vue
@@ -38,6 +38,7 @@
     >
       <div
         class="title"
+        dir="auto"
       >
         {{ titleForDisplay }}
       </div>

--- a/src/renderer/components/FtProfileBubble/FtProfileBubble.vue
+++ b/src/renderer/components/FtProfileBubble/FtProfileBubble.vue
@@ -11,13 +11,17 @@
       class="bubble"
       :style="{ background: backgroundColor, color: textColor }"
     >
-      <div class="initial">
+      <div
+        class="initial"
+        dir="auto"
+      >
         {{ profileInitial }}
       </div>
     </div>
     <div
       :id="id"
       class="profileName"
+      dir="auto"
     >
       {{ translatedProfileName }}
     </div>

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -60,6 +60,7 @@
               >
                 <div
                   class="initial"
+                  dir="auto"
                 >
                   {{ profileInitial }}
                 </div>

--- a/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
+++ b/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
@@ -16,6 +16,7 @@
     >
       <div
         class="initial"
+        dir="auto"
       >
         {{ activeProfileInitial }}
       </div>
@@ -63,6 +64,7 @@
           >
             <div
               class="initial"
+              dir="auto"
             >
               {{ profileInitials[profile._id] }}
             </div>
@@ -70,6 +72,7 @@
           <p
             :id="id + profile._id"
             class="profileName"
+            dir="auto"
           >
             {{ translateProfileName(profile) }}
           </p>

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -13,6 +13,7 @@
       <option
         v-for="(name, index) in selectNames"
         :key="selectValues[index]"
+        :dir="isLocaleSelector ? 'auto' : null"
         :value="selectValues[index]"
         :lang="isLocaleSelector && selectValues[index] !== 'system' ? selectValues[index] : null"
       >

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -72,6 +72,7 @@
           >
             <div
               class="initial"
+              dir="auto"
             >
               {{ isProfileSubscribed(profile) ? $t('checkmark') : profileInitials[profile._id] }}
             </div>
@@ -79,6 +80,7 @@
           <p
             :id="id + '-' + index"
             class="profileName"
+            dir="auto"
           >
             {{ profile.name }}
           </p>

--- a/src/renderer/components/FtTimestampCatcher.vue
+++ b/src/renderer/components/FtTimestampCatcher.vue
@@ -1,5 +1,6 @@
 <template>
   <p
+    dir="auto"
     @timestamp-clicked="catchTimestampClick"
     v-html="displayText"
   />

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -63,6 +63,7 @@
       >
         <h2
           class="playlistTitle"
+          dir="auto"
         >
           {{ title }}
         </h2>
@@ -97,8 +98,10 @@
     <p
       v-else
       class="playlistDescription"
-      v-text="description"
-    />
+      dir="auto"
+    >
+      {{ description }}
+    </p>
 
     <hr class="playlistInfoSeparator">
 
@@ -117,6 +120,7 @@
         >
         <h3
           class="channelName"
+          dir="auto"
         >
           {{ channelName }}
         </h3>
@@ -127,6 +131,7 @@
       >
         <h3
           class="channelName"
+          dir="auto"
         >
           {{ channelName }}
         </h3>

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -96,10 +96,18 @@
 
 .navChannel .navLabel {
   overflow: hidden;
-  margin-inline-start: 40px;
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  margin-left: 40px;
   overflow-wrap: break-word;
   font-size: 12px;
 }
+
+/* stylelint-disable liberty/use-logical-spec */
+:global(body[dir='rtl'] .navChannel .navLabel) {
+  margin-left: initial;
+  margin-right: 40px;
+}
+/* stylelint-enable liberty/use-logical-spec */
 
 .thumbnailContainer {
   inline-size: 35px;
@@ -164,7 +172,7 @@
 }
 
 .closed .navLabel {
-  margin-inline-start: 0;
+  margin-inline: 0;
   inline-size: 100%;
   text-align: center;
   inset-inline-start: 0;
@@ -237,7 +245,7 @@
   }
 
   .navLabel {
-    margin-inline-start: 0;
+    margin-inline: 0;
     inline-size: 100%;
     text-align: center;
     inset-inline-start: 0;

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -223,6 +223,7 @@
           <p
             v-if="isOpen"
             class="navLabel"
+            dir="auto"
           >
             {{ channel.name }}
           </p>

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.css
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.css
@@ -37,13 +37,16 @@
   transform: translateX(4px) rotate(90deg);
 }
 
+.chaptersDetails[open]:dir(rtl) .chaptersChevron {
+  transform: translateX(-4px) rotate(90deg);
+}
+
 .chapter {
   display: grid;
   grid-template:
     'thumbnail title' 2fr
     'thumbnail timestamp' 2fr / auto 1fr;
   column-gap: 10px;
-  justify-items: start;
   cursor: pointer;
   font-size: 15px;
 }
@@ -76,7 +79,7 @@
 
 .chapterTimestamp {
   grid-area: timestamp;
-  align-self: flex-start;
+  place-self: flex-start start;
   padding-block: 3px;
   padding-inline: 4px;
   border-radius: 5px;

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -11,7 +11,7 @@
           {{ kind === 'keyMoments' ? $t('Chapters.Key Moments') : $t("Chapters.Chapters") }}
 
           <span class="currentChapter">
-            • {{ currentTitle }}
+            • <bdi>{{ currentTitle }}</bdi>
           </span>
 
           <FontAwesomeIcon
@@ -54,7 +54,10 @@
           <div class="chapterTimestamp">
             {{ chapter.timestamp }}
           </div>
-          <p class="chapterTitle">
+          <p
+            class="chapterTitle"
+            dir="auto"
+          >
             {{ chapter.title }}
           </p>
         </div>

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -39,6 +39,10 @@
   margin-block-start: 1em;
 }
 
+.videoDescription.short .descriptionStatus:dir(rtl) {
+  background: linear-gradient(270deg, transparent 0%, var(--card-bg-color) 25%);
+}
+
 .videoDescription.short .description {
   max-block-size: 4lh;
   overflow: hidden;

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -22,12 +22,12 @@
       @timestamp-event="onTimestamp"
       @click="expandDescriptionWithClick"
     />
-    <span
+    <bdi
       v-if="license && showFullDescription"
       class="license"
     >
       {{ license }}
-    </span>
+    </bdi>
     <span
       v-if="showControls && showFullDescription"
       class="descriptionStatus"

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -3,6 +3,7 @@
     <div>
       <h1
         class="videoTitle"
+        dir="auto"
       >
         {{ title }}
       </h1>
@@ -57,6 +58,7 @@
             <RouterLink
               :to="`/channel/${channelId}`"
               class="channelName"
+              dir="auto"
             >
               {{ channelName }}
             </RouterLink>

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -74,11 +74,11 @@
           <p
             class="superChatContent"
           >
-            <span
+            <bdi
               class="donationAmount"
             >
               {{ comment.superChat.amount }}
-            </span>
+            </bdi>
           </p>
         </div>
       </div>
@@ -106,17 +106,20 @@
             >
             <p
               class="channelName"
+              dir="auto"
             >
               {{ superChat.author.name }}
             </p>
             <p
               class="donationAmount"
+              dir="auto"
             >
               {{ superChat.superChat.amount }}
             </p>
           </div>
           <p
             class="chatMessage"
+            dir="auto"
             v-html="superChat.message"
           />
         </div>
@@ -147,11 +150,13 @@
               >
               <p
                 class="channelName"
+                dir="auto"
               >
                 {{ comment.author.name }}
               </p>
               <p
                 class="donationAmount"
+                dir="auto"
               >
                 {{ comment.superChat.amount }}
               </p>
@@ -159,6 +164,7 @@
             <p
               v-if="comment.message"
               class="chatMessage"
+              dir="auto"
               v-html="comment.message"
             />
           </template>
@@ -173,7 +179,7 @@
             <p
               class="chatContent"
             >
-              <span
+              <bdi
                 class="channelName"
                 :class="{
                   member: comment.author.isMember,
@@ -182,7 +188,7 @@
                 }"
               >
                 {{ comment.author.name }}
-              </span>
+              </bdi>
               <span
                 v-if="comment.author.badge"
                 class="badge"
@@ -194,7 +200,7 @@
                   class="badgeImage"
                 >
               </span>
-              <span
+              <bdi
                 class="chatMessage"
                 v-html="comment.message"
               />

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -115,7 +115,10 @@
         :to="watchVideoRouterLink"
         @click="handleWatchPageLinkClick"
       >
-        <h3 class="h3Title">
+        <h3
+          class="h3Title"
+          dir="auto"
+        >
           {{ displayTitle }}
         </h3>
       </router-link>
@@ -123,13 +126,14 @@
         <router-link
           v-if="channelId !== null"
           class="channelName"
+          dir="auto"
           :to="`/channel/${channelId}`"
         >
-          <span>{{ channelName }}</span>
-        </router-link>
-        <span v-else-if="channelName !== null">
           {{ channelName }}
-        </span>
+        </router-link>
+        <bdi v-else-if="channelName !== null">
+          {{ channelName }}
+        </bdi>
         <span
           v-if="!isLive && !isUpcoming && !isPremium && !hideViews && viewCount != null"
           class="viewCount"
@@ -235,6 +239,7 @@
       <p
         v-if="description && effectiveListTypeIsList && appearance === 'result'"
         class="description"
+        dir="auto"
         v-html="description"
       />
     </div>

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -184,7 +184,7 @@
   transition: opacity cubic-bezier(0.4, 0, 0.6, 1) 0.6s;
 }
 
-:global(body[dir='rtl'] .playerFullscreenTitleOverlay) {
+:deep(.playerFullscreenTitleOverlay:dir(rtl)) {
   left: initial;
   right: 5px;
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -996,6 +996,7 @@ export default defineComponent({
       const fullscreenTitleOverlay = document.createElement('h1')
       fullscreenTitleOverlay.textContent = props.title
       fullscreenTitleOverlay.className = 'playerFullscreenTitleOverlay'
+      fullscreenTitleOverlay.dir = 'auto'
       controlsContainer.appendChild(fullscreenTitleOverlay)
 
       if (hasLoaded.value && props.chapters.length > 0) {

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.vue
@@ -12,6 +12,7 @@
       >
         <router-link
           class="playlistTitleLink"
+          dir="auto"
           :to="playlistPageLinkTo"
         >
           {{ playlistTitle }}
@@ -23,16 +24,17 @@
         <router-link
           v-if="channelId"
           class="channelName"
+          dir="auto"
           :to="`/channel/${channelId}`"
         >
           {{ channelName }} -
         </router-link>
-        <span
+        <bdi
           v-else
           class="channelName"
         >
           {{ channelName }} -
-        </span>
+        </bdi>
       </template>
       <span
         class="playlistIndex"
@@ -74,7 +76,10 @@
                 <div class="previewText">
                   {{ previewVideoIndex }} / {{ playlistVideoCount }}
                 </div>
-                <div class="previewVideoTitle">{{ previewVideoTitle }}</div>
+                <div
+                  class="previewVideoTitle"
+                  dir="auto"
+                >{{ previewVideoTitle }}</div>
               </div>
             </div>
           </div>

--- a/src/renderer/views/About/About.vue
+++ b/src/renderer/views/About/About.vue
@@ -56,7 +56,7 @@ const chunks = computed(() => [
   {
     icon: ['fab', 'github'],
     title: t('About.Source code'),
-    content: `<a href="https://github.com/FreeTubeApp/FreeTube" lang="en">GitHub: FreeTubeApp/FreeTube</a><br>${t('About.Licensed under the')} <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">${t('About.AGPLv3')}</a>`
+    content: `<a href="https://github.com/FreeTubeApp/FreeTube" lang="en" dir="ltr">GitHub: FreeTubeApp/FreeTube</a><br>${t('About.Licensed under the')} <a href="https://www.gnu.org/licenses/agpl-3.0.en.html">${t('About.AGPLv3')}</a>`
   },
   {
     icon: ['fas', 'file-download'],

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -14,7 +14,7 @@
           aria-hidden="false"
           class="headingIcon"
         />
-        {{ hashtag }}
+        <bdi>{{ hashtag }}</bdi>
       </h2>
       <FtElementList
         v-if="videos.length > 0"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -56,6 +56,7 @@
             </router-link>
             <router-link
               class="channelName"
+              dir="auto"
               :title="channel.name"
               :to="`/channel/${channel.id}`"
             >


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8364

## Description

Currently we set the text direction on the `<body>` element to match the chosen display language e.g. left-to-right for English and right-to-left for Arabic, which means that an English video title is shown as right-to-left when the display language is set to Arabic. This pull request corrects that by informing the browser that it should detect the text direction automatically based on the text in places where we show text returned by YouTube or entered by the user. If the element that needed the text direction setting was a `<span>` I replaced it with a `<bdi>` element and for all other elements I set the `dir` attribute to `"auto"` to avoid creating extra HTML elements on the page. For the changelog text, which is always in English I used `<bdo dir="ltr">` instead.

## Screenshots

Language selector before:

<img width="240" height="582" alt="Screen shot of the display language selector before the changes" src="https://github.com/user-attachments/assets/b71df44c-603c-4f24-ba84-c5b926ceefcb" />

Language selector after:

<img width="240" height="582" alt="Screen shot of the display language selector after the changes" src="https://github.com/user-attachments/assets/fdbd8be4-57b9-4646-80ea-2356a6e67cdb" />

Before watch page with Arabic as the display language before:
<img width="1045" height="630" alt="Screen shot of the watch page with an English video with the display language set to Arabic before the changes" src="https://github.com/user-attachments/assets/11aab304-8f52-487c-a51d-810741ff2815" />

Before watch page with Arabic as the display language after:
<img width="1038" height="609" alt="Screen shot of the watch page with an English video with the display language set to Arabic after the changes" src="https://github.com/user-attachments/assets/d3fb5b04-a9b4-4ad9-9ad0-050f33234aef" />

## Testing

Set the display language to English and search for right-to-left content such as the following examples provided in the linked issue:

כאן
הארץ
ידיעות אחרונות

Set the display language to Arabic and search for left-to-right (e.g. English) content such as the official `@YouTube` channel.

## Desktop

- **OS:** Windows
- **OS Version:** 11