### PR TITLE
Fix SOCKS proxies not using authentication by using proxy-chain

### DIFF
--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -4,6 +4,7 @@ import packageDetails from '../package.json' with { type: 'json' }
 export default {
   appId: `io.freetubeapp.${packageDetails.name}`,
   copyright: 'Copyleft © 2020-2026 freetubeapp@protonmail.com',
+  asarUnpack: ['dist/proxyProcess.js'],
   // asar: false,
   // compression: 'store',
   productName: packageDetails.productName,

--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -12,6 +12,7 @@ const config = {
   devtool: isDevMode ? 'eval-cheap-module-source-map' : false,
   entry: {
     main: path.join(__dirname, '../src/main/index.js'),
+    proxyProcess: path.join(__dirname, '../src/main/proxyProcess.js'),
   },
   module: {
     rules: [

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "googlevideo": "^4.0.4",
     "marked": "^18.0.0",
     "process": "^0.11.10",
+    "proxy-chain": "^2.7.1",
     "shaka-player": "^5.0.10",
     "swiper": "^12.1.3",
     "vue": "^3.5.32",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,7 +2,7 @@ import {
   app, BrowserWindow, dialog, Menu, ipcMain,
   powerSaveBlocker, screen, session, shell,
   nativeTheme, net, protocol, clipboard,
-  Tray
+  Tray, utilityProcess
 } from 'electron'
 import path from 'path'
 import cp from 'child_process'
@@ -370,6 +370,11 @@ function runApp() {
   }
 
   let proxyUrl
+  let proxyChainProcess
+  let proxyProcessPath = path.join(__dirname, 'proxyProcess.js')
+  if (app.isPackaged) {
+    proxyProcessPath = proxyProcessPath.replace('app.asar', 'app.asar.unpacked')
+  }
 
   app.on('ready', async (_, __) => {
     if (process.platform === 'darwin') {
@@ -530,7 +535,25 @@ function runApp() {
     }
 
     if (useProxy) {
-      proxyUrl = `${proxyProtocol}://${proxyHostname}:${proxyPort}`
+      const proxyUsername = (await baseHandlers.settings._findOne('proxyUsername'))?.value
+      const proxyPassword = (await baseHandlers.settings._findOne('proxyPassword'))?.value
+
+      if (proxyProtocol.startsWith('socks') && proxyUsername && proxyPassword) {
+        if (proxyChainProcess) {
+          proxyChainProcess.kill()
+          proxyChainProcess = undefined
+        }
+        proxyChainProcess = utilityProcess.fork(proxyProcessPath)
+        proxyChainProcess.postMessage({ protocol: proxyProtocol, hostname: proxyHostname, port: proxyPort, username: proxyUsername, password: proxyPassword })
+        const localPort = await new Promise((resolve) => {
+          proxyChainProcess.once('message', (port) => {
+            resolve(port)
+          })
+        })
+        proxyUrl = `http://127.0.0.1:${localPort}`
+      } else {
+        proxyUrl = `${proxyProtocol}://${proxyHostname}:${proxyPort}`
+      }
 
       session.defaultSession.setProxy({
         proxyRules: proxyUrl
@@ -1267,15 +1290,36 @@ function runApp() {
     }
   })
 
-  ipcMain.on(IpcChannels.ENABLE_PROXY, (event, url) => {
+  ipcMain.on(IpcChannels.ENABLE_PROXY, async (event, url) => {
     if (!isFreeTubeUrl(event.senderFrame.url)) {
       return
     }
+    const proxyUsername = (await baseHandlers.settings._findOne('proxyUsername'))?.value
+    const proxyPassword = (await baseHandlers.settings._findOne('proxyPassword'))?.value
+
+    if (url.startsWith('socks') && proxyUsername && proxyPassword) {
+      const proxyProtocol = url.slice(0, 6)
+      const proxyHostname = url.split(':')[1].replaceAll('/', '')
+      const proxyPort = url.split(':')[2]
+      if (proxyChainProcess) {
+        proxyChainProcess.kill()
+        proxyChainProcess = undefined
+      }
+      proxyChainProcess = utilityProcess.fork(proxyProcessPath)
+      proxyChainProcess.postMessage({ protocol: proxyProtocol, hostname: proxyHostname, port: proxyPort, username: proxyUsername, password: proxyPassword })
+      const localPort = await new Promise((resolve) => {
+        proxyChainProcess.once('message', (port) => {
+          resolve(port)
+        })
+      })
+      proxyUrl = `http://127.0.0.1:${localPort}`
+    } else {
+      proxyUrl = url
+    }
 
     session.defaultSession.setProxy({
-      proxyRules: url
+      proxyRules: proxyUrl
     })
-    proxyUrl = url
     session.defaultSession.closeAllConnections()
   })
 

--- a/src/main/proxyProcess.js
+++ b/src/main/proxyProcess.js
@@ -1,0 +1,15 @@
+const ProxyChain = require('proxy-chain')
+
+process.parentPort.once('message', async (event) => {
+  const { protocol, hostname, port, username, password } = event.data
+  const upstreamUrl = `${protocol}://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${hostname}:${port}`
+
+  const server = new ProxyChain.Server({
+    port: 0,
+    verbose: false,
+    prepareRequestFunction: () => ({ upstreamProxyUrl: upstreamUrl }),
+  })
+
+  await server.listen()
+  process.parentPort.postMessage(server.port)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6861,6 +6861,15 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-chain@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/proxy-chain/-/proxy-chain-2.7.1.tgz#2ba902b1e0feaed4dce392e2a7dd464a3afe3014"
+  integrity sha512-LtXu0miohJYrHWJxv8wA6EoGreRcX1hxKb7qlE1pMFH+BXE7bqMvpyhzR/JvR6M5SzYKzyHFpvfmYJrZeMtwAg==
+  dependencies:
+    socks "^2.8.3"
+    socks-proxy-agent "^8.0.3"
+    tslib "^2.3.1"
+
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -8107,7 +8116,7 @@ tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.4.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The current implementation of proxy authentication does not work with SOCKS proxies because Electron/Chromium does not support it.
To fix this, I implemented a local proxy that redirects traffic to the SOCKS5 proxy using [proxy-chain ](https://www.npmjs.com/package/proxy-chain) to expose the SOCKS proxy through a local HTTP proxy.
The local proxy is launched via an Electron [utilityProcess](https://www.electronjs.org/docs/latest/api/utility-process) only when the user configures a SOCKS proxy with a username and password.
The first time the proxy is launched, a firewall popup may appear. This will only occur for users who configure a SOCKS proxy with authentication.
The local proxy only listens on localhost and runs as a child process of FreeTube, so it is killed when the app exits.


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Enter a SOCKS5 or SOCKS4 proxy with username and password
2. A local proxy is automatically launched on a free port chosen by the OS
3. Click on "test proxy"
4. Check the reported proxy IP address

If you do not have a SOCKS5 proxy with authentication, you can set up a local proxy using [3proxy](https://github.com/3proxy/3proxy). Here is an example configuration file:
```cfg
nserver 8.8.8.8
nserver 1.1.1.1

auth strong
users username:CL:password

allow username
socks -p1080
```

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11
- **OS Version:** Version 25H2
- **FreeTube version:** v0.24.0