### PR TITLE
Fix case-sensitive profile sorting

### DIFF
--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -41,9 +41,7 @@ const getters = {
 function profileSort(a, b) {
   if (a._id === MAIN_PROFILE_ID) return -1
   if (b._id === MAIN_PROFILE_ID) return 1
-  if (a.name < b.name) return -1
-  if (a.name > b.name) return 1
-  return 0
+  return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
 }
 
 const actions = {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue


## Description
Profile names were sorted using JavaScript's `<` and `>` operators, which compare strings by Unicode code point. This causes uppercase letters to sort before all lowercase letters (e.g. "AB" before "Aa").

This replaces the comparison with `String.prototype.localeCompare()` using `sensitivity: 'base'`, which performs a case-insensitive, locale-aware alphabetical sort.

## Screenshots

**Before:** Profiles sorted as `AB, Aa, Ab, Ac` (uppercase takes priority)
**After:** Profiles sorted as `Aa, AB, Ab, Ac` (proper alphabetical order)

<img width="1218" height="428" alt="image" src="https://github.com/user-attachments/assets/4b6b382c-ca9c-4fb6-a461-279746dffa00" />


## Testing

1. Create multiple profiles with mixed-case names (e.g. "Aa", "AB", "Ab", "Ac")
2. Open the profile selection menu
3. Verify profiles are sorted alphabetically regardless of capitalization

## Desktop

- **OS:** Linux (Fedora)
- **OS Version:** 6.18.13-200.fc43.x86_64
- **FreeTube version:** v0.23.14 Beta (development branch)

## Additional context

The previous PR attempt (#8727) was closed. This is a minimal one-line fix using `localeCompare` which is the idiomatic JavaScript approach for locale-aware string sorting.