### PR TITLE
Disable automatically running the flatpak workflow

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -6,8 +6,10 @@ name: Create Flatpak PR
 # or API.
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  # Disable running automatically as we now use flathub's external data checker
+  # to automatically open pull requests when we release updates
+  # release:
+  #   types: [published]
 
 permissions: {}
 


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue

- https://github.com/flathub/io.freetubeapp.FreeTube/pull/154

## Description

In https://github.com/flathub/io.freetubeapp.FreeTube/pull/154 I added the `x-checker-data` configuration to the FreeTube flatpak manifest which tells the [flatpak-external-data-checker](https://github.com/flathub-infra/flatpak-external-data-checker) how to check for FreeTube updates and automatically open pull requests in the FreeTube flathub repository. According to the flathub documation on the external data checker, they run it hourly, so under normal circumstances the pull request should appear not long after we do a release.

As we should no longer need the flatpak workflow in this repository, this pull request disables that automatic triggering of it when a release is created. For the moment I haven't deleted the workflow and have left the `workflow_dispatch` trigger enabled, as we won't know external data checker setup works as expected until the next release, giving us the option to manually trigger it just in case.