### PR TITLE
Add SponsorBlock unskip and reskip feature

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -174,6 +174,7 @@ const KeyboardShortcuts = {
       VOLUME_DOWN: 'arrowdown',
       STATS: 'd',
       TAKE_SCREENSHOT: 'u',
+      UNSKIP_SPONSOR_BLOCK: 'enter',
     },
     PLAYBACK: {
       PLAY: 'k',

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -144,6 +144,7 @@ const localizedShortcutNameToShortcutsMappings = computed(() => {
     [t('KeyboardShortcutPrompt.Volume Down'), ['VOLUME_DOWN']],
     [t('KeyboardShortcutPrompt.Take Screenshot'), ['TAKE_SCREENSHOT']],
     [t('KeyboardShortcutPrompt.Stats'), ['STATS']],
+    [t('KeyboardShortcutPrompt.Unskip Sponsor Block'), ['UNSKIP_SPONSOR_BLOCK']],
 
     [t('KeyboardShortcutPrompt.Play'), ['PLAY']],
     [t('KeyboardShortcutPrompt.Large Rewind'), ['LARGE_REWIND']],

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -145,6 +145,12 @@
   border-radius: 20px;
   background-color: rgb(0 0 0 / 80%);
   color: #fff;
+  text-align: center;
+}
+
+.unskipInstruction {
+  font-size: 0.8em;
+  opacity: 0.8;
 }
 
 :deep(.markerContainer) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -135,6 +135,12 @@
   border-radius: 20px;
   background-color: rgb(0 0 0 / 80%);
   color: #fff;
+  text-align: center;
+}
+
+.unskipInstruction {
+  font-size: 0.8em;
+  opacity: 0.8;
 }
 
 :deep(.markerContainer) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -479,7 +479,7 @@ export default defineComponent({
      * @type {import('vue').Ref<{uuid: string, translatedCategory: string, timeoutId: number, startTime: number, endTime: number, unskipped: boolean}[]>}
      */
     const skippedSponsorBlockSegments = ref([])
-    const ignoredSponsorBlockSegments = ref(new Set())
+    const ignoredSponsorBlockSegments = reactive(new Set())
 
     async function setupSponsorBlock() {
       let segments, averageDuration
@@ -511,7 +511,7 @@ export default defineComponent({
     function skipSponsorBlockSegments(currentTime) {
       skippedSponsorBlockSegments.value = skippedSponsorBlockSegments.value.filter(segment => {
         if (segment.unskipped && (currentTime >= segment.endTime || currentTime < segment.startTime)) {
-          ignoredSponsorBlockSegments.value.delete(segment.uuid)
+          ignoredSponsorBlockSegments.delete(segment.uuid)
           return false
         }
         return true
@@ -529,7 +529,7 @@ export default defineComponent({
       const skippedSegments = []
 
       sponsorBlockSegments.forEach(segment => {
-        if (!ignoredSponsorBlockSegments.value.has(segment.uuid) && autoSkip.has(segment.category) && currentTime < segment.endTime &&
+        if (!ignoredSponsorBlockSegments.has(segment.uuid) && autoSkip.has(segment.category) && currentTime < segment.endTime &&
           (segment.startTime <= currentTime ||
             // if we already have a segment to skip, check if there are any that are less than 150ms later,
             // so that we can skip them all in one go (especially useful on slow connections)
@@ -565,7 +565,7 @@ export default defineComponent({
               clearInterval(segment.intervalId)
               skippedSponsorBlockSegments.value.splice(index, 1)
             }
-            ignoredSponsorBlockSegments.value.delete(uuid)
+            ignoredSponsorBlockSegments.delete(uuid)
           }
 
           const existingSkip = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
@@ -2314,14 +2314,14 @@ export default defineComponent({
               if (index !== -1) {
                 skippedSponsorBlockSegments.value.splice(index, 1)
               }
-              ignoredSponsorBlockSegments.value.delete(segment.uuid)
+              ignoredSponsorBlockSegments.delete(segment.uuid)
             } else {
               video_.currentTime = segment.startTime
               segment.unskipped = true
               clearTimeout(segment.timeoutId)
               clearInterval(segment.intervalId)
               segment.timeLeft = null
-              ignoredSponsorBlockSegments.value.add(segment.uuid)
+              ignoredSponsorBlockSegments.add(segment.uuid)
             }
           }
           break

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -579,7 +579,7 @@ export default defineComponent({
             }, 1000)
             existingSkip.timeoutId = setTimeout(removeSegment, 4000)
           } else {
-            const segmentObj = reactive({
+            const segmentObj = {
               uuid,
               translatedCategory: translateSponsorBlockCategory(category),
               startTime,
@@ -588,14 +588,15 @@ export default defineComponent({
               timeLeft: 4,
               intervalId: null,
               timeoutId: null
-            })
-
-            segmentObj.intervalId = setInterval(() => {
-              segmentObj.timeLeft--
-            }, 1000)
-            segmentObj.timeoutId = setTimeout(removeSegment, 4000)
+            }
 
             skippedSponsorBlockSegments.value.push(segmentObj)
+            const reactiveSegmentObj = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
+
+            reactiveSegmentObj.intervalId = setInterval(() => {
+              reactiveSegmentObj.timeLeft--
+            }, 1000)
+            reactiveSegmentObj.timeoutId = setTimeout(removeSegment, 4000)
           }
         })
       }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -476,9 +476,10 @@ export default defineComponent({
     /**
      * Yes a map would be much more suitable for this (unlike objects they retain the order that items were inserted),
      * but Vue 2 doesn't support reactivity on Maps, so we have to use an array instead
-     * @type {import('vue').Ref<{uuid: string, translatedCategory: string, timeoutId: number}[]>}
+     * @type {import('vue').Ref<{uuid: string, translatedCategory: string, timeoutId: number, startTime: number, endTime: number, unskipped: boolean}[]>}
      */
     const skippedSponsorBlockSegments = ref([])
+    const ignoredSponsorBlockSegments = ref(new Set())
 
     async function setupSponsorBlock() {
       let segments, averageDuration
@@ -508,6 +509,14 @@ export default defineComponent({
      * @param {number} currentTime
      */
     function skipSponsorBlockSegments(currentTime) {
+      skippedSponsorBlockSegments.value = skippedSponsorBlockSegments.value.filter(segment => {
+        if (segment.unskipped && (currentTime >= segment.endTime || currentTime < segment.startTime)) {
+          ignoredSponsorBlockSegments.value.delete(segment.uuid)
+          return false
+        }
+        return true
+      })
+
       const { autoSkip } = sponsorSkips.value
 
       if (autoSkip.size === 0) {
@@ -520,7 +529,7 @@ export default defineComponent({
       const skippedSegments = []
 
       sponsorBlockSegments.forEach(segment => {
-        if (autoSkip.has(segment.category) && currentTime < segment.endTime &&
+        if (!ignoredSponsorBlockSegments.value.has(segment.uuid) && autoSkip.has(segment.category) && currentTime < segment.endTime &&
           (segment.startTime <= currentTime ||
             // if we already have a segment to skip, check if there are any that are less than 150ms later,
             // so that we can skip them all in one go (especially useful on slow connections)
@@ -547,26 +556,46 @@ export default defineComponent({
       video_.currentTime = newTime
 
       if (sponsorBlockShowSkippedToast.value) {
-        skippedSegments.forEach(({ uuid, category }) => {
-          // if the element already exists, just update the timeout, instead of creating a duplicate
-          // can happen at the end of the video sometimes
+        skippedSegments.forEach(({ uuid, category, startTime, endTime }) => {
+          const removeSegment = () => {
+            const index = skippedSponsorBlockSegments.value.findIndex(skipped => skipped.uuid === uuid)
+            if (index !== -1) {
+              const segment = skippedSponsorBlockSegments.value[index]
+              clearTimeout(segment.timeoutId)
+              clearInterval(segment.intervalId)
+              skippedSponsorBlockSegments.value.splice(index, 1)
+            }
+            ignoredSponsorBlockSegments.value.delete(uuid)
+          }
+
           const existingSkip = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
           if (existingSkip) {
             clearTimeout(existingSkip.timeoutId)
+            clearInterval(existingSkip.intervalId)
 
-            existingSkip.timeoutId = setTimeout(() => {
-              const index = skippedSponsorBlockSegments.value.findIndex(skipped => skipped.uuid === uuid)
-              skippedSponsorBlockSegments.value.splice(index, 1)
-            }, 2000)
+            existingSkip.timeLeft = 4
+            existingSkip.intervalId = setInterval(() => {
+              existingSkip.timeLeft--
+            }, 1000)
+            existingSkip.timeoutId = setTimeout(removeSegment, 4000)
           } else {
-            skippedSponsorBlockSegments.value.push({
+            const segmentObj = reactive({
               uuid,
               translatedCategory: translateSponsorBlockCategory(category),
-              timeoutId: setTimeout(() => {
-                const index = skippedSponsorBlockSegments.value.findIndex(skipped => skipped.uuid === uuid)
-                skippedSponsorBlockSegments.value.splice(index, 1)
-              }, 2000)
+              startTime,
+              endTime,
+              unskipped: false,
+              timeLeft: 4,
+              intervalId: null,
+              timeoutId: null
             })
+
+            segmentObj.intervalId = setInterval(() => {
+              segmentObj.timeLeft--
+            }, 1000)
+            segmentObj.timeoutId = setTimeout(removeSegment, 4000)
+
+            skippedSponsorBlockSegments.value.push(segmentObj)
           }
         })
       }
@@ -2275,6 +2304,28 @@ export default defineComponent({
       }
 
       switch (event.key.toLowerCase()) {
+        case 'enter': {
+          if (skippedSponsorBlockSegments.value.length > 0) {
+            event.preventDefault()
+            const segment = skippedSponsorBlockSegments.value[skippedSponsorBlockSegments.value.length - 1]
+            if (segment.unskipped) {
+              video_.currentTime = segment.endTime
+              const index = skippedSponsorBlockSegments.value.indexOf(segment)
+              if (index !== -1) {
+                skippedSponsorBlockSegments.value.splice(index, 1)
+              }
+              ignoredSponsorBlockSegments.value.delete(segment.uuid)
+            } else {
+              video_.currentTime = segment.startTime
+              segment.unskipped = true
+              clearTimeout(segment.timeoutId)
+              clearInterval(segment.intervalId)
+              segment.timeLeft = null
+              ignoredSponsorBlockSegments.value.add(segment.uuid)
+            }
+          }
+          break
+        }
         case ' ':
         case 'spacebar': // older browsers might return spacebar instead of a space character
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.PLAY:
@@ -3142,7 +3193,10 @@ export default defineComponent({
         navigator.mediaSession.playbackState = 'none'
       }
 
-      skippedSponsorBlockSegments.value.forEach(segment => clearTimeout(segment.timeoutId))
+      skippedSponsorBlockSegments.value.forEach(segment => {
+        clearTimeout(segment.timeoutId)
+        clearInterval(segment.intervalId)
+      })
 
       window.removeEventListener('online', onlineHandler)
       window.removeEventListener('offline', offlineHandler)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2305,7 +2305,7 @@ export default defineComponent({
       }
 
       switch (event.key.toLowerCase()) {
-        case 'enter': {
+        case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.UNSKIP_SPONSOR_BLOCK: {
           if (skippedSponsorBlockSegments.value.length > 0) {
             event.preventDefault()
             const segment = skippedSponsorBlockSegments.value[skippedSponsorBlockSegments.value.length - 1]

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2322,7 +2322,7 @@ export default defineComponent({
       }
 
       switch (event.key.toLowerCase()) {
-        case 'enter': {
+        case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.UNSKIP_SPONSOR_BLOCK: {
           if (skippedSponsorBlockSegments.value.length > 0) {
             event.preventDefault()
             const segment = skippedSponsorBlockSegments.value[skippedSponsorBlockSegments.value.length - 1]

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -479,9 +479,10 @@ export default defineComponent({
     /**
      * Yes a map would be much more suitable for this (unlike objects they retain the order that items were inserted),
      * but Vue 2 doesn't support reactivity on Maps, so we have to use an array instead
-     * @type {import('vue').Ref<{uuid: string, translatedCategory: string, timeoutId: number}[]>}
+     * @type {import('vue').Ref<{uuid: string, translatedCategory: string, timeoutId: number, startTime: number, endTime: number, unskipped: boolean}[]>}
      */
     const skippedSponsorBlockSegments = ref([])
+    const ignoredSponsorBlockSegments = ref(new Set())
 
     async function setupSponsorBlock() {
       let segments, averageDuration
@@ -511,6 +512,14 @@ export default defineComponent({
      * @param {number} currentTime
      */
     function skipSponsorBlockSegments(currentTime) {
+      skippedSponsorBlockSegments.value = skippedSponsorBlockSegments.value.filter(segment => {
+        if (segment.unskipped && (currentTime >= segment.endTime || currentTime < segment.startTime)) {
+          ignoredSponsorBlockSegments.value.delete(segment.uuid)
+          return false
+        }
+        return true
+      })
+
       const { autoSkip } = sponsorSkips.value
 
       if (autoSkip.size === 0) {
@@ -523,7 +532,7 @@ export default defineComponent({
       const skippedSegments = []
 
       sponsorBlockSegments.forEach(segment => {
-        if (autoSkip.has(segment.category) && currentTime < segment.endTime &&
+        if (!ignoredSponsorBlockSegments.value.has(segment.uuid) && autoSkip.has(segment.category) && currentTime < segment.endTime &&
           (segment.startTime <= currentTime ||
             // if we already have a segment to skip, check if there are any that are less than 150ms later,
             // so that we can skip them all in one go (especially useful on slow connections)
@@ -550,26 +559,46 @@ export default defineComponent({
       video_.currentTime = newTime
 
       if (sponsorBlockShowSkippedToast.value) {
-        skippedSegments.forEach(({ uuid, category }) => {
-          // if the element already exists, just update the timeout, instead of creating a duplicate
-          // can happen at the end of the video sometimes
+        skippedSegments.forEach(({ uuid, category, startTime, endTime }) => {
+          const removeSegment = () => {
+            const index = skippedSponsorBlockSegments.value.findIndex(skipped => skipped.uuid === uuid)
+            if (index !== -1) {
+              const segment = skippedSponsorBlockSegments.value[index]
+              clearTimeout(segment.timeoutId)
+              clearInterval(segment.intervalId)
+              skippedSponsorBlockSegments.value.splice(index, 1)
+            }
+            ignoredSponsorBlockSegments.value.delete(uuid)
+          }
+
           const existingSkip = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
           if (existingSkip) {
             clearTimeout(existingSkip.timeoutId)
+            clearInterval(existingSkip.intervalId)
 
-            existingSkip.timeoutId = setTimeout(() => {
-              const index = skippedSponsorBlockSegments.value.findIndex(skipped => skipped.uuid === uuid)
-              skippedSponsorBlockSegments.value.splice(index, 1)
-            }, 2000)
+            existingSkip.timeLeft = 4
+            existingSkip.intervalId = setInterval(() => {
+              existingSkip.timeLeft--
+            }, 1000)
+            existingSkip.timeoutId = setTimeout(removeSegment, 4000)
           } else {
-            skippedSponsorBlockSegments.value.push({
+            const segmentObj = reactive({
               uuid,
               translatedCategory: translateSponsorBlockCategory(category),
-              timeoutId: setTimeout(() => {
-                const index = skippedSponsorBlockSegments.value.findIndex(skipped => skipped.uuid === uuid)
-                skippedSponsorBlockSegments.value.splice(index, 1)
-              }, 2000)
+              startTime,
+              endTime,
+              unskipped: false,
+              timeLeft: 4,
+              intervalId: null,
+              timeoutId: null
             })
+
+            segmentObj.intervalId = setInterval(() => {
+              segmentObj.timeLeft--
+            }, 1000)
+            segmentObj.timeoutId = setTimeout(removeSegment, 4000)
+
+            skippedSponsorBlockSegments.value.push(segmentObj)
           }
         })
       }
@@ -2292,6 +2321,28 @@ export default defineComponent({
       }
 
       switch (event.key.toLowerCase()) {
+        case 'enter': {
+          if (skippedSponsorBlockSegments.value.length > 0) {
+            event.preventDefault()
+            const segment = skippedSponsorBlockSegments.value[skippedSponsorBlockSegments.value.length - 1]
+            if (segment.unskipped) {
+              video_.currentTime = segment.endTime
+              const index = skippedSponsorBlockSegments.value.indexOf(segment)
+              if (index !== -1) {
+                skippedSponsorBlockSegments.value.splice(index, 1)
+              }
+              ignoredSponsorBlockSegments.value.delete(segment.uuid)
+            } else {
+              video_.currentTime = segment.startTime
+              segment.unskipped = true
+              clearTimeout(segment.timeoutId)
+              clearInterval(segment.intervalId)
+              segment.timeLeft = null
+              ignoredSponsorBlockSegments.value.add(segment.uuid)
+            }
+          }
+          break
+        }
         case ' ':
         case 'spacebar': // older browsers might return spacebar instead of a space character
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.PLAY:
@@ -3171,7 +3222,10 @@ export default defineComponent({
         navigator.mediaSession.playbackState = 'none'
       }
 
-      skippedSponsorBlockSegments.value.forEach(segment => clearTimeout(segment.timeoutId))
+      skippedSponsorBlockSegments.value.forEach(segment => {
+        clearTimeout(segment.timeoutId)
+        clearInterval(segment.intervalId)
+      })
 
       window.removeEventListener('online', onlineHandler)
       window.removeEventListener('offline', offlineHandler)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -582,7 +582,7 @@ export default defineComponent({
             }, 1000)
             existingSkip.timeoutId = setTimeout(removeSegment, 4000)
           } else {
-            const segmentObj = reactive({
+            const segmentObj = {
               uuid,
               translatedCategory: translateSponsorBlockCategory(category),
               startTime,
@@ -591,14 +591,15 @@ export default defineComponent({
               timeLeft: 4,
               intervalId: null,
               timeoutId: null
-            })
-
-            segmentObj.intervalId = setInterval(() => {
-              segmentObj.timeLeft--
-            }, 1000)
-            segmentObj.timeoutId = setTimeout(removeSegment, 4000)
+            }
 
             skippedSponsorBlockSegments.value.push(segmentObj)
+            const reactiveSegmentObj = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
+
+            reactiveSegmentObj.intervalId = setInterval(() => {
+              reactiveSegmentObj.timeLeft--
+            }, 1000)
+            reactiveSegmentObj.timeoutId = setTimeout(removeSegment, 4000)
           }
         })
       }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -577,6 +577,7 @@ export default defineComponent({
             clearInterval(existingSkip.intervalId)
 
             existingSkip.timeLeft = 4
+            existingSkip.segmentTimeLeft = 0
             existingSkip.intervalId = setInterval(() => {
               existingSkip.timeLeft--
             }, 1000)
@@ -589,6 +590,7 @@ export default defineComponent({
               endTime,
               unskipped: false,
               timeLeft: 4,
+              segmentTimeLeft: 0,
               intervalId: null,
               timeoutId: null
             }
@@ -1256,6 +1258,14 @@ export default defineComponent({
 
         if (useSponsorBlock.value && sponsorBlockSegments.length > 0 && canSeek()) {
           skipSponsorBlockSegments(currentTime)
+        }
+
+        if (useSponsorBlock.value) {
+          for (const segment of skippedSponsorBlockSegments.value) {
+            if (segment.unskipped) {
+              segment.segmentTimeLeft = Math.max(0, segment.endTime - currentTime)
+            }
+          }
         }
       }
     }
@@ -2339,6 +2349,7 @@ export default defineComponent({
               clearTimeout(segment.timeoutId)
               clearInterval(segment.intervalId)
               segment.timeLeft = null
+              segment.segmentTimeLeft = Math.max(0, segment.endTime - video_.currentTime)
               ignoredSponsorBlockSegments.add(segment.uuid)
             }
           }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2338,10 +2338,21 @@ export default defineComponent({
             const segment = skippedSponsorBlockSegments.value[skippedSponsorBlockSegments.value.length - 1]
             if (segment.unskipped) {
               video_.currentTime = segment.endTime
-              const index = skippedSponsorBlockSegments.value.indexOf(segment)
-              if (index !== -1) {
-                skippedSponsorBlockSegments.value.splice(index, 1)
-              }
+              segment.unskipped = false
+              segment.timeLeft = 4
+              segment.segmentTimeLeft = 0
+              clearTimeout(segment.timeoutId)
+              clearInterval(segment.intervalId)
+              segment.intervalId = setInterval(() => {
+                segment.timeLeft--
+              }, 1000)
+              segment.timeoutId = setTimeout(() => {
+                const index = skippedSponsorBlockSegments.value.indexOf(segment)
+                if (index !== -1) {
+                  skippedSponsorBlockSegments.value.splice(index, 1)
+                }
+                ignoredSponsorBlockSegments.delete(segment.uuid)
+              }, 4000)
               ignoredSponsorBlockSegments.delete(segment.uuid)
             } else {
               video_.currentTime = segment.startTime

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -482,7 +482,7 @@ export default defineComponent({
      * @type {import('vue').Ref<{uuid: string, translatedCategory: string, timeoutId: number, startTime: number, endTime: number, unskipped: boolean}[]>}
      */
     const skippedSponsorBlockSegments = ref([])
-    const ignoredSponsorBlockSegments = ref(new Set())
+    const ignoredSponsorBlockSegments = reactive(new Set())
 
     async function setupSponsorBlock() {
       let segments, averageDuration
@@ -514,7 +514,7 @@ export default defineComponent({
     function skipSponsorBlockSegments(currentTime) {
       skippedSponsorBlockSegments.value = skippedSponsorBlockSegments.value.filter(segment => {
         if (segment.unskipped && (currentTime >= segment.endTime || currentTime < segment.startTime)) {
-          ignoredSponsorBlockSegments.value.delete(segment.uuid)
+          ignoredSponsorBlockSegments.delete(segment.uuid)
           return false
         }
         return true
@@ -532,7 +532,7 @@ export default defineComponent({
       const skippedSegments = []
 
       sponsorBlockSegments.forEach(segment => {
-        if (!ignoredSponsorBlockSegments.value.has(segment.uuid) && autoSkip.has(segment.category) && currentTime < segment.endTime &&
+        if (!ignoredSponsorBlockSegments.has(segment.uuid) && autoSkip.has(segment.category) && currentTime < segment.endTime &&
           (segment.startTime <= currentTime ||
             // if we already have a segment to skip, check if there are any that are less than 150ms later,
             // so that we can skip them all in one go (especially useful on slow connections)
@@ -568,7 +568,7 @@ export default defineComponent({
               clearInterval(segment.intervalId)
               skippedSponsorBlockSegments.value.splice(index, 1)
             }
-            ignoredSponsorBlockSegments.value.delete(uuid)
+            ignoredSponsorBlockSegments.delete(uuid)
           }
 
           const existingSkip = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
@@ -2331,14 +2331,14 @@ export default defineComponent({
               if (index !== -1) {
                 skippedSponsorBlockSegments.value.splice(index, 1)
               }
-              ignoredSponsorBlockSegments.value.delete(segment.uuid)
+              ignoredSponsorBlockSegments.delete(segment.uuid)
             } else {
               video_.currentTime = segment.startTime
               segment.unskipped = true
               clearTimeout(segment.timeoutId)
               clearInterval(segment.intervalId)
               segment.timeLeft = null
-              ignoredSponsorBlockSegments.value.add(segment.uuid)
+              ignoredSponsorBlockSegments.add(segment.uuid)
             }
           }
           break

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -116,11 +116,15 @@
       class="skippedSegmentsWrapper"
     >
       <p
-        v-for="{ uuid, translatedCategory } in skippedSponsorBlockSegments"
+        v-for="{ uuid, translatedCategory, unskipped, timeLeft } in skippedSponsorBlockSegments"
         :key="uuid"
         class="skippedSegment"
       >
         {{ $t('Video.Player.Skipped segment', { segmentCategory: translatedCategory }) }}
+        <br>
+        <span class="unskipInstruction">
+          {{ unskipped ? $t('Video.Player.Press Enter to reskip') : $t('Video.Player.Press Enter to unskip', { timeLeft }) }}
+        </span>
       </p>
     </div>
   </div>

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -116,14 +116,14 @@
       class="skippedSegmentsWrapper"
     >
       <p
-        v-for="{ uuid, translatedCategory, unskipped, timeLeft } in skippedSponsorBlockSegments"
+        v-for="{ uuid, translatedCategory, unskipped, timeLeft, segmentTimeLeft } in skippedSponsorBlockSegments"
         :key="uuid"
         class="skippedSegment"
       >
         {{ $t('Video.Player.Skipped segment', { segmentCategory: translatedCategory }) }}
         <br>
         <span class="unskipInstruction">
-          {{ unskipped ? $t('Video.Player.Press Enter to reskip') : $t('Video.Player.Press Enter to unskip', { timeLeft }) }}
+          {{ unskipped ? $t('Video.Player.Press Enter to reskip', { timeLeft: Math.ceil(segmentTimeLeft) }) : $t('Video.Player.Press Enter to unskip', { timeLeft }) }}
         </span>
       </p>
     </div>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1211,3 +1211,4 @@ KeyboardShortcutPrompt:
   End: Seek to the end of the video
   Skip to Next Video: Skip to the next video in a playlist or next recommended video
   Skip to Previous Video: Skip to the previous video in a playlist
+  Unskip Sponsor Block: Unskip sponsor block segment

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -943,6 +943,8 @@ Video:
     You appear to be offline: You appear to be offline.
     Playback will resume automatically when your connection comes back: Playback will resume automatically when your connection comes back.
     Skipped segment: 'Skipped {segmentCategory} segment'
+    Press Enter to unskip: 'Press Enter to unskip ({timeLeft}s)'
+    Press Enter to reskip: 'Press Enter to reskip'
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Remaining preroll-ad time: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Remaining SABR backoff time: {remindingTimeSeconds}s'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1205,3 +1205,4 @@ KeyboardShortcutPrompt:
   End: Seek to the end of the video
   Skip to Next Video: Skip to the next video in a playlist or next recommended video
   Skip to Previous Video: Skip to the previous video in a playlist
+  Unskip Sponsor Block: Unskip sponsor block segment

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -937,6 +937,8 @@ Video:
     You appear to be offline: You appear to be offline.
     Playback will resume automatically when your connection comes back: Playback will resume automatically when your connection comes back.
     Skipped segment: 'Skipped {segmentCategory} segment'
+    Press Enter to unskip: 'Press Enter to unskip ({timeLeft}s)'
+    Press Enter to reskip: 'Press Enter to reskip'
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Remaining preroll-ad time: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Remaining SABR backoff time: {remindingTimeSeconds}s'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -938,7 +938,7 @@ Video:
     Playback will resume automatically when your connection comes back: Playback will resume automatically when your connection comes back.
     Skipped segment: 'Skipped {segmentCategory} segment'
     Press Enter to unskip: 'Press Enter to unskip ({timeLeft}s)'
-    Press Enter to reskip: 'Press Enter to reskip'
+    Press Enter to reskip: 'Press Enter to reskip ({timeLeft}s remaining)'
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Remaining preroll-ad time: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Remaining SABR backoff time: {remindingTimeSeconds}s'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #1380

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds unskipping and reskipping segments from SponsorBlock. When a segment is skipped it gives the option to press enter in unskip it. When watching the segment you can also choose to press enter again to reskip the segment. This feature is present in the SponsorBlock extension.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Enable SponsorBlock in settings
2. Go to any video with a segment to auto skip.
3. When the segment skips you will see the option to unskip
4. Once you press enter you will also see the option to reskip

## Desktop
<!-- Please complete the following information-->
- **OS: Arch Linux**
- **OS Version: N/A**
- **FreeTube version: v0.23.13 Beta**