### PR TITLE
Fix: handle non-JSON Invidious API responses gracefully

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -58,7 +58,19 @@ function invidiousAPICall({ resource, id = '', params = {}, doLogError = true, s
   return new Promise((resolve, reject) => {
     const requestUrl = getCurrentInstanceUrl() + '/api/v1/' + resource + '/' + id + (!isNullOrEmpty(subResource) ? `/${subResource}` : '') + '?' + new URLSearchParams(params).toString()
     invidiousFetch(requestUrl)
-      .then((response) => response.json())
+      .then(async (response) => {
+        const responseText = await response.text()
+
+        if (!response.ok) {
+          throw new Error(responseText || `${response.status}: ${response.statusText}`)
+        }
+
+        try {
+          return JSON.parse(responseText)
+        } catch {
+          throw new Error(responseText || 'Invalid response from Invidious instance')
+        }
+      })
       .then((json) => {
         if (json.error !== undefined) {
           // community is empty, no need to display error.


### PR DESCRIPTION
## Summary

- When an Invidious instance returns non-JSON responses (e.g. plain text `"API disabled"`), the app currently crashes with `SyntaxError: Unexpected token 'A', "API disabled" is not valid JSON`
- This change reads the response as text first, checks `response.ok`, and wraps `JSON.parse` in a try/catch, so the actual server message is surfaced as the error instead of a cryptic JSON parse failure
- This is the single most commonly reported error in the app, affecting users whose Invidious instances have disabled their APIs

relates to #7883, #8527, #5720, #5506

## Test plan

- [ ] Configure an Invidious instance that has its API disabled and verify the error message now shows the actual server response (e.g. "API disabled") instead of a JSON SyntaxError
- [ ] Verify normal Invidious API usage still works correctly with a working instance
- [ ] Verify that Invidious JSON error responses (e.g. `{"error": "..."}`) are still handled as before