### PR TITLE
Fix playlist import object cloning error

### DIFF
--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -1196,7 +1196,7 @@ async function importPlaylists() {
       shouldAddDuplicateVideos = existingPlaylist.videos.length > existingVideoIdSet.size
     }
 
-    const playlistVideos = [...existingPlaylist.videos]
+    const playlistVideos = deepCopy(existingPlaylist.videos)
 
     playlistObject.videos.forEach((video) => {
       let videoExists = false


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #8940

## Description

As the playlist data in FreeTube is stored in deeply reactive we also need to deeply clone it to remove the reactivity, instead of just using a shallow clone.

## Testing

1. Export a playlist in the FreeTube database format
2. Import that same playlist into FreeTube again
3. Profit!

## Desktop

- **OS:** Windows
- **OS Version:** 11