### PR TITLE
Revert "[Bug fix] Set max-block-size to prevent thin videos from passing the bottom of view"

### DIFF
--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -83,7 +83,6 @@
       margin-inline: auto;
       max-inline-size: calc(80vh * 1.78);
       position: relative;
-      max-block-size: 81vh;
 
       .videoThumbnail {
         inline-size: 100%;


### PR DESCRIPTION
## Pull Request Type
- [x] Revert

## Related issue
Reverts FreeTubeApp/FreeTube#8386
Reopens https://github.com/FreeTubeApp/FreeTube/issues/7259

## Description
Discussed in https://github.com/FreeTubeApp/FreeTube/pull/8386#issuecomment-3645735185