### PR TITLE
Fix TypeScript 6 deprecations in jsconfig

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
       "postcss",
       "scss"
   ],
-  "eslint.packageManager": "yarn",
   "eslint.probe": [
       "javascript",
       "vue",
@@ -29,6 +28,5 @@
     "jsonc",
     "yml",
     "yaml"
-  ],
-  "javascript.preferences.importModuleSpecifier": "relative"
+  ]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,11 +6,10 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "strictNullChecks": true,
-    "baseUrl": "./",
     "paths": {
       "DB_HANDLERS_ELECTRON_RENDERER_OR_WEB": [
-        "src/datastores/handlers/electron",
-        "src/datastores/handlers/web"
+        "./src/datastores/handlers/electron",
+        "./src/datastores/handlers/web"
       ],
       "shaka-player": [
         "./node_modules/shaka-player/dist/shaka-player.ui-es2021"


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

Visual Studio Code was complaining about `baseUrl` being deprecated in the `jsconfig.json` file due to that field being removed in TypeScript 6. The change also means we no longer need to override the `javascript.preferences.importModuleSpecifier`, as the TypeScript language server no longer creates broken imports based on the `baseUrl`. I also removed the `eslint.packageManager` setting as the Visual Studio Code ESLint plugin has been automatically detecting the package manager itself for a long time now, so that setting doesn't exist anymore.

## Testing
not applicable

## Desktop

- **OS:** Windows
- **OS Version:** 11