### PR TITLE
Reuse a single PO-token session with data cleanup

### DIFF
--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -2,11 +2,44 @@ import { session, WebContentsView } from 'electron'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 
+// #region queue
+
+/**
+ * This is the internal Promise object which resolves when all the tasks of the queue are done.
+ * It will change any time {@linkcode enqueueAsyncFunction} is called.
+ */
+let queueGuardian = Promise.resolve()
+
+/**
+ * Enqueues an asynchronous function to be executed after the previous ones in the queue have finished.
+ * That way the promises/asynchronous functions are executed sequentially rather than in parallel.
+ *
+ * @template T
+ * @param {T} func
+ * @param {Parameters<T>} args
+ * @returns {ReturnType<T>}
+ */
+function enqueueAsyncFunction(func, ...args) {
+  queueGuardian = queueGuardian.then(() => {
+    return func(...args)
+      .then(result => ({ error: false, result }), result => ({ error: true, result }))
+  })
+
+  return queueGuardian.then(({ error, result }) => {
+    if (error) return Promise.reject(result)
+    else return Promise.resolve(result)
+  })
+}
+
+// #endregion queue
+
+let firstTime = true
+
 /**
  * Generates a content-bound poToken (proof of origin token) using `bgutils-js`.
  * The script to generate it is `src/botGuardScript.js`
  *
- * This is intentionally split out into it's own thing, with it's own temporary in-memory session,
+ * This is intentionally split out into it's own thing, with it's own in-memory session,
  * as the BotGuard stuff accesses the global `document` and `window` objects and also requires making some requests.
  * So we definitely don't want it running in the same places as the rest of the FreeTube code with the user data.
  * @param {string} videoId
@@ -14,22 +47,48 @@ import { join } from 'path'
  * @param {string|undefined} proxyUrl
  * @returns {Promise<string>}
  */
-export async function generatePoToken(videoId, context, proxyUrl) {
-  const sessionUuid = crypto.randomUUID()
+export function generatePoToken(videoId, context, proxyUrl) {
+  if (firstTime) {
+    firstTime = false
+    enqueueAsyncFunction(sharedInit)
+  }
 
-  const theSession = session.fromPartition(`potoken-${sessionUuid}`, { cache: false })
+  // We use a promise queue instead of running the `internalGeneratePotoken` function directly
+  // so that we can reuse the same session by clearing all data
+  // associated with the session before triggering generating the next PO token.
+
+  // Electron's session objects stick around for the entire lifetime of the Electron main process,
+  // holding onto OS resources such as the OS DNS resolver, so if we created a new session for each PO token generation
+  // the OS will eventually complain about the resources being exhausted (e.g. too many inotify instances on Linux)
+
+  // References
+  // - https://github.com/FreeTubeApp/FreeTube/issues/8640
+  // - https://github.com/electron/electron/pull/46131
+  // - https://github.com/electron/electron/commit/bac2f46ba981cc1763c0485cec44813c1d07fa18
+  const potokenPromise = enqueueAsyncFunction(internalGeneratePotoken, videoId, context, proxyUrl)
+
+  // schedule the cleanup separately,
+  // so that we can return the potoken without having to wait until the cleanup is done
+  enqueueAsyncFunction(cleanupSession)
+
+  return potokenPromise
+}
+
+/** @type {import('electron').Session} */
+let theSession
+/** @type {string} */
+let cachedScript
+
+async function sharedInit() {
+  // setup session
+
+  theSession = session.fromPartition('potoken', { cache: false })
 
   theSession.setPermissionCheckHandler(() => false)
   // eslint-disable-next-line n/no-callback-literal
   theSession.setPermissionRequestHandler((webContents, permission, callback) => callback(false))
 
   theSession.setUserAgent(session.defaultSession.getUserAgent())
-
-  if (proxyUrl) {
-    await theSession.setProxy({
-      proxyRules: proxyUrl
-    })
-  }
 
   theSession.webRequest.onBeforeSendHeaders({
     urls: ['https://www.google.com/js/*', 'https://www.youtube.com/youtubei/*']
@@ -68,80 +127,90 @@ export async function generatePoToken(videoId, context, proxyUrl) {
     callback({ cancel: true })
   })
 
-  const webContentsView = new WebContentsView({
-    webPreferences: {
-      backgroundThrottling: false,
-      safeDialogs: true,
-      sandbox: true,
-      contextIsolation: true,
-      v8CacheOptions: 'none',
-      session: theSession,
-      offscreen: true,
-      disableBlinkFeatures: 'ElectronCSSCornerSmoothing'
-    }
-  })
+  // load script file
 
-  webContentsView.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
+  const pathToScript = process.env.NODE_ENV === 'development'
+    ? join(__dirname, '../../dist/botGuardScript.js')
+    : join(__dirname, 'botGuardScript.js')
 
-  webContentsView.webContents.setAudioMuted(true)
-  webContentsView.setBounds({
-    x: 0,
-    y: 0,
-    width: 1920,
-    height: 1080
-  })
+  const scriptContent = await readFile(pathToScript, 'utf-8')
 
-  webContentsView.webContents.debugger.attach()
+  const scriptExportMatch = scriptContent.match(/export{(\w+) as default};/)
 
-  await webContentsView.webContents.loadURL('data:text/html,<!DOCTYPE html><html lang="en"><head><title></title></head><body></body></html>', {
-    baseURLForDataURL: 'https://www.youtube.com/'
-  })
-
-  await webContentsView.webContents.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
-    width: 1920,
-    height: 1080,
-    deviceScaleFactor: 1,
-    mobile: false,
-    screenWidth: 1920,
-    screenHeight: 1080,
-    positionX: 0,
-    positionY: 0,
-    screenOrientation: {
-      type: 'landscapePrimary',
-      angle: 0
-    }
-  })
-
-  const script = await getScript(videoId, context)
-
-  const response = await webContentsView.webContents.executeJavaScript(script)
-
-  webContentsView.webContents.close({ waitForBeforeUnload: false })
-  await theSession.closeAllConnections()
-
-  return response
+  cachedScript = scriptContent.replace(scriptExportMatch[0], `;${scriptExportMatch[1]}(FT_PARAMS)`)
 }
