### PR TITLE
Use FontAwesome SVG Core's plugins API

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -192,6 +192,9 @@ const config = {
 
       // change to "shaka-player.ui.debug.js" to get debug logs (update jsconfig to get updated types)
       'shaka-player$': 'shaka-player/dist/shaka-player.ui.js',
+
+      // Make @fortawesome/vue-fontawesome use the trimmed down API instead of the original @fortawesome/fontawesome-svg-core
+      '@fortawesome/fontawesome-svg-core$': path.resolve(__dirname, '../src/renderer/fontawesome-minimal.js')
     },
     extensions: ['.js', '.vue']
   },

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -168,6 +168,9 @@ const config = {
 
       // change to "shaka-player.ui.debug.js" to get debug logs (update jsconfig to get updated types)
       'shaka-player$': 'shaka-player/dist/shaka-player.ui.js',
+
+      // Make @fortawesome/vue-fontawesome use the trimmed down API instead of the original @fortawesome/fontawesome-svg-core
+      '@fortawesome/fontawesome-svg-core$': path.resolve(__dirname, '../src/renderer/fontawesome-minimal.js')
     },
     extensions: ['.js', '.vue']
   },

--- a/src/renderer/fontawesome-minimal.js
+++ b/src/renderer/fontawesome-minimal.js
@@ -1,0 +1,25 @@
+// https://docs.fontawesome.com/apis/javascript/plugins
+// As FontAwesome doesn't provide types for the plugins entrypoint the types are manually applied to each export
+
+import { register, Layers, ReplaceElements } from '@fortawesome/fontawesome-svg-core/plugins'
+
+// the `icon` function is inside the ReplaceElements plugin
+const api = register([Layers, ReplaceElements])
+
+/** @type {import('@fortawesome/fontawesome-svg-core').Library} */
+export const library = api.library
+
+// used by the FontAwesomeIcon component
+
+/** @type {import('@fortawesome/fontawesome-svg-core')['parse']} */
+export const parse = api.parse
+/** @type {import('@fortawesome/fontawesome-svg-core')['icon']} */
+export const icon = api.icon
+
+// used by the FontAwesomeLayers component
+/** @type {import('@fortawesome/fontawesome-svg-core')['config']} */
+export const config = api.config
+
+// used by the FontAwesomeLayersText component, which we don't use but we have to specify this here
+// to make webpack happy (imports are processed before unused code is removed)
+export const text = () => { }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,10 +1,11 @@
-// import the styles
 import { createApp } from 'vue'
 import i18n from './i18n/index'
 import router from './router/index'
 import store from './store/index'
 import App from './App.vue'
-import { library } from '@fortawesome/fontawesome-svg-core'
+import { library } from './fontawesome-minimal'
+// import the styles
+import '@fortawesome/fontawesome-svg-core/styles.css'
 
 import { register as registerSwiper } from 'swiper/element'
 


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

As we only use a small subset of FontAwesome's feature set and it doesn't support treeshaking out of the box the unused parts don't get removed automatically. This pull request switches to their [plugins API](https://docs.fontawesome.com/apis/javascript/plugins), which allows us to only register the parts of FontAwesome that we actually use. The plugin registration doesn't add any extra overhead as the default fontawesome JavaScript file uses the plugins API too, it just registers all plugins.

As measured with `yarn run pack:renderer` these changes shaved 32067 bytes (~32kb) off the `renderer.js` file and added just 11005 bytes (~11kb) to the renderer CSS file. The CSS increase is because in the old setup FontAwesome injected the CSS into the page with its JavaScript whereas it is now bundled into the same CSS file as the rest of the CSS in FreeTube.

## Testing

Open FreeTube and check that icons show up.

## Desktop

- **OS:** Windows
- **OS Version:** 11