### PR TITLE
Show more detailed error when decipher script throws an error

### DIFF
--- a/src/renderer/sigFrameScript.js
+++ b/src/renderer/sigFrameScript.js
@@ -12,7 +12,7 @@ window.addEventListener('message', (event) => {
   } catch (error) {
     window.parent.postMessage(JSON.stringify({
       id: data.id,
-      error
+      error: error.toString()
     }), '*')
   }
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
When the `sigFrameScript` throws an error, the error is not properly serialized, and this causes the non-descriptive `[Object object]` error. This PR addresses this by passing the error back to the main view as a string.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
|before|after|
|---|---|
|<img width="946" height="958" alt="Screenshot-2026-03-11_19:55:58" src="https://github.com/user-attachments/assets/72b50238-4306-44b3-995a-f9ce6f320aa9" />|<img width="946" height="958" alt="Screenshot-2026-03-11_20:00:05" src="https://github.com/user-attachments/assets/ea3b48e8-1a94-436b-a989-0f14024d5129" />|



## Testing
In order to trigger the error to show up, the `player_id` needs to be removed from `local.js`. Additionally, `yarn dev` needs to be restarted between checking out changes.

1. `yarn dev`
2. Open a video
3. Check if the error says something other than `[Object object]`

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora
- **OS Version:** Fedora 42 w/ hyprland 0.51
- **FreeTube version:** a9747ce7a26089792dc8e9e8a5f3bd926f848d6e

## Additional context
The reason I noticed this is because FTA's sigFrameView doesn't have this issue (because passing objects of any kind through the java bridge can be tricky, so I was already serializing it to a string). 
