### PR TITLE
Show channels with errors sorted by name

### DIFF
--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -9,7 +9,7 @@
       <h3> {{ $t("Subscriptions.Error Channels") }}</h3>
       <FtFlexBox>
         <FtChannelBubble
-          v-for="channel in errorChannels"
+          v-for="channel in errorChannels.toSorted((a, b) => a.name.localeCompare(b.name))"
           :key="channel.id"
           :channel-name="channel.name"
           :channel-id="channel.id"


### PR DESCRIPTION
Sorry about the drive by pull request but this was bothering me and I thought it would be less friction to just post a fix.

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
n/a

## Description

When channels fail to get updated for whatever reason, they are inserted into an array of channels with errors in the order they finish processing. Since this is indeterministic it results in the channels being presented to the user in a seemingly random order.

This sorts the list of channels with errors when presenting them so they are always in a consistent order.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing

- Subscribe to multiple channels
- Stub out `getLocalChannelVideos` in `src/renderer/helpers/api/local.js` to always return `null`
- Refresh video subscriptions a few times, they should always render in the same order

## Desktop
<!-- Please complete the following information-->
- **OS:** any
- **OS Version:** n/a
- **FreeTube version:** v0.23.15-beta

## Additional context
<!-- Add any other context about the pull request here. -->
