### PR TITLE
Clean up Voice Boost detection after YouTube.js update

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1,5 +1,4 @@
 import { ClientType, Constants, Innertube, Misc, Mixins, Parser, Platform, UniversalCache, Utils, YT, YTNodes } from 'youtubei.js'
-import { FormatXTags } from '../../../../node_modules/youtubei.js/dist/protos/generated/misc/common'
 import Autolinker from 'autolinker'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
@@ -2179,17 +2178,4 @@ export async function getLocalCommunityPostComments(postId, channelId) {
   const innertube = await createInnertube()
 
   return await innertube.getPostComments(postId, channelId)
-}
-
-/**
- * @param {Misc.Format} format
- */
-export function formatHasVoiceBoostTag(format) {
-  if (!format.xtags) {
-    return undefined
-  }
-
-  const xtags = FormatXTags.decode(Utils.base64ToU8(format.xtags)).xtags
-
-  return xtags.some(tag => tag.key === 'vb' && tag.value === '1')
 }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -23,7 +23,6 @@ import {
   showToast
 } from '../../helpers/utils'
 import {
-  formatHasVoiceBoostTag,
   getLocalVideoInfo,
   mapLocalLegacyFormat,
   parseLocalSubscriberCount,
@@ -1575,7 +1574,7 @@ export default defineComponent({
           audioSampleRate: format.audio_sample_rate,
           audioChannels: format.audio_channels,
           isDrc: format.is_drc,
-          isVoiceBoost: formatHasVoiceBoostTag(format),
+          isVoiceBoost: format.is_vb,
           isOriginal: format.is_original,
           isDubbed: format.is_dubbed,
           isAutoDubbed: format.is_auto_dubbed,


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

This pull request removes our voice boost detection workaround that we introduced in the SABR PR in favour of the `Format.is_vb` property added in YouTube.js 17.

## Testing

Open any video, it shouldn't error.

## Desktop

- **OS:** Windows
- **OS Version:** 11