### PR TITLE
Fix using Shift on watch page

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2283,6 +2283,9 @@ export default defineComponent({
           changeVolume(-0.05)
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_REWIND:
+          if (event.shiftKey) {
+            break
+          }
           event.preventDefault()
           if (canChapterJump(event, 'previous')) {
             // Jump to the previous chapter
@@ -2294,6 +2297,9 @@ export default defineComponent({
           }
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_FAST_FORWARD:
+          if (event.shiftKey) {
+            break
+          }
           event.preventDefault()
           if (canChapterJump(event, 'next')) {
             // Jump to the next chapter


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #8474

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This adds an extra check in the arrow key handling so that it doesnt seek in the player anymore while trying to highlight text

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Load a video
2. Double-click a word in the video's text description
3. Press Ctrl+Shift+Left/Right Arrow to attempt to highlight more adjacent words
4. The video wont change its playback location and will highlight the words
