### PR TITLE
Fix typo in auto-merge workflow

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   build:
     if: |
-      github.event.pull_request == 'open' &&
+      github.event.pull_request.state == 'open' &&
       !github.event.pull_request.draft &&
       (contains(github.event.pull_request.base.ref, 'development') || contains(github.event.pull_request.base.ref, 'RC'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- #8504

## Description

This fixes the typo in the auto merge workflow that was resulting in it always skipping.

## Testing

The schema for the payload is here: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=opened#pull_request