### PR TITLE
Clean up FtSlider CSS

### DIFF
--- a/src/renderer/components/FtSlider/FtSlider.css
+++ b/src/renderer/components/FtSlider/FtSlider.css
@@ -1,14 +1,7 @@
-/* stylelint-disable no-descending-specificity */
 .pure-material-slider {
-  --pure-material-safari-helper1: var(--accent-color-opacity1);
-  --pure-material-safari-helper2: var(--accent-color-opacity2);
-  --pure-material-safari-helper3: var(--accent-color-opacity3);
-  --pure-material-safari-helper4: var(--accent-color-opacity4);
-
   display: inline-block;
   inline-size: 380px;
   color: rgb(var(--primary-text-color) 0.87);
-  font-family: var(--pure-material-font, 'Roboto', 'Segoe UI', BlinkMacSystemFont, system-ui, -apple-system);
   font-size: 16px;
   line-height: 1.5;
   padding: 5px;
@@ -16,8 +9,7 @@
   margin-inline: 8px;
 }
 
-/* Input */
-.pure-material-slider > input {
+.input {
   appearance: none;
   position: relative;
   inset-block-start: 24px;
@@ -31,35 +23,30 @@
 }
 
 /* Without Span */
-.pure-material-slider > input:last-child {
+.input:last-child {
   position: static;
   margin: 0;
 }
 
-/* Span */
-.pure-material-slider > span {
+.label {
   display: inline-block;
   margin-block-end: 36px;
 }
-
-/* Focus */
 /* stylelint-disable-next-line a11y/no-outline-none */
-.pure-material-slider > input:focus {
+.input:focus {
   outline: none;
 }
 
-/* Disabled */
-.pure-material-slider > input:disabled {
+.input:disabled {
   cursor: default;
   opacity: 0.38;
 }
 
-.pure-material-slider > input:disabled + span {
+.input:disabled + .label {
   opacity: 0.38;
 }
 
-/* Webkit | Track */
-.pure-material-slider > input::-webkit-slider-runnable-track {
+.input::-webkit-slider-runnable-track {
   margin-block: 17px;
   margin-inline: 0;
   border-radius: 1px;
@@ -68,8 +55,7 @@
   background-color: var(--accent-color-opacity4);
 }
 
-/* Webkit | Thumb */
-.pure-material-slider > input::-webkit-slider-thumb {
+.input::-webkit-slider-thumb {
   appearance: none;
   border: 0;
   border-radius: 50%;
@@ -80,38 +66,34 @@
   transition: box-shadow 0.2s;
 }
 
-/* Webkit | Hover, Focus */
-.pure-material-slider:hover > input::-webkit-slider-thumb {
-  box-shadow: 0 0 0 2px var(--pure-material-safari-helper1);
+.input:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity2);
 }
 
-.pure-material-slider > input:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 2px var(--pure-material-safari-helper2);
+.input:active::-webkit-slider-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
 }
 
-.pure-material-slider:hover > input:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 2px var(--pure-material-safari-helper3);
-}
-
-/* Webkit | Active */
-.pure-material-slider > input:active::-webkit-slider-thumb {
-  box-shadow: 0 0 0 2px var(--pure-material-safari-helper4) !important;
-}
-
-/* Webkit | Disabled */
-.pure-material-slider > input:disabled::-webkit-slider-runnable-track {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0) 0.38);
-}
-
-.pure-material-slider > input:disabled::-webkit-slider-thumb {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
-  color: rgb(var(--pure-material-surface-rgb, 255, 255, 255)); /* Safari */
-  box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
+.input:disabled::-webkit-slider-thumb {
+  background-color: #000;
+  color: #fff; /* Safari */
+  box-shadow: 0 0 0 1px #fff !important;
   transform: scale(4, 4);
 }
 
-/* Moz | Track */
-.pure-material-slider > input::-moz-range-track {
+.pure-material-slider:hover > .input::-webkit-slider-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity1);
+}
+
+.pure-material-slider:hover > .input:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity3);
+}
+
+.input:disabled::-webkit-slider-runnable-track {
+  background-color: rgb(0 0 0 / 38%);
+}
+
+.input::-moz-range-track {
   margin-block: 0;
   margin: 17px;
   border-radius: 1px;
@@ -120,8 +102,7 @@
   background-color: var(--accent-color-opacity4);
 }
 
-/* Moz | Thumb */
-.pure-material-slider > input::-moz-range-thumb {
+.input::-moz-range-thumb {
   appearance: none;
   border: 0;
   border-radius: 50%;
@@ -132,123 +113,44 @@
   transition: box-shadow 0.2s;
 }
 
-/* Moz | Progress */
-.pure-material-slider > input::-moz-range-progress {
+.input::-moz-range-progress {
   border-radius: 1px;
   block-size: 2px;
   background-color: var(--accent-color);
 }
 
-/* Moz | Hover, Focus */
-.pure-material-slider:hover > input:hover::-moz-range-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity1);
+.input:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity2);
 }
 
