### PR TITLE
Update shaka-player to 5.0.6

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -196,8 +196,8 @@ const config = {
 
       'youtubei.js$': 'youtubei.js/web',
 
-      // change to "shaka-player.ui.debug.js" to get debug logs (update jsconfig to get updated types)
-      'shaka-player$': 'shaka-player/dist/shaka-player.ui.js',
+      // change to "shaka-player.ui-es2021.debug.js" to get debug logs (update jsconfig to get updated types)
+      'shaka-player$': 'shaka-player/dist/shaka-player.ui-es2021.js',
 
       // Make @fortawesome/vue-fontawesome use the trimmed down API instead of the original @fortawesome/fontawesome-svg-core
       '@fortawesome/fontawesome-svg-core$': path.resolve(__dirname, '../src/renderer/fontawesome-minimal.js'),

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -173,8 +173,8 @@ const config = {
     alias: {
       DB_HANDLERS_ELECTRON_RENDERER_OR_WEB$: path.resolve(__dirname, '../src/datastores/handlers/web.js'),
 
-      // change to "shaka-player.ui.debug.js" to get debug logs (update jsconfig to get updated types)
-      'shaka-player$': 'shaka-player/dist/shaka-player.ui.js',
+      // change to "shaka-player.ui-es2021.debug.js" to get debug logs (update jsconfig to get updated types)
+      'shaka-player$': 'shaka-player/dist/shaka-player.ui-es2021.js',
 
       // Make @fortawesome/vue-fontawesome use the trimmed down API instead of the original @fortawesome/fontawesome-svg-core
       '@fortawesome/fontawesome-svg-core$': path.resolve(__dirname, '../src/renderer/fontawesome-minimal.js')

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -13,7 +13,7 @@
         "src/datastores/handlers/web"
       ],
       "shaka-player": [
-        "./node_modules/shaka-player/dist/shaka-player.ui"
+        "./node_modules/shaka-player/dist/shaka-player.ui-es2021"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "googlevideo": "^4.0.4",
     "marked": "^17.0.4",
     "process": "^0.11.10",
-    "shaka-player": "^5.0.5",
+    "shaka-player": "^5.0.6",
     "swiper": "^12.1.2",
     "vue": "^3.5.30",
     "vue-i18n": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "googlevideo": "^4.0.4",
     "marked": "^17.0.4",
     "process": "^0.11.10",
-    "shaka-player": "^4.16.20",
+    "shaka-player": "^5.0.4",
     "swiper": "^12.1.2",
     "vue": "^3.5.30",
     "vue-i18n": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "googlevideo": "^4.0.4",
     "marked": "^17.0.4",
     "process": "^0.11.10",
-    "shaka-player": "^5.0.4",
+    "shaka-player": "^5.0.5",
     "swiper": "^12.1.2",
     "vue": "^3.5.30",
     "vue-i18n": "^11.3.0",

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -197,11 +197,7 @@
   opacity: 1;
 }
 
-:deep(.shaka-controls-container > .shaka-play-button-container > .shaka-play-button) {
-  padding: min(calc(15% / 2), 55px);
-}
-
-:deep(.shaka-controls-button-panel>.ft-shaka-skip-button .material-svg-icon) {
+:deep(.shaka-controls-button-panel>.ft-shaka-skip-button .shaka-ui-icon) {
   font-size: 32px;
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -259,7 +259,7 @@ export default defineComponent({
 
     watch(displayVideoPlayButton, (newValue) => {
       ui.configure({
-        addBigPlayButton: newValue
+        bigButtons: newValue ? ['play_pause'] : []
       })
     })
 
@@ -616,7 +616,6 @@ export default defineComponent({
           // This only affects the "auto" quality, users can still manually select whatever quality they want.
           restrictToElementSize: true
         },
-        autoShowText: shaka.config.AutoShowText.NEVER,
 
         // Prioritise variants that are predicted to play:
         // - `smooth`: without dropping frames
@@ -908,9 +907,21 @@ export default defineComponent({
           volumeBarColors: {
             level: 'var(--primary-color)'
           },
+          mediaSession: {
+            // The WatchVideoInfo component handles that
+            handleMetadata: false,
+            // Need to override the default list so it doesn't override the next and previous video handlers in the WatchVideoPlaylist component.
+            supportedActions: [
+              'pause',
+              'play',
+              'seekbackward',
+              'seekforward',
+              'seekto'
+            ]
+          },
 
           // these have their own watchers
-          addBigPlayButton: displayVideoPlayButton.value,
+          bigButtons: displayVideoPlayButton.value ? ['play_pause'] : [],
           enableFullscreenOnRotation: enterFullscreenOnDisplayRotate.value,
           playbackRates: playbackRates.value,
           tapSeekDistance: defaultSkipInterval.value,
@@ -920,7 +931,13 @@ export default defineComponent({
 
           // TODO: enable this when electron gets document PiP support
           // https://github.com/electron/electron/issues/39633
-          preferDocumentPictureInPicture: false
+          documentPictureInPicture: {
+            enabled: false
+          }
+        }
+
+        if (document.pictureInPictureEnabled) {
+          firstTimeConfig.mediaSession.supportedActions.push('enterpictureinpicture')
         }
 
         // Combine the config objects so we only need to do one configure call
@@ -2321,16 +2338,23 @@ export default defineComponent({
             showValueChange(message, messageIcon)
           }
           break
-        case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.CAPTIONS:
+        case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.CAPTIONS: {
           // Toggle caption/subtitles
-          if (player.getTextTracks().length > 0) {
+
+          const textTracks = player.getTextTracks()
+          if (textTracks.length > 0) {
             event.preventDefault()
 
-            const currentlyVisible = player.isTextTrackVisible()
-            player.setTextTrackVisibility(!currentlyVisible)
+            if (textTracks.some(track => track.active)) {
+              player.selectTextTrack(null)
+            } else {
+              player.selectTextTrack(textTracks[0])
+            }
+
             showOverlayControls()
           }
           break
+        }
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.VOLUME_UP:
           // Increase volume
           event.preventDefault()
@@ -2939,8 +2963,6 @@ export default defineComponent({
 
         if (textTrack) {
           player.selectTextTrack(textTrack)
-
-          await player.setTextTrackVisibility(true)
         }
       }
 
@@ -2998,12 +3020,12 @@ export default defineComponent({
 
         const activeCaptionIndex = player.getTextTracks().findIndex(caption => caption.active)
 
-        if (activeCaptionIndex >= 0 && player.isTextTrackVisible()) {
+        if (activeCaptionIndex >= 0) {
           restoreCaptionIndex = activeCaptionIndex
 
           // hide captions before switching as shaka/the browser doesn't clean up the displayed captions
           // when switching away from the legacy formats
-          await player.setTextTrackVisibility(false)
+          player.selectTextTrack(null)
         } else {
           restoreCaptionIndex = null
         }
@@ -3053,7 +3075,14 @@ export default defineComponent({
 
             if (useAutoQuality) {
               if (label) {
-                player.selectVariantsByLabel(label)
+                const audioTracks = deduplicateAudioTracks(player.getAudioTracks()).values()
+
+                for (const track of audioTracks) {
+                  if (label === track.label) {
+                    player.selectAudioTrack(track)
+                    break
+                  }
+                }
               }
             } else {
               if (dimension) {

--- a/src/renderer/components/ft-shaka-video-player/player-components/AudioTrackSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AudioTrackSelection.js
@@ -17,7 +17,7 @@ export class AudioTrackSelection extends shaka.ui.SettingsMenu {
     this.menu.classList.add('audio-tracks')
 
     /** @type {SVGElement} */
-    const checkmarkIcon = new shaka.ui.MaterialSVGIcon(null, PlayerIcons.DONE_FILLED).getSvgElement()
+    const checkmarkIcon = new shaka.ui.Icon(null, PlayerIcons.DONE_FILLED).getSvgElement()
     checkmarkIcon.classList.add('shaka-chosen-item')
     checkmarkIcon.ariaHidden = 'true'
 
@@ -43,6 +43,16 @@ export class AudioTrackSelection extends shaka.ui.SettingsMenu {
     this.eventManager.listen(this.player, 'adaptation', () => {
       this.updateAudioTracks_()
     })
+
+    if (this.isSubMenu) {
+      this.eventManager.listen(this.controls, 'submenuopen', () => {
+        this.updateAudioTracks_()
+      })
+
+      this.eventManager.listen(this.controls, 'submenuclose', () => {
+        this.updateAudioTracks_()
+      })
+    }
 
     this.updateLocalisedStrings_()
 
@@ -94,7 +104,7 @@ export class AudioTrackSelection extends shaka.ui.SettingsMenu {
 
     this.button.setAttribute('shaka-status', this.currentSelection.innerText)
 
-    if (count > 1) {
+    if (count > 1 && !this.isSubMenuOpened) {
       this.button.classList.remove('shaka-hidden')
     } else {
       this.button.classList.add('shaka-hidden')

--- a/src/renderer/components/ft-shaka-video-player/player-components/AutoplayToggle.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AutoplayToggle.js
@@ -18,7 +18,7 @@ export class AutoplayToggle extends shaka.ui.Element {
     this.button_.classList.add('autoplay-toggle', 'shaka-tooltip')
 
     /** @private */
-    this.icon_ = new shaka.ui.MaterialSVGIcon(this.button_, PlayerIcons.PAUSE_CIRCLE_FILLED)
+    this.icon_ = new shaka.ui.Icon(this.button_, PlayerIcons.PAUSE_CIRCLE_FILLED)
 
     const label = document.createElement('label')
     label.classList.add(

--- a/src/renderer/components/ft-shaka-video-player/player-components/FullWindowButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/FullWindowButton.js
@@ -19,7 +19,7 @@ export class FullWindowButton extends shaka.ui.Element {
     this.button_.classList.add('full-window-button', 'shaka-tooltip')
 
     /** @private */
-    this.icon_ = new shaka.ui.MaterialSVGIcon(this.button_, PlayerIcons.OPEN_IN_FULL_FILLED)
+    this.icon_ = new shaka.ui.Icon(this.button_, PlayerIcons.OPEN_IN_FULL_FILLED)
 
     const label = document.createElement('label')
     label.classList.add(

--- a/src/renderer/components/ft-shaka-video-player/player-components/LegacyQualitySelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/LegacyQualitySelection.js
@@ -17,7 +17,7 @@ export class LegacyQualitySelection extends shaka.ui.SettingsMenu {
     this.menu.classList.add('legacy-qualities')
 
     /** @type {SVGElement} */
-    const checkmarkIcon = new shaka.ui.MaterialSVGIcon(null, PlayerIcons.DONE_FILLED).getSvgElement()
+    const checkmarkIcon = new shaka.ui.Icon(null, PlayerIcons.DONE_FILLED).getSvgElement()
     checkmarkIcon.classList.add('shaka-chosen-item')
     checkmarkIcon.ariaHidden = 'true'
 
@@ -62,6 +62,16 @@ export class LegacyQualitySelection extends shaka.ui.SettingsMenu {
       this.activeLegacyFormat_ = event.detail.format
       this.updateResolutionSelection_()
     })
+
+    if (this.isSubMenu) {
+      this.eventManager.listen(this.controls, 'submenuopen', () => {
+        this.button.classList.add('shaka-hidden')
+      })
+
+      this.eventManager.listen(this.controls, 'submenuclose', () => {
+        this.button.classList.remove('shaka-hidden')
+      })
+    }
 
     this.updateResolutionSelection_()
   }
@@ -116,12 +126,12 @@ export class LegacyQualitySelection extends shaka.ui.SettingsMenu {
     const activeCaptionIndex = this.player.getTextTracks().findIndex(caption => caption.active)
     let restoreCaptionIndex = null
 
-    if (activeCaptionIndex >= 0 && this.player.isTextTrackVisible()) {
+    if (activeCaptionIndex >= 0) {
       restoreCaptionIndex = activeCaptionIndex
 
       // hide captions before switching as shaka/the browser doesn't clean up the displayed captions
       // when switching away from the legacy formats
-      await this.player.setTextTrackVisibility(false)
+      this.player.selectTextTrack(null)
     }
 
     this.events_.dispatchEvent(new CustomEvent('setLegacyFormat', {

--- a/src/renderer/components/ft-shaka-video-player/player-components/ScreenshotButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/ScreenshotButton.js
@@ -17,8 +17,8 @@ export class ScreenshotButton extends shaka.ui.Element {
     this.button_ = document.createElement('button')
     this.button_.classList.add('screenshot-button', 'shaka-tooltip')
 
-    /** @private */
-    this.icon_ = new shaka.ui.MaterialSVGIcon(this.button_, PlayerIcons.PHOTO_CAMERA_FILLED)
+    // eslint-disable-next-line no-new
+    new shaka.ui.Icon(this.button_, PlayerIcons.PHOTO_CAMERA_FILLED)
 
     const label = document.createElement('label')
     label.classList.add(

--- a/src/renderer/components/ft-shaka-video-player/player-components/SkipButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/SkipButton.js
@@ -20,9 +20,9 @@ export class SkipButton extends shaka.ui.Element {
     this.button_ = document.createElement('button')
     this.button_.classList.add(`skip-${type}-button`, 'shaka-tooltip', 'ft-shaka-skip-button')
 
-    /** @private */
     const icon = type === 'next' ? PlayerIcons.SKIP_NEXT_FILLED : PlayerIcons.SKIP_PREVIOUS_FILLED
-    this.icon_ = new shaka.ui.MaterialSVGIcon(this.button_, icon)
+    // eslint-disable-next-line no-new
+    new shaka.ui.Icon(this.button_, icon)
 
     const label = document.createElement('label')
     label.classList.add(

--- a/src/renderer/components/ft-shaka-video-player/player-components/StatsButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/StatsButton.js
@@ -19,7 +19,7 @@ export class StatsButton extends shaka.ui.Element {
     this.button_.classList.add('stats-button')
 
     /** @private */
-    this.icon_ = new shaka.ui.MaterialSVGIcon(this.button_, PlayerIcons.INSERT_CHART_DEFAULT)
+    this.icon_ = new shaka.ui.Icon(this.button_, PlayerIcons.INSERT_CHART_DEFAULT)
 
     const label = document.createElement('label')
     label.classList.add('shaka-overflow-button-label', 'shaka-simple-overflow-button-label-inline')

--- a/src/renderer/components/ft-shaka-video-player/player-components/TheatreModeButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/TheatreModeButton.js
@@ -19,7 +19,7 @@ export class TheatreModeButton extends shaka.ui.Element {
     this.button_.classList.add('theatre-button', 'shaka-tooltip')
 
     /** @private */
-    this.icon_ = new shaka.ui.MaterialSVGIcon(this.button_, PlayerIcons.RECTANGLE_DEFAULT)
+    this.icon_ = new shaka.ui.Icon(this.button_, PlayerIcons.RECTANGLE_DEFAULT)
 
     const label = document.createElement('label')
     label.classList.add(

--- a/src/renderer/helpers/player/SabrManifestParser.js
+++ b/src/renderer/helpers/player/SabrManifestParser.js
@@ -238,12 +238,14 @@ class SabrManifestParser {
 
     const imageStreams = /** @__NOINLINE__ */ createImageStreams(manifestData.storyboards, presentationTimeline, currentId)
 
+    /** @type {shaka.extern.Manifest} */
     const manifest = {
       type: 'SABR',
       startTime: 0,
       variants,
       textStreams,
       imageStreams,
+      chapterStreams: [],
       presentationTimeline,
 
       gapCount: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7414,10 +7414,10 @@ setprototypeof@1.2.0, setprototypeof@~1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-5.0.4.tgz#5d8504e8bf7f3ba6638255b425f27a4908761d48"
-  integrity sha512-Fuctx77d2iQCrThCcUQkuDtuAu7amomFgRGY9eV3O67/Jojg5mY8xnipSrjHez+HiHqTuXcWpeWRWzHYHKVGVQ==
+shaka-player@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-5.0.5.tgz#3628966826c7040c8389c89dad75cdddfbd55b66"
+  integrity sha512-dvqzCoL4ViV/F4ytm1OC1hjxu/0t+J9TepQ2qJAJKjYGjY+SWwvu2xyi/xG0MOezavoPfOHhW7t8nziTWvakVg==
 
 shallow-clone@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7414,10 +7414,10 @@ setprototypeof@1.2.0, setprototypeof@~1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-5.0.5.tgz#3628966826c7040c8389c89dad75cdddfbd55b66"
-  integrity sha512-dvqzCoL4ViV/F4ytm1OC1hjxu/0t+J9TepQ2qJAJKjYGjY+SWwvu2xyi/xG0MOezavoPfOHhW7t8nziTWvakVg==
+shaka-player@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-5.0.6.tgz#23c897fe0a23df3c0bed7e7f0b2c8d335eee3c20"
+  integrity sha512-WE322LJpmFBuvebhjEhE++RrXH1xIX2oQOzO3EuByExfkp9podSEhRV+KcB19SOS1rMpQ85q4v+sURsETkCwtA==
 
 shallow-clone@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7414,10 +7414,10 @@ setprototypeof@1.2.0, setprototypeof@~1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shaka-player@^4.16.20:
-  version "4.16.20"
-  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-4.16.20.tgz#0c2063e4cffbf0ded1961f3d155598313b50d474"
-  integrity sha512-duds1dssmFZ3fSbNV2Cmez0qR7YNrrFzcn5DVXhiNTPOw/E0mUEzW+EFJkuAfA43s3UuwG5y+orbhELakBj4yw==
+shaka-player@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/shaka-player/-/shaka-player-5.0.4.tgz#5d8504e8bf7f3ba6638255b425f27a4908761d48"
+  integrity sha512-Fuctx77d2iQCrThCcUQkuDtuAu7amomFgRGY9eV3O67/Jojg5mY8xnipSrjHez+HiHqTuXcWpeWRWzHYHKVGVQ==
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Pull Request Type

- [x] Dependency upgrade

## Related issue
Closes #6106

## Description

This pull request upgrade shaka-player to version 5.0.6. I also switched to the new ES2021 bundle as it includes a lot less polyfills so is about 100kb smaller.
The goal of this pull request is just to do the upgrade, other changes such as switching to shaka-players chapter markers or testing and enabling their new subtitle settings should be done in follow up pull requests, to avoid stretching the scope of this pull request.

References:
- [v5.0.0 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.0)
- [v5.0.1 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.1)
- [v5.0.2 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.2)
- [v5.0.3 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.3)
- [v5.0.4 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.4)
- [v5.0.5 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.5)
- [v5.0.6 changelog](https://github.com/shaka-project/shaka-player/releases/tag/v5.0.6)
- [v5 upgrade guide](https://shaka-project.github.io/shaka-player/docs/api/tutorial-upgrade.html#v5.0)

## Testing

I spent a few hours testing this and going through all the changelogs and upgrade guides, but as this is a major version bump for something that many users consider to be a core part of the application, please include this in your daily driver builds and test this for a bit before approving. I have to say I was expecting to have to change more things, so I am a bit worried that I have missed some things.

Test build: https://github.com/absidue/FreeTube/actions/runs/22826293673

## Desktop

- **OS:** Windows
- **OS Version:** 11