### PR TITLE
Use bash even in workflows that run on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,11 +68,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
     - run: yarn run ci
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
       env:
         ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     - run: yarn run lint
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
     - name: Get Version Number
       id: getPackageInfo
       uses: jaywcjlove/github-action-package@ee84f0c52bd8de8d25601af0402a9059320cb87a
@@ -112,7 +112,7 @@ jobs:
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
       run: yarn run build
 
     - name: Build ARMv7l with Node.js ${{ matrix.node-version}}
@@ -122,7 +122,7 @@ jobs:
 
     - name: Build ARM64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'arm64')
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
       run: yarn run build:arm64
 
     - name: Convert X64 AppImage to static runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"
     - run: yarn run ci
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
       env:
         ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
     - run: yarn run lint
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
 
     - name: Get Version Number
       id: getPackageInfo
@@ -92,7 +92,7 @@ jobs:
 
     - name: Build x64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'x64')
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
       run: yarn run build
 
     - name: Build ARMv7l with Node.js ${{ matrix.node-version}}
@@ -102,7 +102,7 @@ jobs:
 
     - name: Build ARM64 with Node.js ${{ matrix.node-version}}
       if: contains(matrix.runtime, 'arm64')
-      shell: ${{ (startsWith(matrix.os, 'windows') && 'cmd') || 'bash' }}
+      shell: bash
       run: yarn run build:arm64
 
     - name: Convert X64 AppImage to static runtime and add update information


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

Turns out you can only use variables [in certain places in workflow files](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability) and the `shell` key is not one of them. This pull request switches to hardcoding bash on all runners, on Linux and macOS it will use standard bash and on Windows it uses the bash build included with Git for Windows.

## Testing

Successful run: https://github.com/absidue/FreeTube/actions/runs/20763204906