### PR TITLE
Create a dependabot group for webpack dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,15 @@ updates:
       fortawesome:
         patterns:
           - "@fortawesome/*"
+      webpack:
+        patterns:
+          - "css-loader"
+          - "mini-css-extract-plugin"
+          - "sass"
+          - "sass-loader"
+          - "webpack"
+          - "webpack-*"
+          - "*-webpack-plugin"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

This pull request adds a dependabot pull request group for webpack. We already have groups for babel, eslint, stylelint and fortawesome. This week we received 3 dependabot pull requests with webpack related packages (`webpack`, `css-minimizer-webpack-plugin` and `copy-webpack-plugin`) which have similar dependencies so conflicted with each other each time one of the pull requests was merged. Additionally grouping together related packages into a single pull request saves us work on checking and approving because there will be less pull requests overall.

## Additional context

The babel group could probably be merged into the webpack group but I decided it was alright to leave it separate for now.
