### PR TITLE
Always use SABR, remove experimental setting

### DIFF
--- a/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
+++ b/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
@@ -16,16 +16,6 @@
         @change="handleRestartPrompt"
       />
     </FtFlexBox>
-    <FtFlexBox v-if="sabrAllowedOnPlatform">
-      <FtToggleSwitch
-        tooltip-position="top"
-        :label="$t('Settings.SABR.Label')"
-        compact
-        :default-value="sabrEnabled"
-        :tooltip="$t('Settings.SABR.Tooltip')"
-        @change="updateSabrEnabled"
-      />
-    </FtFlexBox>
     <FtPrompt
       v-if="showRestartPrompt"
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
@@ -37,14 +27,12 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
-
-import store from '../../store/index'
 
 const replaceHttpCacheLoading = ref(true)
 const replaceHttpCache = ref(false)
@@ -81,18 +69,6 @@ function handleReplaceHttpCache(value) {
     window.ftElectron.toggleReplaceHttpCache()
   }
 }
-
-const sabrAllowedOnPlatform = process.env.SUPPORTS_LOCAL_API
-/** @type {import('vue').ComputedRef<boolean>} */
-const sabrEnabled = process.env.SUPPORTS_LOCAL_API ? computed(() => store.getters.getSabrEnabled) : false
-
-/**
- * @param {boolean} value
- */
-function updateSabrEnabled(value) {
-  store.dispatch('updateSabrEnabled', value)
-}
-
 </script>
 
 <style scoped src="./ExperimentalSettings.css" />

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2794,9 +2794,8 @@ export default defineComponent({
         })
       }
 
-      const delayLoadUntilUnix = props.delayLoadUntilUnix
-      const initialLoadDelayMs = delayLoadUntilUnix - Date.now()
-      if (initialLoadDelayMs > 0) {
+      const initialLoadDelayMs = props.delayLoadUntilUnix - Date.now()
+      if (initialLoadDelayMs > 0 && (props.format === 'legacy' || props.manifestMimeType !== MANIFEST_TYPE_SABR)) {
         showToast(
           ({ remainingMs }) => {
             // `+value` converts string back to float

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -168,7 +168,6 @@ const state = {
   defaultSkipInterval: 5,
   defaultViewingMode: 'default',
   defaultVideoFormat: 'dash',
-  sabrEnabled: true,
   disableSmoothScrolling: false,
   displayVideoPlayButton: false,
   enableSearchSuggestions: true,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -692,9 +692,6 @@ Settings:
     Set Password To Prevent Access: Set a password to prevent access to settings
     Set Password: Set Password
     Remove Password: Remove Password
-  SABR:
-    Label: Enable SABR as DASH backend
-    Tooltip: SABR will become the only DASH backend in future release and cannot be disabled. This toggle is provided in case early implementation has unrecoverable issues.
 About:
   #On About page
   About: About


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

This pull request removes the experimental setting for SABR, so we will always use SABR for both audio DASH and audio+video DASH. It also remove the MWEB workaround as it is no longer needed and uses the skip time for skippable ads rather than the full duration. We also use the time when the `/player` response actually arrived instead of when YouTube.js returned the `VideoInfo` object, as the VideoInfo object is only returned after both the `/player` and `/next` responses have arrived and been parsed and the `/next` request can occasionally take a bit longer than the `/player` request.

## Testing

Test playback with the audio, DASH and legacy formats.

Video without ads (playback should start immediately): https://youtu.be/icxrUIGoEg8
Video with ads: https://youtu.be/ko70cExuzZM

## Desktop

- **OS:** Windows
- **OS Version:** 11