### PR TITLE
Prompt for default screenshot folder when it is unset

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -42,7 +42,6 @@ const IpcChannels = {
 
   GENERATE_PO_TOKEN: 'generate-po-token',
 
-  GET_SCREENSHOT_FALLBACK_FOLDER: 'get-screenshot-fallback-folder',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   WRITE_TO_DEFAULT_FOLDER: 'write-to-default-folder',
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -125,16 +125,10 @@ export default {
   /**
    * @param {string} filename
    * @param {ArrayBuffer} contents
+   * @returns {Promise<boolean>}
    */
   writeToDefaultFolder: async (filename, contents) => {
-    await ipcRenderer.invoke(IpcChannels.WRITE_TO_DEFAULT_FOLDER, filename, contents)
-  },
-
-  /**
-   * @returns {Promise<string>}
-   */
-  getScreenshotFallbackFolder: () => {
-    return ipcRenderer.invoke(IpcChannels.GET_SCREENSHOT_FALLBACK_FOLDER)
+    return await ipcRenderer.invoke(IpcChannels.WRITE_TO_DEFAULT_FOLDER, filename, contents)
   },
 
   relaunch: () => {

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -211,7 +211,7 @@
         </p>
         <FtInput
           class="screenshotFolderPath"
-          :placeholder="screenshotFolderPlaceholder"
+          :placeholder="screenshotFolder"
           :show-action-button="false"
           :show-label="false"
           :disabled="true"
@@ -255,7 +255,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
@@ -607,14 +607,8 @@ function updateScreenshotAskPath(value) {
   store.dispatch('updateScreenshotAskPath', value)
 }
 
-const screenshotFolderPlaceholder = ref('')
-
 /** @type {import('vue').ComputedRef<string>} */
 const screenshotFolder = computed(() => store.getters.getScreenshotFolderPath)
-
-watch(screenshotFolder, () => {
-  getScreenshotFolderPlaceholder()
-})
 
 function chooseScreenshotFolder() {
   // only use with electron
@@ -623,24 +617,10 @@ function chooseScreenshotFolder() {
   }
 }
 
-async function getScreenshotFolderPlaceholder() {
-  if (screenshotFolder.value !== '') {
-    screenshotFolderPlaceholder.value = screenshotFolder.value
-    return
-  }
-
-  if (process.env.IS_ELECTRON) {
-    screenshotFolderPlaceholder.value = await window.ftElectron.getScreenshotFallbackFolder()
-  } else {
-    screenshotFolderPlaceholder.value = ''
-  }
-}
-
 /** @type {import('vue').ComputedRef<string>} */
 const screenshotFilenamePattern = computed(() => store.getters.getScreenshotFilenamePattern)
 
 onMounted(() => {
-  getScreenshotFolderPlaceholder()
   getScreenshotFilenameExample(screenshotFilenamePattern.value)
 })
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1733,9 +1733,9 @@ export default defineComponent({
         } else {
           const arrayBuffer = await blob.arrayBuffer()
 
-          await window.ftElectron.writeToDefaultFolder(filenameWithExtension, arrayBuffer)
-
-          showToast(t('Screenshot Success'))
+          if (await window.ftElectron.writeToDefaultFolder(filenameWithExtension, arrayBuffer)) {
+            showToast(t('Screenshot Success'))
+          }
         }
       } catch (error) {
         console.error(error)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- https://github.com/FreeTubeApp/FreeTube/issues/8180

## Description

Currently if the user disables the ask for save folder setting in the screen shot settings but doesn't chose a default folder, we fall back to the pictures folder. That doesn't work in the flatpak build though, as we don't grant it access to the users picture's folder (it's not needed for most FreeTube functionality and the screenshot setting is disabled by default).

To fix that FreeTube will now prompt the user to choose a folder when they take a screenshot if they haven't previously chosen one or it doesn't have write access to the folder that is configured, the latter can occur if the user copies their settings between machines or intentionally revokes access to the previously chosen folder through flatseal. If the user clicks cancel in the folder chooser dialog, FreeTube doesn't save the screenshot and the user will be prompted again the next time they take a screenshot.

## Testing

1. Open your settings.db file in a text editor and delete the `screenshotFolderPath` line (if it exists)
2. Open FreeTube
3. Enable taking screenshots
4. Disable prompting for the folder
5. Open a video
6. Take a screenshot
7. You should be prompted for a save folder
8. If you selected a folder the next screenshot you take should get saved to that location without another prompt.

## Desktop

- **OS:** Windows
- **OS Version:** 11