### PR TITLE
Remove leftover string from blog removal

### DIFF
--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -34,7 +34,6 @@ Close Banner: Close Banner
 Version {versionNumber} is now available!  Click for more details: Version {versionNumber} is now available!  Click
   for more details
 Download From Site: Download From Site
-  Click to view more
 Are you sure you want to open this link?: Are you sure you want to open this link?
 
 # Global


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
#8907

## Description
This string is a leftover from the blog removal. It was a multiline string in the yaml, so it makes sense it was missed.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
| before | after |
| -- | -- |
|<img width="946" height="958" alt="Screenshot-2026-04-04_06:39:01" src="https://github.com/user-attachments/assets/d085d6f9-b0e0-4f4f-97d1-47b666b83491" />|<img width="946" height="958" alt="Screenshot-2026-04-04_06:39:32" src="https://github.com/user-attachments/assets/08e942c1-0287-4661-a74c-c9a80cd36386" />|

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Change the package.json version to `0.23.0`
2. Check if the update dialog shows `Download from Site`

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora
- **OS Version:** Fedora 42 Workstation Edition (w/ hyprland 0.51.1)
- **FreeTube version:** f8e6d395fbc7f480d045a135b43903f1a778edea

## Additional context
I noticed this when testing fta before release.