### PR TITLE
Use tr instead of bash syntax to do case conversion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,11 @@ jobs:
         original_version="$(jq -r '.version' package.json)"
         version="$original_version"
 
-        if [[ "${GITHUB_REF,,}" == *development* ]]; then
+        lower_case_ref="$(echo -E "$GITHUB_REF" | tr '[:upper:]' '[:lower:]')"
+
+        if [[ "$lower_case_ref" == *development* ]]; then
           version="${original_version}-nightly-${GITHUB_RUN_NUMBER}"
-        elif [[ "${GITHUB_REF^^}" == *RC* ]]; then
+        elif [[ "$lower_case_ref" == *rc* ]]; then
           version="${original_version}-RC-${GITHUB_RUN_NUMBER}"
         fi
 


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

The version of bash on the macOS runners was too old (from 2014), so use the `tr` command instead.

## Testing

Successful build here (branch named `fake-development` so it uses the nightly version format): https://github.com/absidue/FreeTube/actions/runs/21650784163