### PR TITLE
Fix not being able to select and copy stats in the player

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -60,7 +60,12 @@
   color: #fff;
   z-index: 2;
 
-  /* user-select is intentionally not disabled, so that you can select and copy the stats */
+  /*
+    shaka-player sets `user-select: none` on the container element,
+    so we need to explicitly set `user-select: text` here to allow
+    the stats to be selected and copied.
+  */
+  user-select: text;
 }
 
 .valueChangePopup {
@@ -180,7 +185,6 @@
   font-weight: normal;
   background-color: rgb(0 0 0 / 50%);
   border-radius: 5px;
-  user-select: none;
   text-overflow: ellipsis;
   text-wrap: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

shaka-player v5 added `user-select: none` to the player container element, while that makes sense for most things in the player there is one notable exception where we want to allow text to be selected: the stats overlay. This pull request adds `user-select: text` to the stats overlay so that they can be selected and copied again, it also removes the now unnecessary `user-select: none` from the full screen title overlay as that is now covered by the `user-select: none` on the player container.

## Testing

1. Right click on the player
2. Click on show stats
3. Try selecting text in the stats overlay

## Desktop

- **OS:** Windows
- **OS Version:** 11