### PR TITLE
spam

### DIFF
--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -34,6 +34,13 @@
           @change="updateEnableSearchSuggestions"
         />
         <FtToggleSwitch
+          :label="t('Settings.General Settings.Use Locale for Content')"
+          :default-value="useLocaleForContent"
+          :compact="true"
+          :tooltip="t('Tooltips.General Settings.Use Locale for Content')"
+          @change="updateUseLocaleForContent"
+        />
+        <FtToggleSwitch
           v-if="USING_ELECTRON"
           :label="t('Settings.General Settings.Open Deep Links In New Window')"
           :default-value="openDeepLinksInNewWindow"
@@ -410,6 +417,16 @@ const region = computed(() => store.getters.getRegion)
  */
 function updateRegion(value) {
   store.dispatch('updateRegion', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const useLocaleForContent = computed(() => store.getters.getUseLocaleForContent)
+
+/**
+ * @param {boolean} value
+ */
+function updateUseLocaleForContent(value) {
+  store.dispatch('updateUseLocaleForContent', value)
 }
 
 const EXTERNAL_LINK_HANDLING_VALUES = ['', 'openLinkAfterPrompt', 'doNothing']

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -73,6 +73,12 @@
           :default-value="enterFullscreenOnDisplayRotate"
           @change="updateEnterFullscreenOnDisplayRotate"
         />
+        <FtToggleSwitch
+          :label="t('Settings.Player Settings.Enable Loop by Default')"
+          :compact="true"
+          :default-value="enableLoopByDefault"
+          @change="updateEnableLoopByDefault"
+        />
       </div>
     </div>
     <FtFlexBox>
@@ -379,6 +385,16 @@ const enterFullscreenOnDisplayRotate = computed(() => store.getters.getEnterFull
  */
 function updateEnterFullscreenOnDisplayRotate(value) {
   store.dispatch('updateEnterFullscreenOnDisplayRotate', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const enableLoopByDefault = computed(() => store.getters.getEnableLoopByDefault)
+
+/**
+ * @param {boolean} value
+ */
+function updateEnableLoopByDefault(value) {
+  store.dispatch('updateEnableLoopByDefault', value)
 }
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2873,6 +2873,10 @@ export default defineComponent({
       hasLoaded.value = true
       emit('loaded')
 
+      if (store.getters.getEnableLoopByDefault) {
+        video.value.loop = true
+      }
+
       // ideally we would set this in the `streaming` event handler, but for HLS this is only set to true after the loaded event fires.
       isLive.value = player.isLive()
       // getAudioTracks() returns an empty array when no variant is active, so we can't do this in the `streaming` event

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -534,8 +534,10 @@ export async function getInvidiousPopularFeed() {
  * @param {string} query
  * @param {number} page
  * @param {any} searchSettings
+ * @param {string} [region] the region code (e.g. 'BR') to get region-relevant results
+ * @param {string} [lang] the language code (e.g. 'pt') for localized results
  */
-export async function getInvidiousSearchResults(query, page, searchSettings) {
+export async function getInvidiousSearchResults(query, page, searchSettings, region, lang) {
   const DURATION_MAP = {
     '': '',
     under_three_mins: 'short',
@@ -543,19 +545,29 @@ export async function getInvidiousSearchResults(query, page, searchSettings) {
     over_twenty_mins: 'long',
   }
 
+  const params = {
+    q: query,
+    page,
+    sort_by: searchSettings.prioritize === 'popularity' ? 'view_count' : searchSettings.prioritize,
+    date: searchSettings.time,
+    duration: DURATION_MAP[searchSettings.duration],
+    type: searchSettings.type,
+    features: searchSettings.features.join(','),
+  }
+
+  if (region) {
+    params.region = region
+  }
+
+  if (lang) {
+    params.hl = lang
+  }
+
   /** @type {Promise<(InvidiousChannelObject | InvidiousPlaylistObject | InvidiousVideoType | InvidiousHashtagObject)[] | null>} */
   let results = await invidiousAPICall({
     resource: 'search',
     id: '',
-    params: {
-      q: query,
-      page,
-      sort_by: searchSettings.prioritize === 'popularity' ? 'view_count' : searchSettings.prioritize,
-      date: searchSettings.time,
-      duration: DURATION_MAP[searchSettings.duration],
-      type: searchSettings.type,
-      features: searchSettings.features.join(',')
-    }
+    params
   })
 
   if (!results) {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -70,13 +70,14 @@ if (process.env.SUPPORTS_LOCAL_API) {
  * @param {object} options
  * @param {boolean} options.withPlayer set to true to get an Innertube instance that can decode the streaming URLs
  * @param {string|undefined} options.location the geolocation to pass to YouTube get different content
+ * @param {string|undefined} options.lang the language code (e.g. 'pt') for localized content
  * @param {boolean} options.safetyMode whether to hide mature content
  * @param {import('youtubei.js').ClientType} options.clientType use an alterate client
  * @param {boolean} options.generateSessionLocally generate the session locally or let YouTube generate it (local is faster, remote is more accurate)
  * @param {?import('youtubei.js').FetchFunction} options.fetchFunc optional custom fetch function
  * @returns the Innertube instance
  */
-async function createInnertube({ withPlayer = false, location = undefined, safetyMode = false, clientType = undefined, generateSessionLocally = true, fetchFunc = null } = {}) {
+async function createInnertube({ withPlayer = false, location = undefined, lang = undefined, safetyMode = false, clientType = undefined, generateSessionLocally = true, fetchFunc = null } = {}) {
   let cache
   if (withPlayer) {
     if (process.env.IS_ELECTRON) {
@@ -94,6 +95,7 @@ async function createInnertube({ withPlayer = false, location = undefined, safet
     user_agent: navigator.userAgent,
 
     retrieve_player: !!withPlayer,
+    lang: lang,
     location: location,
     enable_safety_mode: !!safetyMode,
     client_type: clientType,
@@ -350,9 +352,11 @@ export async function getLocalTrending(location, tab) {
  * @param {string} query
  * @param {object} filters
  * @param {boolean} safetyMode
+ * @param {string} [location] the region/location code (e.g. 'BR') to get region-relevant results
+ * @param {string} [lang] the language code (e.g. 'pt') for localized results
  */
-export async function getLocalSearchResults(query, filters, safetyMode) {
-  const innertube = await createInnertube({ safetyMode })
+export async function getLocalSearchResults(query, filters, safetyMode, location, lang) {
+  const innertube = await createInnertube({ safetyMode, location, lang })
   const response = await innertube.search(query, convertSearchFilters(filters))
 
   return handleSearchResponse(response)
@@ -387,13 +391,15 @@ export async function getLocalSearchContinuation(continuationData) {
  *   adEndTimeUnixMs: number
  * }>}
  */
-export async function getLocalVideoInfo(id) {
+export async function getLocalVideoInfo(id, location, lang) {
   let responseTime = Date.now()
   let totalAdTimeMilliseconds = 0
 
   const webInnertube = await createInnertube({
     withPlayer: true,
     generateSessionLocally: false,
+    location,
+    lang,
     fetchFunc: async (input, init) => {
       if (!(input.url?.startsWith('https://www.youtube.com/youtubei/v1/player'))) {
         return fetch(input, init)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -169,6 +169,7 @@ const state = {
   defaultVideoFormat: 'dash',
   disableSmoothScrolling: false,
   displayVideoPlayButton: false,
+  enableLoopByDefault: false,
   enableSearchSuggestions: true,
   enableSubtitlesByDefault: false,
   enterFullscreenOnDisplayRotate: false,
@@ -235,6 +236,7 @@ const state = {
   proxyProtocol: 'socks5',
   proxyVideos: !process.env.SUPPORTS_LOCAL_API,
   region: 'US',
+  useLocaleForContent: false,
   rememberHistory: true,
   rememberSearchHistory: true,
   // 'auto', 'semi-auto', 'never'

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -63,7 +63,7 @@ import {
 import { getInvidiousSearchResults } from '../../helpers/api/invidious'
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
 
-const { t } = useI18n()
+const { locale, t } = useI18n()
 const route = useRoute()
 
 const isLoading = ref(false)
@@ -91,6 +91,15 @@ const showFamilyFriendlyOnly = computed(() => store.getters.getShowFamilyFriendl
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const rememberSearchHistory = computed(() => store.getters.getRememberSearchHistory)
+
+/** @type {import('vue').ComputedRef<string>} */
+const region = computed(() => store.getters.getRegion)
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const useLocaleForContent = computed(() => store.getters.getUseLocaleForContent)
+
+const searchRegion = computed(() => useLocaleForContent.value ? region.value : undefined)
+const searchLang = computed(() => useLocaleForContent.value ? locale.value.split('-')[0] : undefined)
 
 watch(route, () => {
   const query_ = route.params.query.trim()
@@ -196,7 +205,9 @@ async function performSearchLocal(payload) {
     const { results, continuationData } = await getLocalSearchResults(
       payload.query,
       payload.searchSettings,
-      showFamilyFriendlyOnly.value
+      showFamilyFriendlyOnly.value,
+      searchRegion.value,
+      searchLang.value
     )
 
     apiUsed.value = 'local'
@@ -285,7 +296,7 @@ async function performSearchInvidious(payload, options = { resetSearchPage: fals
   }
 
   try {
-    const results = await getInvidiousSearchResults(payload.query, searchPage.value, payload.searchSettings)
+    const results = await getInvidiousSearchResults(payload.query, searchPage.value, payload.searchSettings, searchRegion.value, searchLang.value)
     if (!results) {
       return
     }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -429,7 +429,10 @@ export default defineComponent({
       }
 
       try {
-        const videoInfo = await getLocalVideoInfo(this.videoId)
+        const useLocaleForContent = this.$store.getters.getUseLocaleForContent
+        const region = useLocaleForContent ? this.$store.getters.getRegion : undefined
+        const lang = useLocaleForContent ? this.$i18n.locale.split('-')[0] : undefined
+        const videoInfo = await getLocalVideoInfo(this.videoId, region, lang)
         const { info: result, poToken, clientInfo, adEndTimeUnixMs } = videoInfo
 
         this.adEndTimeUnixMs = adEndTimeUnixMs

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -274,6 +274,7 @@ Settings:
     Fallback to Non-Preferred Backend on Failure: Fallback to Non-Preferred Backend
       on Failure
     Enable Search Suggestions: Enable Search Suggestions
+    Use Locale for Content: Use Region & Language for Search and Video Titles
     Open Deep Links In New Window: Open URLs Passed to FreeTube in a New Window
     Minimize to system tray: Minimize to system tray
     Auto Load Next Page:
@@ -450,6 +451,7 @@ Settings:
     Skip by Scrolling Over Video Player: Skip by Scrolling Over Video Player
     Display Play Button In Video Player: Display Play Button In Video Player
     Enter Fullscreen on Display Rotate: Enter Fullscreen on Display Rotate
+    Enable Loop by Default: Enable Loop by Default
     Next Video Interval: Autoplay Countdown Timer
     Autoplay Interruption Timer: Autoplay Interruption Timer
     Fast-Forward / Rewind Interval: Fast-Forward / Rewind Interval
@@ -1041,6 +1043,9 @@ Tooltips:
       calls.
     Region for Trending: The region of trends allows you to pick which country's trending
       videos you want to have displayed.
+    Use Locale for Content: When enabled, search results and video titles will use
+      your selected region and language, showing content and titles localized for
+      your language instead of English.
     External Link Handling: |
       Choose the default behavior when a link, which cannot be opened in FreeTube, is clicked.
       By default FreeTube will open the clicked link in your default browser.

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -204,6 +204,7 @@ Settings:
     General Settings: 'Geral'
     Fallback to Non-Preferred Backend on Failure: 'Usar mecanismo de busca alternativo em caso de falha'
     Enable Search Suggestions: 'Habilitar sugestões de busca'
+    Use Locale for Content: 'Usar região e idioma para buscas e títulos de vídeos'
     Default Landing Page: 'Página inicial preferida'
     Locale Preference: 'Idioma'
     Preferred API Backend:
@@ -410,6 +411,7 @@ Settings:
       Quality Label: Qualidade da captura de tela
       File Name Tooltip: 'Você pode usar estas variáveis: %Y - ano com 4 dígitos, %M - mês com 2 dígitos, %D - dia com 2 dígitos, %H - hora com 2 dígitos, %N - minuto com 2 dígitos, %S - segundos com 2 dígitos, %T - milissegundos com 3 dígitos, %s - segundos do vídeo, %t - milissegundos do vídeo com 3 dígitos, %i - id do vídeo.'
     Enter Fullscreen on Display Rotate: Entrar em tela cheia ao girar o dispositivo para o modo paisagem
+    Enable Loop by Default: Ativar repetição por padrão
     Skip by Scrolling Over Video Player: Avançar ou retroceder com o botão de rolagem do mouse com o cursor sobre a reprodução
     Autoplay Interruption Timer: Mostrar temporizador de interrupções para reprodução automática
     Default Viewing Mode:
@@ -953,6 +955,7 @@ Tooltips:
     Skip by Scrolling Over Video Player: Use o botão de rolagem do mouse para avançar ou retroceder o vídeo, estilo MPV.
   General Settings:
     Region for Trending: A região de tendências permite que você escolha os vídeos em alta do país que deseja exibir.
+    Use Locale for Content: Quando ativado, os resultados de busca e títulos de vídeos usarão a região e idioma selecionados, mostrando conteúdo e títulos no seu idioma em vez de inglês.
     Invidious Instance: A instância Invidious à qual o FreeTube se conectará para chamadas de API.
     Thumbnail Preference: Todas as miniaturas no FreeTube serão substituídas por um quadro do vídeo, desfocado ou oculto, em vez da miniatura padrão.
     Fallback to Non-Preferred Backend on Failure: Quando sua API preferida tiver um problema, o FreeTube tentará automaticamente usar sua API não preferencial como método alternativo quando habilitada.


### PR DESCRIPTION
## Summary

- **Use Locale for Content** — New toggle in General Settings that passes the user's selected region and language to search requests (Local API and Invidious) and video info fetching, so search results are region-relevant and video titles/metadata appear in the user's language instead of English
- **Enable Loop by Default** — New toggle in Player Settings that automatically enables video loop when a video loads, using Shaka Player's built-in loop functionality
- Both features are **disabled by default** to preserve current behavior

## Problem

Currently, FreeTube's search does not pass the user's configured region or language to the YouTube/Invidious APIs. This means:
- Search results are not filtered by region, returning mostly English content even for users in non-English regions
- Video titles always come back in English, even when localized titles are available from the channel
- There is no way to set video loop as default — users must manually enable it each time

## Changes

### Use Locale for Content (General Settings)
| File | Change |
|------|--------|
| `settings.js` | Added `useLocaleForContent: false` setting |
| `GeneralSettings.vue` | Added toggle switch with tooltip |
| `local.js` | Added `lang` param to `createInnertube()` and `getLocalSearchResults()` |
| `local.js` | Pass `location` and `lang` to `getLocalVideoInfo()` for localized titles |
| `invidious.js` | Added `region` and `hl` params to `getInvidiousSearchResults()` |
| `SearchPage.vue` | Pass region and lang to both search backends when toggle is on |
| `Watch.js` | Pass region and lang to `getLocalVideoInfo()` when toggle is on |

### Enable Loop by Default (Player Settings)
| File | Change |
|------|--------|
| `settings.js` | Added `enableLoopByDefault: false` setting |
| `PlayerSettings.vue` | Added toggle switch |
| `ft-shaka-video-player.js` | Set `video.loop = true` on `handleLoaded()` when enabled |

### Localization
- Added `en-US` and `pt-BR` translations for both features including tooltips

## How It Works

When **Use Locale for Content** is enabled:
1. **Local API (YouTube.js):** Passes `location` (e.g. `'BR'`) and `lang` (e.g. `'pt'`) to `Innertube.create()`, which uses them as geolocation and language context for all API requests
2. **Invidious API:** Passes `region` and `hl` query parameters to the `/api/v1/search` endpoint
3. **Video Info:** Passes `location` and `lang` when fetching video details, so YouTube returns localized titles and metadata
4. Works for **all languages and regions** — it uses whatever locale and region the user has configured in General Settings

## Test plan

- [ ] Enable "Use Locale for Content" in General Settings with Region set to Brazil and Locale set to Português (Brasil)
- [ ] Search for a topic and verify results prioritize Portuguese content
- [ ] Open a video that has localized titles and verify the title appears in Portuguese
- [ ] Disable the toggle and verify search returns default (English-biased) results
- [ ] Test with other locale/region combinations (e.g. Japanese/Japan, German/Germany)
- [ ] Test with Invidious backend
- [ ] Enable "Enable Loop by Default" in Player Settings
- [ ] Open a video and verify the loop icon in the player is active
- [ ] Disable the toggle and verify loop is not set by default

🤖 Generated with [Claude Code](https://claude.ai/code)