### PR TITLE
Add QMPlay2 as an external player

### DIFF
--- a/static/external-player-map.json
+++ b/static/external-player-map.json
@@ -21,6 +21,23 @@
         }
     },
     {
+        "name": "QMPlay2",
+        "value": "QMPlay2",
+        "cmdArguments": {
+            "defaultExecutable": "QMPlay2",
+            "defaultCustomArguments": null,
+            "supportsYtdlProtocol": true,
+            "videoUrl": "",
+            "playlistUrl": "",
+            "startOffset": "",
+            "playbackRate": "--speed",
+            "playlistIndex": null,
+            "playlistReverse": null,
+            "playlistShuffle": null,
+            "playlistLoop": null
+        }
+    },
+    {
         "name": "VLC",
         "value": "vlc",
         "cmdArguments": {
@@ -52,7 +69,7 @@
             "playlistLoop": "--mpv-loop-playlist"
         }
     },
-      {
+    {
         "name": "SMPlayer",
         "value": "smplayer",
         "cmdArguments": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ x ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
No issue to address, it's a discrete feature.

## Description
Adds QMPlay2 to the list of available external media players.

## Screenshots <!-- If appropriate --> (none)
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
0. Have QMPlay2 (https://github.com/zaps166/QMPlay2) installed and added to PATH.
1. Select QMPlay2 as the external player in Freetube's settings.
2. Click the "open external" icon on a video thumbnail and wait for the video to load.

## Desktop
Tested on Linux.
<!-- Please complete the following information-->
- **OS: 6.19.6-2-cachyos Linux kernel**
- **OS Version: Fri, 06 Mar 2026 11:29:20 +0000**
- **FreeTube version: v0.23.14 Beta**

## Additional context (not necessary)
<!-- Add any other context about the pull request here. -->
