### PR TITLE
Fix DeArrow thumbnails for shorts getting stretched

### DIFF
--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -337,6 +337,9 @@ $watched-transition-duration: 0.5s;
       .thumbnailImage {
         // Ensure placeholder image displayed at same aspect ratio as most other images
         aspect-ratio: 16/9;
+        // DeArrrow thumbnails are vertical for shorts.
+        // Set the object-fit so they don't get stretched to 16:9
+        object-fit: contain;
       }
     }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #5568

## Description

Set the CSS `object-fit` rule to `contain` for video thumbnails to fix DeArrow thumbnails on shorts getting stretched to 16:9.

## Screenshots

The first video has the original thumbnail from YouTube the second one has a thumbnail produced by DeArrow.

<img width="566" height="258" alt="before" src="https://github.com/user-attachments/assets/a80d3d84-2294-4be6-a327-ab01ebe0fdf2" />

<img width="578" height="253" alt="after" src="https://github.com/user-attachments/assets/de8dc808-333e-400a-81a5-8a99f5c2203f" />

## Testing

1. Turn on DeArrow thumbnails
2. Vist the `@google` YouTube channel
3. Click on the shorts tab
4. Wait for the DeArrow thumbnails to load and check that the aspect ratio looks correct.

## Desktop

- **OS:** Windows
- **OS Version:** 11