### PR TITLE
Fix opening playlists in external players not working when ignore default args is enabled

### DIFF
--- a/src/main/externalPlayer.js
+++ b/src/main/externalPlayer.js
@@ -90,7 +90,13 @@ export async function handleOpenInExternalPlayer(event, payload) {
   }
 
   if (ignoreDefaultArgs) {
-    if (hasValidVideoId) {
+    if (hasValidPlaylistId && !hasValidVideoId) {
+      if (typeof cmdArgs.playlistUrl === 'string') {
+        args.push(`${cmdArgs.playlistUrl}https://youtube.com/playlist?list=${payload.playlistId}`)
+      } else if (!ignoreWarnings) {
+        unsupportedActions.push(UnsupportedPlayerActions.OPENING_PLAYLISTS)
+      }
+    } else {
       args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
     }
   } else {

--- a/src/main/externalPlayer.js
+++ b/src/main/externalPlayer.js
@@ -96,7 +96,7 @@ export async function handleOpenInExternalPlayer(event, payload) {
       } else if (!ignoreWarnings) {
         unsupportedActions.push(UnsupportedPlayerActions.OPENING_PLAYLISTS)
       }
-    } else {
+    } else if (hasValidVideoId) {
       args.push(`${cmdArgs.videoUrl}https://www.youtube.com/watch?v=${payload.videoId}`)
     }
   } else {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

Currently if the "Ignore Default Arguments" setting is enabled and you try to open a playlist in an external player it silently fails. With this change it will open the playlist if only a playlist ID is available such as trying to open a playlist in the external player, but will open the video if no playlist ID is passed or if both a playlist ID and video ID are passed, the latter differs from the default behaviour, as the "Ignore Default Arguments" setting means we are not allowed to pass an extra argument to indicate which video in the playlist to open.

## Testing

1. Setup an external player
2. Go to the playlists tab on a channel
3. Click on open in external player in the kebab menu

## Desktop

- **OS:** Windows
- **OS Version:** 11