### PR TITLE
Bump electron-builder from 26.4.0 to 26.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "css-loader": "^7.1.3",
     "css-minimizer-webpack-plugin": "^7.0.4",
     "electron": "^40.1.0",
-    "electron-builder": "^26.6.0",
+    "electron-builder": "^26.7.0",
     "eslint": "^9.39.2",
     "eslint-plugin-jsdoc": "^62.5.0",
     "eslint-plugin-jsonc": "^2.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,10 +2604,10 @@ app-builder-bin@5.0.0-alpha.12:
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz#2daf82f8badc698e0adcc95ba36af4ff0650dc80"
   integrity sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==
 
-app-builder-lib@26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-26.6.0.tgz#1884ec93ffa25a4512111a369117bc2ae34666cd"
-  integrity sha512-P2naoSaGOqJY54cqTceO9lms2M790UM7BA8AlOuaolQhRp/LOshAVc4vzVlYFw4YNPtiuBJqdAhWALuoEKnayQ==
+app-builder-lib@26.7.0:
+  version "26.7.0"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-26.7.0.tgz#fffbd99ec6a1e6a2bd30a84f2cbd8c5e16c75f94"
+  integrity sha512-/UgCD8VrO79Wv8aBNpjMfsS1pIUfIPURoRn0Ik6tMe5avdZF+vQgl/juJgipcMmH3YS0BD573lCdCHyoi84USg==
   dependencies:
     "@develar/schema-utils" "~2.6.5"
     "@electron/asar" "3.4.1"
@@ -2641,7 +2641,7 @@ app-builder-lib@26.6.0:
     proper-lockfile "^4.1.2"
     resedit "^1.7.0"
     semver "~7.7.3"
-    tar "^7.5.6"
+    tar "^7.5.7"
     temp-file "^3.4.0"
     tiny-async-pool "1.3.0"
     which "^5.0.0"
@@ -3748,12 +3748,12 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dmg-builder@26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-26.6.0.tgz#f80124372af2f601a75294eb543eba0582e61fb7"
-  integrity sha512-IkGlOLfJ3q7y9iaDMnNSArDdPg3Ntx8Ps6aL7yTEIpL6znA+t5L/LRTAGFz1J/12hM/NiNEYg0LoBEheqGdZXw==
+dmg-builder@26.7.0:
+  version "26.7.0"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-26.7.0.tgz#3f1d2ef65c4a6087daf63a9b94621bd465993297"
+  integrity sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==
   dependencies:
-    app-builder-lib "26.6.0"
+    app-builder-lib "26.7.0"
     builder-util "26.4.1"
     fs-extra "^10.1.0"
     iconv-lite "^0.6.2"
@@ -3897,17 +3897,17 @@ ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-builder@^26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-26.6.0.tgz#0847c9a65486f969369576df60bd7be187548095"
-  integrity sha512-57JzccIwhqVRw83RaTdMLnSjzLL0dRQcp8r8oD7piRNBQh8UcCPaKeFmuJIzJabAAvQhG0+gx3F0pOVEOVXYwQ==
+electron-builder@^26.7.0:
+  version "26.7.0"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-26.7.0.tgz#e1f5b4434b453c19bceb0ccac859c3104e3c26d8"
+  integrity sha512-LoXbCvSFxLesPneQ/fM7FB4OheIDA2tjqCdUkKlObV5ZKGhYgi5VHPHO/6UUOUodAlg7SrkPx7BZJPby+Vrtbg==
   dependencies:
-    app-builder-lib "26.6.0"
+    app-builder-lib "26.7.0"
     builder-util "26.4.1"
     builder-util-runtime "9.5.1"
     chalk "^4.1.2"
     ci-info "^4.2.0"
-    dmg-builder "26.6.0"
+    dmg-builder "26.7.0"
     fs-extra "^10.1.0"
     lazy-val "^1.0.5"
     simple-update-notifier "2.0.0"
@@ -8751,7 +8751,7 @@ tar@^7.4.3:
     minizlib "^3.1.0"
     yallist "^5.0.0"
 
-tar@^7.5.6:
+tar@^7.5.6, tar@^7.5.7:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.7.tgz#adf99774008ba1c89819f15dbd6019c630539405"
   integrity sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bump

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
They're having some issues with publishing to npm for a while now that's why Dependabot didn't open a PR for it so i'm bumping manually. 

Its been on https://www.npmjs.com/package/electron-builder `26.4.0` for a month even though https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.7.0 is tagged as latest. They have acknowledged the issue and working on resolving it.

Release notes:
* https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.4.1
* https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.5.0
* https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.6.0
* https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.7.0
