### PR TITLE
replace SideNav 'closed' class to 'open'

### DIFF
--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -197,8 +197,15 @@
     font-size: 16px;
   }
 
+  .opened .channelLink {
+    display: flex;
+    align-items: center;
+  }
+
   .opened .navChannel .navLabel {
     font-size: 12px;
+    flex-grow: 1;
+    margin: 0;
   }
 
   .opened .thumbnailContainer {
@@ -206,6 +213,12 @@
     position: absolute;
     transform: translateY(-50%);
     margin-block: 0;
+  }
+
+  .opened .navChannel .thumbnailContainer {
+    position: static;
+    transform: none;
+    margin: 5px;
   }
 
   .opened.hiddenLabels .navLabel {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -164,51 +164,51 @@
     block-size: 10px;
   }
 
-  .open {
+  .opened {
     inline-size: 200px;
   }
 
-  .open .inner {
+  .opened .inner {
     inline-size: 200px;
   }
 
-  .open .refreshIcon {
+  .opened .refreshIcon {
     display: block;
   }
 
-  .open .navIcon {
+  .opened .navIcon {
     inline-size: 1.25em;
     margin-inline-start: 10px;
   }
 
-  .open .navIconExpand.fa-user-check {
+  .opened .navIconExpand.fa-user-check {
     /* This icon is too big by default */
     inline-size: 1em;
   }
 
-  .open .navOption {
+  .opened .navOption {
     padding-inline: 5px;
   }
 
-  .open .navLabel {
+  .opened .navLabel {
     text-align: start;
     margin-inline-start: 40px;
     margin-block-end: 16px;
     font-size: 16px;
   }
 
-  .open .navChannel .navLabel {
+  .opened .navChannel .navLabel {
     font-size: 12px;
   }
 
-  .open .thumbnailContainer {
+  .opened .thumbnailContainer {
     inset-block-start: 50%;
     position: absolute;
     transform: translateY(-50%);
     margin-block: 0;
   }
 
-  .open.hiddenLabels .navLabel {
+  .opened.hiddenLabels .navLabel {
     display: block;
   }
 }

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -1,7 +1,7 @@
 .sideNav {
   display: block;
   block-size: calc(100vh - 60px);
-  inline-size: 200px;
+  inline-size: 80px;
   overflow-x: hidden;
   position: sticky;
   inset-inline-start: 0;
@@ -17,20 +17,8 @@
 
 .inner {
   block-size: 100%;
-  inline-size: 200px;
-  overflow: hidden auto;
-}
-
-.closed .inner {
   inline-size: 80px;
-}
-
-.closed .hiddenLabels {
-  inline-size: 60px;
-}
-
-.closed.hiddenLabels {
-  inline-size: 60px;
+  overflow: hidden auto;
 }
 
 .topNavOption {
@@ -44,26 +32,23 @@
   min-block-size: 35px;
 }
 
-.navOption {
-  -webkit-user-drag: none;
-}
-
 .moreOption {
   display: none;
 }
 
-.navOption,
+.navOption {
+  display: block;
+  color: inherit;
+  text-decoration: inherit;
+  padding-block: 5px;
+  padding-inline: 0;
+  -webkit-user-drag: none;
+}
+
 .channelLink {
   display: block;
   color: inherit;
   text-decoration: inherit;
-}
-
-
-.navOption .navLabel {
-  margin-inline-start: 40px;
-  overflow: hidden;
-  overflow-wrap: break-word;
 }
 
 .navOption:hover,
@@ -82,16 +67,31 @@
 
 .navIcon {
   block-size: 1em;
-  inline-size: 1.25em;
-  margin-inline-start: 10px;
+  margin-inline-start: 0;
+  inline-size: 100%;
+  display: block;
+  margin-block-end: 0;
 }
 
 .navIcon.fa-user-check {
   /* This icon is too big by default */
-  inline-size: 1em;
+  block-size: 1.15em;
 
   /* Align icon according to torso */
   transform: translateX(0.2em);
+}
+
+.navLabel {
+  text-align: center;
+  inset-inline-start: 0;
+  margin-inline-start: 0;
+  font-size: 11px;
+  margin-block-end: 0;
+}
+
+.navOption .navLabel {
+  overflow: hidden;
+  overflow-wrap: break-word;
 }
 
 .navChannel .navLabel {
@@ -111,11 +111,15 @@
 
 .thumbnailContainer {
   inline-size: 35px;
+  display: block;
   margin: 0;
-  position: absolute;
-  inset-block-start: 50%;
-  transform: translateY(-50%);
+  position: static;
   text-align: center;
+  transform: none;
+  float: none;
+  margin-inline: auto;
+  inset-block-start: 0;
+  margin-block: 0.3em;
 }
 
 .channelThumbnail {
@@ -128,10 +132,6 @@
   font-size: 35px;
 }
 
-.closed {
-  inline-size: 80px;
-}
-
 .sideNav hr {
   inline-size: 90%;
   block-size: 1px;
@@ -140,67 +140,76 @@
 }
 
 .refreshIcon {
+  display: none;
   position: absolute;
   inset-block-start: 20px;
   inset-inline-end: 20px;
 }
 
-.closed .refreshIcon {
+.hiddenLabels {
+  inline-size: 60px;
+}
+
+.hiddenLabels .navLabel {
   display: none;
 }
 
-.closed .navOption {
-  inline-size: 100%;
-  padding-block: 5px;
-  padding-inline: 0;
-}
-
-.closed .navIcon {
-  margin-inline-start: 0;
-  inline-size: 100%;
-  display: block;
-  margin-block-end: 0;
-}
-
-.closed .navIconExpand {
+.navIconExpand {
   block-size: 1.3em;
-}
-
-.closed .navIconExpand.fa-user-check {
-  /* This icon is too big by default */
-  block-size: 1.15em;
-}
-
-.closed .navLabel {
-  margin-inline: 0;
-  inline-size: 100%;
-  text-align: center;
-  inset-inline-start: 0;
-  font-size: 11px;
-  margin-block-end: 0;
-}
-
-.closed .navChannel {
-  inline-size: 100%;
-  block-size: 45px;
-  padding-block: 5px;
-  padding-inline: 0;
-}
-
-.closed .thumbnailContainer {
-  position: static;
-  display: block;
-  float: none;
-  margin-inline: auto;
-  inset-block-start: 0;
-  transform: none;
-  margin-block: 0.3em;
 }
 
 @media only screen and (width > 680px) {
   ::-webkit-scrollbar {
     inline-size: 10px;
     block-size: 10px;
+  }
+
+  .open {
+    inline-size: 200px;
+  }
+
+  .open .inner {
+    inline-size: 200px;
+  }
+
+  .open .refreshIcon {
+    display: block;
+  }
+
+  .open .navIcon {
+    inline-size: 1.25em;
+    margin-inline-start: 10px;
+  }
+
+  .open .navIconExpand.fa-user-check {
+    /* This icon is too big by default */
+    inline-size: 1em;
+  }
+
+  .open .navOption {
+    padding-inline: 5px;
+  }
+
+  .open .navLabel {
+    text-align: start;
+    margin-inline-start: 40px;
+    margin-block-end: 16px;
+    font-size: 16px;
+  }
+
+  .open .navChannel .navLabel {
+    font-size: 12px;
+  }
+
+  .open .thumbnailContainer {
+    inset-block-start: 50%;
+    position: absolute;
+    transform: translateY(-50%);
+    margin-block: 0;
+  }
+
+  .open.hiddenLabels .navLabel {
+    display: block;
   }
 }
 
@@ -216,19 +225,9 @@
   }
 
   .sideNav {
-    position: fixed;
     inset-inline-start: 0;
-    inset-block-end: 0;
+    position: fixed;
     display: flex;
-  }
-
-  .topNavOption {
-    margin-block-start: 0;
-    padding-inline: 10px;
-  }
-
-  .sideNav,
-  .closed {
     margin-block-start: 0;
     block-size: 60px;
     inline-size: 100%;
@@ -236,12 +235,9 @@
     overflow-y: hidden;
   }
 
-  .navOption,
-  .closed .navOption {
-    inline-size: 70px;
-    block-size: 40px;
-    padding: 0;
-    padding-block: 10px;
+  .topNavOption {
+    margin-block-start: 0;
+    padding-inline: 10px;
   }
 
   .navLabel {
@@ -256,7 +252,14 @@
     display: block;
   }
 
-  .closed.hiddenLabels {
+  .navOption {
+    inline-size: 70px;
+    block-size: 40px;
+    padding: 0;
+    padding-block: 10px;
+  }
+
+  .hiddenLabels {
     inline-size: 100%;
   }
 }

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -72,9 +72,6 @@
 }
 
 .navIcon.fa-user-check {
-  /* This icon is too big by default */
-  block-size: 1.15em;
-
   /* Align icon according to torso */
   transform: translateX(0.2em);
 }
@@ -178,9 +175,8 @@
     margin-inline-start: 10px;
   }
 
-  .opened .navIconExpand.fa-user-check {
-    /* This icon is too big by default */
-    inline-size: 1em;
+  .opened .navIcon.fa-user-check {
+    block-size: 1em;
   }
 
   .opened .navOption {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -67,10 +67,8 @@
 
 .navIcon {
   block-size: 1em;
-  margin-inline-start: 0;
   inline-size: 100%;
   display: block;
-  margin-block-end: 0;
 }
 
 .navIcon.fa-user-check {
@@ -84,7 +82,6 @@
 .navLabel {
   text-align: center;
   inset-inline-start: 0;
-  margin-inline-start: 0;
   font-size: 11px;
   margin-block-end: 0;
 }

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -1,7 +1,7 @@
 <template>
   <FtFlexBox
     class="sideNav"
-    :class="[{open: isOpen}, applyHiddenLabels]"
+    :class="[{opened: isOpen}, applyHiddenLabels]"
     role="navigation"
   >
     <div

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -1,7 +1,7 @@
 <template>
   <FtFlexBox
     class="sideNav"
-    :class="[{closed: !isOpen}, applyHiddenLabels]"
+    :class="[{open: isOpen}, applyHiddenLabels]"
     role="navigation"
   >
     <div
@@ -24,7 +24,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("Subscriptions.Subscriptions") }}
@@ -46,7 +45,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("Channels.Channels") }}
@@ -69,7 +67,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("Trending.Trending") }}
@@ -92,7 +89,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("Most Popular") }}
@@ -115,7 +111,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("Playlists") }}
@@ -138,7 +133,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("History.History") }}
@@ -161,7 +155,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t('Settings.Settings') }}
@@ -183,7 +176,6 @@
           />
         </div>
         <p
