### PR TITLE
Update electron-builder config so alpine can drop their patch

### DIFF
--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -21,7 +21,7 @@ export default {
   files: [
     '_icons/iconColor.*',
     'icon.svg',
-    './dist/**/*',
+    'dist/**/*',
     '!dist/web/*',
     '!node_modules/**/*',
   ],


### PR DESCRIPTION
## Pull Request Type
- [x] Other

## Description
The way electron apps are being packaged in Alpine (through electron_tasje) requires a patch for FreeTube to build. This change should allow Alpine to drop that patch https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/testing/freetube/tasje-dotdash.patch

## Testing
```bash
yarn run build
```

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 43
- **FreeTube version:** latest nightly