### PR TITLE
Fix spacing in the window title on the playlist page

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -545,13 +545,7 @@ const windowTitle = computed(() => {
     !routePath.startsWith('/playlist/') &&
     !routePath.startsWith('/search/')
   ) {
-    let title = translateWindowTitle(route.meta.title)
-    if (!title) {
-      title = packageDetails.productName
-    } else {
-      title = `${title} - ${packageDetails.productName}`
-    }
-    return title
+    return translateWindowTitle(route.meta.title) ?? ''
   } else {
     return null
   }
@@ -561,7 +555,11 @@ const windowTitle = computed(() => {
 const appTitle = computed(() => store.getters.getAppTitle)
 
 watch(appTitle, (value) => {
-  document.title = value
+  if (value.length > 0) {
+    document.title = `${value} - ${packageDetails.productName}`
+  } else {
+    document.title = packageDetails.productName
+  }
 })
 
 watch(windowTitle, setWindowTitle)

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -283,7 +283,6 @@ import FtSelect from '../../components/FtSelect/FtSelect.vue'
 
 import store from '../../store/index'
 
-import packageDetails from '../../../../package.json'
 import {
   copyToClipboard,
   extractNumberFromString,
@@ -681,7 +680,7 @@ async function getChannelLocal() {
       channelName.value = channelName
       thumbnailUrl.value = channelThumbnailUrl
 
-      store.commit('setAppTitle', `${channelName_} - ${packageDetails.productName}`)
+      store.commit('setAppTitle', channelName_)
 
       store.dispatch('updateSubscriptionDetails', { channelThumbnailUrl, channelName: channelName_, channelId: id.value })
 
@@ -729,7 +728,7 @@ async function getChannelLocal() {
     }
     tags.value = tags_
 
-    store.commit('setAppTitle', `${channelName_} - ${packageDetails.productName}`)
+    store.commit('setAppTitle', channelName_)
 
     if (subscriberText) {
       const subCount_ = parseLocalSubscriberCount(subscriberText)
@@ -944,7 +943,7 @@ async function getChannelInfoInvidious() {
     const channelName_ = response.author
     const channelId = response.authorId
     channelName.value = channelName_
-    store.commit('setAppTitle', `${channelName_} - ${packageDetails.productName}`)
+    store.commit('setAppTitle', channelName_)
     id.value = channelId
     isFamilyFriendly.value = response.isFamilyFriendly
     subCount.value = response.subCount

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -58,7 +58,6 @@ import FtLoader from '../../components/FtLoader/FtLoader.vue'
 import FtAutoLoadNextPageWrapper from '../../components/FtAutoLoadNextPageWrapper.vue'
 import store from '../../store/index'
 import { useRoute } from 'vue-router'
-import packageDetails from '../../../../package.json'
 import { getHashtagLocal, parseLocalListVideo } from '../../helpers/api/local'
 import { copyToClipboard, showToast } from '../../helpers/utils'
 import { isNullOrEmpty } from '../../helpers/strings'
@@ -115,7 +114,7 @@ async function getHashtag() {
   } else {
     await getInvidiousHashtag()
   }
-  store.commit('setAppTitle', `#${hashtag.value} - ${packageDetails.productName}`)
+  store.commit('setAppTitle', `#${hashtag.value}`)
 }
 
 /**

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -188,7 +188,6 @@ import {
 } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getSortedPlaylistItems, videoDurationPresent, videoDurationWithFallback, SORT_BY_VALUES } from '../../helpers/playlists'
-import packageDetails from '../../../../package.json'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 
 const { locale, t } = useI18n()
@@ -824,7 +823,7 @@ function updatePageTitle() {
     }
   }
 
-  store.commit('setAppTitle', `${titleText} - ${packageDetails.productName}`)
+  store.commit('setAppTitle', titleText)
 }
 
 /**

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -818,7 +818,7 @@ function updatePageTitle() {
 
   if (channelName_) {
     if (titleText.length > 0) {
-      titleText += `| ${channelName_}`
+      titleText += ` | ${channelName_}`
     } else {
       titleText = channelName_
     }

--- a/src/renderer/views/Post.vue
+++ b/src/renderer/views/Post.vue
@@ -28,7 +28,6 @@
 <script setup>
 import { computed, onMounted, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import packageDetails from '../../../package.json'
 import { useI18n } from '../composables/use-i18n-polyfill'
 
 import FtCard from '../components/ft-card/ft-card.vue'
@@ -74,7 +73,7 @@ onMounted(async () => {
 })
 
 function updateTitleAndRoute() {
-  store.commit('setAppTitle', `${post.value.author} - ${packageDetails.productName}`)
+  store.commit('setAppTitle', post.value.author)
   isLoading.value = false
 
   // If the authorId is missing from the URL we should add it,

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -49,7 +49,6 @@ import FtAutoLoadNextPageWrapper from '../../components/FtAutoLoadNextPageWrappe
 
 import store from '../../store'
 
-import packageDetails from '../../../../package.json'
 import {
   copyToClipboard,
   searchFiltersMatch,
@@ -115,13 +114,13 @@ watch(route, () => {
 
   query.value = query_
 
-  store.commit('setAppTitle', `${processedQuery.value} - ${packageDetails.productName}`)
+  store.commit('setAppTitle', processedQuery.value)
   checkSearchCache(payload)
 }, { deep: true })
 
 onMounted(() => {
   query.value = route.params.query
-  store.commit('setAppTitle', `${processedQuery.value} - ${packageDetails.productName}`)
+  store.commit('setAppTitle', processedQuery.value)
 
   let features = route.query.features
   // if page gets refreshed and there's only one feature then it will be a string

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -13,7 +13,6 @@ import WatchVideoLiveChat from '../../components/WatchVideoLiveChat/WatchVideoLi
 import WatchVideoPlaylist from '../../components/WatchVideoPlaylist/WatchVideoPlaylist.vue'
 import WatchVideoRecommendations from '../../components/WatchVideoRecommendations/WatchVideoRecommendations.vue'
 import FtAgeRestricted from '../../components/FtAgeRestricted/FtAgeRestricted.vue'
-import packageDetails from '../../../../package.json'
 import {
   buildVTTFileLocally,
   copyToClipboard,
@@ -1805,7 +1804,7 @@ export default defineComponent({
     },
 
     updateTitle: function () {
-      this.setAppTitle(`${this.videoTitle} - ${packageDetails.productName}`)
+      this.setAppTitle(this.videoTitle)
     },
 
     isHiddenVideo: function (forbiddenTitles, channelsHidden, video) {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

This pull request fixes the missing space between the playlist title and channel name in the window title when viewing a YouTube playlist. I also took the opportunity to simplify the window title setting code a bit, it now adds the `- FreeTube` suffix in one place right before we set the window title, instead of having that code duplicated across all the bits of code that set a window title.

## Screenshots

Before:
<img width="253" height="48" alt="before" src="https://github.com/user-attachments/assets/a977571e-cf5c-4205-b255-b481080f41fc" />

After:
<img width="255" height="48" alt="after" src="https://github.com/user-attachments/assets/87b9ea96-56fb-4199-8765-0b4214ee9eb2" />

## Testing

Open a YouTube playlist, check that the window title looks correct.

## Desktop

- **OS:** Windows
- **OS Version:** 11