### PR TITLE
Remove sort by rating and date in video search filters

### DIFF
--- a/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
+++ b/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
@@ -89,8 +89,6 @@ const { t } = useI18n()
 
 const SORT_BY_VALUES = [
   'relevance',
-  'rating',
-  'upload_date',
   'view_count'
 ]
 
@@ -142,8 +140,6 @@ const title = computed(() => t('Search Filters.Search Filters'))
 
 const sortByLabels = computed(() => [
   t('Search Filters.Sort By.Most Relevant'),
-  t('Search Filters.Sort By.Rating'),
-  t('Search Filters.Sort By.Upload Date'),
   t('Search Filters.Sort By.View Count')
 ])
 
@@ -186,7 +182,7 @@ const featureLabels = computed(() => [
 
 const searchSettings = store.getters.getSearchSettings
 
-/** @type {import('vue').Ref<'relevance' | 'rating' | 'upload_date' | 'view_count'>} */
+/** @type {import('vue').Ref<'relevance' | 'view_count'>} */
 const sortByValue = ref(searchSettings.sortBy)
 
 watch(sortByValue, (value) => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes https://github.com/FreeTubeApp/FreeTube/issues/8636

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Removes rating and date sorting options since Youtube removed them both acording to their thread:

```
The two filters we’re removing are ‘Upload Date - Last Hour’ and ‘Sort by Rating.’
```
(https://support.google.com/youtube/thread/400586735/changes-to-youtube-search-filters-to-improve-content-discovery)

Invidious search API works fine if the Preferred API backend is set to an Invidious instance.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

<img width="207" height="149" alt="image" src="https://github.com/user-attachments/assets/e75b560d-b95b-433f-8bbe-8c4c3a8c9421" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Clone FreeTube
2. Execute `git fetch origin pull/8676/head:remove-deprecated-sort-options` to fetch the PR
3. Checkout the PR: `git checkout remove-deprecated-sort-options`
4. Build FreeTube: `yarn run build`
5. Open FreeTube and see that the deprecated filters are no longer there

## Desktop
<!-- Please complete the following information-->
- **OS: Arch Linux**
- **OS Version: Rolling**
- **FreeTube version: v0.23.13 Beta (development branch)**

## Additional context
<!-- Add any other context about the pull request here. -->

https://github.com/iv-org/invidious/issues/5626