### PR TITLE
Add more details and emphasis to the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -15,9 +15,9 @@ body:
       options:
         - label: I have encountered this bug in the [latest release of FreeTube](https://github.com/FreeTubeApp/FreeTube/releases).
           required: true
-        - label: I have encountered this bug in the [official downloads of FreeTube](https://github.com/FreeTubeApp/FreeTube#official-downloads).
+        - label: I have encountered this bug in the [official downloads of FreeTube](https://github.com/FreeTubeApp/FreeTube#official-downloads). **The only official downloads are from the [https://freetubeapp.io](https://freetubeapp.io/#download) website, the [FreeTubeApp/FreeTube GitHub repository](https://github.com/FreeTubeApp/FreeTube/releases) and the [io.freetubeapp.FreeTube flatpak](https://flathub.org/en/apps/io.freetubeapp.FreeTube) from Flathub.**
           required: true
-        - label: I have [searched the issue tracker for open and closed issues](https://github.com/FreeTubeApp/FreeTube/issues?q=is%3Aissue+sort%3Arelevance-desc) that are similar to the bug report I want to file, without success.
+        - label: I have [searched the issue tracker for **open and closed** issues](https://github.com/FreeTubeApp/FreeTube/issues?q=is%3Aissue+sort%3Arelevance-desc) that are similar to the bug report I want to file, without success.
           required: true
         - label: I have searched the [documentation](https://docs.freetubeapp.io/) for information that matches the description of the bug I want to file, without success.
           required: true
@@ -140,5 +140,5 @@ body:
       label: Nightly Build
       description: Please ensure you've completed the following, if applicable.
       options:
-        - label: I have encountered this bug in the latest [nightly build](https://docs.freetubeapp.io/development/nightly-builds).
+        - label: I have encountered this bug in the latest **official** [nightly build](https://docs.freetubeapp.io/development/nightly-builds), do not check this box if you are using an unofficial or custom build.
           required: false


### PR DESCRIPTION
## Pull Request Type

- [x] Documentation

## Description

This pull request makes a few changes to the bug report template with the goal of curbing some of the duplicate and unrelated bug reports that we get. Clarifies that we mean the official downloads from the FreeTube project, not what a given Linux distro considers their official download source (e.g. the recent issues opened by CachyOS users using the custom builds from AUR that were using an old version of Electron, which was what was causing their problems). I also added emphasis to the open and closed issues bullet point as various users have admitted that the reason they opened a duplicate was because they only checked the open issues. Additionally I extended the nightly build check box to clarify that we only mean official nightly builds, as some people have checked that box in the past when they were using the "built from the development branch but using the system Electron" packages from the AUR repository.

I am open to changes to the wording, especially if you consider it to be too direct or harsh.