### PR TITLE
Fix menus on small player sizes

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/player-components/AutoplayToggle.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AutoplayToggle.js
@@ -62,6 +62,16 @@ export class AutoplayToggle extends shaka.ui.Element {
       this.updateLocalisedStrings_()
     })
 
+    if (this.isSubMenu) {
+      this.eventManager.listen(this.controls, 'submenuopen', () => {
+        this.updateVisibility_()
+      })
+
+      this.eventManager.listen(this.controls, 'submenuclose', () => {
+        this.updateVisibility_()
+      })
+    }
+
     this.updateLocalisedStrings_()
   }
 
@@ -74,5 +84,14 @@ export class AutoplayToggle extends shaka.ui.Element {
     this.currentState_.textContent = this.localization.resolve(this.autoplayEnabled_ ? 'ON' : 'OFF')
 
     this.button_.ariaLabel = this.autoplayEnabled_ ? i18n.global.t('Video.Player.Autoplay is on') : i18n.global.t('Video.Player.Autoplay is off')
+  }
+
+  /** @private */
+  updateVisibility_() {
+    if (this.isSubMenuOpened) {
+      this.button_.classList.add('shaka-hidden')
+    } else {
+      this.button_.classList.remove('shaka-hidden')
+    }
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/player-components/FullWindowButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/FullWindowButton.js
@@ -62,6 +62,16 @@ export class FullWindowButton extends shaka.ui.Element {
       this.updateLocalisedStrings_()
     })
 
+    if (this.isSubMenu) {
+      this.eventManager.listen(this.controls, 'submenuopen', () => {
+        this.updateVisibility_()
+      })
+
+      this.eventManager.listen(this.controls, 'submenuclose', () => {
+        this.updateVisibility_()
+      })
+    }
+
     this.updateLocalisedStrings_()
   }
 
@@ -76,5 +86,14 @@ export class FullWindowButton extends shaka.ui.Element {
       KeyboardShortcuts.VIDEO_PLAYER.GENERAL.FULLWINDOW
     )
     this.nameSpan_.textContent = this.button_.ariaLabel = newLabel
+  }
+
+  /** @private */
+  updateVisibility_() {
+    if (this.isSubMenuOpened) {
+      this.button_.classList.add('shaka-hidden')
+    } else {
+      this.button_.classList.remove('shaka-hidden')
+    }
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/player-components/ScreenshotButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/ScreenshotButton.js
@@ -45,6 +45,16 @@ export class ScreenshotButton extends shaka.ui.Element {
       this.updateLocalisedStrings_()
     })
 
+    if (this.isSubMenu) {
+      this.eventManager.listen(this.controls, 'submenuopen', () => {
+        this.updateVisibility_()
+      })
+
+      this.eventManager.listen(this.controls, 'submenuclose', () => {
+        this.updateVisibility_()
+      })
+    }
+
     this.updateLocalisedStrings_()
   }
 
@@ -55,5 +65,14 @@ export class ScreenshotButton extends shaka.ui.Element {
       KeyboardShortcuts.VIDEO_PLAYER.GENERAL.TAKE_SCREENSHOT
     )
     this.nameSpan_.textContent = this.button_.ariaLabel = label
+  }
+
+  /** @private */
+  updateVisibility_() {
+    if (this.isSubMenuOpened) {
+      this.button_.classList.add('shaka-hidden')
+    } else {
+      this.button_.classList.remove('shaka-hidden')
+    }
   }
 }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

shaka-player 5 switched the way that menus are handled and buttons need to hide themselves now. In the shaka-player 5 migration pull request I only implemented that for buttons that would be in the menus on desktop screen sizes but on mobile we move a lot more buttons into the menus which was causing the buggy behaviour visible in the screen shots below.

## Screenshots

<img width="572" height="324" alt="buggy-behaviour-1" src="https://github.com/user-attachments/assets/7aebcbc1-8f88-4c04-9344-ac8d77a48cda" />

<img width="567" height="324" alt="buggy-behaviour-2" src="https://github.com/user-attachments/assets/4ff710f3-3993-4c1d-a1e4-49b5bea0d2e7" />

## Testing

Resize the window to a very small size and check that when you open submenus such as the quality selector or the playback speed selector, you can only see the buttons that belong to that menu.

## Desktop

- **OS:** Windows
- **OS Version:** 11