### PR TITLE
Use `.some` instead of `.every` to show Allow Adding Duplicate Videos toggle when adding videos to playlist

### DIFF
--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -270,7 +270,7 @@ const playlistIdsContainingVideosToBeAdded = computed(() => {
   allPlaylists.value.forEach((playlist) => {
     const playlistVideoIdSet = playlist.videos.reduce((s, v) => s.add(v.videoId), new Set())
 
-    if (toBeAddedToPlaylistVideoIdList_.every((vid) => playlistVideoIdSet.has(vid))) {
+    if (toBeAddedToPlaylistVideoIdList_.some((vid) => playlistVideoIdSet.has(vid))) {
       ids.add(playlist._id)
     }
   })


### PR DESCRIPTION

## Pull Request Type

- [X] Bugfix

## Related issue
Closes #8233 

## Description
This PR fixes a bug that hides the Allow Adding Duplicate Videos toggle when the user loads additional videos from a playlist and attempts to add them to another playlist that already contains some of its videos.

## Screenshots 

https://github.com/user-attachments/assets/4bdad128-002c-4cda-9880-dfb22e63fc22

## Testing

1. Go to https://youtube.com/playlist?list=PL8mG-RkN2uTw7PhlnAr4pZZz2QubIbujH
2. Click on Copy playlist button
3. Create a new playlist
4. Add the videos to the playlist
5. Click on Copy playlist button again
6. Notice the Allow adding duplicate videos toggle is present
7. Click the Cancel button
8. Scroll all the way down untill you see the Load more videos button
9. Click on Load more videos button
10. Click on Copy playlist button
11. Notice the Allow adding duplicate videos toggle is present

## Desktop

- **OS:** MacOS
- **OS Version:** 26.1 Tahoe
- **FreeTube version:** v0.23.12 Beta