-          v-if="!hideText"
           class="navLabel"
         >
           {{ $t("About.About") }}
@@ -324,12 +316,12 @@ const hideActiveSubscriptions = computed(() => {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideText = computed(() => {
-  return !isOpen.value && store.getters.getHideLabelsSideBar
+  return store.getters.getHideLabelsSideBar
 })
 
 const applyNavIconExpand = computed(() => {
   return {
-    navIconExpand: hideText.value
+    navIconExpand: hideText.value && !store.getters.getIsSideNavOpen
   }
 })
 

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -316,12 +316,12 @@ const hideActiveSubscriptions = computed(() => {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideText = computed(() => {
-  return store.getters.getHideLabelsSideBar
+  return !isOpen.value && store.getters.getHideLabelsSideBar
 })
 
 const applyNavIconExpand = computed(() => {
   return {
-    navIconExpand: hideText.value && !store.getters.getIsSideNavOpen
+    navIconExpand: hideText.value
   }
 })
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
closes #6091

## Description
This pull request is mostly a refactor and doesn't have any visual or functional effect besides fixing the mentioned issue.

The 'open' state now becomes the default for styling. This has three advantages:
- This makes it consistent with the rest of the application logic (isOpen)
- Simplifies styling. The open styles can now be done for desktop easily with a media query
- Fixes #6091 [Bug]: Theme Settings > Expand side bar by default is affecting the bottom navigation for mobile devices 


## Testing
Ensure that the interface behaves as before when the app resolution (media queries), nav bar open toggle and the Theme > Hide Side Bar Labels option vary.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** N/A
- **FreeTube version:** v0.23.12-beta