-.pure-material-slider > input:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity2);
+.input:active::-moz-range-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
+}
+
+.input:disabled::-moz-range-thumb {
+  background-color: #000;
+  box-shadow: 0 0 0 1px #fff !important;
+  transform: scale(4, 4);
+}
+
+.pure-material-slider:hover > .input:hover::-moz-range-thumb {
+  box-shadow: 0 0 0 2px var(--accent-color-opacity1);
 }
 
 .pure-material-slider:hover > input:focus::-moz-range-thumb {
   box-shadow: 0 0 0 2px var(--accent-color-opacity3);
 }
 
-/* Moz | Active */
-.pure-material-slider > input:active::-moz-range-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
+.input:disabled::-moz-range-track {
+  background-color: rgb(0 0 0 / 38%);
 }
 
-/* Moz | Disabled */
-.pure-material-slider > input:disabled::-moz-range-track {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0) 0.38);
+.input:disabled::-moz-range-progress {
+  background-color: rgb(0 0 0 / 87%);
 }
 
-.pure-material-slider > input:disabled::-moz-range-progress {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0) 0.87);
-}
-
-.pure-material-slider > input:disabled::-moz-range-thumb {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
-  box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
-  transform: scale(4, 4);
-}
-
-.pure-material-slider > input::-moz-focus-outer {
+.input::-moz-focus-outer {
   border: 0;
-}
-
-/* MS | Track */
-.pure-material-slider > input::-ms-track {
-  box-sizing: border-box;
-  margin-block: 17px;
-  margin-inline: 0;
-  border: 0;
-  border-radius: 1px;
-  padding-block: 0;
-  padding-inline: 17px;
-  inline-size: 100%;
-  block-size: 2px;
-  background-color: transparent;
-}
-
-.pure-material-slider > input::-ms-fill-lower {
-  border-radius: 1px;
-  block-size: 2px;
-  background-color: var(--accent-color);
-}
-
-/* MS | Progress */
-.pure-material-slider > input::-ms-fill-upper {
-  border-radius: 1px;
-  block-size: 2px;
-  background-color: var(--accent-color-opacity4);
-}
-
-/* MS | Thumb */
-.pure-material-slider > input::-ms-thumb {
-  appearance: none;
-  margin-block: 0;
-  margin-inline: 17px;
-  border: 0;
-  border-radius: 50%;
-  block-size: 2px;
-  inline-size: 2px;
-  background-color: var(--accent-color);
-  transform: scale(6, 6);
-  transition: box-shadow 0.2s;
-}
-
-/* MS | Hover, Focus */
-.pure-material-slider:hover > input::-ms-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity1);
-}
-
-.pure-material-slider > input:focus::-ms-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity2);
-}
-
-.pure-material-slider:hover > input:focus::-ms-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity3);
-}
-
-/* MS | Active */
-.pure-material-slider > input:active::-ms-thumb {
-  box-shadow: 0 0 0 2px var(--accent-color-opacity4) !important;
-}
-
-/* MS | Disabled */
-.pure-material-slider > input:disabled::-ms-fill-lower {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0) 0.38);
-}
-
-.pure-material-slider > input:disabled::-ms-fill-upper {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0) 0.38);
-  opacity: 0.38;
-}
-
-.pure-material-slider > input:disabled::-ms-thumb {
-  background-color: rgb(var(--pure-material-onsurface-rgb, 0, 0, 0));
-  box-shadow: 0 0 0 1px rgb(var(--pure-material-surface-rgb, 255, 255, 255)) !important;
-  transform: scale(4, 4);
 }
 
 @media only screen and (width <= 680px) {

--- a/src/renderer/components/FtSlider/FtSlider.vue
+++ b/src/renderer/components/FtSlider/FtSlider.vue
@@ -6,6 +6,7 @@
     <input
       :id="id"
       v-model.number="currentValue"
+      class="input"
       :disabled="disabled"
       type="range"
       :min="minValue"
@@ -13,7 +14,7 @@
       :step="step"
       @change="change"
     >
-    <span>
+    <span class="label">
       {{ $t('Display Label', {label: label, value: displayLabel}) }}
     </span>
   </label>


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

List of changes:
- Switch from using child combinators to using classes and relying on Vue's scoped CSS feature to scope it to the component
- Remove Internet Explorer vendor prefixes
- Remove unused CSS variables
- Fix `no-descending-specificity` lint

## Testing

Look at and interact with sliders, they should look and behave the same as before.

## Desktop

- **OS:** Windows
- **OS Version:** 11