### PR TITLE
Address profile channel list TODOs about using Sets with Vue 3

### DIFF
--- a/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
+++ b/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
@@ -14,8 +14,8 @@
           :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
-          selectable
-          :selected="selected.includes(channel.id)"
+          :selectable="true"
+          :selected="selected.has(channel.id)"
           @change="handleChannelToggle(channel.id)"
         />
       </FtFlexBox>
@@ -48,7 +48,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, reactive, ref, shallowRef, watch } from 'vue'
 import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import FtCard from '../ft-card/ft-card.vue'
@@ -77,6 +77,7 @@ import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 const { locale, t } = useI18n()
 
 const props = defineProps({
+  /** @type {import('vue').PropType<Profile>} */
   profile: {
     type: Object,
     required: true
@@ -101,11 +102,10 @@ const intlCollator = computed(() => {
   return new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' })
 })
 
-/** @type {import('vue').Ref<Profile['subscriptions']>} */
-const subscriptions = ref([])
+/** @type {import('vue').ShallowRef<Profile['subscriptions']>} */
+const subscriptions = shallowRef([])
 
 function loadSubscriptions() {
-  /** @type {Profile['subscriptions']} */
   const subscriptions_ = deepCopy(props.profile.subscriptions)
 
   const collator = intlCollator.value
@@ -132,35 +132,31 @@ watch(() => props.profile, () => {
   selectNone()
 }, { deep: true })
 
-/**
- * TODO: Replace with a Set with Vue 3
- *
- * @type {import('vue').Ref<string[]>}
- */
-const selected = ref([])
+/** @type {import('vue').Reactive<Set<string>>} */
+const selected = reactive(new Set())
 
 const selectedText = computed(() => {
-  return t('Profile.{number} selected', { number: selected.value.length })
+  return t('Profile.{number} selected', { number: selected.size })
 })
 
 function selectAll() {
-  selected.value = subscriptions.value.map(channel => channel.id)
+  subscriptions.value.forEach(channel => {
+    return selected.add(channel.id)
+  })
 }
 
 function selectNone() {
-  selected.value = []
+  selected.clear()
 }
 
 /**
  * @param {string} channelId
  */
 function handleChannelToggle(channelId) {
-  const index = selected.value.indexOf(channelId)
-
-  if (index === -1) {
-    selected.value.push(channelId)
+  if (selected.has(channelId)) {
+    selected.delete(channelId)
   } else {
-    selected.value.splice(index, 1)
+    selected.add(channelId)
   }
 }
 
@@ -187,7 +183,7 @@ const deletePromptMessage = computed(() => {
 })
 
 function displayDeletePrompt() {
-  if (selected.value.length === 0) {
+  if (selected.size === 0) {
     showToast(t('Profile.No channel(s) have been selected'))
   } else {
     showDeletePrompt.value = true
@@ -199,18 +195,16 @@ function displayDeletePrompt() {
  */
 function handleDeletePromptClick(value) {
   if (value === 'delete') {
-    const selected_ = selected.value
+    subscriptions.value = subscriptions.value.filter((channel) => {
+      return !selected.has(channel.id)
+    })
 
     if (props.isMainProfile) {
-      subscriptions.value = subscriptions.value.filter((channel) => {
-        return !selected_.includes(channel.id)
-      })
-
       profileList.value.forEach((x) => {
         const profile = deepCopy(x)
 
         profile.subscriptions = profile.subscriptions.filter((channel) => {
-          return !selected_.includes(channel.id)
+          return !selected.has(channel.id)
         })
 
         // Only update changed profiles
@@ -222,10 +216,6 @@ function handleDeletePromptClick(value) {
       showToast(t('Profile.Profile has been updated'))
       selectNone()
     } else {
-      subscriptions.value = subscriptions.value.filter((channel) => {
-        return !selected_.includes(channel.id)
-      })
-
       /** @type {Profile} */
       const profile = {
         ...props.profile,

--- a/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
+++ b/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
@@ -24,8 +24,8 @@
           :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
-          selectable
-          :selected="selected.includes(channel.id)"
+          :selectable="true"
+          :selected="selected.has(channel.id)"
           @change="handleChannelToggle(channel.id)"
         />
       </FtFlexBox>
@@ -50,7 +50,7 @@
 </template>
 
 <script setup>
-import { computed, ref, shallowRef, watch } from 'vue'
+import { computed, reactive, ref, shallowRef, watch } from 'vue'
 import { useI18n } from '../../composables/use-i18n-polyfill'
 
 import FtCard from '../ft-card/ft-card.vue'
@@ -113,8 +113,8 @@ const intlCollator = computed(() => {
 
 const filteredProfileIndex = ref(0)
 
-/** @type {import('vue').Ref<Profile['subscriptions']>} */
-const channels = ref([])
+/** @type {import('vue').ShallowRef<Profile['subscriptions']>} */
+const channels = shallowRef([])
 
 function loadChannels() {
   const profileId = profileIdList.value[filteredProfileIndex.value]
@@ -155,35 +155,31 @@ watch(() => props.profile, () => {
 
 watch(filteredProfileIndex, loadChannels)
 
-/**
- * TODO: Replace with a Set with Vue 3
- *
- * @type {import('vue').Ref<string[]>}
- */
-const selected = ref([])
+/** @type {import('vue').Reactive<Set<string>>} */
+const selected = reactive(new Set())
 
 const selectedText = computed(() => {
-  return t('Profile.{number} selected', { number: selected.value.length })
+  return t('Profile.{number} selected', { number: selected.size })
 })
 
 function selectAll() {
-  selected.value = channels.value.map(channel => channel.id)
+  channels.value.forEach(channel => {
+    return selected.add(channel.id)
+  })
 }
 
 function selectNone() {
-  selected.value = []
+  selected.clear()
 }
 
 /**
  * @param {string} channelId
  */
 function handleChannelToggle(channelId) {
-  const index = selected.value.indexOf(channelId)
-
-  if (index === -1) {
-    selected.value.push(channelId)
+  if (selected.has(channelId)) {
+    selected.delete(channelId)
   } else {
-    selected.value.splice(index, 1)
+    selected.add(channelId)
   }
 }
 
@@ -213,16 +209,14 @@ function handleProfileFilterChange(profileId) {
 }
 
 function addChannelsToProfile() {
-  if (selected.value.length === 0) {
+  if (selected.size === 0) {
     showToast(t('Profile.No channel(s) have been selected'))
   } else {
-    const selected_ = selected.value
-
     const profileId = profileIdList.value[filteredProfileIndex.value]
     const subscriptions = profileList.value
       .find((profile) => profile._id === profileId)
       .subscriptions
-      .filter((channel) => selected_.includes(channel.id))
+      .filter((channel) => selected.has(channel.id))
 
     const profile = deepCopy(props.profile)
     profile.subscriptions.push(...deepCopy(subscriptions))


### PR DESCRIPTION
## Pull Request Type

- [x] Refactor

## Description

This pull request resolves some open TODOs in the profile channel list components about using Sets instead of arrays on Vue 3. I also switched another array to shallow ref as we never modify the array itself, we only change it by setting the variable.

## Testing

Check that selecting, adding and removing channels works correctly on the profile edit page.

## Desktop

- **OS:** Windows
- **OS Version:** 11