### PR TITLE
fix: improve Catppuccin Mocha owner comment contrast

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -320,6 +320,11 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --logo-text: url('../../_icons/textCatppuccinMochaLightSmall.svg');
 }
 
+/* Fix owner comment contrast - secondary-card-bg-color (#1e1e2e) has only 1.07:1 contrast with card-bg-color (#181825). Use Surface1 (#45475a) for improved visibility (1.92:1) while maintaining text readability (6.30:1). See #6597 */
+.catppuccinMocha .commentOwner {
+  background-color: #45475a;
+}
+
 .dracula {
   --primary-text-color: #f8f8f2;
   --secondary-text-color: #c6cee6;


### PR DESCRIPTION


## Summary
Owner comments in the Catppuccin Mocha theme had insufficient color contrast. The highlight used \secondary-card-bg-color\ (#1e1e2e) which had only **1.07:1** contrast with \card-bg-color\ (#181825), making the uploader's username barely distinguishable.

## Changes
- Add theme-specific override for \.commentOwner\ in Catppuccin Mocha
- Use Surface1 (#45475a) from the Catppuccin Mocha palette for the owner comment highlight
- Improves highlight visibility to **1.92:1** contrast with the card background
- Maintains text readability at **6.30:1** (WCAG AA pass)

Note: Achieving 4.5:1 contrast between the two background colors while keeping text readable would require a lighter highlight that would fail text contrast. This fix provides the best balance—significantly improved visibility while preserving accessibility for the text.