### PR TITLE
fix: apply 'hide watched' filter before per-channel video limit

### DIFF
--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -149,14 +149,47 @@ const hideWatchedSubs = computed(() => {
   return store.getters.getHideWatchedSubs
 })
 
+const onlyShowLatestFromChannel = computed(() => {
+  return store.getters.getOnlyShowLatestFromChannel
+})
+
+const onlyShowLatestFromChannelNumber = computed(() => {
+  return store.getters.getOnlyShowLatestFromChannelNumber
+})
+
 const filteredVideoList = computed(() => {
+  let videoList = props.videoList
+
   if (hideWatchedSubs.value && !props.isCommunity) {
-    return props.videoList.filter((video) => {
+    videoList = videoList.filter((video) => {
       return historyCacheById.value[video.videoId] === undefined
     })
-  } else {
-    return props.videoList
   }
+
+  if (onlyShowLatestFromChannel.value && !props.isCommunity) {
+    const authors = new Map()
+    videoList = videoList.filter((video) => {
+      if (!video.authorId) {
+        return true
+      }
+
+      if (!authors.has(video.authorId)) {
+        authors.set(video.authorId, 1)
+        return true
+      } else {
+        const currentVideos = authors.get(video.authorId)
+
+        if (currentVideos < onlyShowLatestFromChannelNumber.value) {
+          authors.set(video.authorId, currentVideos + 1)
+          return true
+        }
+      }
+
+      return false
+    })
+  }
+
+  return videoList
 })
 
 function increaseLimit() {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -158,15 +158,19 @@ const onlyShowLatestFromChannelNumber = computed(() => {
 })
 
 const filteredVideoList = computed(() => {
+  if (props.isCommunity) {
+    return props.videoList
+  }
+
   let videoList = props.videoList
 
-  if (hideWatchedSubs.value && !props.isCommunity) {
+  if (hideWatchedSubs.value) {
     videoList = videoList.filter((video) => {
       return historyCacheById.value[video.videoId] === undefined
     })
   }
 
-  if (onlyShowLatestFromChannel.value && !props.isCommunity) {
+  if (onlyShowLatestFromChannel.value) {
     const authors = new Map()
     videoList = videoList.filter((video) => {
       if (!video.authorId) {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -31,31 +31,6 @@ export function updateVideoListAfterProcessing(videos) {
     })
   }
 
-  // ordered last to show first eligible video from channel
-  // if the first one incidentally failed one of the above checks
-  if (store.getters.getOnlyShowLatestFromChannel) {
-    const authors = new Map()
-    videoList = videoList.filter((video) => {
-      if (!video.authorId) {
-        return true
-      }
-
-      if (!authors.has(video.authorId)) {
-        authors.set(video.authorId, 1)
-        return true
-      } else {
-        const currentVideos = authors.get(video.authorId)
-
-        if (currentVideos < store.getters.getOnlyShowLatestFromChannelNumber) {
-          authors.set(video.authorId, currentVideos + 1)
-          return true
-        }
-      }
-
-      return false
-    })
-  }
-
   videoList.sort((a, b) => {
     return b.published - a.published
   })


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
Closes #8970 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR fixes a regression introduced in v0.24 where the "Limit number of videos per channel" feature incorrectly counted watched videos towards its limit. 

Previously, the "single channel" limit was evaluated inside the static `updateVideoListAfterProcessing` helper *before* the video list was passed to the UI where the "hide watched" filter was applied. This resulted in watched videos burning up limit slots.

To fix this --> I moved the channel limit logic into `SubscriptionsTabUi.vue` inside the `filteredVideoList`. Now, it  evaluates *after* the hide watched filter is applied. this way we can restore the expected v0.23 behavior. As an added bonus, because the logic is now inside a Vue evaluated property like -> the channel limit "reactively" updates *if a user watches a video and returns to the subscriptions tab without requiring a hard refresh.*

**Filter Pipeline Correction:**

| Step | Before (v0.24 broken) | After (this PR) |
|------|----------------------|----------------|
| 1 | Hide live streams | Hide live streams |
| 2 | Hide premieres | Hide premieres |
| 3 | **Limit per channel**  | Sort by date |
| 4 | Sort by date | **Hide watched**  |
| 5 | **Hide watched**  | **Limit per channel**  |



## Screenshots

### 1. Baseline Behavior
**Settings:** `"Hide Videos on Watch"` = **OFF** | `Channel Limit` = **5**
*The baseline state showing the standard 5 newest videos.*
<img width="2559" height="1439" alt="Baseline Behavior" src="https://github.com/user-attachments/assets/100cbfb8-29c9-42de-b45b-9fcdc0f01b55" />

<br>

### 2. After watching some videos
**Settings:** `"Hide Videos on Watch"` = **OFF** | `Channel Limit` = **5**
<img width="2559" height="1439" alt="Before PR (Broken)" src="https://github.com/user-attachments/assets/1ac196e0-75f5-4a01-a2cf-80332c99c565" />

<br>

### 3. After this PR (Fixed State)
**Settings:** `"Hide Videos on Watch"` = **ON** | `Channel Limit` = **5**
*Previously it used to remove those watched videos but "never" add new videos so there will be only 3 videos but after the changes it works correctly*
<img width="2559" height="1439" alt="After PR (Fixed)" src="https://github.com/user-attachments/assets/abfa2dc6-0ba4-4abe-bf60-060bd4b8ade1" />


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
1. Go to Settings and enable **"Limit number of videos per channel"** (e.g., set it to 5).
2. Enable **"Hide watched videos"**.
3. Go to the Subscriptions tab and locate a channel with 5 visible videos.
4. Watch 3 of those videos.
5. Return to the Subscriptions tab.
6. **Before this PR:** You would only see 2 unwatched videos remaining for that channel.
7. **With this PR:** You will correctly see the next 5 unwatched videos for that channel, filling the gaps of the videos you just watched.

## Desktop
<!-- Please complete the following information-->
- **OS:**  Windows 11
- **OS Version:**  Version 25H2
- **FreeTube version:** v0.24.0

## Additional context
<!-- Add any other context about the pull request here. -->
none
