### PR TITLE
Move external player handling to the main process

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,6 @@ const IpcChannels = {
   STOP_POWER_SAVE_BLOCKER: 'stop-power-save-blocker',
   START_POWER_SAVE_BLOCKER: 'start-power-save-blocker',
   CREATE_NEW_WINDOW: 'create-new-window',
-  OPEN_IN_EXTERNAL_PLAYER: 'open-in-external-player',
   NATIVE_THEME_UPDATE: 'native-theme-update',
   APP_READY: 'app-ready',
   RELAUNCH_REQUEST: 'relaunch-request',
@@ -46,6 +45,9 @@ const IpcChannels = {
   GET_SCREENSHOT_FALLBACK_FOLDER: 'get-screenshot-fallback-folder',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   WRITE_TO_DEFAULT_FOLDER: 'write-to-default-folder',
+
+  OPEN_IN_EXTERNAL_PLAYER: 'open-in-external-player',
+  OPEN_IN_EXTERNAL_PLAYER_RESULT: 'open-in-external-player-result'
 }
 
 const DBActions = {
@@ -228,6 +230,20 @@ const PlayerIcons = {
   SKIP_PREVIOUS_FILLED: 'M220-280v-400q0-17 11.5-28.5T260-720q17 0 28.5 11.5T300-680v400q0 17-11.5 28.5T260-240q-17 0-28.5-11.5T220-280Zm458-1L430-447q-9-6-13.5-14.5T412-480q0-10 4.5-18.5T430-513l248-166q5-4 11-5t11-1q16 0 28 11t12 29v330q0 18-12 29t-28 11q-5 0-11-1t-11-5Z'
 }
 
+const UnsupportedPlayerActions = /** @type {const} */({
+  STARTING_VIDEO_AT_OFFSET: 1,
+  PLAYBACK_RATE: 2,
+  OPENING_PLAYLISTS: 3,
+  PLAYLIST_SPECIFIC_VIDEO: 4,
+  PLAYLIST_REVERSE: 5,
+  PLAYLIST_SHUFFLE: 6,
+  PLAYLIST_LOOP: 7,
+})
+
+/**
+ * @typedef {UnsupportedPlayerActions[(keyof typeof UnsupportedPlayerActions)]} UnsupportedPlayerAction
+ */
+
 // Utils
 const MAIN_PROFILE_ID = 'allChannels'
 
@@ -256,6 +272,7 @@ export {
   DefaultFolderKind,
   KeyboardShortcuts,
   PlayerIcons,
+  UnsupportedPlayerActions,
   MAIN_PROFILE_ID,
   MOBILE_WIDTH_THRESHOLD,
   PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD,

--- a/src/main/externalPlayer.js
+++ b/src/main/externalPlayer.js
@@ -1,0 +1,203 @@
+import { spawn } from 'node:child_process'
+import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { settings } from '../datastores/handlers/base'
+import { isFreeTubeUrl } from './utils'
+import { IpcChannels, UnsupportedPlayerActions } from '../constants'
+
+/**
+ * @typedef ExternalPlayerPayload
+ * @property {string | undefined | null} [videoId]
+ * @property {string | undefined | null} [playlistId]
+ * @property {number | undefined | null} [startTime]
+ * @property {number | undefined | null} [playbackRate]
+ * @property {number | undefined | null} [playlistIndex]
+ * @property {boolean | undefined | null} [playlistReverse]
+ * @property {boolean | undefined | null} [playlistShuffle]
+ * @property {boolean | undefined | null} [playlistLoop]
+ */
+
+/**
+ * @typedef CmdArgs
+ * @property {string} defaultExecutable
+ * @property {string[] | null} defaultCustomArguments
+ * @property {string} videoUrl
+ * @property {string | null} playlistUrl
+ * @property {string | null} startOffset
+ * @property {string | null} playbackRate
+ * @property {string | null} playlistIndex
+ * @property {string | null} playlistReverse
+ * @property {string | null} playlistShuffle
+ * @property {string | null} playlistLoop
+ */
+
+const ID_REGEX = /^[\w-]+$/
+
+/** @type {Map<string, CmdArgs>} */
+const externalPlayerCmdArgs = new Map()
+
+/**
+ * @param {import('electron').IpcMainEvent} event
+ * @param {ExternalPlayerPayload} payload
+ */
+export async function handleOpenInExternalPlayer(event, payload) {
+  if (!isFreeTubeUrl(event.senderFrame.url) || !event.sender.isFocused()) {
+    return
+  }
+
+  const hasValidVideoId = typeof payload.videoId === 'string' && payload.videoId.length === 11 && ID_REGEX.test(payload.videoId)
+  const hasValidPlaylistId = typeof payload.playlistId === 'string' && payload.playlistId.length > 2 && ID_REGEX.test(payload.playlistId)
+
+  if (!hasValidVideoId && !hasValidPlaylistId) {
+    return
+  }
+
+  /** @type {string} */
+  const externalPlayer = (await settings._findOne('externalPlayer'))?.value || ''
+
+  // External player setting not set or set to "none"
+  if (externalPlayer === '') {
+    return
+  }
+
+  if (externalPlayerCmdArgs.size === 0) {
+    await loadExternalPlayerData()
+  }
+
+  const cmdArgs = externalPlayerCmdArgs.get(externalPlayer)
+
+  if (cmdArgs === undefined) {
+    return
+  }
+
+  const args = []
+  /** @type {import('../constants').UnsupportedPlayerAction[]} */
+  const unsupportedActions = []
+
+  /** @type {boolean} */
+  const ignoreWarnings = (await settings._findOne('externalPlayerIgnoreWarnings'))?.value || false
+
+  /** @type {boolean} */
+  const ignoreDefaultArgs = (await settings._findOne('externalPlayerIgnoreDefaultArgs'))?.value || false
+
+  /** @type {string[] | string} */
+  const customArgs = (await settings._findOne('externalPlayerCustomArgs'))?.value || '[]'
+
+  if (typeof customArgs === 'string' && customArgs !== '[]') {
+    args.push(...JSON.parse(customArgs))
+  } else if (!ignoreDefaultArgs && Array.isArray(cmdArgs.defaultCustomArguments)) {
+    args.push(...cmdArgs.defaultCustomArguments)
+  }
+
+  if (ignoreDefaultArgs) {
+    if (hasValidVideoId) {
+      args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
+    }
+  } else {
+    if (typeof payload.startTime === 'number' && payload.startTime > 0) {
+      if (typeof cmdArgs.startOffset === 'string') {
+        if (cmdArgs.defaultExecutable.startsWith('mpc')) {
+          // For mpc-hc and mpc-be, which require startOffset to be in milliseconds
+          args.push(cmdArgs.startOffset, 1000 * Math.trunc(payload.startTime))
+        } else if (cmdArgs.startOffset.endsWith('=')) {
+          // For players using `=` in arguments
+          // e.g. vlc --start-time=xxxxx
+          args.push(`${cmdArgs.startOffset}${payload.startTime}`)
+        } else {
+          // For players using space in arguments
+          // e.g. smplayer -start xxxxx
+          args.push(cmdArgs.startOffset, Math.trunc(payload.startTime))
+        }
+      } else if (!ignoreWarnings) {
+        unsupportedActions.push(UnsupportedPlayerActions.STARTING_VIDEO_AT_OFFSET)
+      }
+    }
+
+    if (typeof payload.playbackRate === 'number' && payload.playbackRate > 0) {
+      if (typeof cmdArgs.playbackRate === 'string') {
+        args.push(`${cmdArgs.playbackRate}${payload.playbackRate}`)
+      } else if (!ignoreWarnings) {
+        unsupportedActions.push(UnsupportedPlayerActions.PLAYBACK_RATE)
+      }
+    }
+
+    // Check whether the video is in a playlist
+    if (hasValidPlaylistId && typeof cmdArgs.playlistUrl === 'string') {
+      if (typeof payload.playlistIndex === 'number' && payload.playlistIndex >= 0) {
+        if (typeof cmdArgs.playlistIndex === 'string') {
+          args.push(`${cmdArgs.playlistIndex}${payload.playlistIndex}`)
+        } else if (!ignoreWarnings) {
+          unsupportedActions.push(UnsupportedPlayerActions.PLAYLIST_SPECIFIC_VIDEO)
+        }
+      }
+
+      if (payload.playlistReverse) {
+        if (typeof cmdArgs.playlistReverse === 'string') {
+          args.push(cmdArgs.playlistReverse)
+        } else if (!ignoreWarnings) {
+          unsupportedActions.push(UnsupportedPlayerActions.PLAYLIST_REVERSE)
+        }
+      }
+
+      if (payload.playlistShuffle) {
+        if (typeof cmdArgs.playlistShuffle === 'string') {
+          args.push(cmdArgs.playlistShuffle)
+        } else if (!ignoreWarnings) {
+          unsupportedActions.push(UnsupportedPlayerActions.PLAYLIST_SHUFFLE)
+        }
+      }
+
+      if (payload.playlistLoop) {
+        if (typeof cmdArgs.playlistLoop === 'string') {
+          args.push(cmdArgs.playlistLoop)
+        } else if (!ignoreWarnings) {
+          unsupportedActions.push(UnsupportedPlayerActions.PLAYLIST_LOOP)
+        }
+      }
+
+      // If the player supports opening playlists but not indexes, send only the video URL if an index is specified
+      if (cmdArgs.playlistIndex == null && typeof payload.playlistIndex === 'number') {
+        args.push(`${cmdArgs.videoUrl}https://youtube.com/watch?v=${payload.videoId}`)
+      } else {
+        args.push(`${cmdArgs.playlistUrl}https://youtube.com/playlist?list=${payload.playlistId}`)
+      }
+    } else {
+      if (hasValidPlaylistId && !ignoreWarnings) {
+        unsupportedActions.push(UnsupportedPlayerActions.OPENING_PLAYLISTS)
+      }
+
+      if (hasValidVideoId) {
+        args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
+      }
+    }
+  }
+
+  event.reply(
+    IpcChannels.OPEN_IN_EXTERNAL_PLAYER_RESULT,
+    externalPlayer,
+    unsupportedActions,
+    hasValidPlaylistId
+  )
+
+  /** @type {string} */
+  const externalPlayerExecutable = (await settings._findOne('externalPlayerExecutable'))?.value || ''
+
+  const executable = externalPlayerExecutable.length > 0 ? externalPlayerExecutable : cmdArgs.defaultExecutable
+
+  const child = spawn(executable, args, { detached: true, stdio: 'ignore' })
+  child.unref()
+}
+
+async function loadExternalPlayerData() {
+  const path = process.env.NODE_ENV === 'development'
+    ? '../../static/external-player-map.json'
+    : 'static/external-player-map.json'
+
+  const json = JSON.parse(await readFile(join(__dirname, path)))
+
+  for (const entry of json) {
+    if (entry.value.length > 0) {
+      externalPlayerCmdArgs.set(entry.value, entry.cmdArguments)
+    }
+  }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,7 +26,9 @@ import { brotliDecompress } from 'zlib'
 import contextMenu from 'electron-context-menu'
 
 import packageDetails from '../../package.json'
+import { handleOpenInExternalPlayer } from './externalPlayer'
 import { generatePoToken } from './poTokenGenerator'
+import { isFreeTubeUrl } from './utils'
 
 const brotliDecompressAsync = promisify(brotliDecompress)
 
@@ -857,25 +859,6 @@ function runApp() {
     }
   }
 
-  /**
-   * @param {string | URL} url
-   */
-  function isFreeTubeUrl(url) {
-    let url_
-
-    if (url instanceof URL) {
-      url_ = url
-    } else {
-      url_ = URL.parse(url)
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-      return url_ !== null && url_.protocol === 'http:' && url_.host === 'localhost:9080' && (url_.pathname === '/' || url_.pathname === '/index.html')
-    } else {
-      return url_ !== null && url_.protocol === 'app:' && url_.host === 'bundle' && (url_.pathname === '/' || url_.pathname === '/index.html')
-    }
-  }
-
   async function createWindow(
     {
       replaceMainWindow = true,
@@ -1486,12 +1469,7 @@ function runApp() {
     })
   })
 
-  ipcMain.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, (event, executable, args) => {
-    if (isFreeTubeUrl(event.senderFrame.url)) {
-      const child = cp.spawn(executable, args, { detached: true, stdio: 'ignore' })
-      child.unref()
-    }
-  })
+  ipcMain.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, handleOpenInExternalPlayer)
 
   ipcMain.handle(IpcChannels.GET_REPLACE_HTTP_CACHE, (event) => {
     if (isFreeTubeUrl(event.senderFrame.url)) {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,0 +1,18 @@
+/**
+ * @param {string | URL} url
+ */
+export function isFreeTubeUrl(url) {
+  let url_
+
+  if (url instanceof URL) {
+    url_ = url
+  } else {
+    url_ = URL.parse(url)
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    return url_ !== null && url_.protocol === 'http:' && url_.host === 'localhost:9080' && (url_.pathname === '/' || url_.pathname === '/index.html')
+  } else {
+    return url_ !== null && url_.protocol === 'app:' && url_.host === 'bundle' && (url_.pathname === '/' || url_.pathname === '/index.html')
+  }
+}

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -146,11 +146,27 @@ export default {
   },
 
   /**
-   * @param {string} executable
-   * @param {string} args
+   * @param {import('../main/externalPlayer').ExternalPlayerPayload} payload
    */
-  openInExternalPlayer: (executable, args) => {
-    ipcRenderer.send(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, executable, args)
+  openInExternalPlayer: (payload) => {
+    // require the user to have interacted with the page recently
+    if (navigator.userActivation.isActive) {
+      ipcRenderer.send(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, payload)
+    }
+  },
+
+  /**
+   * @param {(
+   *   externalPlayer: string,
+   *   unsuportedActions: (import('../constants').UnsupportedPlayerAction)[],
+   *   isPlaylist: boolean
+   * ) => void} handler
+   */
+  handleOpenInExternalPlayerResult: (handler) => {
+    ipcRenderer.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER_RESULT,
+      (event, externalPlayer, unsupportedActions, isPlaylist) => {
+        handler(externalPlayer, unsupportedActions, isPlaylist)
+      })
   },
 
   /**

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -269,16 +269,12 @@ const externalPlayer = computed(() => store.getters.getExternalPlayer)
 const defaultPlayback = computed(() => store.getters.getDefaultPlayback)
 
 function handleExternalPlayer() {
-  store.dispatch('openInExternalPlayer', {
-    watchProgress: 0,
-    playbackRate: defaultPlayback.value,
-    videoId: null,
-    playlistId: playlistId,
-    playlistIndex: null,
-    playlistReverse: null,
-    playlistShuffle: null,
-    playlistLoop: null
-  })
+  if (process.env.IS_ELECTRON) {
+    window.ftElectron.openInExternalPlayer({
+      playlistId: playlistId,
+      playbackRate: defaultPlayback.value,
+    })
+  }
 }
 </script>
 

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -367,18 +367,16 @@ function handleExternalPlayer() {
   // Only play video in non playlist mode when user playlist detected
   if (props.inUserPlaylist) {
     payload = {
-      watchProgress: props.getTimestamp(),
-      playbackRate: defaultPlayback.value,
       videoId: props.id,
-      videoLength: props.lengthSeconds
+      startTime: props.getTimestamp(),
+      playbackRate: defaultPlayback.value,
     }
   } else {
     payload = {
-      watchProgress: props.getTimestamp(),
-      playbackRate: defaultPlayback.value,
       videoId: props.id,
-      videoLength: props.lengthSeconds,
       playlistId: props.playlistId,
+      startTime: props.getTimestamp(),
+      playbackRate: defaultPlayback.value,
       playlistIndex: props.getPlaylistIndex(),
       playlistReverse: props.getPlaylistReverse(),
       playlistShuffle: props.getPlaylistShuffle(),
@@ -386,7 +384,9 @@ function handleExternalPlayer() {
     }
   }
 
-  store.dispatch('openInExternalPlayer', payload)
+  if (process.env.IS_ELECTRON) {
+    window.ftElectron.openInExternalPlayer(payload)
+  }
 
   if (rememberHistory.value) {
     // Marking as watched

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -636,11 +636,10 @@ export default defineComponent({
       this.$emit('pause-player')
 
       const payload = {
-        watchProgress: this.watchProgress,
-        playbackRate: this.defaultPlayback,
         videoId: this.id,
-        videoLength: this.data.lengthSeconds,
         playlistId: this.playlistIdFinal,
+        startTime: this.watchProgress,
+        playbackRate: this.defaultPlayback,
         playlistIndex: this.playlistIndex,
         playlistReverse: this.playlistReverse,
         playlistShuffle: this.playlistShuffle,
@@ -656,7 +655,9 @@ export default defineComponent({
           playlistLoop: null,
         })
       }
-      this.openInExternalPlayer(payload)
+      if (process.env.IS_ELECTRON) {
+        window.ftElectron.openInExternalPlayer(payload)
+      }
 
       if (this.rememberHistory) {
         this.markAsWatched()
@@ -895,7 +896,6 @@ export default defineComponent({
     },
 
     ...mapActions([
-      'openInExternalPlayer',
       'updateHistory',
       'removeFromHistory',
       'updateChannelsHidden',

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1,6 +1,7 @@
+import { nextTick } from 'vue'
 import i18n from '../i18n/index'
 import router from '../router/index'
-import { nextTick } from 'vue'
+import { UnsupportedPlayerActions } from '../../constants'
 
 // allowed characters in channel handle: A-Z, a-z, 0-9, -, _, .
 // https://support.google.com/youtube/answer/11585688#change_handle
@@ -555,8 +556,40 @@ export function extractNumberFromString(str) {
   }
 }
 
+/**
+ * @param {string} externalPlayer
+ * @param {import('../../constants').UnsupportedPlayerAction} action
+ */
 export function showExternalPlayerUnsupportedActionToast(externalPlayer, action) {
-  const message = i18n.global.t('Video.External Player.UnsupportedActionTemplate', { externalPlayer, action })
+  let actionString = ''
+
+  switch (action) {
+    case UnsupportedPlayerActions.STARTING_VIDEO_AT_OFFSET:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.starting video at offset')
+      break
+    case UnsupportedPlayerActions.PLAYBACK_RATE:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.setting a playback rate')
+      break
+    case UnsupportedPlayerActions.OPENING_PLAYLISTS:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.opening playlists')
+      break
+    case UnsupportedPlayerActions.PLAYLIST_SPECIFIC_VIDEO:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.opening specific video in a playlist (falling back to opening the video)')
+      break
+    case UnsupportedPlayerActions.PLAYLIST_REVERSE:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.reversing playlists')
+      break
+    case UnsupportedPlayerActions.PLAYLIST_SHUFFLE:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.shuffling playlists')
+      break
+    case UnsupportedPlayerActions.PLAYLIST_LOOP:
+      actionString = i18n.global.t('Video.External Player.Unsupported Actions.looping playlists')
+      break
+  }
+
+  const message = i18n.global.t('Video.External Player.UnsupportedActionTemplate', {
+    externalPlayer, action: actionString
+  })
   showToast(message)
 }
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -3,6 +3,7 @@ import i18n from './i18n/index'
 import router from './router/index'
 import store from './store/index'
 import App from './App.vue'
+import { showExternalPlayerUnsupportedActionToast, showToast } from './helpers/utils'
 import { library } from './fontawesome-minimal'
 // import the styles
 import '@fortawesome/fontawesome-svg-core/styles.css'
@@ -283,4 +284,18 @@ if (process.env.IS_ELECTRON) {
   window.ftElectron.handleChangeView((route) => {
     router.push(route)
   })
+
+  window.ftElectron.handleOpenInExternalPlayerResult(
+    (externalPlayer, unsupportedActions, isPlaylist) => {
+      for (const action of unsupportedActions) {
+        showExternalPlayerUnsupportedActionToast(externalPlayer, action)
+      }
+
+      const videoOrPlaylist = isPlaylist
+        ? i18n.global.t('Video.External Player.playlist')
+        : i18n.global.t('Video.External Player.video')
+
+      showToast(i18n.global.t('Video.External Player.OpeningTemplate', { videoOrPlaylist, externalPlayer }))
+    }
+  )
 }


### PR DESCRIPTION
## Pull Request Type

- [x] Security improvement

## Description

This pull request moves the external player command construction to the main process, this allows us to add more validation and security checks to prevent abuse.

List of changes:
- The IPC call only has a limited set of parameters such as the video ID, everything else that is needed is read from the external player map and settings in the main process.
- Validation that the video ID and playlist ID are in the correct format and that other parameters have the correct datatypes and valid values.
- Check that the external player setting is actually enabled.
- Require the page that made the IPC call to be focused and the user to have [recently interacted with the page](https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation).

## Testing

Test that opening the external player by clicking on a button or with the default viewing mode set to external player still works correctly.

Try programmatically triggering the external player IPC call through the dev tools `window.ftElectron.openInExternalPlayer({ videoID: '12345678911' })`, it should do nothing/fail silently if you try it.

If you don't have an external player installed you can choose any one in the external player settings and replace lines 187 and 188 in `src/main/externalPlayer.js` with `console.log(executable, args)`, you'll also need to uncomment line 75 in `_scripts/dev-runner.js` if you are running in dev mode.

## Desktop

- **OS:** Windows
- **OS Version:** 11