### PR TITLE
Switch the auto-merge workflow back to the PUSH_TOKEN

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -20,6 +20,6 @@ jobs:
     - name: Auto Merge PR
       shell: bash
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PUSH_TOKEN }}
         PR_URL: ${{ github.event.pull_request.html_url }}
       run: gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- #8541

## Description

As it turns out the auto-generated GITHUB_TOKEN token isn't strong enough to enable auto-merge on dependabot pull requests, so this pull request switches the auto-merge workflow back to using the dedicated PUSH_TOKEN secret.

## Testing

It worked before but the PUSH_TOKEN secret was re-recreated so I guess we'll find out if it works...

## Desktop

- **OS:** Windows
- **OS Version:** 11