### PR TITLE
Fixed issue #8711

### DIFF
--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -41,8 +41,8 @@ const getters = {
 function profileSort(a, b) {
   if (a._id === MAIN_PROFILE_ID) return -1
   if (b._id === MAIN_PROFILE_ID) return 1
-  if (a.name < b.name) return -1
-  if (a.name > b.name) return 1
+  if (a.name.toLowerCase() < b.name.toLowerCase()) return -1
+  if (a.name.toLowerCase() > b.name.toLowerCase()) return 1
   return 0
 }
 


### PR DESCRIPTION
added two lines in profileSort() to mean that capitalisation does not take priority over alphabetical order

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue


## Description

added two lines in profileSort() in profiles.js to mean that capitalisation does not take priority over alphabetical order when displaying profile list

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Go to profile list
2. Capital letters no longer have precedence over lowercase and alphabetical order is maintained
## Desktop
<!-- Please complete the following information-->
- **OS: Mac OS**
- **OS Version: Tahoe 26.3**
- **FreeTube version:[v0.23.13-beta]**

## Additional context
My first pull request for this project so apologies if there are mistakes in this description
