### PR TITLE
Properly sanitize HTML

### DIFF
--- a/_scripts/_undefinedDefaultExport.mjs
+++ b/_scripts/_undefinedDefaultExport.mjs
@@ -1,0 +1,1 @@
+export default undefined

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -200,7 +200,10 @@ const config = {
       'shaka-player$': 'shaka-player/dist/shaka-player.ui.js',
 
       // Make @fortawesome/vue-fontawesome use the trimmed down API instead of the original @fortawesome/fontawesome-svg-core
-      '@fortawesome/fontawesome-svg-core$': path.resolve(__dirname, '../src/renderer/fontawesome-minimal.js')
+      '@fortawesome/fontawesome-svg-core$': path.resolve(__dirname, '../src/renderer/fontawesome-minimal.js'),
+
+      // Fix dompurify not being tree-shaking friendly
+      dompurify$: path.resolve(__dirname, '_undefinedDefaultExport.mjs')
     },
     extensions: ['.js', '.vue']
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -270,7 +270,11 @@ export default [
     rules: {
       '@stylistic/space-before-function-paren': 'off',
       '@stylistic/comma-dangle': ['error', 'only-multiline'],
-      'vue/no-v-html': 'off',
+
+      // Ban v-html as it inserts HTML via innerHTML without sanitizing it
+      // if inserting raw HTML is unavoidable the custom v-safer-html directive should be used
+      // which sanitizes the HTML before inserting it into the DOM
+      'vue/no-v-html': 'error',
 
       'no-console': ['error', {
         allow: ['warn', 'error'],
@@ -339,6 +343,15 @@ export default [
     languageOptions: {
       globals: {
         __FREETUBE_ALLOWED_PATHS__: 'readable'
+      }
+    }
+  },
+  {
+    files: ['src/renderer/directives/vSaferHtml.js'],
+    languageOptions: {
+      globals: {
+        // Fix Sanitizer not being listed in `globals` yet, remove it it gets added in the future
+        Sanitizer: 'readable'
       }
     }
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -350,7 +350,7 @@ export default [
     files: ['src/renderer/directives/vSaferHtml.js'],
     languageOptions: {
       globals: {
-        // Fix Sanitizer not being listed in `globals` yet, remove it it gets added in the future
+        // Fix Sanitizer not being listed in `globals` yet, remove it when it gets added in the future
         Sanitizer: 'readable'
       }
     }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@seald-io/nedb": "^4.1.2",
     "autolinker": "^4.1.5",
     "bgutils-js": "^3.2.0",
+    "dompurify": "^3.3.3",
     "electron-context-menu": "^4.1.1",
     "googlevideo": "^4.0.4",
     "marked": "^17.0.4",

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -66,10 +66,10 @@
         </h1>
       </template>
       <bdo
+        v-safer-html.lenient="updateChangelog"
         class="changeLogText"
         dir="ltr"
         lang="en"
-        v-html="updateChangelog"
       />
       <FtFlexBox>
         <FtButton
@@ -129,6 +129,7 @@ import FtPlaylistAddVideoPrompt from './components/FtPlaylistAddVideoPrompt/FtPl
 import FtCreatePlaylistPrompt from './components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue'
 import FtKeyboardShortcutPrompt from './components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue'
 import FtSearchFilters from './components/FtSearchFilters/FtSearchFilters.vue'
+import { vSaferHtml } from './directives/vSaferHtml.js'
 
 import store from './store/index'
 

--- a/src/renderer/components/ChannelAbout/ChannelAbout.vue
+++ b/src/renderer/components/ChannelAbout/ChannelAbout.vue
@@ -7,9 +7,9 @@
     >
       <h2>{{ $t("Channel.About.Channel Description") }}</h2>
       <div
+        v-safer-html="description"
         class="aboutInfo"
         dir="auto"
-        v-html="description"
       />
     </template>
     <template
@@ -121,6 +121,7 @@ import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import FtChannelBubble from '../../components/FtChannelBubble/FtChannelBubble.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
+import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import store from '../../store/index'
 

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -53,9 +53,9 @@
       </p>
     </div>
     <p
+      v-safer-html="postText"
       class="postText"
       dir="auto"
-      v-html="postText"
     />
     <swiper-container
       v-if="postType === 'multiImage' && postContent.content.length > 0"
@@ -177,6 +177,7 @@ import FtListVideo from '../ft-list-video/ft-list-video.vue'
 import FtListPlaylist from '../FtListPlaylist/FtListPlaylist.vue'
 import FtCommunityPoll from '../FtCommunityPoll/FtCommunityPoll.vue'
 import FtShareButton from '../FtShareButton/FtShareButton.vue'
+import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import store from '../../store/index'
 

--- a/src/renderer/components/FtListChannel/FtListChannel.vue
+++ b/src/renderer/components/FtListChannel/FtListChannel.vue
@@ -60,9 +60,9 @@
         </div>
         <p
           v-if="listType !== 'grid'"
+          v-safer-html="description"
           class="description"
           dir="auto"
-          v-html="description"
         />
       </div>
       <FtSubscribeButton
@@ -80,6 +80,7 @@
 import { computed } from 'vue'
 
 import FtSubscribeButton from '../FtSubscribeButton/FtSubscribeButton.vue'
+import { vSaferHtml } from '../../directives/vSaferHtml'
 
 import store from '../../store/index'
 

--- a/src/renderer/components/FtTimestampCatcher.vue
+++ b/src/renderer/components/FtTimestampCatcher.vue
@@ -1,14 +1,17 @@
 <template>
+  <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
   <p
+    v-safer-html="displayText"
     dir="auto"
-    @timestamp-clicked="catchTimestampClick"
-    v-html="displayText"
+    @click="catchTimestampClick"
   />
 </template>
 
 <script setup>
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+
+import { vSaferHtml } from '../directives/vSaferHtml.js'
 
 const props = defineProps({
   inputHtml: {
@@ -40,15 +43,27 @@ const displayText = computed(() => props.inputHtml.replaceAll(/(?:(\d+):)?(\d+):
   }).href
 
   // Adding the URL lets the user open the video in a new window at this timestamp
-  return `<a tabindex="${props.linkTabIndex}" href="${url}" onclick="event.preventDefault();this.dispatchEvent(new CustomEvent('timestamp-clicked',{bubbles:true,detail:${time}}));window.scrollTo(0,0)">${timestamp}</a>`
+  return `<a tabindex="${props.linkTabIndex}" href="${url}" data-time="${time}">${timestamp}</a>`
 }))
 
 const emit = defineEmits(['timestamp-event'])
 
 /**
- * @param {CustomEvent} event
+ * @param {PointerEvent} event
  */
 function catchTimestampClick(event) {
-  emit('timestamp-event', event.detail)
+  /** @type {HTMLAnchorElement} */
+  const target = event.target
+
+  if (target.tagName === 'A' && target.dataset.time) {
+    const timeSeconds = parseInt(target.dataset.time)
+
+    if (!isNaN(timeSeconds)) {
+      event.preventDefault()
+
+      emit('timestamp-event', timeSeconds)
+      window.scrollTo(0, 0)
+    }
+  }
 }
 </script>

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -136,9 +136,9 @@
             </p>
           </div>
           <p
+            v-safer-html="superChat.message"
             class="chatMessage"
             dir="auto"
-            v-html="superChat.message"
           />
         </div>
       </div>
@@ -181,9 +181,9 @@
             </div>
             <p
               v-if="comment.message"
+              v-safer-html="comment.message"
               class="chatMessage"
               dir="auto"
-              v-html="comment.message"
             />
           </template>
           <template
@@ -219,8 +219,8 @@
                 >
               </span>
               <bdi
+                v-safer-html="comment.message"
                 class="chatMessage"
-                v-html="comment.message"
               />
             </p>
           </template>
@@ -255,6 +255,7 @@ import { YTNodes } from 'youtubei.js'
 import FtLoader from '../FtLoader/FtLoader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtButton from '../FtButton/FtButton.vue'
+import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import store from '../../store/index'
 

--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -14,11 +14,15 @@ import {
 } from '../../helpers/utils'
 import { deArrowData, deArrowThumbnail } from '../../helpers/sponsorblock'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
+import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 export default defineComponent({
   name: 'FtListVideo',
   components: {
     'ft-icon-button': FtIconButton
+  },
+  directives: {
+    'safer-html': vSaferHtml
   },
   props: {
     data: {

--- a/src/renderer/components/ft-list-video/ft-list-video.vue
+++ b/src/renderer/components/ft-list-video/ft-list-video.vue
@@ -238,9 +238,9 @@
       </div>
       <p
         v-if="description && effectiveListTypeIsList && appearance === 'result'"
+        v-safer-html="description"
         class="description"
         dir="auto"
-        v-html="description"
       />
     </div>
   </div>

--- a/src/renderer/directives/vSaferHtml.js
+++ b/src/renderer/directives/vSaferHtml.js
@@ -33,7 +33,7 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
             // live chat emojis (see parseLocalTextRuns)
             {
               name: 'img',
-              attributes: ['alt', 'height', 'loading', 'src', 'style', 'width']
+              attributes: ['alt', 'height', 'loading', 'src', 'style', 'title', 'width']
             }
           ]
         })
@@ -44,7 +44,7 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
       if (domPurifyStrictConfig === undefined) {
         domPurifyStrictConfig = {
           ALLOWED_TAGS: ['br', 'b', 'i', 's', 'a', 'img'],
-          ALLOWED_ATTR: ['alt', 'data-time', 'dir', 'height', 'href', 'lang', 'loading', 'src', 'style', 'tabindex', 'width']
+          ALLOWED_ATTR: ['alt', 'data-time', 'dir', 'height', 'href', 'lang', 'loading', 'src', 'style', 'tabindex', 'title', 'width']
         }
       }
 

--- a/src/renderer/directives/vSaferHtml.js
+++ b/src/renderer/directives/vSaferHtml.js
@@ -1,0 +1,54 @@
+import DOMPurify from 'dompurify'
+
+const USE_NATIVE_SANITIZER = process.env.IS_ELECTRON || ('Sanitizer' in window && typeof HTMLElement.prototype.setHTML === 'function')
+
+let sanitizer
+/** @type {import('dompurify').Config | undefined} */
+let domPurifyStrictConfig
+
+/** @type {import('vue').FunctionDirective<HTMLElement, string, 'lenient'>} */
+export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
+  if (oldValue === null || value !== oldValue) {
+    if (modifiers.lenient) {
+      // Use the default browser sanitizer configuration e.g. for the changelog
+      if (USE_NATIVE_SANITIZER) {
+        element.setHTML(value)
+      } else {
+        element.innerHTML = DOMPurify.sanitize(value, { RETURN_TRUSTED_TYPE: false })
+      }
+    } else if (USE_NATIVE_SANITIZER) {
+      // Use a much stricter sanitzer configuration, should be used in most places
+      if (sanitizer === undefined) {
+        sanitizer = new Sanitizer({
+          comments: false,
+          elements: [
+            'br',
+            'b',
+            'i',
+            's',
+            {
+              name: 'a',
+              attributes: ['data-time', 'dir', 'href', 'lang', 'tabindex']
+            },
+            // live chat emojis (see parseLocalTextRuns)
+            {
+              name: 'img',
+              attributes: ['alt', 'height', 'loading', 'src', 'style', 'width']
+            }
+          ]
+        })
+      }
+
+      element.setHTML(value, { sanitizer })
+    } else {
+      if (domPurifyStrictConfig === undefined) {
+        domPurifyStrictConfig = {
+          ALLOWED_TAGS: ['br', 'b', 'i', 's', 'a', 'img'],
+          ALLOWED_ATTR: ['alt', 'data-time', 'dir', 'height', 'href', 'lang', 'loading', 'src', 'style', 'tabindex', 'width']
+        }
+      }
+
+      element.innerHTML = DOMPurify.sanitize(value, domPurifyStrictConfig)
+    }
+  }
+}

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -1,9 +1,5 @@
 import store from '../../store/index'
-import {
-  calculatePublishedDate,
-  getRelativeTimeFromDate,
-  stripHTML,
-} from '../utils'
+import { calculatePublishedDate, getRelativeTimeFromDate } from '../utils'
 import { isNullOrEmpty } from '../strings'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
@@ -616,7 +612,7 @@ function parseInvidiousCommentData(response) {
       authorThumb: youtubeImageUrlToInvidious(comment.authorThumbnails.at(-1).url),
       author: comment.author,
       likes: comment.likeCount,
-      text: autolinker.link(stripHTML(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstanceUrl()))),
+      text: autolinker.link(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstanceUrl())),
       dataType: 'invidious',
       isOwner: comment.authorIsChannelOwner,
       isPinned: comment.isPinned,

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -432,15 +432,6 @@ export function createWebURL(path) {
 }
 
 /**
- * strip html tags but keep <br>, <b>, </b> <s>, </s>, <i>, </i>
- * @param {string} value
- * @returns {string}
- */
-export function stripHTML(value) {
-  return value.replaceAll(/(<(?!br|\/?[abis]|img>)([^>]+)>)/gi, '')
-}
-
-/**
  * This formats the duration of a video in seconds into a user friendly timestamp.
  * It will return strings like LIVE or UPCOMING, without making any changes
  * @param {string|number} lengthSeconds the video duration in seconds or the strings LIVE or UPCOMING

--- a/src/renderer/views/About/About.vue
+++ b/src/renderer/views/About/About.vue
@@ -28,8 +28,8 @@
             {{ chunk.title }}
           </h3>
           <div
+            v-safer-html="chunk.content"
             class="content"
-            v-html="chunk.content"
           />
         </figure>
       </section>
@@ -44,6 +44,7 @@ import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtLogoFull from '../../components/FtLogoFull/FtLogoFull.vue'
+import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import { ABOUT_BITCOIN_ADDRESS } from '../../../constants'
 import packageDetails from '../../../../package.json'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,6 +1984,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/verror@^1.10.3":
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/@types/verror/-/verror-1.10.5.tgz#2a1413aded46e67a1fe2386800e291123ed75eb1"
@@ -3663,6 +3668,13 @@ domhandler@^5.0.1, domhandler@^5.0.2:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
+  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
## Pull Request Type

- [x] Security improvement

## Description

Currently we have a mix of different ways of handling raw HTML, none of them are bulletproof. This pull request removes all uses of `v-html` and replaces them with a custom `v-safer-html` directive that uses the brand new HTML Sanitizer API which we can use with the Electron 41 upgrade and falls back to the DOMPurify library outside of Electron when the HTML Sanitizer API is not available. I went with two different sanitizing configurations a default one that is very strict that only allows the `<br>`, `<b>`, `<i>`, `<s>`, `<a>`, `<img>` elements, which is used in most places and a lenient one that uses the default Sanitizer/DOMpurify configurations that only strip dangerours things (e.g. `<script>` tags and inline event handlers) that is used for the changelog display.

## Testing
1. Check that the About page still looks correct
2. Check that video descriptions look correct and clicking on timestamps still works (as playback is broken you don't actually need to check that it seeked, just that it scrolled to the top of the page, as that happens in the same event handler).
3. Check that comments with formatting look correct
4. Hard-code `USE_NATIVE_SANITIZER` to `false` and remove the dompurify alias in the renderer webpack config, then repeat steps 1-3

If you are unsure about what videos to use for 2 and 3, the LinusTechTips WAN show ones usually have timestamps in both the description and comments, as well as formatting in the comments.

## Desktop

- **OS:** Windows
- **OS Version:** 11