### PR TITLE
Feat: Pin subscriptions from the side nav

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -156,12 +156,12 @@ class Profiles {
     if (profileIds.length === 1) {
       return db.profiles.updateAsync(
         { _id: profileIds[0] },
-        { $pull: { subscriptions: { id: channelId } } }
+        { $pull: { subscriptions: { id: channelId }, pinnedChannels: channelId } }
       )
     } else {
       return db.profiles.updateAsync(
         { _id: { $in: profileIds } },
-        { $pull: { subscriptions: { id: channelId } } },
+        { $pull: { subscriptions: { id: channelId }, pinnedChannels: channelId } },
         { multi: true }
       )
     }

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -204,7 +204,8 @@ function saveProfile() {
     name: profileName.value,
     bgColor: profileBgColor.value,
     textColor: profileTextColor.value,
-    subscriptions: deepCopy(props.profile.subscriptions)
+    subscriptions: deepCopy(props.profile.subscriptions),
+    pinnedChannels: deepCopy(props.profile.pinnedChannels ?? [])
   }
 
   if (!props.isNew) {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -266,3 +266,46 @@
   }
 }
 
+.pinnedIcon {
+  position: absolute;
+  inset-block-start: 10px;
+  inset-inline-end: 10px;
+  font-size: 10px;
+  color: var(--primary-color);
+  transform: rotate(45deg);
+}
+
+.contextMenu {
+  position: fixed;
+  z-index: 1000;
+  background-color: var(--card-bg-color);
+  border-radius: 5px;
+  box-shadow: 2px 2px 5px var(--primary-shadow-color);
+  min-inline-size: 150px;
+}
+
+.contextMenuList {
+  list-style: none;
+  margin: 0;
+  padding-block: 5px;
+  padding-inline: 0;
+}
+
+.contextMenuItem {
+  display: flex;
+  align-items: center;
+  padding-block: 8px;
+  padding-inline: 12px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.contextMenuItem:hover,
+.contextMenuItem:focus-visible {
+  background-color: var(--side-nav-hover-color);
+}
+
+.contextMenuIcon {
+  margin-inline-end: 8px;
+  inline-size: 14px;
+}

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -314,11 +314,7 @@ const activeProfile = computed(() => {
 
 /** @type {import('vue').ComputedRef<string[]>} */
 const pinnedChannelIds = computed(() => {
-  try {
-    return JSON.parse(store.getters.getSideNavChannelPinned)
-  } catch {
-    return []
-  }
+  return activeProfile.value.pinnedChannels ?? []
 })
 
 /**
@@ -454,7 +450,9 @@ function togglePinChannel() {
     currentPinned.push(channelId)
   }
 
-  store.dispatch('updateSideNavChannelPinned', JSON.stringify(currentPinned))
+  const updatedProfile = deepCopy(activeProfile.value)
+  updatedProfile.pinnedChannels = currentPinned
+  store.dispatch('updateProfile', updatedProfile)
   hideContextMenu()
 }
 

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -199,7 +199,6 @@
           :key="channel.id"
           :to="`/channel/${channel.id}`"
           class="navChannel channelLink mobileHidden"
-          :class="{ pinnedChannel: isChannelPinned(channel.id) }"
           :title="channel.name"
           role="button"
           @contextmenu.prevent="showContextMenu($event, channel)"

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -9,7 +9,8 @@ const state = {
     name: 'All Channels',
     bgColor: '#000000',
     textColor: '#FFFFFF',
-    subscriptions: []
+    subscriptions: [],
+    pinnedChannels: []
   }],
   activeProfile: MAIN_PROFILE_ID
 }
@@ -67,7 +68,8 @@ const actions = {
         name: defaultName,
         bgColor: randomColor,
         textColor: textColor,
-        subscriptions: []
+        subscriptions: [],
+        pinnedChannels: []
       }
 
       try {

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -267,6 +267,10 @@ const mutations = {
       // use filter instead of splice in case the subscription appears multiple times
       // https://github.com/FreeTubeApp/FreeTube/pull/3468#discussion_r1179290877
       profile.subscriptions = profile.subscriptions.filter(channel => channel.id !== channelId)
+
+      if (profile.pinnedChannels) {
+        profile.pinnedChannels = profile.pinnedChannels.filter(id => id !== channelId)
+      }
     }
   },
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -220,7 +220,6 @@ const state = {
   hideUploader: false,
   unsubscriptionPopupStatus: false,
   hideLabelsSideBar: false,
-  sideNavChannelPinned: '[]',
   hideChapters: false,
   showDistractionFreeTitles: false,
   landingPage: 'subscriptions',

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -220,6 +220,7 @@ const state = {
   hideUploader: false,
   unsubscriptionPopupStatus: false,
   hideLabelsSideBar: false,
+  sideNavChannelPinned: '[]',
   hideChapters: false,
   showDistractionFreeTitles: false,
   landingPage: 'subscriptions',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -134,6 +134,9 @@ Subscriptions:
   Subscriptions Tabs: Subscriptions Tabs
   All Subscription Tabs Hidden: 'All subscription tabs are hidden. To see content here, please unhide some tabs in the "{subsection}" section in "{settingsSection}".'
 More: More
+Side Nav:
+  Pin to Top: Pin to Top
+  Unpin from Top: Unpin from Top
 Channels:
   Channels: Channels
   Title: Channel List


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #958
## Description
This PR adds a feature that allows users to pin subscribed channels in the side nav.

## Screenshots
### Pin menu:
<img width="194" height="403" alt="Capture d’écran 2025-12-08 à 17 33 33" src="https://github.com/user-attachments/assets/912d6210-8922-471a-9c95-83a835b1319b" />

### Unpin menu
<img width="202" height="403" alt="Capture d’écran 2025-12-08 à 17 44 17" src="https://github.com/user-attachments/assets/f20817a4-fb1c-4845-b280-5fe0fdfc6a02" />

### Pinned channels
<img width="145" height="481" alt="Capture d’écran 2025-12-08 à 17 33 05" src="https://github.com/user-attachments/assets/f04619ce-9d60-4923-8879-ba541c32539e" />

## Testing

1. Make sure to be subscribed to channels.
2. Right click on a channel from the side nav.
3. Click on the button to pin it.
4. Channel will be pinned.

## Desktop

- **OS:** MacOS
- **OS Version:** 26.1 Tahoe
- **FreeTube version:** v0.23.12

## Additional context

1. Pins are profile dependent. 
2. The order of the pins in the side nav is from oldest to latest.