### PR TITLE
fix: (follow up of #8317 PR) respect Hide Sharing Actions setting for community posts

### DIFF
--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -158,6 +158,7 @@
           :icon="['fas', 'comment']"
         /> {{ commentCount }}</span>
       <FtShareButton
+        v-if="!hideSharingActions"
         :id="postId"
         share-target-type="Post"
         class="shareButton"
@@ -222,6 +223,9 @@ const forbiddenTitles = computed(() => {
 const hideVideo = computed(() => {
   return forbiddenTitles.value.some((text) => props.data.postContent.content.title?.toLowerCase().includes(text.toLowerCase()))
 })
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideSharingActions = computed(() => store.getters.getHideSharingActions)
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Related issue
Follow-up to #8317 -> addresses reviewer feedback regarding the "Hide Sharing Actions" setting.
closes #7136 (the share button feature was added in #8317, this PR fixes a missing setting check)

## Description
The share button I added to community posts in #8317 doesn't get hidden when "Hide Sharing Actions" is enabled in Distraction Free settings. This fixes that by adding the same `v-if` check used by the other share buttons throughout the app.

## Screenshots

https://github.com/user-attachments/assets/2b8b35ec-cc71-444e-866a-606ff03e48bc


## Testing
1. Open FreeTube and navigate to a channel with community posts (e.g., `https://www.youtube.com/channel/UCQeRaTukNYft1_6AZPACnog`)
2. Go to the **Posts** tab
3. Verify the share button is visible next to community posts
4. Go to **Settings → Distraction Free Settings → Hide Sharing Actions** and enable it
5. Go back to the channel's Posts tab
6. Verify the share button is now **hidden** on community posts
7. Disable the setting again and verify the share button **reappears**

## Desktop
- **OS:** Windows 11
- **OS Version:** Windows 11 24H2 (OS Build 26100.7171)
- **FreeTube version:** 0.23.15 (development build)

## Additional context
This is a minimal 2-line change:
1. Added `v-if="!hideSharingActions"` to the `<FtShareButton>` in the template
2. Added a computed property [hideSharingActions](cci:1://file:///c:/Users/adity/Music/Free/FreeTube/src/renderer/components/ft-list-video/ft-list-video.js:248:4-250:5) reading from `store.getters.getHideSharingActions`

No other files need modification -> the store getter is auto-generated from the existing [hideSharingActions](cci:1://file:///c:/Users/adity/Music/Free/FreeTube/src/renderer/components/ft-list-video/ft-list-video.js:248:4-250:5) key in [settings.js](cci:7://file:///c:/Users/adity/Music/Free/FreeTube/src/renderer/store/modules/settings.js:0:0-0:0).
