### PR TITLE
fix(watch): show persistent error for unavailable and removed videos

### DIFF
--- a/src/renderer/helpers/colors.js
+++ b/src/renderer/helpers/colors.js
@@ -99,10 +99,27 @@ export function getRandomColor() {
 }
 
 export function calculateColorLuminance(colorValue) {
-  const cutHex = colorValue.substring(1, 7)
-  const colorValueR = parseInt(cutHex.substring(0, 2), 16)
-  const colorValueG = parseInt(cutHex.substring(2, 4), 16)
-  const colorValueB = parseInt(cutHex.substring(4, 6), 16)
+  let colorValues
+
+  if (colorValue.startsWith('#')) {
+    const cutHex = colorValue.length === 4
+      ? colorValue.slice(1).split('').map(value => value + value).join('')
+      : colorValue.substring(1, 7)
+
+    colorValues = [
+      parseInt(cutHex.substring(0, 2), 16),
+      parseInt(cutHex.substring(2, 4), 16),
+      parseInt(cutHex.substring(4, 6), 16)
+    ]
+  } else {
+    colorValues = colorValue.match(/\d+(\.\d+)?/g)?.slice(0, 3).map(Number)
+  }
+
+  if (!colorValues || colorValues.some(value => isNaN(value))) {
+    return '#FFFFFF'
+  }
+
+  const [colorValueR, colorValueG, colorValueB] = colorValues
 
   const luminance = (0.299 * colorValueR + 0.587 * colorValueG + 0.114 * colorValueB) / 255
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -13,6 +13,7 @@ import WatchVideoLiveChat from '../../components/WatchVideoLiveChat/WatchVideoLi
 import WatchVideoPlaylist from '../../components/WatchVideoPlaylist/WatchVideoPlaylist.vue'
 import WatchVideoRecommendations from '../../components/WatchVideoRecommendations/WatchVideoRecommendations.vue'
 import FtAgeRestricted from '../../components/FtAgeRestricted/FtAgeRestricted.vue'
+import { calculateColorLuminance } from '../../helpers/colors'
 import {
   buildVTTFileLocally,
   copyToClipboard,
@@ -59,16 +60,6 @@ const UNAVAILABLE_VIDEO_THUMBNAILS = {
   light: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video.png',
   dark: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
 }
-const LIGHT_BASE_THEMES = new Set([
-  'light',
-  'pastelPink',
-  'catppuccinLatte',
-  'solarizedLight',
-  'gruvboxLight',
-  'everforestLightHard',
-  'everforestLightMedium',
-  'everforestLightLow'
-])
 
 export default defineComponent({
   name: 'Watch',
@@ -204,9 +195,6 @@ export default defineComponent({
     },
     backendFallback: function () {
       return this.$store.getters.getBackendFallback
-    },
-    baseTheme: function () {
-      return this.$store.getters.getBaseTheme
     },
     currentInvidiousInstanceUrl: function () {
       return this.$store.getters.getCurrentInvidiousInstanceUrl
@@ -1093,9 +1081,8 @@ export default defineComponent({
     },
 
     getUnavailableVideoThumbnail: function () {
-      const baseTheme = this.baseTheme || 'system'
-      const isLightTheme = LIGHT_BASE_THEMES.has(baseTheme) ||
-        (baseTheme === 'system' && !window.matchMedia('(prefers-color-scheme: dark)').matches)
+      const backgroundColor = window.getComputedStyle(document.body).backgroundColor
+      const isLightTheme = calculateColorLuminance(backgroundColor) === '#000000'
 
       return isLightTheme
         ? UNAVAILABLE_VIDEO_THUMBNAILS.light

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -350,18 +350,11 @@ export default defineComponent({
 
       // react to route changes...
       this.videoId = this.$route.params.id
+      this.resetVideoState()
 
       this.firstLoad = true
       this.videoPlayerLoaded = false
-      this.errorMessage = null
-      this.customErrorIcon = null
       this.activeFormat = this.defaultVideoFormat
-      this.sabrData = null
-      this.videoStoryboardSrc = ''
-      this.captions = []
-      this.vrProjection = null
-      this.videoCurrentChapterIndex = 0
-      this.videoGenreIsMusic = false
 
       this.checkIfTimestamp()
       this.checkIfPlaylist()
@@ -375,6 +368,53 @@ export default defineComponent({
           break
       }
     },
+
+    resetVideoState: function () {
+      this.isLoading = true
+      this.isFamilyFriendly = false
+      this.isLive = false
+      this.liveChat = null
+      this.isLiveContent = false
+      this.isUpcoming = false
+      this.isPostLiveDvr = false
+      this.isUnlisted = false
+      this.upcomingTimestamp = null
+      this.upcomingTimeLeft = null
+      this.thumbnail = ''
+      this.videoTitle = ''
+      this.videoDescription = ''
+      this.videoDescriptionHtml = ''
+      this.license = ''
+      this.videoViewCount = 0
+      this.videoLikeCount = 0
+      this.videoDislikeCount = 0
+      this.videoLengthSeconds = 0
+      this.videoChapters = []
+      this.videoCurrentChapterIndex = 0
+      this.videoChaptersKind = 'chapters'
+      this.channelName = ''
+      this.channelThumbnail = ''
+      this.channelId = ''
+      this.channelSubscriptionCountText = ''
+      this.videoPublished = 0
+      this.premiereDate = undefined
+      this.videoStoryboardSrc = ''
+      this.manifestSrc = null
+      this.manifestMimeType = MANIFEST_TYPE_DASH
+      this.sabrData = null
+      this.legacyFormats = []
+      this.captions = []
+      this.vrProjection = null
+      this.recommendedVideos = []
+      this.playabilityStatus = ''
+      this.adEndTimeUnixMs = 0
+      this.errorMessage = null
+      this.customErrorIcon = null
+      this.videoGenreIsMusic = false
+      this.streamingDataExpiryDate = null
+      this.updateTitle()
+    },
+
     onMountedDependOnLocalStateLoading() {
       // Prevent running twice
       if (this.onMountedRun) { return }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -865,12 +865,12 @@ export default defineComponent({
         this.isLoading = false
         this.updateTitle()
       } catch (err) {
-        const errorMessage = this.$t('Local API Error (Click to copy)')
-        showToast(`${errorMessage}: ${err}`, 10000, () => {
-          copyToClipboard(err)
-        })
         console.error(err)
         if (this.backendPreference === 'local' && this.backendFallback && !err.toString().includes('private') && !err.toString().includes('unavailable')) {
+          const errorMessage = this.$t('Local API Error (Click to copy)')
+          showToast(`${errorMessage}: ${err}`, 10000, () => {
+            copyToClipboard(err)
+          })
           showToast(this.$t('Falling back to Invidious API'))
           this.getVideoInformationInvidious()
         } else {
@@ -1056,11 +1056,11 @@ export default defineComponent({
         })
         .catch(err => {
           console.error(err)
-          const errorMessage = this.$t('Invidious API Error (Click to copy)')
-          showToast(`${errorMessage}: ${err}`, 10000, () => {
-            copyToClipboard(err)
-          })
           if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
+            const errorMessage = this.$t('Invidious API Error (Click to copy)')
+            showToast(`${errorMessage}: ${err}`, 10000, () => {
+              copyToClipboard(err)
+            })
             showToast(this.$t('Falling back to Local API'))
             this.getVideoInformationLocal()
           } else {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -55,6 +55,20 @@ import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 
 const MANIFEST_TYPE_DASH = 'application/dash+xml'
 const MANIFEST_TYPE_HLS = 'application/x-mpegurl'
+const UNAVAILABLE_VIDEO_THUMBNAILS = {
+  light: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video.png',
+  dark: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
+}
+const LIGHT_BASE_THEMES = new Set([
+  'light',
+  'pastelPink',
+  'catppuccinLatte',
+  'solarizedLight',
+  'gruvboxLight',
+  'everforestLightHard',
+  'everforestLightMedium',
+  'everforestLightLow'
+])
 
 export default defineComponent({
   name: 'Watch',
@@ -190,6 +204,9 @@ export default defineComponent({
     },
     backendFallback: function () {
       return this.$store.getters.getBackendFallback
+    },
+    baseTheme: function () {
+      return this.$store.getters.getBaseTheme
     },
     currentInvidiousInstanceUrl: function () {
       return this.$store.getters.getCurrentInvidiousInstanceUrl
@@ -872,7 +889,7 @@ export default defineComponent({
           this.isLoading = false
 
           if (!this.thumbnail) {
-            this.thumbnail = `https://i.ytimg.com/vi/${this.videoId}/maxresdefault.jpg`
+            this.thumbnail = this.getUnavailableVideoThumbnail()
           }
           this.errorMessage = err.message || err.toString()
         }
@@ -1062,7 +1079,7 @@ export default defineComponent({
             this.isLoading = false
 
             if (!this.thumbnail) {
-              this.thumbnail = `https://i.ytimg.com/vi/${this.videoId}/maxresdefault.jpg`
+              this.thumbnail = this.getUnavailableVideoThumbnail()
             }
             this.errorMessage = err.message || err.toString()
           }
@@ -1073,6 +1090,16 @@ export default defineComponent({
       const expireString = new URL(url).searchParams.get('expire')
 
       return new Date(parseInt(expireString) * 1000)
+    },
+
+    getUnavailableVideoThumbnail: function () {
+      const baseTheme = this.baseTheme || 'system'
+      const isLightTheme = LIGHT_BASE_THEMES.has(baseTheme) ||
+        (baseTheme === 'system' && !window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+      return isLightTheme
+        ? UNAVAILABLE_VIDEO_THUMBNAILS.light
+        : UNAVAILABLE_VIDEO_THUMBNAILS.dark
     },
 
     /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -865,11 +865,16 @@ export default defineComponent({
           copyToClipboard(err)
         })
         console.error(err)
-        if (this.backendPreference === 'local' && this.backendFallback && !err.toString().includes('private')) {
+        if (this.backendPreference === 'local' && this.backendFallback && !err.toString().includes('private') && !err.toString().includes('unavailable')) {
           showToast(this.$t('Falling back to Invidious API'))
           this.getVideoInformationInvidious()
         } else {
           this.isLoading = false
+
+          if (!this.thumbnail) {
+            this.thumbnail = `https://i.ytimg.com/vi/${this.videoId}/maxresdefault.jpg`
+          }
+          this.errorMessage = err.message || err.toString()
         }
       }
     },
@@ -1050,12 +1055,16 @@ export default defineComponent({
           showToast(`${errorMessage}: ${err}`, 10000, () => {
             copyToClipboard(err)
           })
-          console.error(err)
           if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
             showToast(this.$t('Falling back to Local API'))
             this.getVideoInformationLocal()
           } else {
             this.isLoading = false
+
+            if (!this.thumbnail) {
+              this.thumbnail = `https://i.ytimg.com/vi/${this.videoId}/maxresdefault.jpg`
+            }
+            this.errorMessage = err.message || err.toString()
           }
         })
     },


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Related issue
closes #8472

## Description

Opening a removed/unavailable video currently shows a blank watch page with a error that disappears after a few seconds. The existing error overlay (used for members-only, age-restricted, DRM videos) never triggers because the catch blocks do not set `errorMessage` variable for unavailable videos.

I have made changes so that unavailable/removed video errors now set `errorMessage`, so the error stays visible inside the player instead of only appearing as a temporary toast.

Since unavailable videos may not have a usable thumbnail, the player area can shrink and hide the error. To avoid that, I added YouTube's official unavailable video fallback thumbnails:

- `https://www.youtube.com/img/desktop/unavailable/unavailable_video.png` for light themes
- `https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png` for dark themes

The thumbnail is chosen by checking the actual page background color with `calculateColorLuminance`, so it should keep working with current and future themes.

It also skips falling back to Invidious when the Local API error contains `unavailable`, since unavailable videos will fail there too.

Finally, I removed the redundant API error toast when the same message is already shown persistently in the player. The toast is now only shown when FreeTube is actually falling back to the other backend.

While testing the review feedback, I also found that the stale thumbnail/title issue existed before this PR. When FreeTube is playing a normal video and then switches to an unavailable video, the unavailable video request fails, but some data from the previous video, like `thumbnail`, `videoTitle`, `channelName`, and `channelThumbnail`, can still be kept around.

Before this PR, that was easier to miss because FreeTube mostly stayed visually on the previous video and showed a temporary unavailable-video toast. After this PR, the issue became more obvious because the unavailable message stays inside the player, so it could appear on top of the previous video’s thumbnail/title.

The fix is to clear the previous video’s state when the watch route changes, before loading the next video. Then, if the new video is unavailable, FreeTube shows the unavailable fallback thumbnail and persistent error instead of accidentally reusing details from the last normal video.

## Screenshots
**Before:** 

the error of video unavailable stays for only few seconds so if you're not actively looking for it, then you likely won't see it before it disappears.

<img width="2559" height="1439" alt="image" src="https://github.com/user-attachments/assets/71489ee1-d4cc-41e5-8bea-7a86c9f42c6f" />

**After:**

_Testing On Multiple Themes_


https://github.com/user-attachments/assets/1e89c33b-56cf-4da2-9ab6-4a12574e4553


_Testing On Normal Video_



https://github.com/user-attachments/assets/3cd5d4c0-db48-4f38-b002-234ba7b30035

---

_Before this PR during watch route change to unavailable video_

https://github.com/user-attachments/assets/075919d4-c170-4464-b7dc-846f8f70e78e

_After this PR during watch route change to unavailable video_

https://github.com/user-attachments/assets/74ee9038-9c02-4895-9cdc-1c8a5d75735c

## Testing

1. Open https://www.youtube.com/watch?v=Y0Aqc174FMM
2. Check that the "Video unavailable" error is shown inside the player and does not disappear.
3. Check that there is no duplicate API error toast when the player already shows the same error.
4. Open a normal video and check that it still plays.
5. Open other unplayable videos, like members-only or age-restricted videos, and check that their existing player error behavior still works.
6. Also retest the feature with different themes. 


## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.24.0 