-
-let cachedScript
 
 /**
  * @param {string} videoId
  * @param {string} context
+ * @param {string|undefined} proxyUrl
+ * @returns {Promise<string>}
  */
-async function getScript(videoId, context) {
-  if (!cachedScript) {
-    const pathToScript = process.env.NODE_ENV === 'development'
-      ? join(__dirname, '../../dist/botGuardScript.js')
-      : join(__dirname, 'botGuardScript.js')
+async function internalGeneratePotoken(videoId, context, proxyUrl) {
+  let webContentsView
 
-    const content = await readFile(pathToScript, 'utf-8')
+  try {
+    if (proxyUrl) {
+      await theSession.setProxy({
+        proxyRules: proxyUrl
+      })
+    }
 
-    const match = content.match(/export{(\w+) as default};/)
+    webContentsView = new WebContentsView({
+      webPreferences: {
+        backgroundThrottling: false,
+        safeDialogs: true,
+        sandbox: true,
+        contextIsolation: true,
+        v8CacheOptions: 'none',
+        session: theSession,
+        offscreen: true,
+        disableBlinkFeatures: 'ElectronCSSCornerSmoothing'
+      }
+    })
 
-    const functionName = match[1]
+    webContentsView.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
 
-    cachedScript = content.replace(match[0], `;${functionName}(FT_PARAMS)`)
+    webContentsView.webContents.setAudioMuted(true)
+    webContentsView.setBounds({
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080
+    })
+
+    webContentsView.webContents.debugger.attach()
+
+    await webContentsView.webContents.loadURL('data:text/html,<!DOCTYPE html><html lang="en"><head><title></title></head><body></body></html>', {
+      baseURLForDataURL: 'https://www.youtube.com/'
+    })
+
+    await webContentsView.webContents.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
+      width: 1920,
+      height: 1080,
+      deviceScaleFactor: 1,
+      mobile: false,
+      screenWidth: 1920,
+      screenHeight: 1080,
+      positionX: 0,
+      positionY: 0,
+      screenOrientation: {
+        type: 'landscapePrimary',
+        angle: 0
+      }
+    })
+
+    const script = cachedScript.replace('FT_PARAMS', `"${videoId}",${context}`)
+
+    return await webContentsView.webContents.executeJavaScript(script)
+  } finally {
+    if (webContentsView) {
+      webContentsView.webContents.close({ waitForBeforeUnload: false })
+    }
   }
+}
 
-  return cachedScript.replace('FT_PARAMS', `"${videoId}",${context}`)
+async function cleanupSession() {
+  await theSession.closeAllConnections()
+  await theSession.clearData()
 }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8640

## Description

Currently we create a new in-memory session each time we generate a proof-of-origin token, while this is probably the best approach privacy wise it has a serious downside due to how sessions are handled in Electron. In Electron once a session object is created it sticks around until the main process ends, which also means it retains it handles on operating system resources such as the DNS resolver/cache and the system time/timezone information. On Linux specifically that means file watchers. So as we create a new session to generate a proof-of-origin token each time you view a video the operating system will eventually complain that it has reached the operating system wide limit on file watchers.

The solution I decided to go with in this pull request is to still use separate in-memory sessions for the proof-of-origin token generation so it is still separate from the session that the rest of FreeTube uses as that contains user data, but instead of creating a new one each time, we create one the first time and reuse it for all other proof-of-origin token generations. To avoid potential data leaking between generations, we use a queue to ensure that only one token is generated at a time and clear the session data after each generation. In normal use not being able to generate tokens in parallel anymore shouldn't have a big impact as token generation is generally quite fast, so you would either have to rapidly change between videos or open videos in multiple windows at the same time.

References:
- https://github.com/electron/electron/pull/46131
- https://github.com/electron/electron/commit/bac2f46ba981cc1763c0485cec44813c1d07fa18

## Testing

Test build: https://github.com/absidue/FreeTube/actions/runs/22025664140

## Desktop

- **OS:** Windows
- **OS Version:** 11