### PR TITLE
Add a show all windows button to the tray menu

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -797,14 +797,14 @@ function runApp() {
   function defaultTrayMenu() {
     return [
       {
-        label: 'New window',
+        label: 'New Window',
         click: () => createWindow({
           showWindowNow: true,
           replaceMainWindow: trayWindows.some(item => item.id === mainWindow.id)
         })
       },
       {
-        label: 'Show all windows',
+        label: 'Show All Windows',
         click: () => {
           // Use while loop instead of for loop as trayClick modifies the trayWindows array
           while (trayWindows.length > 0) {


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

- closes #8479

## Description

This pull request adds a show all windows button to the tray menu, which does what it says on the tin: shows all hidden windows.

## Testing

The tray menu is only implemented on Windows and Linux

1. Enable the minimize to tray setting
2. Open multiple windows
3. Minimize all or most of them
4. Click on "Show all windows" in the tray menu
5. All windows should appear and the tray icon should disappear.

## Desktop

- **OS:** Windows
- **OS Version:** 11