### PR TITLE
Ensure popup does not obstruct video title in full screen

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -60,7 +60,7 @@
 
 .valueChangePopup {
   position: absolute;
-  top: 20px;
+  top: 70px;
   left: 50%;
   transform: translateX(-50%);
   padding: 10px;


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue
Requested by https://github.com/FreeTubeApp/FreeTube/pull/7729#issuecomment-4119695838, since the previous implementation would appear on top of the titles in full screen mode.

## Description
Increases the top scss value for the popup, so that is does not obstruct the title when in full screen.

## Screenshots
<img width="1922" height="1080" alt="Capture d’écran_2026-03-24_14-27-28 (copie 1)" src="https://github.com/user-attachments/assets/2af2959e-66b4-45b1-b7be-3e4d7154aa3e" />


<img width="1920" height="1080" alt="Capture d’écran_2026-03-24_14-36-19" src="https://github.com/user-attachments/assets/aee874ae-c364-49d0-a7e7-0dc8c3cbe8d2" />

## Testing
Open video with a long title in full screen
Use left or right arrows
See the pop up below the title

## Desktop

- OS: Linux
- OS Version: Ubuntu 24.04.2 LTS
- FreeTube version: v0.23.15 Beta