### PR TITLE
Remove unused NS*UsageDescription keys from Info.plist

### DIFF
--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -84,7 +84,15 @@ export default {
       ],
       CFBundleURLSchemes: [
         'freetube'
-      ]
+      ],
+
+      // Clear the default usage descriptions in the Info.plist file set by Electron that we don't need
+      // see: https://github.com/electron/electron/blob/main/shell/browser/resources/mac/Info.plist
+      NSAudioCaptureUsageDescription: undefined,
+      NSBluetoothAlwaysUsageDescription: undefined,
+      NSBluetoothPeripheralUsageDescription: undefined,
+      NSCameraUsageDescription: undefined,
+      NSMicrophoneUsageDescription: undefined,
     }
   },
   win: {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

By default Electron allows all permissions so they include the permission descriptions for audio capture, bluetooth, camera and microphone usage [in their macOS Info.plist file](https://github.com/electron/electron/blob/main/shell/browser/resources/mac/Info.plist). As FreeTube doesn't need those permissions and therefore rejects all requests for them (Our allow list only allows `fullscreen`, `clipboard-sanitized-write` and `fileSystem`), we also don't need the `NS*UsageDescription` keys for them in our `Info.plist` file.

## Testing

Diff for the `FreeTube.app/Contents/Info.plist` file in the `freetube-*-mac-x64.zip` file for the [latest nightly build a the time of writing](https://github.com/FreeTubeApp/FreeTube/actions/runs/22267737622) and [this test build](https://github.com/absidue/FreeTube/actions/runs/22281266433):

```diff
diff --git a/Info-before.plist b/Info-after.plist
index 3e99cf0be..c8340e25d 100644
--- a/Info-before.plist
+++ b/Info-after.plist
@@ -17,7 +17,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.23.13-nightly-7017</string>
+    <string>0.23.13</string>
     <key>CFBundleURLSchemes</key>
     <array>
       <string>freetube</string>
@@ -36,7 +36,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>0.23.13-nightly-7017</string>
+    <string>0.23.13</string>
     <key>DTCompiler</key>
     <string>com.apple.compilers.llvm.clang.1_0</string>
     <key>DTSDKBuild</key>
@@ -54,7 +54,7 @@
         <key>algorithm</key>
         <string>SHA256</string>
         <key>hash</key>
-        <string>055f8a1d700087056da0747d1a58c040c32241342abba6b8145c56173ada81fb</string>
+        <string>28d548b6483a1a4aadcf9124058fd41b9e3eb4e615d8be50667713bd6c69fdc1</string>
       </dict>
     </dict>
     <key>LSApplicationCategoryType</key>
@@ -102,22 +102,12 @@
         </dict>
       </dict>
     </dict>
-    <key>NSAudioCaptureUsageDescription</key>
-    <string>This app needs access to audio capture</string>
-    <key>NSBluetoothAlwaysUsageDescription</key>
-    <string>This app needs access to Bluetooth</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>This app needs access to Bluetooth</string>
-    <key>NSCameraUsageDescription</key>
-    <string>This app needs access to the camera</string>
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyleft © 2020-2026 freetubeapp@protonmail.com</string>
     <key>NSMainNibFile</key>
     <string>MainMenu</string>
-    <key>NSMicrophoneUsageDescription</key>
-    <string>This app needs access to the microphone</string>
     <key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
     <false/>
     <key>NSPrincipalClass</key>

```

## Desktop

- **OS:** Windows
- **OS Version:** 11