### PR TITLE
Use cached subscription data when RSS feeds are unavailable

### DIFF
--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -237,7 +237,12 @@ async function loadVideosForSubscriptionsFromRemote() {
       })
     }
 
-    return videos ?? []
+    if (videos == null) {
+      const cachedEntry = store.getters.getLiveCache[channel.id]
+      return cachedEntry?.videos ?? []
+    }
+
+    return videos
   }))).flat()
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -213,7 +213,12 @@ async function loadVideosForSubscriptionsFromRemote() {
       })
     }
 
-    return videos ?? []
+    if (videos == null) {
+      const cachedEntry = store.getters.getShortsCache[channel.id]
+      return cachedEntry?.videos ?? []
+    }
+
+    return videos
   }))).flat()
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -236,7 +236,12 @@ async function loadVideosForSubscriptionsFromRemote() {
       })
     }
 
-    return videos ?? []
+    if (videos == null) {
+      const cachedEntry = store.getters.getVideoCache[channel.id]
+      return cachedEntry?.videos ?? []
+    }
+
+    return videos
   }))).flat()
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)


### PR DESCRIPTION
When YouTube's RSS feeds are down or return errors, subscription fetches return `null` for videos. Instead of showing an empty list, this change falls back to the previously cached data for each affected channel, so users can still see their subscriptions during outages. The cache is not updated when the fetch fails, preserving the last known good data.