### PR TITLE
Fix the proxy test by stripping the request headers

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -597,6 +597,9 @@ function runApp() {
 
         // YouTube doesn't send the Content-Type header for the media requests, so we shouldn't either
         delete requestHeaders['Content-Type']
+      } else if (urlObj.origin === 'https://ipwho.is') {
+        // Fix the CORS error with the proxy test button
+        requestHeaders = {}
       } else if (webContents) {
         const invidiousAuthorization = invidiousAuthorizations.get(webContents.id)
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue
- closes #8703

## Description

The API we are using for the proxy test button added CORS protection, this pull request strips the request headers from the requests to that API so that the requests still go through.

## Testing

I added this patch to the `src/renderer/components/ProxySettings/ProxySettings.vue` component to force it to show the proxy test button even when a proxy is not configured and clicked the proxy test button.

```diff
diff --git a/src/renderer/components/ProxySettings/ProxySettings.vue b/src/renderer/components/ProxySettings/ProxySettings.vue
index 84749afc9..ab34818b4 100644
--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -20,7 +20,7 @@
       />
     </FtFlexBox>
     <template
-      v-if="useProxy"
+      v-if="true"
     >
       <FtFlexBox>
         <FtSelect
@@ -301,12 +301,6 @@ function disableProxy() {
 }
 
 async function testProxy() {
-  isLoading.value = true
-
-  if (!useProxy.value) {
-    enableProxy()
-  }
-
   try {
     const response = await fetch(proxyTestUrl.value)
     const json = await response.json()
@@ -321,10 +315,6 @@ async function testProxy() {
     showToast(t('Settings.Proxy Settings["Error getting network information. Is your proxy configured properly?"]'))
     dataAvailable.value = false
   } finally {
-    if (!useProxy.value) {
-      disableProxy()
-    }
-
     isLoading.value = false
   }
 }

```

## Desktop

- **OS:** Windows
- **OS Version:** 11