### PR TITLE
[AI spam] Fix export producing 0-byte files by using native Electron save dialog

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,8 @@ const IpcChannels = {
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   WRITE_TO_DEFAULT_FOLDER: 'write-to-default-folder',
 
+  SHOW_SAVE_DIALOG: 'show-save-dialog',
+
   OPEN_IN_EXTERNAL_PLAYER: 'open-in-external-player',
   OPEN_IN_EXTERNAL_PLAYER_RESULT: 'open-in-external-player-result'
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1387,6 +1387,40 @@ function runApp() {
     }
   })
 
+  ipcMain.handle(IpcChannels.SHOW_SAVE_DIALOG, async (event, { fileName, content, fileTypeDescription, fileExtension }) => {
+    if (!isFreeTubeUrl(event.senderFrame.url)) {
+      return false
+    }
+
+    const window = BrowserWindow.fromWebContents(event.sender)
+
+    const dialogOptions = {
+      defaultPath: fileName,
+      filters: [
+        { name: fileTypeDescription, extensions: [fileExtension.replace('.', '')] }
+      ]
+    }
+
+    let result
+    if (window) {
+      result = await dialog.showSaveDialog(window, dialogOptions)
+    } else {
+      result = await dialog.showSaveDialog(dialogOptions)
+    }
+
+    if (result.canceled || !result.filePath) {
+      return false
+    }
+
+    if (content instanceof ArrayBuffer) {
+      await asyncFs.writeFile(result.filePath, new DataView(content))
+    } else {
+      await asyncFs.writeFile(result.filePath, content, 'utf-8')
+    }
+
+    return true
+  })
+
   ipcMain.handle(IpcChannels.WRITE_TO_DEFAULT_FOLDER, async (event, filename, arrayBuffer) => {
     if (
       !isFreeTubeUrl(event.senderFrame.url) ||

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -118,6 +118,18 @@ export default {
     return ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKEN, videoId, context)
   },
 
+  /**
+   * @param {object} options
+   * @param {string} options.fileName
+   * @param {string} options.content
+   * @param {string} options.fileTypeDescription
+   * @param {string} options.fileExtension
+   * @returns {Promise<boolean>}
+   */
+  showSaveDialog: async (options) => {
+    return await ipcRenderer.invoke(IpcChannels.SHOW_SAVE_DIALOG, options)
+  },
+
   chooseDefaultFolder: () => {
     ipcRenderer.send(IpcChannels.CHOOSE_DEFAULT_FOLDER)
   },

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -350,7 +350,19 @@ export async function writeFileWithPicker(
   // https://developer.mozilla.org/en-US/docs/Web/API/Window/showOpenFilePicker#browser_compatibility
   // As we know it is supported in Electron, adding the build flag means we can skip the runtime check in Electron
   // and allow terser to remove the unused else block
-  if (process.env.IS_ELECTRON || 'showSaveFilePicker' in window) {
+  if (process.env.IS_ELECTRON) {
+    // Use Electron's native dialog.showSaveDialog + fs.writeFile via IPC
+    // instead of the File System Access API (showSaveFilePicker + createWritable),
+    // as the latter produces 0-byte files in some environments (e.g. Flatpak sandboxes)
+    // where the FileSystemWritableFileStream doesn't work correctly.
+    // See: https://github.com/FreeTubeApp/FreeTube/issues/8670
+    return await window.ftElectron.showSaveDialog({
+      fileName,
+      content,
+      fileTypeDescription,
+      fileExtension
+    })
+  } else if ('showSaveFilePicker' in window) {
     let writableFileStream
 
     try {


### PR DESCRIPTION
## Description

Fixes — Exporting subscriptions, history and playlists generates 0-byte files.

## Root Cause

The `writeFileWithPicker` function uses the Web File System Access API (`showSaveFilePicker` + `FileSystemWritableFileStream.createWritable()` + `write()`) for file exports in the Electron build. This API can produce 0-byte files in certain environments, particularly Flatpak sandboxes where the `FileSystemWritableFileStream` write through the xdg-desktop-portal doesn't work correctly.

This is a known class of issues with the File System Access API in Electron (see [electron/electron#33648](https://github.com/electron/electron/issues/33648)).

## Fix

For the Electron build, use Electron's native `dialog.showSaveDialog()` + `fs.writeFile()` via IPC instead of the File System Access API. This is more reliable across all platforms and sandbox environments.

### Changes:
- **`src/constants.js`**: Added `SHOW_SAVE_DIALOG` IPC channel
- **`src/main/index.js`**: Added IPC handler that shows a native save dialog and writes the file using Node.js `fs.writeFile`
- **`src/preload/interface.js`**: Exposed `showSaveDialog` method to the renderer
- **`src/renderer/helpers/utils.js`**: Updated `writeFileWithPicker` to use the native IPC path for Electron builds

The web browser code path (`showSaveFilePicker` / download link fallback) is unchanged.

## Testing

- All webpack builds (main, preload, renderer) compile successfully
- ESLint passes with no errors
- The fix affects all export operations: subscriptions, history, playlists, search history, video screenshots, and playlist exports