### PR TITLE
Fix: Remove overflow-x: hidden to fix extra scrollbar in settings

### DIFF
--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -5,7 +5,6 @@
 
 .settingsSections,
 .switchRow {
-  overflow-x: hidden;
   max-inline-size: 90%;
 }
 
@@ -41,6 +40,7 @@
   .settingsSections,
   .switchRow {
     max-inline-size: 100%;
+    overflow-x: hidden;
   }
 }
 


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Related issue


## Description
This pull request fixes an issue where an unnecessary vertical scrollbar appeared in the settings page for certain languages (e.g., German, Turkish).

Changes made:
- Removed the overflow-x: hidden property from .settingsSections and .switchRow within the Settings.css file.

## Testing
- Tested across multiple languages that previously showed the issue (German, Polish, Turkish).
- Validated responsive behavior at different screen sizes.