### PR TITLE
adding number of views filter

### DIFF
--- a/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
+++ b/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
@@ -54,6 +54,13 @@
         :values="DURATION_VALUES"
         class="searchRadio"
       />
+      <FtRadioButton
+        v-model="maxViewsValue"
+        :title="$t('Search Filters.Views.Views')"
+        :labels="maxViewsLabels"
+        :values="MAX_VIEWS_VALUES"
+        class="searchRadio"
+      />
       <FtCheckboxList
         v-model="featuresValue"
         :title="$t('Search Filters.Features.Features')"
@@ -131,6 +138,13 @@ const FEATURE_VALUES = [
   'vr180'
 ]
 
+const MAX_VIEWS_VALUES = [
+  '',
+  '10',
+  '100',
+  '1000'
+]
+
 const NOT_ALLOWED_FOR_MOVIES_FEATURES = [
   'live',
   'subtitles',
@@ -184,6 +198,13 @@ const featureLabels = computed(() => [
   t('Search Filters.Features.VR180')
 ])
 
+const maxViewsLabels = computed(() => [
+  t('Search Filters.Views.Any Views'),
+  t('Search Filters.Views.Less than 10'),
+  t('Search Filters.Views.Less than 100'),
+  t('Search Filters.Views.Less than 1000')
+])
+
 const searchSettings = store.getters.getSearchSettings
 
 /** @type {import('vue').Ref<'relevance' | 'rating' | 'upload_date' | 'view_count'>} */
@@ -212,6 +233,7 @@ watch(typeValue, (value) => {
     timeValue.value = ''
     durationValue.value = ''
     sortByValue.value = SORT_BY_VALUES[0]
+    maxViewsValue.value = ''
     if (featuresValue.value.length > 0) {
       featuresValue.value = []
     }
@@ -246,12 +268,24 @@ watch(featuresValue, (values) => {
   store.commit('setSearchFeatures', [...values])
 }, { deep: true })
 
+/** @type {import('vue').Ref<'' | '10' | '100' | '1000'>} */
+const maxViewsValue = ref(searchSettings.maxViews)
+
+watch(maxViewsValue, (value) => {
+  if (value !== '' && !isVideoOrMovieOrAll(typeValue.value)) {
+    typeValue.value = 'all'
+  }
+
+  store.commit('setSearchMaxViews', value)
+})
+
 const searchFilterValueChanged = computed(() => {
   return sortByValue.value !== SORT_BY_VALUES[0] ||
     timeValue.value !== TIME_VALUES[0] ||
     typeValue.value !== TYPE_VALUES[0] ||
     durationValue.value !== DURATION_VALUES[0] ||
-    featuresValue.value.length > 0
+    featuresValue.value.length > 0 ||
+    maxViewsValue.value !== MAX_VIEWS_VALUES[0]
 })
 
 watch(searchFilterValueChanged, (value) => {
@@ -275,6 +309,7 @@ function clearFilters() {
   typeValue.value = TYPE_VALUES[0]
   durationValue.value = DURATION_VALUES[0]
   featuresValue.value = []
+  maxViewsValue.value = MAX_VIEWS_VALUES[0]
 }
 
 </script>

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -494,6 +494,7 @@ function goToSearch(queryText, { event }) {
             duration: searchSettings.value.duration,
             // Array proxy cannot be cloned during IPC call
             features: [...searchSettings.value.features],
+            maxViews: searchSettings.value.maxViews,
           },
           doCreateNewWindow,
           searchQueryText: queryText,

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -483,8 +483,8 @@ export function formatDurationAsTimestamp(lengthSeconds) {
 }
 
 /**
- * @param {{sortBy? : string, time?: string, duration?: string, features: string[]}?} filtersA
- * @param {{sortBy? : string, time?: string, duration?: string, features: string[]}?} filtersB
+ * @param {{sortBy? : string, time?: string, duration?: string, maxViews?: string, features: string[]}?} filtersA
+ * @param {{sortBy? : string, time?: string, duration?: string, maxViews?: string, features: string[]}?} filtersB
  * @returns {boolean}
  */
 export function searchFiltersMatch(filtersA, filtersB) {
@@ -492,6 +492,7 @@ export function searchFiltersMatch(filtersA, filtersB) {
     filtersA?.time === filtersB?.time &&
     filtersA?.type === filtersB?.type &&
     filtersA?.duration === filtersB?.duration &&
+    filtersA?.maxViews === filtersB?.maxViews &&
     filtersA?.features?.length === filtersB?.features?.length && filtersA?.features?.every((val, index) => val === filtersB?.features[index])
 }
 

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -41,6 +41,7 @@ const state = {
     type: 'all',
     duration: '',
     features: [],
+    maxViews: '',
   },
   externalPlayerNames: [],
   externalPlayerValues: [],
@@ -525,7 +526,8 @@ const actions = {
           time: searchSettings.time,
           type: searchSettings.type,
           duration: searchSettings.duration,
-          features: searchSettings.features
+          features: searchSettings.features,
+          maxViews: searchSettings.maxViews
         }
 
         for (const [param, value] of url.searchParams) {
@@ -838,6 +840,10 @@ const mutations = {
 
   setSearchFeatures (state, value) {
     state.searchSettings.features = value
+  },
+
+  setSearchMaxViews (state, value) {
+    state.searchSettings.maxViews = value
   },
 
   setRegionNames (state, value) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -101,6 +101,12 @@ Search Filters:
     Short (< 4 minutes): Short (< 4 minutes)
     Medium (4 - 20 minutes): Medium (4 - 20 minutes)
     Long (> 20 minutes): Long (> 20 minutes)
+  Views:
+    Views: Views
+    Any Views: Any Views
+    Less than 10: Less than 10 views
+    Less than 100: Less than 100 views
+    Less than 1000: Less than 1000 views
   Features:
     Features: Features
     HD: HD


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Added maxViews to search settings state and setSearchMaxViews mutation

## Screenshots
https://i.imgur.com/AdHWcIK.png
<img width="839" height="675" alt="2" src="https://github.com/user-attachments/assets/c385dc9c-ac84-4bde-b733-ec8aa74a7f9f" />

## Testing
The filter works client-side by filtering results after they're fetched, since YouTube's API doesn't support filtering by view count directly. This means you may see fewer results than a typical page if many videos exceed the view threshold.

## Desktop
- **OS: macOS
- **OS Version: 26.1
- **FreeTube version: 0.23.12

## Additional context
Useful for finding "gems" of videos not yet popular.
