### PR TITLE
Reduce workflow contention with changes to long running workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,28 @@ name: Build
 on:
   push:
     branches: [ master, development, '**-RC' ]
+    paths-ignore:
+      - 'README.md'
+      - '.github/**/*.md'
+      - '.github/workflows/autoMerge.yml'
+      - '.github/workflows/calibreapp-image-actions.yml'
+      - '.github/workflows/codeql.yml'
+      - '.github/workflows/conflicts.yml'
+      - '.github/workflows/label-issue.yml'
+      - '.github/workflows/label-pr.yml'
+      - '.github/workflows/no-response.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/remove-outdated-labels.yml'
+      - '.github/workflows/stale.yml'
+      - '.github/workflows/updateSite.yml'
+
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
   build:
+    name: Build
 
     # As this action runs on every push to the default branch and uses quite a lot of resources (both minutes and caches),
     # only run it in the FreeTubeApp/FreeTube repository to avoid unnecessary GitHub Actions usage/billing in forks.

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -10,8 +10,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
+    name: Check for conflicts
     runs-on: ubuntu-slim
 
     permissions:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,26 +1,23 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Linter
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   pull_request:
     branches: [ master, development, '**-RC' ]
 
 permissions: {}
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # This workflow contains a single job called "build"
   lint:
-    # The type of runner that the job will run on
+    name: Linter
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Get yarn cache directory
       id: cache_dir

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,6 @@ concurrency:
 
 jobs:
   lint:
-    name: Linter
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -13,9 +13,15 @@ permissions: {}
 
 jobs:
   noResponse:
+    name: No Response
+
     # As this action runs on a schedule, only run it in the FreeTubeApp/FreeTube repository to avoid unnecessary GitHub Actions usage/billing in forks.
     # If a fork does need this workflow, they can change this condition in their fork to include their repository.
-    if: github.repository == 'FreeTubeApp/FreeTube'
+    if: |
+      github.repository == 'FreeTubeApp/FreeTube' &&
+      (github.event_name == 'schedule' ||
+      (github.event.comment.user.id == github.event.issue.user.id &&
+      contains(github.event.issue.labels.*.name, 'U: Waiting for Response from Author')))
 
     runs-on: ubuntu-slim
 


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

As an open source project GitHub gives us unlimited (within reason) GitHub Actions minutes for free and doesn't charge us for storage use, we are however still limited by how many workflows we can run in parallel (I can't find the actual limit in the docs but from my observations the limit seems to be around 4-6), when we hit the limit any other workflows sit in the queue but the timeout already starts counting then. `ubuntu-slim` based workflows only have a 15 minute timeout. This is especially relevant for the weekly dependabot batch, as merging each pull request triggers at least 4 workflows, more if it causes conflicts with other one and dependabot has to resolve the conflicts, so unless we wait about 10 minutes between each merge, the majority of the workflows will sit in the queue for a while.

This pull request does not speed any of those workflows up but it should still help by skipping unnecessary runs or aborting duplicate runs early on long running workflows:
| Workflows | Changes |
| --- | --- |
| Build | Add `paths-ignore` to skip running on changes to other workflows that don't result in a different build e.g. Dependabot updates to the stale workflow. |
| Conflicts and Linter | Add cancel in progress for changes to the same branch/pull request, as we only care that the latest commit passes the linter and that there are no conflicts with the most recent commit. |
| No Response | Currently this runs on a daily schedule and on every single comment but we can skip most comments as they will be on issues without the "waiting for response from author" label or from other accounts that are not the original author. |