### PR TITLE
Fix SOCKS proxies not using authentication by hiding the username and password fields

### DIFF
--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -52,7 +52,9 @@
           @keydown.enter="testProxy"
         />
       </FtFlexBox>
-      <FtFlexBox>
+      <FtFlexBox
+        v-if="isCredentialsSupported"
+      >
         <FtInput
           :placeholder="$t('Settings.Proxy Settings.Proxy Username')"
           :show-action-button="false"
@@ -200,6 +202,11 @@ const proxyTestUrl = computed(() => {
   }
 
   return proxyTestUrl
+})
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const isCredentialsSupported = computed(() => {
+  return proxyProtocol.value === 'http' || proxyProtocol.value === 'https'
 })
 
 /**

--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -53,7 +53,7 @@
         />
       </FtFlexBox>
       <FtFlexBox
-        v-if="isCredentialsSupported"
+        v-if="areCredentialsSupported"
       >
         <FtInput
           :placeholder="$t('Settings.Proxy Settings.Proxy Username')"
@@ -205,7 +205,7 @@ const proxyTestUrl = computed(() => {
 })
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const isCredentialsSupported = computed(() => {
+const areCredentialsSupported = computed(() => {
   return proxyProtocol.value === 'http' || proxyProtocol.value === 'https'
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #9019

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Chromium does not support authentication for SOCKS proxies, so this pull request hides the username and password fields when the user selects these protocols.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- Select SOCKS5 or SOCKS4 as the proxy protocol -> the Username and Password fields disappear
- Select HTTPS or HTTP as the proxy protocol -> the Username and Password fields appear

## Desktop
<!-- Please complete the following information-->
- **OS:** Windows 11
- **OS Version:** Version 25H2
- **FreeTube version:** v0.24.0