### PR TITLE
Add support for Wayland IMEs

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -275,6 +275,9 @@ function runApp() {
   process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true'
   const isDebug = process.argv.includes('--debug')
 
+  // Add support for Wayland IME
+  app.commandLine.appendSwitch('enable-wayland-ime')
+
   let mainWindow
   let startupUrl
   let tray = null


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Hopefully closes #8272 and #6950

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Add the `--enable-wayland-ime` flag to tell Electron to use the Wayland IME pathway if on Wayland.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Run FreeTube on a Wayland session for KDE Plasma, Mint, or GNOME (or another popular DE)
2. Set an IME in the system settings
3. Verify that typing in the search bar can now use the IME

## Additional context
<!-- Add any other context about the pull request here. -->
Applying the `--enable-wayland-ime` flag seems to be the current solution for the upstream issue, but this may become deprecated or unnecessary if/when Electron implements it by default.