### PR TITLE
Use GITHUB_TOKEN instead of dedicated PUSH_TOKEN in auto-merge workflow

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -13,10 +13,13 @@ jobs:
       (contains(github.event.pull_request.base.ref, 'development') || contains(github.event.pull_request.base.ref, 'RC'))
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
     - name: Auto Merge PR
       shell: bash
       env:
-        GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: gh pr merge "https://github.com/FreeTubeApp/FreeTube/pull/${PR_NUMBER}" --auto --squash
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      run: gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

Using the temporary `GITHUB_TOKEN` token is better for security, as it get revoked automatically as soon as the workflow ends and is scoped to just this repository, so if it were to somehow get leaked the damage that could be done is much lower and it would only be useable for as long as the workflow is running. This lets us remove the dedicated `PUSH_TOKEN` token.

## Testing

Successful run here ("github-action[bot] enabled auto-merge (squash)"): https://github.com/absidue/FreeTube/pull/5