### PR TITLE
Add a note to contributing to discourage AI PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
  * If you want to implement a bugfix or feature request from an existing issue, please comment on that issue that you will work on it. This helps us to coordinate what needs to be done and what not.
  * If you want to implement a feature request without an existing issue, please create an issue, so we know what you are working on and discuss the feature.
  * For major feature implementations make sure you are able to maintain your code in the future in regard to bugs and possible code conflicts in future updates. Optionally you could join the [Matrix](https://matrix.to/#/#freetube:matrix.org) channel, so you will hear instantly if something needs to be worked on. 
- * Do not open pull requests that are primarily written by AI. It isn't compatible with our license and is a waste of our team's time. Repeat offenders will be banned.
+ * Do not open pull requests that are primarily written by AI. It's a waste of our team's time. Repeat offenders will be banned.
 
 ## Before your Pull Request
 Please follow these guidelines before sending your pull request and making contributions.


### PR DESCRIPTION
## Pull Request Type
- [x] Documentation

## Description
Apparently the new AI agents like harassing open-source devs (https://theshamblog.com/an-ai-agent-published-a-hit-piece-on-me/) so I thought it'd be a good idea to include this in CONTRIBUTING.md (There's also a comment that's part of the PR template but it isn't as noticeable)

Related: #7224

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 43
- **FreeTube version:** latest nightly

