### PR TITLE
[Enhancement] Use the same opacity as YT for the player popups

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -71,7 +71,7 @@
   padding: 10px;
   border-radius: 5px;
   font-size: 1.1em;
-  background-color: rgb(0 0 0 / 70%);
+  background-color: rgb(0 0 0 / 60%);
   color: #fff;
   width: 85px;
   display: flex;


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue
Requested by https://github.com/FreeTubeApp/FreeTube/pull/8870#issuecomment-4160363784

## Description
This PR makes the popup opacity the same as YouTube, which is not too opaque nor too transparent.

## Screenshots 
It is hard to see the difference, so I put the popups together against the same background to compare.

<img width="1443" height="790" alt="prfreetube" src="https://github.com/user-attachments/assets/9f5cdd19-2f6f-452b-adfb-0e956079408f" />
<img width="1636" height="536" alt="yt-ft" src="https://github.com/user-attachments/assets/685f2c29-7320-42ce-afbb-9c9aa93c6f91" />

## Testing
Open a video on FT and on YT and trigger a popup
See the popups are the same transparency

## Desktop

- **OS:** Linux
- **OS Version:** 24.04.2 LTS
- **FreeTube version:** v0.23.15 Beta
