### PR TITLE
Fix Up Next section missing upload date

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1577,8 +1577,11 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       let premiereDate
 
       /** @type {YTNodes.ThumbnailOverlayBadgeView | undefined} */
+      /** @type {YTNodes.ThumbnailBottomOverlayView | undefined } */
       const thumbnailOverlayBadgeView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailOverlayBadgeView)
 
+      // New structure appears to use ThumbnailBottomOverlayView so we need to check for both
+      const thumbnailBottomOverlayView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailBottomOverlayView)
       if (thumbnailOverlayBadgeView) {
         if (thumbnailOverlayBadgeView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
           liveNow = true
@@ -1593,6 +1596,21 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
 
           if (durationBadge) {
             lengthSeconds = Utils.timeToSeconds(durationBadge.text)
+          }
+        }
+      } else if (thumbnailBottomOverlayView) {
+        const badge = thumbnailBottomOverlayView?.badges?.[0]
+        if (badge) {
+          if (badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE') {
+            liveNow = true
+          } else if (badge.text.toLowerCase() === 'upcoming') {
+            isUpcoming = true
+          } else {
+            const durationBadge = thumbnailBottomOverlayView.badges.find(badge => /^[\d:]+$/.test(badge.text))
+
+            if (durationBadge) {
+              lengthSeconds = Utils.timeToSeconds(durationBadge.text)
+            }
           }
         }
       }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1594,9 +1594,10 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
           if (durationBadge) {
             lengthSeconds = Utils.timeToSeconds(durationBadge.text)
           }
-
-          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
         }
+      }
+      if (!liveNow && !isUpcoming) {
+        publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
       }
 
       let viewCount = null

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1578,6 +1578,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
 
       /** @type {YTNodes.ThumbnailBottomOverlayView | undefined } */
       const thumbnailBottomOverlayView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailBottomOverlayView)
+
       if (thumbnailBottomOverlayView) {
         if (thumbnailBottomOverlayView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
           liveNow = true
@@ -1597,6 +1598,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
           publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
         }
       }
+
       let viewCount = null
 
       const viewsText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1576,48 +1576,27 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       let isUpcoming = false
       let premiereDate
 
-      /** @type {YTNodes.ThumbnailOverlayBadgeView | undefined} */
       /** @type {YTNodes.ThumbnailBottomOverlayView | undefined } */
-      const thumbnailOverlayBadgeView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailOverlayBadgeView)
-
-      // New structure appears to use ThumbnailBottomOverlayView so we need to check for both
       const thumbnailBottomOverlayView = lockupView.content_image?.overlays?.firstOfType(YTNodes.ThumbnailBottomOverlayView)
-      if (thumbnailOverlayBadgeView) {
-        if (thumbnailOverlayBadgeView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
+      if (thumbnailBottomOverlayView) {
+        if (thumbnailBottomOverlayView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
           liveNow = true
-        } else if (thumbnailOverlayBadgeView.badges.some(badge => badge.text.toLowerCase() === 'upcoming')) {
+        } else if (thumbnailBottomOverlayView.badges.some(badge => badge.text.toLowerCase() === 'upcoming')) {
           isUpcoming = true
 
           if (lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.[1].text?.text) {
             premiereDate = new Date(lockupView.metadata.metadata.metadata_rows[1].metadata_parts[1].text.text)
           }
         } else {
-          const durationBadge = thumbnailOverlayBadgeView.badges.find(badge => /^[\d:]+$/.test(badge.text))
+          const durationBadge = thumbnailBottomOverlayView.badges.find(badge => /^[\d:]+$/.test(badge.text))
 
           if (durationBadge) {
             lengthSeconds = Utils.timeToSeconds(durationBadge.text)
           }
-        }
-      } else if (thumbnailBottomOverlayView) {
-        const badge = thumbnailBottomOverlayView?.badges?.[0]
-        if (badge) {
-          if (badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE') {
-            liveNow = true
-          } else if (badge.text.toLowerCase() === 'upcoming') {
-            isUpcoming = true
-          } else {
-            const durationBadge = thumbnailBottomOverlayView.badges.find(badge => /^[\d:]+$/.test(badge.text))
 
-            if (durationBadge) {
-              lengthSeconds = Utils.timeToSeconds(durationBadge.text)
-            }
-          }
+          publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
         }
       }
-      if (!liveNow && !isUpcoming) {
-        publishedText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
-      }
-
       let viewCount = null
 
       const viewsText = lockupView.metadata.metadata?.metadata_rows[1].metadata_parts?.find(part => {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
closes #8754 

## Description
Videos had stopped displaying the metadata ` #  hours/days/months/years ago ` and the duration of the video in the Up Next section
## Screenshots 
## Before

<img width="1874" height="1096" alt="image" src="https://github.com/user-attachments/assets/25ccd165-578e-4896-bfbb-b191349d820f" />

## After 

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/73d84656-de59-4fd8-999d-05d95ec54407" />

## Testing

1. Open video
2. Observe metadata being visible

## Desktop

- **OS:*MacOS*
- **OS Version:*Tahoe 26.3*
- **FreeTube version:*0.23.14-beta*
