### PR TITLE
[Bug fix] Set max-block-size to prevent thin videos from passing the bottom of view

### DIFF
--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -83,6 +83,7 @@
       margin-inline: auto;
       max-inline-size: calc(80vh * 1.78);
       position: relative;
+      max-block-size: 81vh;
 
       .videoThumbnail {
         inline-size: 100%;
@@ -194,12 +195,6 @@
   @media only screen and (width >= 1051px) {
     &.useTheatreMode {
       @include theatre-mode-template;
-
-      .videoArea {
-        .videoPlayer {
-          max-block-size: 81vh;
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Related issue
Closes #7259

## Description
Add max-block-size to fix an issue where videos with thinner aspect ratios extend past the bottom of view.

## Screenshots

Left is the old version, right is the updated one (ignore the status bar).

### Video with thinner aspect ratio:
<img width="3840" height="1080" alt="Capture d’écran_2025-12-07_09-37-10" src="https://github.com/user-attachments/assets/2dd522e8-975e-4a48-bfcb-6941392601f5" />

### Video with regular aspect ratio (no differences):
<img width="3840" height="1080" alt="Capture d’écran_2025-12-07_09-33-27" src="https://github.com/user-attachments/assets/c1f44cb6-af20-478a-bab3-30d3de823b99" />

### Shorts (no differences):
<img width="3840" height="1080" alt="Capture d’écran_2025-12-07_09-34-38" src="https://github.com/user-attachments/assets/9cabdc80-a0f0-4e3e-a7ad-b4af61ebe187" />

## Testing

1. Open video with thinner aspect ratio, [here's an example video](https://youtu.be/HsPIgTdUd_I).
2. Enable theater mode view by turning it on or by disabling recommended videos in watch page within settings.
3. See that the video no longer passes the bottom view, like the others.

## Desktop
- **OS:** Linux
- **OS Version:** Ubuntu 24
- **FreeTube version:** v0.23.12 Beta

## Additional context

81vh is the value that I found to not affect the other videos while fixing the issue.
