### PR TITLE
Fix age-restricted videos breaking the watch page

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -470,28 +470,32 @@ export async function getLocalVideoInfo(id) {
       info.playability_status.reason === 'Sign in to confirm your age') ||
     (hasTrailer && trailerIsAgeRestricted)
   ) {
-    const webEmbeddedInnertube = await createInnertube({ clientType: ClientType.WEB_EMBEDDED })
-    webEmbeddedInnertube.session.context.client.visitorData = webInnertube.session.context.client.visitorData
+    try {
+      const webEmbeddedInnertube = await createInnertube({ clientType: ClientType.WEB_EMBEDDED })
+      webEmbeddedInnertube.session.context.client.visitorData = webInnertube.session.context.client.visitorData
 
-    const videoId = hasTrailer && trailerIsAgeRestricted ? info.playability_status.error_screen.video_id : id
+      const videoId = hasTrailer && trailerIsAgeRestricted ? info.playability_status.error_screen.video_id : id
 
-    // getBasicInfo needs the signature timestamp (sts) from inside the player
-    webEmbeddedInnertube.session.player = webInnertube.session.player
+      // getBasicInfo needs the signature timestamp (sts) from inside the player
+      webEmbeddedInnertube.session.player = webInnertube.session.player
 
-    const bypassedInfo = await webEmbeddedInnertube.getBasicInfo(videoId, { client: 'WEB_EMBEDDED', po_token: contentPoToken })
+      const bypassedInfo = await webEmbeddedInnertube.getBasicInfo(videoId, { client: 'WEB_EMBEDDED', po_token: contentPoToken })
 
-    if (bypassedInfo.playability_status.status === 'OK' && bypassedInfo.streaming_data) {
-      info.playability_status = bypassedInfo.playability_status
-      info.streaming_data = bypassedInfo.streaming_data
-      info.basic_info.start_timestamp = bypassedInfo.basic_info.start_timestamp
-      info.basic_info.duration = bypassedInfo.basic_info.duration
-      info.captions = bypassedInfo.captions
-      info.storyboards = bypassedInfo.storyboards
+      if (bypassedInfo.playability_status.status === 'OK' && bypassedInfo.streaming_data) {
+        info.playability_status = bypassedInfo.playability_status
+        info.streaming_data = bypassedInfo.streaming_data
+        info.basic_info.start_timestamp = bypassedInfo.basic_info.start_timestamp
+        info.basic_info.duration = bypassedInfo.basic_info.duration
+        info.captions = bypassedInfo.captions
+        info.storyboards = bypassedInfo.storyboards
 
-      hasTrailer = false
-      trailerIsAgeRestricted = false;
+        hasTrailer = false
+        trailerIsAgeRestricted = false;
 
-      ({ clientName, clientVersion, osName, osVersion } = webEmbeddedInnertube.session.context.client)
+        ({ clientName, clientVersion, osName, osVersion } = webEmbeddedInnertube.session.context.client)
+      }
+    } catch (error) {
+      console.warn('WEB_EMBEDDED fallback errored, using the original response instead', error)
     }
   }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

Mentioned in the Matrix FreeTube General chat

## Description

YouTube made some changes to how the WEB_EMBEDDED_PLAYER client works, so it currently throws errors in FreeTube, which means that instead of showing the age-restricted message to the user, we show an empty page with an error message. As fixing the WEB_EMBEDDED_PLAYER support still requires some investigation and the workaround only works for a very small number of age-restricted videos anyway, this pull request currently only fixes the watch page breaking so that we show the user friendly message as originally intended but doesn't fix the WEB_EMBEDDED_PLAYER requests.

## Screenshots

Before:
<img width="1070" height="776" alt="Before the change. Broken watch page with &quot;This video is unavailable&quot; message." src="https://github.com/user-attachments/assets/2e59e063-18a2-41ae-9467-3553858389ce" />

After:
<img width="1059" height="798" alt="After the change. Properly displayed watch page with the player replaced with a user friendly error message about the video being age-restricted." src="https://github.com/user-attachments/assets/23b0ca3c-ce7e-4ccf-98de-c2b09f2a10d5" />

## Testing

1. Open an age-restricted video e.g. Linus Torvalds NVIDIA rant: https://youtu.be/iYWzMvlj2RQ
2. The player should be replaced with a message about the video being age-restricted, up next should be empty like on YouTube but all the other information should be shown (description, channel information, comments, etc).

## Desktop

- **OS:** Windows
- **OS Version:** 11