### PR TITLE
Improve the accessibility of the <TopNav> component

### DIFF
--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -1,12 +1,13 @@
 <template>
-  <div
+  <nav
     class="topNav"
     :class="{ topNavBarColor: barColor }"
-    role="navigation"
   >
     <div class="side">
       <button
         class="menuButton navButton"
+        :aria-label="expandCollapseSideBarLabel"
+        :title="expandCollapseSideBarLabel"
         @click="toggleSideNav"
       >
         <FontAwesomeIcon
@@ -63,16 +64,12 @@
           :icon="['fas', 'clone']"
         />
       </button>
-      <div
+      <RouterLink
         v-if="!hideHeaderLogo"
         class="logo"
         dir="ltr"
-        role="link"
-        tabindex="0"
         :title="headerLogoTitle"
-        @click="goToLandingPage"
-        @keydown.space.prevent="goToLandingPage"
-        @keydown.enter.prevent="goToLandingPage"
+        :to="landingPage"
       >
         <div
           class="logoIcon"
@@ -80,7 +77,7 @@
         <div
           class="logoText"
         />
-      </div>
+      </RouterLink>
     </div>
     <div class="middle">
       <div
@@ -118,7 +115,7 @@
       </div>
     </div>
     <FtProfileSelector class="side profiles" />
-  </div>
+  </nav>
 </template>
 
 <script setup>
@@ -159,6 +156,10 @@ const enableSearchSuggestions = computed(() => store.getters.getEnableSearchSugg
 /** @type {import('vue').ComputedRef<string>} */
 const barColor = computed(() => store.getters.getBarColor)
 
+const expandCollapseSideBarLabel = computed(() => {
+  return store.getters.getIsSideNavOpen ? t('Compact side navigation') : t('Expand side navigation')
+})
+
 const landingPage = computed(() => '/' + store.getters.getLandingPage)
 
 const headerLogoTitle = computed(() => {
@@ -169,10 +170,6 @@ const headerLogoTitle = computed(() => {
         .meta.title)
   })
 })
-
-function goToLandingPage() {
-  router.push(landingPage.value)
-}
 
 const navigationHistoryAddendum = computed(() => {
   return navigationHistoryDropdownOptions.value.length === 0

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -22,6 +22,8 @@ Toggle fullscreen: Toggle fullscreen
 Window: Window
 Minimize: Minimize
 Close: Close
+Compact side navigation: Compact side navigation
+Expand side navigation: Expand side navigation
 Back: Back
 Forward: Forward
 Right-click or hold to see history: Right-click or hold to see history


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

This pull request contains three accessibility improvements for the `<TopNav>` component.

- Use a `<nav>` element instead of a `<div>` with the `"navigation"` `role`.
- Add a title and aria-label to the expand/compact button.
- Use the `<RouterLink>` component for the FreeTube logo so it is an actual link instead of a `<div>` with the `"link"` `role` and a bunch of event listeners. This does remove the ability to trigger it with the <kbd>Spacebar</kbd> key but I think that is okay as the behaviour now matches the behaviour of other links in FreeTube.

## Testing

1. Check that the label on the side nav button changes when the side nav is compacted and expanded.
2. Test that you can <kbd>Ctrl</kbd>+left click on the FreeTube logo to open a new window.

## Desktop

- **OS:** Windows
- **OS Version:** 11