### PR TITLE
Avoid creating temporary arrays in recommended video sorting

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -436,18 +436,14 @@ export default defineComponent({
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
 
-        const recommendedVideos = result.watch_next_feed
+        this.recommendedVideos = result.watch_next_feed
           ?.filter((item) => {
             return item.type === 'CompactVideo' || item.type === 'CompactMovie' ||
               (item.type === 'LockupView' && item.content_type === 'VIDEO')
           })
-          .map(parseLocalWatchNextVideo) ?? []
-
-        // place watched recommended videos last
-        this.recommendedVideos = [
-          ...recommendedVideos.filter((video) => !this.isRecommendedVideoWatched(video.videoId)),
-          ...recommendedVideos.filter((video) => this.isRecommendedVideoWatched(video.videoId))
-        ]
+          .map(parseLocalWatchNextVideo)
+          // place watched recommended videos last
+          .sort(this.sortWatchedVideosLast) ?? []
 
         if (this.showFamilyFriendlyOnly && !this.isFamilyFriendly) {
           this.isLoading = false
@@ -933,10 +929,8 @@ export default defineComponent({
           })
 
           // place watched recommended videos last
-          this.recommendedVideos = [
-            ...recommendedVideos.filter((video) => !this.isRecommendedVideoWatched(video.videoId)),
-            ...recommendedVideos.filter((video) => this.isRecommendedVideoWatched(video.videoId))
-          ]
+          this.recommendedVideos = recommendedVideos.sort(this.sortWatchedVideosLast)
+
           this.isLive = result.liveNow
           this.isFamilyFriendly = result.isFamilyFriendly
           this.isPostLiveDvr = !!result.isPostLiveDvr
@@ -1202,8 +1196,25 @@ export default defineComponent({
       })
     },
 
+    /**
+     * @param {{ videoId: string }} a
+     * @param {{ videoId: string }} b
+     */
+    sortWatchedVideosLast: function (a, b) {
+      const aWasWatched = this.isRecommendedVideoWatched(a.videoId)
+      const bWasWatched = this.isRecommendedVideoWatched(b.videoId)
+
+      if (aWasWatched && !bWasWatched) {
+        return 1
+      } else if (!aWasWatched && bWasWatched) {
+        return -1
+      } else {
+        return 0
+      }
+    },
+
     isRecommendedVideoWatched: function (videoId) {
-      return !!this.$store.getters.getHistoryCacheById[videoId]
+      return Object.hasOwn(this.$store.getters.getHistoryCacheById, videoId)
     },
 
     handleVideoLoaded: function () {


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

To reduce the chance of looping between the same few recommended videos when auto-play is enabled we move the watched videos to the bottom of the list, while retaining the original order in the unwatched and watched groups. Currently that is implemented with two Array.filter calls the resulting arrays are then spread into a third array, the code was also duplicated for the local API and the Invidious API. This pull request replaces that with a custom array sort function, that is shared between the local and Invidious APIs, retaining the original behaviour but without the extra overhead.

## Testing

1. Open a video
2. Mark some of the recommended videos as watched
3. Leave the watch page
4. Open the same video again
5. The watched videos should be sorted to the bottom of the list

## Desktop

- **OS:** Windows
- **OS Version:** 11

## Additional context
I am well aware that those arrays are usually quite small ~10 videos but I think it is fair to say that we already have quite a lot going on on the watch page, so these changes will still help (everything we create the garbage collector will need to spend time cleaning up at some point).