### PR TITLE
Re-order search filters to match YouTube.com

### DIFF
--- a/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
+++ b/src/renderer/components/FtSearchFilters/FtSearchFilters.vue
@@ -27,20 +27,6 @@
 
     <FtFlexBox class="radioFlexBox">
       <FtRadioButton
-        v-model="prioritizeValue"
-        :title="$t('Search Filters.Prioritize.Prioritize')"
-        :labels="prioritizeLabels"
-        :values="PRIORITIZE_VALUES"
-        class="searchRadio"
-      />
-      <FtRadioButton
-        v-model="timeValue"
-        :title="$t('Search Filters.Time.Time')"
-        :labels="timeLabels"
-        :values="TIME_VALUES"
-        class="searchRadio"
-      />
-      <FtRadioButton
         v-model="typeValue"
         :title="$t('Search Filters.Type.Type')"
         :labels="typeLabels"
@@ -54,11 +40,25 @@
         :values="DURATION_VALUES"
         class="searchRadio"
       />
+      <FtRadioButton
+        v-model="timeValue"
+        :title="$t('Search Filters.Time.Time')"
+        :labels="timeLabels"
+        :values="TIME_VALUES"
+        class="searchRadio"
+      />
       <FtCheckboxList
         v-model="featuresValue"
         :title="$t('Search Filters.Features.Features')"
         :labels="featureLabels"
         :values="FEATURE_VALUES"
+        class="searchRadio"
+      />
+      <FtRadioButton
+        v-model="prioritizeValue"
+        :title="$t('Search Filters.Prioritize.Prioritize')"
+        :labels="prioritizeLabels"
+        :values="PRIORITIZE_VALUES"
         class="searchRadio"
       />
     </FtFlexBox>
@@ -117,16 +117,16 @@ const DURATION_VALUES = [
 ]
 
 const FEATURE_VALUES = [
+  'live',
+  '4k',
   'hd',
   'subtitles',
   'creative_commons',
-  '3d',
-  'live',
-  '4k',
   '360',
-  'location',
+  'vr180',
+  '3d',
   'hdr',
-  'vr180'
+  'location',
 ]
 
 const NOT_ALLOWED_FOR_MOVIES_FEATURES = [
@@ -168,16 +168,16 @@ const durationLabels = computed(() => [
 ])
 
 const featureLabels = computed(() => [
+  t('Search Filters.Features.Live'),
+  t('Search Filters.Features.4K'),
   t('Search Filters.Features.HD'),
   t('Search Filters.Features.Subtitles'),
   t('Search Filters.Features.Creative Commons'),
-  t('Search Filters.Features.3D'),
-  t('Search Filters.Features.Live'),
-  t('Search Filters.Features.4K'),
   t('Search Filters.Features.360 Video'),
-  t('Search Filters.Features.Location'),
+  t('Search Filters.Features.VR180'),
+  t('Search Filters.Features.3D'),
   t('Search Filters.Features.HDR'),
-  t('Search Filters.Features.VR180')
+  t('Search Filters.Features.Location'),
 ])
 
 const searchSettings = store.getters.getSearchSettings


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

- #8812

## Description

@efb4f5ff-1298-471a-8973-3d47447115dc mentioned that testing the search filter changes was a bit annoying as they couldn't easily be tested side by side with the items being ordered completely differently in FreeTube compared to YouTube, so this pull request changes the ordering to match YouTube. It should hopefully also be more familiar for users coming over from YouTube.

In the screenshot of YouTube's search filters there is an extra "Purchased" filter, which I suspect is a bug on YouTube's end because it is impossible to purchase anything from them while logged out and it always returns zero results, so it is not worth adding to FreeTube.

## Screenshots

YouTube:

<img width="690" height="512" alt="search-filters-youtube" src="https://github.com/user-attachments/assets/96471085-1c83-4bac-9307-ee6591d5209d" />

FreeTube:

<img width="776" height="451" alt="search-filters-freetube" src="https://github.com/user-attachments/assets/903552dc-140e-4eb9-856b-7288a72e2788" />

## Testing

Not sure this really needs testing, none of the logic changed and I provided screenshots of what it looks like, that being said you are welcome to do whatever testing you see fit.

## Desktop

- **OS:** Windows
- **OS Version:** 11