### PR TITLE
Support partial parsing for broken video links

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -631,15 +631,15 @@ export function getVideoParamsFromUrl(url) {
     // anything with /watch?v=
     function () {
       if (urlObject.pathname === '/watch' && urlObject.searchParams.has('v')) {
-        extractParams(urlObject.searchParams.get('v'))
+        extractParams(urlObject.searchParams.get('v').slice(0, 11))
         paramsObject.playlistId = urlObject.searchParams.get('list')
         return paramsObject
       }
     },
     // youtu.be
     function () {
-      if (urlObject.host === 'youtu.be' && /^\/[\w-]+$/.test(urlObject.pathname)) {
-        extractParams(urlObject.pathname.slice(1))
+      if (urlObject.host === 'youtu.be' && /^\/[\w-]{11,}/.test(urlObject.pathname)) {
+        extractParams(urlObject.pathname.slice(1, 12))
         paramsObject.playlistId = urlObject.searchParams.get('list')
         return paramsObject
       }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8608
- #8304

## Description

Currently if you pass any of the 3 broken URLs into FreeTube, FreeTube breaks either showing an empty channel page or broken watch page. This pull request makes our URL parsing slightly more robust, so that we can at least extract the video ID from those broken URLs and show a watch page with the video starting from the start. Extracting timestamps or other information from custom broken URL formats is a non-goal of this pull request, ideally users wouldn't be passing in broken URLs into FreeTube in the first place...

## Testing

Test the 3 broken URLs from the linked issues:
- https://youtu.be/OT_iyvOy0Tk&t=90 (using a `&` instead of `?`, which means it counts as part of the path instead of as query parameters)
- https://www.youtube.com/watch?v=b7q2CS8HDHU:2454
- https://www.youtube.com/watch?v=b7q2CS8HDHU%3A2454

## Desktop

- **OS:** Windows
- **OS Version:** 11