### PR TITLE
Fix build script not failing on error

### DIFF
--- a/_scripts/build.mjs
+++ b/_scripts/build.mjs
@@ -37,9 +37,5 @@ if (platform === 'darwin') {
   targets = Platform.LINUX.createTarget(['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'], arch)
 }
 
-try {
-  const output = await build({ targets, config, publish: 'never' })
-  console.log(output)
-} catch (error) {
-  console.error(error)
-}
+const output = await build({ targets, config, publish: 'never' })
+console.log(output)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

In the build script we have wrapped the call to electron-builder's build function in a try-catch but in the catch block we only log the error, which means that the script still finishes with exit code 0. This is problematic in our build and release workflows because the later steps depend on the executables and packages created by electron-builder, so the workflows only fail in those when they try to use the non-existent files e.g. https://github.com/FreeTubeApp/FreeTube/actions/runs/22680398420/job/65748925470

This pull request removes the try-catch so errors cause the script to abort and stop the workflow in the step that actually had the issue.

## Testing

Not applicable