### PR TITLE
Avoid unnecessary deepCopy calls

### DIFF
--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -8,7 +8,7 @@
       class="author-div"
     >
       <template
-        v-if="authorThumbnails.length > 0"
+        v-if="authorThumbnail"
       >
         <router-link
           v-if="authorId"
@@ -17,14 +17,14 @@
           aria-hidden="true"
         >
           <img
-            :src="getBestQualityImage(authorThumbnails)"
+            :src="authorThumbnail"
             class="communityThumbnail"
             alt=""
           >
         </router-link>
         <img
           v-else
-          :src="getBestQualityImage(authorThumbnails)"
+          :src="authorThumbnail"
           class="communityThumbnail"
           alt=""
         >
@@ -183,7 +183,6 @@ import store from '../../store/index'
 
 import {
   createWebURL,
-  deepCopy,
   formatNumber,
   getRelativeTimeFromDate,
 } from '../../helpers/utils'
@@ -231,8 +230,7 @@ const backendPreference = computed(() => {
 let postType = ''
 let postText = ''
 let postId = ''
-/** @type {string[]?} */
-let authorThumbnails = null
+let authorThumbnail = ''
 let postContent = ''
 let author = ''
 let authorId = ''
@@ -267,12 +265,10 @@ function parseCommunityData() {
     postText = 'Shared post'
     postType = 'text'
 
-    authorThumbnails = ['', 'https://yt3.ggpht.com/ytc/AAUvwnjm-0qglHJkAHqLFsCQQO97G7cCNDuDLldsrn25Lg=s88-c-k-c0x00ffffff-no-rj']
+    authorThumbnail = 'https://yt3.ggpht.com/ytc/AAUvwnjm-0qglHJkAHqLFsCQQO97G7cCNDuDLldsrn25Lg=s88-c-k-c0x00ffffff-no-rj'
 
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
-      authorThumbnails.forEach(thumbnail => {
-        thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
-      })
+      authorThumbnail = youtubeImageUrlToInvidious(authorThumbnail)
     }
 
     return
@@ -287,18 +283,12 @@ function parseCommunityData() {
   author = props.data.author
   authorId = props.data.authorId
 
-  authorThumbnails = deepCopy(props.data.authorThumbnails)
+  authorThumbnail = getBestQualityImage(props.data.authorThumbnails)
 
   if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
-    authorThumbnails.forEach(thumbnail => {
-      thumbnail.url = youtubeImageUrlToInvidious(thumbnail.url)
-    })
-  } else {
-    authorThumbnails.forEach(thumbnail => {
-      if (thumbnail.url.startsWith('//')) {
-        thumbnail.url = 'https:' + thumbnail.url
-      }
-    })
+    authorThumbnail = youtubeImageUrlToInvidious(authorThumbnail)
+  } else if (authorThumbnail.startsWith('//')) {
+    authorThumbnail = 'https:' + authorThumbnail
   }
 }
 

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -103,19 +103,27 @@ const actions = {
     const profileList = state.profileList
 
     for (const profile of profileList) {
-      const currentProfileCopy = deepCopy(profile)
+      // Only copied if something has actually changed, in which case this variable will be replaced with the copy.
+      let currentProfile = profile
       let profileUpdated = false
 
       for (const { channelThumbnailUrl, channelName, channelId } of channels) {
-        const channel = currentProfileCopy.subscriptions.find((channel) => {
+        let channel = currentProfile.subscriptions.find((channel) => {
           return channel.id === channelId
         }) ?? null
 
         if (channel === null) { continue }
 
         if (channel.name !== channelName && channelName != null) {
+          if (!profileUpdated) {
+            const index = currentProfile.subscriptions.indexOf(channel)
+
+            currentProfile = deepCopy(currentProfile)
+            channel = currentProfile.subscriptions[index]
+            profileUpdated = true
+          }
+
           channel.name = channelName
-          profileUpdated = true
         }
 
         if (channelThumbnailUrl) {
@@ -126,14 +134,21 @@ const actions = {
             .replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com')
 
           if (channel.thumbnail !== thumbnail) {
+            if (!profileUpdated) {
+              const index = currentProfile.subscriptions.indexOf(channel)
+
+              currentProfile = deepCopy(currentProfile)
+              channel = currentProfile.subscriptions[index]
+              profileUpdated = true
+            }
+
             channel.thumbnail = thumbnail
-            profileUpdated = true
           }
         }
       }
 
       if (profileUpdated) {
-        await dispatch('updateProfile', currentProfileCopy)
+        await dispatch('updateProfile', currentProfile)
       }
     }
   },
@@ -146,22 +161,34 @@ const actions = {
       .replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com') ??
       null
     const profileList = state.profileList
+
     for (const profile of profileList) {
-      const currentProfileCopy = deepCopy(profile)
-      const channel = currentProfileCopy.subscriptions.find((channel) => {
+      const index = profile.subscriptions.findIndex((channel) => {
         return channel.id === channelId
-      }) ?? null
-      if (channel === null) { continue }
-      let updated = false
-      if (channel.name !== channelName && channelName != null) {
-        channel.name = channelName
-        updated = true
+      })
+
+      if (index === -1) { continue }
+
+      // Only copied when something has actually changed
+      let currentProfileCopy
+
+      if (channelName != null && profile.subscriptions[index].name !== channelName) {
+        if (currentProfileCopy === undefined) {
+          currentProfileCopy = deepCopy(profile)
+        }
+
+        currentProfileCopy.subscriptions[index].name = channelName
       }
-      if (channel.thumbnail !== thumbnail && thumbnail != null) {
-        channel.thumbnail = thumbnail
-        updated = true
+
+      if (thumbnail != null && profile.subscriptions[index].thumbnail !== thumbnail) {
+        if (currentProfileCopy === undefined) {
+          currentProfileCopy = deepCopy(profile)
+        }
+
+        currentProfileCopy.subscriptions[index].thumbnail = thumbnail
       }
-      if (updated) {
+
+      if (currentProfileCopy !== undefined) {
         await dispatch('updateProfile', currentProfileCopy)
       } else { // channel has not been updated, stop iterating through profiles
         break


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

This pull request avoids some unnecessary `deepCopy` (aka `JSON.parse(JSON.stringify(obj))`) operations for posts and while updating subscription details. For posts I was able to get rid of it entirely by extracting the desired array element before performing any modifications, rather the copying the entire array, making modifications to all elements and then only picking one of them. While updating the subscription details we only copy the profile when we are actually updating channel details, instead of copying it every time, as channel names and thumbnails don't change very often and even then it is quite rare that all profiles are affected at the same time, so most of the time we were creating copies just to throw them away.

## Testing

1. Open a post with one or more images, the images should still show up correctly.
2. Close FreeTube
3. Edit the names of some of your subscribed channels in the `profiles.db`
4. Visit one of the channels, the name should be corrected (can be checked in the side bar or on the channels tab).
5. Refresh your subscriptions, the remaining names should be fixed (can be checked in the side bar or on the channels tab).

## Desktop

- **OS:** Windows
- **OS Version:** 11