### PR TITLE
Support exporting single playlists in YouTube's CSV format

### DIFF
--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -638,26 +638,34 @@ function handlePlaylistDeleteDisabledClick() {
 
 const EXPORT_VALUES = [
   'database',
+  'youtube',
   'urls',
   'close'
 ]
 
 const exportNames = computed(() => [
   `${t('Settings.Data Settings.Export FreeTube')} (.db)`,
+  `${t('Settings.Data Settings.Export YouTube')} (.csv)`,
   `${t('User Playlists.Export list of URLs')} (.txt)`,
   t('Close')
 ])
 
 /**
- * @param {'database' | 'urls' | null} value
+ * @param {'database' | 'youtube' | 'urls' | null} value
  */
 function handleExport(value) {
   showExportPrompt.value = false
 
-  if (value === 'database') {
-    exportAsFreeTubeDatabase()
-  } else if (value === 'urls') {
-    exportAsListOfUrls()
+  switch (value) {
+    case 'database':
+      exportAsFreeTubeDatabase()
+      break
+    case 'youtube':
+      exportAsYouTubeCsv()
+      break
+    case 'urls':
+      exportAsListOfUrls()
+      break
   }
 }
 
@@ -685,6 +693,41 @@ async function exportAsFreeTubeDatabase() {
       t('Settings.Data Settings.Playlist File'),
       'application/x-freetube-db',
       '.db',
+      'single-playlist-export',
+      'downloads'
+    )
+
+    if (response) {
+      showToast(t('User Playlists.The playlist has been successfully exported'))
+    }
+  } catch (error) {
+    const message = t('Settings.Data Settings.Unable to write file')
+    showToast(`${message}: ${error}`)
+  }
+}
+
+async function exportAsYouTubeCsv() {
+  const exportFileName = getExportFilename(props.title, 'csv')
+
+  const videoData = props.sortedVideos.map((video) => {
+    // Remove milliseconds and replace "Z" with +00:00 to match YouTube's exports
+    const timestamp = new Date(video.timeAdded).toISOString().slice(0, -5) + '+00:00'
+
+    return `${video.videoId},${timestamp}`
+  }).join('\n')
+
+  // YouTube includes 6 line feed characters at the end of the file, so we do the same here
+  const data = `Video ID,Playlist video creation timestamp\n${videoData}\n\n\n\n\n\n`
+
+  // See DataSettings.vue `promptAndWriteToFile`
+
+  try {
+    const response = await writeFileWithPicker(
+      exportFileName,
+      data,
+      '',
+      'text/csv',
+      '.csv',
       'single-playlist-export',
       'downloads'
     )


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

**Note to users that stubble upon this pull request: Importing Google Takeout playlist exports into FreeTube is still NOT SUPPORTED**.

This pull request adds support for exporting single playlists in the CSV format used by Google Takeout. The format is very basic and only includes a CSV header (hard coded to English in FreeTube like the other exports), the video ID and the timestamp of when the video was added to the playlist. One oddity is that YouTube includes 6 line feed `\n` characters at the end of the file, which are probably not needed but I decided to add them here too, just in case some other program expects them to be there.

## Testing

1. Open a user playlist
2. Click the export button
3. Choose "YouTube (.csv)" in the prompt
4. Check that the file looks correct in a text editor.

## Desktop

- **OS:** Windows
- **OS Version:** 11