### PR TITLE
Remove unnecessary jq --binary arg in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           version="${original_version}-RC-${GITHUB_RUN_NUMBER}"
         fi
 
-        package_json="$(jq --binary --arg version "$version" '.version = $version' package.json)"
+        package_json="$(jq --arg version "$version" '.version = $version' package.json)"
 
         echo -E "$package_json" > package.json
         echo "version=${version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

This fixes the build workflow failing on the Ubuntu runners.

I originally added the `--binary` flag to the `jq` call to make `jq` output the line endings as LF (`\n`) instead of CRLF (`\r\n`) on Windows but as we don't change the Git settings before cloning the repository the line endings are already getting converted to CRLF by Git for Windows, so it is actually fine if `jq` outputs CRLF.

The `--binary` flag was added to `jq` in 1.7 but only for Windows, in 1.8 they added no-op support for that flag on Linux and macOS. Unlike the Windows and macOS runners that use the latest `jq` version, the Ubuntu runners use the `jq` version from the Ubuntu repositories so are stuck on `jq` 1.7.

Links:
- https://github.com/jqlang/jq/releases/tag/jq-1.8.0
    - https://github.com/jqlang/jq/pull/3131
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#tools

## Testing

