### PR TITLE
Fix Electron color issue on Linux

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -296,6 +296,13 @@ function runApp() {
     app.commandLine.appendSwitch('disable-http-cache')
   }
 
+  // Workaround for Electron 40 RGBAF16/overexposure on Linux (issue #49566). Disable the new
+  // Wayland color-management/HDR path so Chromium uses the previous rendering path on SDR displays.
+  // Same switch mentioned in Brave issue #50027 for washed-out colors on Wayland
+  if (process.platform === 'linux') {
+    app.commandLine.appendSwitch('disable-features', 'WaylandWpColorManagerV1')
+  }
+
   const PLAYER_CACHE_PATH = `${userDataPath}/player_cache`
 
   // See: https://stackoverflow.com/questions/45570589/electron-protocol-handler-not-working-on-windows


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/electron/electron/issues/49566
https://github.com/brave/brave-browser/issues/50027

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds a workaround for the upstream Electron coloring issue on Linux

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->