### PR TITLE
Fix playing wrong item after deleting first item in playlist

### DIFF
--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -277,10 +277,6 @@ export default defineComponent({
       const prevVideoBeforeDeletion = this.prevVideoBeforeDeletion
       const videoId = this.videoId
       return playlist.findIndex((item) => {
-        // It's possible to get outdated `shufflePlaylistItems` here while recalculating computed values
-        // So the `playlist` here might contain `undefined`
-        if (item == null) { return false }
-
         if (item.playlistItemId && (playlistItemId || prevVideoBeforeDeletion?.playlistItemId)) {
           return item.playlistItemId === playlistItemId || item.playlistItemId === prevVideoBeforeDeletion?.playlistItemId
         } else if (item.videoId) {
@@ -558,8 +554,12 @@ export default defineComponent({
       const remainingItems = [].concat(this.playlistItems)
       const items = []
 
-      items.push(this.currentVideo)
-      remainingItems.splice(this.currentVideoIndexZeroBased, 1)
+      if (this.currentVideo != null) {
+        items.push(this.currentVideo)
+        remainingItems.splice(this.currentVideoIndexZeroBased, 1)
+        // There is no else case
+        // If current video is absent in (removed from) the playlist, nothing should be changed
+      }
 
       while (remainingItems.length > 0) {
         const randomInt = Math.floor(Math.random() * remainingItems.length)

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -540,17 +540,11 @@ export default defineComponent({
       if (!isCurrentVideoInParsedPlaylist) {
         // grab 2nd video if the 1st one is current & deleted
         // or the prior video in the list before the current video's deletion
-        const targetVideoIndex = (this.currentVideoIndexZeroBased === 0 ? 1 : this.currentVideoIndexZeroBased - 1)
-        this.prevVideoBeforeDeletion = this.playlistItems[targetVideoIndex]
+        const targetVideoIndex = this.currentVideoIndexZeroBased - 1
+        this.prevVideoBeforeDeletion = targetVideoIndex >= 0 ? this.playlistItems[targetVideoIndex] : null
       }
 
       this.playlistItems = getSortedPlaylistItems(playlist.videos, this.sortOrder, this.currentLocale, this.reversePlaylist)
-
-      // grab the first video of the parsed playlit if the current video is not in either the current or parsed data
-      // (e.g., reloading the page after the current video has already been removed from the playlist)
-      if (!isCurrentVideoInParsedPlaylist && this.prevVideoBeforeDeletion == null) {
-        this.prevVideoBeforeDeletion = this.playlistItems[0]
-      }
 
       this.isLoading = false
     },

--- a/src/renderer/components/watch-video-playlist/watch-video-playlist.js
+++ b/src/renderer/components/watch-video-playlist/watch-video-playlist.js
@@ -277,6 +277,10 @@ export default defineComponent({
       const prevVideoBeforeDeletion = this.prevVideoBeforeDeletion
       const videoId = this.videoId
       return playlist.findIndex((item) => {
+        // It's possible to get outdated `shufflePlaylistItems` here while recalculating computed values
+        // So the `playlist` here might contain `undefined`
+        if (item == null) { return false }
+
         if (item.playlistItemId && (playlistItemId || prevVideoBeforeDeletion?.playlistItemId)) {
           return item.playlistItemId === playlistItemId || item.playlistItemId === prevVideoBeforeDeletion?.playlistItemId
         } else if (item.videoId) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/8579

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fix playing wrong item after deleting first item in playlist (same as title
See issue for details
Caused by https://github.com/FreeTubeApp/FreeTube/pull/5158 due to previous item assigned as first item in playlist after deletion (see example below)

Playlist before delete
- A
- B
- C

Playlist after delete
- B (problematic code points preview video to 1st item which is wrong)
- C

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Lazy, test yourself

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
A. No shuffle
(1) First item
- Open random playlist
- Open 1st item in new window
- Go back to playlist delete 1st item
- Play next item to ensure it's 2nd item (well 1st item after playlist updated)
- Repeat last 2 steps but test playing prev item to ensure last item played

(2) Not first item
- Open random playlist
- Open nth (not 1st) item in new window
- Go back to playlist delete the same item
- Test play next/prev item to ensure it works as the same as before

B. No shuffle
Similar to (A)?

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
