### PR TITLE
Fix broken URLs not being treated as search queries

### DIFF
--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -404,7 +404,7 @@ const actions = {
     switch (urlType) {
       case 'playlist': {
         if (!url.searchParams.has('list')) {
-          throw new Error('Playlist: "list" field not found')
+          return { urlType: 'unknown' }
         }
 
         const playlistId = url.searchParams.get('list')
@@ -435,7 +435,7 @@ const actions = {
           url.searchParams.delete('q')
         }
         if (searchQuery == null) {
-          throw new Error('Search: "search_query" field not found')
+          return { urlType: 'unknown' }
         }
 
         const searchSettings = state.searchSettings
@@ -509,7 +509,7 @@ const actions = {
         const match = url.pathname.match(channelPattern)
         const channelId = match.groups.channelId
         if (!channelId) {
-          throw new Error('Channel: could not extract id')
+          return { urlType: 'unknown' }
         }
 
         let subPath


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8898

## Description

Currently when a user types or pastes an incomplete URL into the search bar e.g. playlist URL without the `list` query parameter, we throw exceptions. While throwing errors for validation errors makes sense in some places this isn't really the one, as the callers don't expect `getYoutubeUrlInfo` to actually throw errors, so when it does throw errors, the flow breaks. While yes we should probably implement better exception handling, another good change is to use the existing pattern of returning `{ urlType: 'unknown' }` instead of throwing exceptions, as the callers all handle that correctly (in the search bar or if the user clicks on a link it gets treated as a search query, if a URL like that is passed on the command line or via the `freetube://` URL scheme a toast is shown about the URL not being compatible).

## Testing

- `https://www.youtube.com/playlist`
- `https://www.youtube.coCML6vfKjQss`

## Desktop

- **OS:** Windows
- **OS Version:** 11