### PR TITLE
Temporarily patch out the broken auto quality selection

### DIFF
--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -462,7 +462,9 @@ function updateDefaultVideoFormat(value) {
   store.dispatch('updateDefaultVideoFormat', value)
 }
 
-const QUALITY_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144', 'auto']
+// TODO: Revert when auto is fixed
+// const QUALITY_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144', 'auto']
+const QUALITY_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
 
 const qualityNames = computed(() => [
   t('Settings.Player Settings.Default Quality.4k'),
@@ -473,11 +475,20 @@ const qualityNames = computed(() => [
   t('Settings.Player Settings.Default Quality.360p'),
   t('Settings.Player Settings.Default Quality.240p'),
   t('Settings.Player Settings.Default Quality.144p'),
-  t('Settings.Player Settings.Default Quality.Auto')
+
+  // TODO: Revert when auto is fixed
+  // t('Settings.Player Settings.Default Quality.Auto')
 ])
 
 /** @type {import('vue').ComputedRef<'2160' | '1440' | '1080' | '720' | '480' | '360' | '240' | '144' | 'auto'>} */
-const defaultQuality = computed(() => store.getters.getDefaultQuality)
+const defaultQuality = computed(() => {
+  const value = store.getters.getDefaultQuality
+
+  // TODO: Revert when auto is fixed (720 is the default setttings value)
+  if (value === 'auto') { return '720' }
+
+  return value
+})
 
 /**
  * @param {'2160' | '1440' | '1080' | '720' | '480' | '360' | '240' | '144' | 'auto'} value

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1,3 +1,8 @@
+/* TODO: Revert when auto is fixed */
+:deep(.shaka-enable-abr-button) {
+  display: none !important;
+}
+
 /* stylelint-disable liberty/use-logical-spec */
 .ftVideoPlayer {
   display: flex;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -277,7 +277,10 @@ export default defineComponent({
     /** @type {import('vue').ComputedRef<number | 'auto'>} */
     const defaultQuality = computed(() => {
       const value = store.getters.getDefaultQuality
-      if (value === 'auto') { return value }
+
+      // TODO: Revert when auto is fixed (720 is the default setttings value)
+      if (value === 'auto') { return 720 }
+      // if (value === 'auto') { return value }
 
       return parseInt(value)
     })


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- #8906

## Description

As fixing the broken auto-quality selection with SABR requires a more involved rewrite and we only recently discovered the issue, it was decided that it made more sense to temporarily hide the auto quality selection for 0.24.0, to avoid users triggering the broken code paths and being confronted with error messages because of it. The initial auto quality selection works fine, the issue is when auto triggers a quality change e.g. network conditions changing or resizing the player/pip window.

If auto was set as the default quality before it is overriden at runtime to 720p which is the default value of the `defaultQuality` setting, it doesn't actually modify the databases unless the user manually changes the default quality.

The changes are intentionally as minimal as possible with the same todo comment next to each changed line, so make it easier to undo/revert in the future.

## Testing

1. Set your default quality to auto before checking out this branch
2. Check that the auto option doesn't show up in the default quality setting or the video player resolution and audio quality menus and that it is overridden to 720p.

## Desktop

- **OS:** Windows
- **OS Version:** 11