### PR TITLE
Use environment variables in GitHub workflows

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -15,4 +15,5 @@ jobs:
       shell: bash
       env:
         GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
-      run: gh pr merge https://github.com/FreeTubeApp/FreeTube/pull/${{ github.event.pull_request.number }} --auto --squash
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: gh pr merge "https://github.com/FreeTubeApp/FreeTube/pull/${PR_NUMBER}" --auto --squash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,22 +81,19 @@ jobs:
       id: versionNumber
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
       env:
-        IS_DEV: ${{ contains(github.ref, 'development') }}
-        IS_RC: ${{ contains(github.ref, 'RC') }}
         VERSION_NUMBER_NIGHTLY: ${{ steps.getPackageInfo.outputs.version }}-nightly-${{ github.run_number }}
         VERSION_NUMBER_RC: ${{ steps.getPackageInfo.outputs.version }}-RC-${{ github.run_number }}
         VERSION_NUMBER: ${{ steps.getPackageInfo.outputs.version }}
       with:
         result-encoding: string
         script: |
-          if (${{ env.IS_DEV }}) {
-            return "${{ env.VERSION_NUMBER_NIGHTLY }}"
-          } else if (${{ env.IS_RC }}) {
-            return "${{ env.VERSION_NUMBER_RC }}"
+          if (context.ref.toLowerCase().includes('development')) {
+            return `${process.env.VERSION_NUMBER_NIGHTLY}`
+          } else if (context.ref.toUpperCase().includes('RC')) {
+            return `${process.env.VERSION_NUMBER_RC}`
           } else {
-            return "${{env.VERSION_NUMBER }}"
+            return `${process.env.VERSION_NUMBER}`
           }
-        # script: if ${{ env.IS_DEV }} then echo "::set-output name=VERSION_NUMBER::${{ env.VERSION_NUMBER_NIGHTLY }}" else echo "::set-output name=VERSION_NUMBER::${{ env.VERSION_NUMBER }}" fi
 
     - name: Update package.json version
       uses: jaywcjlove/github-action-package@ee84f0c52bd8de8d25601af0402a9059320cb87a
@@ -128,10 +125,12 @@ jobs:
     - name: Convert X64 AppImage to static runtime
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       shell: bash
+      env:
+        VERSION: ${{ steps.versionNumber.outputs.result }}
       run: |
         sudo apt install desktop-file-utils
         cd build
-        appimage="FreeTube-${{ steps.versionNumber.outputs.result }}.AppImage"
+        appimage="FreeTube-${VERSION}.AppImage"
         wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
         chmod +x ./"$appimage" ./appimagetool.AppImage
         ./"$appimage" --appimage-extract && rm -f ./"$appimage"

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -51,9 +51,11 @@ jobs:
         v: ''
     - name: Create Release Branch
       shell: bash
+      env:
+        VERSION: ${{ steps.sub.outputs.result }}
       run: |
-        git checkout -b release-v${{ steps.sub.outputs.result }}
-        git push --set-upstream origin release-v${{ steps.sub.outputs.result }}
+        git checkout -b "release-v${VERSION}"
+        git push --set-upstream origin "release-v${VERSION}"
     - name: Download x64 Release
       uses: fabriciobastian/download-release-asset-action@35e62aa5a2fe4a6ec79004f6052918349013ae4f #v1.0.6
       with:
@@ -67,54 +69,72 @@ jobs:
         repository: FreeTubeApp/FreeTube
         file: freetube-${{ steps.sub.outputs.result }}-beta-linux-arm64-portable.zip
     - name: Set x64 Hash Variable
-      id: hash-x64
+      id: hash_x64
       shell: bash
+      env:
+        VERSION: ${{ steps.sub.outputs.result }}
       run: |
-        echo 'HASH_X64<<EOF' >> $GITHUB_ENV
-        sha256sum freetube-${{ steps.sub.outputs.result }}-beta-linux-x64-portable.zip | awk '{print $1}' >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
+        echo 'HASH_X64<<EOF' >> "$GITHUB_OUTPUT"
+        sha256sum "freetube-${VERSION}-beta-linux-x64-portable.zip" | awk '{print $1}' >> "$GITHUB_OUTPUT"
+        echo 'EOF' >> "$GITHUB_OUTPUT"
     - name: Set ARM Hash Variable
-      id: hash-arm64
+      id: hash_arm64
       shell: bash
+      env:
+        VERSION: ${{ steps.sub.outputs.result }}
       run: |
-        echo 'HASH_ARM64<<EOF' >> $GITHUB_ENV
-        sha256sum freetube-${{ steps.sub.outputs.result }}-beta-linux-arm64-portable.zip | awk '{print $1}' >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
+        echo 'HASH_ARM64<<EOF' >> "$GITHUB_OUTPUT"
+        sha256sum "freetube-${VERSION}-beta-linux-arm64-portable.zip" | awk '{print $1}' >> "$GITHUB_OUTPUT"
+        echo 'EOF' >> "$GITHUB_OUTPUT"
+
     - name: Set Date Variable
-      id: current-date
+      id: current_date
       shell: bash
       run: |
-        echo 'CURRENT_DATE<<EOF' >> $GITHUB_ENV
-        date +"%Y-%m-%d" >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
+        echo 'CURRENT_DATE<<EOF' >> "$GITHUB_OUTPUT"
+        date +"%Y-%m-%d" >> "$GITHUB_OUTPUT"
+        echo 'EOF' >> "$GITHUB_OUTPUT"
     - name: Update x64 File Location in yml File
-      uses: mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8 #v4.50.1
-      with:
-        # The Command which should be run
-        cmd: yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-beta-linux-x64-portable.zip"' io.freetubeapp.FreeTube.yml
+      shell: bash
+      env:
+        VERSION: steps.sub.outputs.result
+      run: |
+        yq -i '.modules[0].sources[0].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v" + strenv(VERSION) + "-beta/freetube-" + strenv(VERSION) + "-beta-linux-x64-portable.zip"' io.freetubeapp.FreeTube.yml
+
     - name: Update x64 Hash in yml File
-      uses: mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8 #v4.50.1
-      with:
-        # The Command which should be run
-        cmd: yq -i '.modules[0].sources[0].sha256 = "${{ env.HASH_X64 }}"' io.freetubeapp.FreeTube.yml
+      shell: bash
+      env:
+        HASH_X64: ${{ steps.hash_x64.outputs.HASH_X64 }}
+      run: |
+        yq -i '.modules[0].sources[0].sha256 = strenv(HASH_X64)' io.freetubeapp.FreeTube.yml
+
     - name: Update ARM File Location in yml File
-      uses: mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8 #v4.50.1
-      with:
-        # The Command which should be run
-        cmd: yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v${{ steps.sub.outputs.result }}-beta/freetube-${{ steps.sub.outputs.result }}-beta-linux-arm64-portable.zip"' io.freetubeapp.FreeTube.yml
+      shell: bash
+      env:
+        VERSION: steps.sub.outputs.result
+      run: |
+        yq -i '.modules[0].sources[1].url = "https://github.com/FreeTubeApp/FreeTube/releases/download/v" + strenv(VERSION) + "-beta/freetube-" + strenv(VERSION) + "-beta-linux-arm64-portable.zip"' io.freetubeapp.FreeTube.yml
+
     - name: Update ARM Hash in yml File
-      uses: mikefarah/yq@065b200af9851db0d5132f50bc10b1406ea5c0a8 #v4.50.1
-      with:
-        # The Command which should be run
-        cmd: yq -i '.modules[0].sources[1].sha256 = "${{ env.HASH_ARM64 }}"' io.freetubeapp.FreeTube.yml
+      shell: bash
+      env:
+        HASH_ARM64: ${{ steps.hash_arm64.outputs.HASH_ARM64 }}
+      run: |
+        yq -i '.modules[0].sources[1].sha256 = strenv(HASH_ARM64)' io.freetubeapp.FreeTube.yml
+
     - name: Add Patch Notes to XML File
       shell: bash
-      run: xmlstarlet ed -L -i /component/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${{ steps.sub.outputs.result }} Beta" -i //releaseTMP -t attr -n date -v "${{ env.CURRENT_DATE }}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${{ steps.sub.outputs.result }}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
+      env:
+        CURRENT_DATE: ${{ steps.current_date.outputs.current_date }}
+        VERSION: ${{ steps.sub.outputs.result }}
+      run: xmlstarlet ed -L -i /component/releases/release[1] -t elem -n releaseTMP -v "" -i //releaseTMP -t attr -n version -v "${VERSION} Beta" -i //releaseTMP -t attr -n date -v "${CURRENT_DATE}" -s //releaseTMP -t elem -n url -v "" -s //releaseTMP/url -t text -n "" -v "https://github.com/FreeTubeApp/FreeTube/releases/tag/v${VERSION}-beta" -r //releaseTMP -v "release" io.freetubeapp.FreeTube.metainfo.xml
     - name: Remove Release Files
       shell: bash
+      env:
+        VERSION: ${{ steps.sub.outputs.result }}
       run: |
-        rm freetube-${{ steps.sub.outputs.result }}-beta-linux-x64-portable.zip
-        rm freetube-${{ steps.sub.outputs.result }}-beta-linux-arm64-portable.zip
+        rm "freetube-${VERSION}-beta-linux-x64-portable.zip"
+        rm "freetube-${VERSION}-beta-linux-arm64-portable.zip"
     - name: Commit Files
       uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 #v7.1.0
       with:
@@ -132,4 +152,5 @@ jobs:
       shell: bash
       env:
         GH_TOKEN: ${{ secrets.FLATHUB_TOKEN }}
-      run: gh pr create --title "Release v${{ steps.sub.outputs.result }}" --body "This is an automated PR for the v${{ steps.sub.outputs.result }} release. This PR will be updated and merged once testing is complete."
+        VERSION: ${{ steps.sub.outputs.result }}
+      run: gh pr create --title "Release v${VERSION}" --body "This is an automated PR for the v${VERSION} release. This PR will be updated and merged once testing is complete."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,10 +108,12 @@ jobs:
     - name: Convert X64 AppImage to static runtime and add update information
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       shell: bash
+      env:
+        VERSION: ${{ steps.getPackageInfo.outputs.version }}
       run: |
         sudo apt install desktop-file-utils
         cd build
-        appimage="FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage"
+        appimage="FreeTube-${VERSION}.AppImage"
         wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
         chmod +x ./"$appimage" ./appimagetool.AppImage
         update_information="gh-releases-zsync|FreeTubeApp|FreeTube|latest-all|freetube-*-amd64.AppImage.zsync"
@@ -123,10 +125,12 @@ jobs:
     - name: Convert ARMv7l AppImage to static runtime and add update information
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       shell: bash
+      env:
+        VERSION: ${{ steps.getPackageInfo.outputs.version }}
       run: |
         sudo apt install desktop-file-utils
         cd build
-        appimage="FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage"
+        appimage="FreeTube-${VERSION}.AppImage"
         wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
         wget "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64" -O runtime
         chmod +x ./"$appimage" ./appimagetool.AppImage ./runtime
@@ -139,10 +143,12 @@ jobs:
     - name: Convert ARM64 AppImage to static runtime and add update information
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       shell: bash
+      env:
+        VERSION: ${{ steps.getPackageInfo.outputs.version }}
       run: |
         sudo apt install desktop-file-utils
         cd build
-        appimage="FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage"
+        appimage="FreeTube-${VERSION}.AppImage"
         wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
         wget "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64" -O runtime
         chmod +x ./"$appimage" ./appimagetool.AppImage ./runtime

--- a/.github/workflows/updateSite.yml
+++ b/.github/workflows/updateSite.yml
@@ -60,8 +60,11 @@ jobs:
         git checkout master
     - name: Update index.php
       shell: bash
+      env:
+        CURRENT: ${{ steps.current.outputs.result }}
+        PREVIOUS: ${{ steps.previous.outputs.result }}
       run: |
-        sed -i 's/${{ steps.previous.outputs.result  }}/${{ steps.current.outputs.result }}/g' src/index.php
+        sed -i "s/${PREVIOUS}/${CURRENT}/g" src/index.php
     - name: Commit Files
       uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 #v7.1.0
       with:


### PR DESCRIPTION
## Pull Request Type

- [x] Security improvement

## Description

Currently we use the GitHub Actions expression syntax directly in the scripts, which means that bad input could break the workflows or result in extra code being run. This pull request switches to using environment variables instead, that way they can be read securely inside the scripts (quoted in shell scripts, using `strenv()` in `yq` commands and with `process.env` in the `actions/github-script` action). Other changes include switching from using the `mikefarah/yq` action to using the `yq` binary that is preinstalled on the GitHub Actions runner and using step outputs with explicit `env:` declarations instead of $GITHUB_ENV.

## Desktop

- **OS:** Windows
- **OS Version:** 11