### PR TITLE
Improve cache handling in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,20 +59,38 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-      with:
-        persist-credentials: false
-
     - name: 'Use faster D: drive for yarn cache on Windows'
       if: startsWith(matrix.os, 'windows')
       shell: cmd
       run: yarn config set cache-folder D:\ft_yarn_cache
 
+    - name: Get yarn cache directory
+      id: cache_dir
+      shell: bash
+      run: |
+        {
+          echo 'cache_dir<<EOF'
+          yarn cache dir
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      with:
+        persist-credentials: false
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0
       with:
         node-version: ${{ matrix.node-version }}
-        cache: "yarn"
+        package-manager-cache: false
+
+    - name: Restore yarn cache
+      id: restore_cache
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      with:
+        key: ${{ format('node-cache-{0}-{1}-yarn-{2}', runner.os, runner.arch, hashFiles('yarn.lock')) }}
+        path: ${{ steps.cache_dir.outputs.cache_dir }}
+
     - run: yarn run ci
       shell: bash
       env:
@@ -341,3 +359,11 @@ jobs:
       with:
         name: freetube-${{ steps.versionNumber.outputs.version }}-mac-arm64.7z
         path: build/freetube-${{ steps.versionNumber.outputs.version }}-arm64-mac.7z
+
+    - name: Save yarn cache
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      # Only save the cache if we weren't able to restore an existing one above
+      if: steps.restore_cache.outputs.cache-primary-key != steps.restore_cache.outputs.cache-matched-key
+      with:
+        key: ${{ steps.restore_cache.outputs.cache-primary-key }}
+        path: ${{ steps.cache_dir.outputs.cache_dir }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,11 +18,20 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      actions: write
       contents: read
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+    - name: Get yarn cache directory
+      id: cache_dir
+      shell: bash
+      run: |
+        {
+          echo 'cache_dir<<EOF'
+          yarn cache dir
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         persist-credentials: false
@@ -31,7 +40,17 @@ jobs:
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0
       with:
         node-version: 24.x
-        cache: "yarn"
+        package-manager-cache: false
+
+    # This workflow runs on pull requests which are untrusted
+    # so we only restore the yarn cache, we don't save it to avoid cache poisoning
+    - name: Restore yarn cache
+      id: restore_cache
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 #v5.0.3
+      with:
+        key: ${{ format('node-cache-{0}-{1}-yarn-{2}', runner.os, runner.arch, hashFiles('yarn.lock')) }}
+        path: ${{ steps.cache_dir.outputs.cache_dir }}
+
     - run: yarn run ci
       shell: bash
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
   build:
 
     permissions:
-      actions: write
       contents: write
 
     strategy:
@@ -62,16 +61,13 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: 'Use faster D: drive for yarn cache on Windows'
-      if: startsWith(matrix.os, 'windows')
-      shell: cmd
-      run: yarn config set cache-folder D:\ft_yarn_cache
-
+    # Do not restore the yarn cache, to avoid cache poisoning affecting releases
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0
       with:
         node-version: ${{ matrix.node-version }}
-        cache: "yarn"
+        package-manager-cache: false
+
     - run: yarn run ci
       shell: bash
       env:


### PR DESCRIPTION
## Pull Request Type

- [x] Security improvement

## Description

Currently we read and write the yarn cache in the build, linter and release workflows, however as anyone can submit a pull request, this enables a potential scenario where someone can get something written to the cache in a pull request through the linter workflow and restored from the cache in the build and release workflows, which we don't want (known as cache poisoning).

This pull request switches to the following caching behaviour:
- Linter workflow: can only read caches, which keeps linting "fast" in pull requests that don't change the dependencies
- Build workflow: can read and write caches as it runs only runs trusted branches or when manually triggered
- Release workflow: To be on the safe side, this workflow does not read or write caches

## Testing

- Successful run of the build workflow with no matching caches (save only): https://github.com/absidue/FreeTube/actions/runs/22118913662
- Successful run of the build workflow with matching caches (restore only): https://github.com/absidue/FreeTube/actions/runs/22119253812