### PR TITLE
Use Shaka chapter tracks for seek bar chapter preview

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -160,13 +160,7 @@
   background-color: var(--primary-color);
 }
 
-:deep(.chapterMarker) {
-  width: 2px;
-  background-color: #000;
-}
-
-:deep(.sponsorBlockMarker),
-:deep(.chapterMarker) {
+:deep(.sponsorBlockMarker) {
   position: absolute;
   opacity: 0.6;
   height: 100%;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -160,7 +160,13 @@
   background-color: var(--primary-color);
 }
 
-:deep(.sponsorBlockMarker) {
+:deep(.chapterMarker) {
+  width: 2px;
+  background-color: #000;
+}
+
+:deep(.sponsorBlockMarker),
+:deep(.chapterMarker) {
   position: absolute;
   opacity: 0.6;
   height: 100%;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -904,7 +904,9 @@ export default defineComponent({
           enableTooltips: true,
           seekBarColors: {
             played: 'var(--primary-color)',
-            chapters: 'rgba(0, 0, 0, 0.6)'
+            // Shaka's native chapter marker gradient renders blurry on
+            // Chromium, so FreeTube keeps drawing the visual markers itself.
+            chapters: 'transparent'
           },
           showAudioCodec: false,
           showVideoCodec: false,
@@ -1021,6 +1023,10 @@ export default defineComponent({
       fullscreenTitleOverlay.className = 'playerFullscreenTitleOverlay'
       fullscreenTitleOverlay.dir = 'auto'
       controlsContainer.appendChild(fullscreenTitleOverlay)
+
+      if (hasLoaded.value && props.chapters.length > 0) {
+        createChapterMarkers()
+      }
 
       if (useSponsorBlock.value && sponsorBlockSegments.length > 0) {
         let duration
@@ -2579,25 +2585,73 @@ export default defineComponent({
       )
     }
 
+    function createChapterMarkers() {
+      const { start, end } = player.seekRange()
+      const duration = end - start
+
+      if (!Number.isFinite(duration) || duration <= 0) {
+        return
+      }
+
+      /**
+       * @type {{
+       *   title: string,
+       *   timestamp: string,
+       *   startSeconds: number,
+       *   endSeconds: number,
+       *   thumbnail?: string
+       * }[]}
+       */
+      const chapters = props.chapters
+
+      addMarkers(
+        chapters.flatMap(chapter => {
+          if (!Number.isFinite(chapter.startSeconds)) {
+            return []
+          }
+
+          const startFraction = (chapter.startSeconds - start) / duration
+
+          if (startFraction < 0 || startFraction > 1) {
+            return []
+          }
+
+          const markerDiv = document.createElement('div')
+
+          markerDiv.title = chapter.title
+          markerDiv.className = 'chapterMarker'
+          markerDiv.style.left = `calc(${startFraction * 100}% - 1px)`
+
+          return [markerDiv]
+        }),
+        'chapterMarker'
+      )
+    }
+
     /**
      * @param {HTMLDivElement[]} markers
+     * @param {string} [markerClassName]
      */
-    function addMarkers(markers) {
+    function addMarkers(markers, markerClassName) {
       const seekBarContainer = container.value.querySelector('.shaka-seek-bar-container')
 
+      /** @type {HTMLDivElement} */
+      let markerBar
+
       if (seekBarContainer.firstElementChild?.classList.contains('markerContainer')) {
-        /** @type {HTMLDivElement} */
-        const markerBar = seekBarContainer.firstElementChild
-
-        markers.forEach(marker => markerBar.appendChild(marker))
+        markerBar = seekBarContainer.firstElementChild
       } else {
-        const markerBar = document.createElement('div')
+        markerBar = document.createElement('div')
         markerBar.className = 'markerContainer'
-
-        markers.forEach(marker => markerBar.appendChild(marker))
 
         seekBarContainer.insertBefore(markerBar, seekBarContainer.firstElementChild)
       }
+
+      if (markerClassName) {
+        markerBar.querySelectorAll(`.${markerClassName}`).forEach(marker => marker.remove())
+      }
+
+      markers.forEach(marker => markerBar.appendChild(marker))
     }
 
     // #endregion seek bar markers
@@ -2989,6 +3043,10 @@ export default defineComponent({
           await player.addChaptersTrack(chaptersVttUrl, 'und', 'text/vtt')
             .catch(error => logShakaError(error, 'addChaptersTrack', props.videoId, props.chapters))
         }
+      }
+
+      if (props.chapters.length > 0) {
+        createChapterMarkers()
       }
 
       if (restoreCaptionIndex !== null) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -903,7 +903,8 @@ export default defineComponent({
           contextMenuElements: ['ft_stats'],
           enableTooltips: true,
           seekBarColors: {
-            played: 'var(--primary-color)'
+            played: 'var(--primary-color)',
+            chapters: 'rgba(0, 0, 0, 0.6)'
           },
           showAudioCodec: false,
           showVideoCodec: false,
@@ -1020,10 +1021,6 @@ export default defineComponent({
       fullscreenTitleOverlay.className = 'playerFullscreenTitleOverlay'
       fullscreenTitleOverlay.dir = 'auto'
       controlsContainer.appendChild(fullscreenTitleOverlay)
-
-      if (hasLoaded.value && props.chapters.length > 0) {
-        createChapterMarkers()
-      }
 
       if (useSponsorBlock.value && sponsorBlockSegments.length > 0) {
         let duration
@@ -2582,34 +2579,6 @@ export default defineComponent({
       )
     }
 
-    function createChapterMarkers() {
-      const { start, end } = player.seekRange()
-      const duration = end - start
-
-      /**
-       * @type {{
-       *   title: string,
-       *   timestamp: string,
-       *   startSeconds: number,
-       *   endSeconds: number,
-       *   thumbnail?: string
-       * }[]}
-       */
-      const chapters = props.chapters
-
-      addMarkers(
-        chapters.map(chapter => {
-          const markerDiv = document.createElement('div')
-
-          markerDiv.title = chapter.title
-          markerDiv.className = 'chapterMarker'
-          markerDiv.style.left = `calc(${(chapter.startSeconds / duration) * 100}% - 1px)`
-
-          return markerDiv
-        })
-      )
-    }
-
     /**
      * @param {HTMLDivElement[]} markers
      */
@@ -2632,6 +2601,64 @@ export default defineComponent({
     }
 
     // #endregion seek bar markers
+
+    // #region chapters
+
+    /**
+     * @param {number} seconds
+     * @returns {string}
+     */
+    function formatSecondsForVtt(seconds) {
+      const milliseconds = Math.round(seconds * 1000)
+      const hours = Math.floor(milliseconds / 3_600_000)
+      const minutes = Math.floor((milliseconds % 3_600_000) / 60_000)
+      const wholeSeconds = Math.floor((milliseconds % 60_000) / 1000)
+      const millisecondsRemainder = milliseconds % 1000
+
+      return [
+        hours.toString().padStart(2, '0'),
+        minutes.toString().padStart(2, '0'),
+        wholeSeconds.toString().padStart(2, '0')
+      ].join(':') + `.${millisecondsRemainder.toString().padStart(3, '0')}`
+    }
+
+    /**
+     * @returns {string|null}
+     */
+    function createChaptersVttUrl() {
+      let vtt = 'WEBVTT\n\n'
+      let hasValidChapter = false
+
+      for (const chapter of props.chapters) {
+        if (
+          !Number.isFinite(chapter.startSeconds) ||
+          !Number.isFinite(chapter.endSeconds) ||
+          chapter.endSeconds <= chapter.startSeconds
+        ) {
+          continue
+        }
+
+        const title = String(chapter.title ?? '')
+          .replaceAll(/\s+/g, ' ')
+          .trim()
+
+        if (title.length === 0) {
+          continue
+        }
+
+        hasValidChapter = true
+
+        vtt += [
+          `${formatSecondsForVtt(chapter.startSeconds)} --> ${formatSecondsForVtt(chapter.endSeconds)}`,
+          title,
+          ''
+        ].join('\n') + '\n'
+      }
+
+      return hasValidChapter ? `data:text/vtt;charset=utf-8,${encodeURIComponent(vtt)}` : null
+    }
+
+    // #endregion chapters
 
     // #region offline message
 
@@ -2955,6 +2982,15 @@ export default defineComponent({
         await Promise.all(promises)
       }
 
+      if (!isLive.value && props.chapters.length > 0) {
+        const chaptersVttUrl = createChaptersVttUrl()
+
+        if (chaptersVttUrl !== null) {
+          await player.addChaptersTrack(chaptersVttUrl, 'und', 'text/vtt')
+            .catch(error => logShakaError(error, 'addChaptersTrack', props.videoId, props.chapters))
+        }
+      }
+
       if (restoreCaptionIndex !== null) {
         const index = restoreCaptionIndex
         restoreCaptionIndex = null
@@ -2964,10 +3000,6 @@ export default defineComponent({
         if (textTrack) {
           player.selectTextTrack(textTrack)
         }
-      }
-
-      if (props.chapters.length > 0) {
-        createChapterMarkers()
       }
 
       if (startInFullscreen && process.env.IS_ELECTRON) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3040,12 +3040,15 @@ export default defineComponent({
         const chaptersVttUrl = createChaptersVttUrl()
 
         if (chaptersVttUrl !== null) {
-          await player.addChaptersTrack(chaptersVttUrl, 'und', 'text/vtt')
-            .catch(error => logShakaError(error, 'addChaptersTrack', props.videoId, props.chapters))
+          try {
+            await player.addChaptersTrack(chaptersVttUrl, 'und', 'text/vtt')
+          } catch (error) {
+            logShakaError(error, 'addChaptersTrack', props.videoId, props.chapters)
+          }
         }
       }
 
-      if (props.chapters.length > 0) {
+      if (!isLive.value && props.chapters.length > 0) {
         createChapterMarkers()
       }
 


### PR DESCRIPTION
## Pull Request Type
* [ ] Bugfix
* [x] Feature Implementation
* [ ] Documentation
* [ ] Other

## Related issue


## Description

Continuation of PR #8312.

This PR adds chapter names to Shaka's seek bar preview when hovering over the timeline.

FreeTube already extracts video chapters from YouTube and passes them into the player component. Previously (in #8312), those chapters were used by FreeTube itself, and the player wrapper manually added small chapter marker elements into Shaka's seek bar.

That worked for showing the visual chapter markers, but it did not let Shaka show the current chapter name in the hover preview which made it very fragile.

Since https://github.com/shaka-project/shaka-player/pull/9413 is already implemented, this PR now uses Shaka's native chapter track support for the preview text. FreeTube takes its existing chapter data, converts it into a `WebVTT` format, and adds it to Shaka with `player.addChaptersTrack(...)` after the player loads.

After Shaka gets the chapter track, it can display the right chapter name in the seek preview.

But there's still one thing FreeTube handles on purpose, the small chapter marker ticks on the seek bar. Shaka’s built-in chapter markers use a CSS gradient, which ends up making the seek bar look kind of blurry when chapters are shown. To keep those markers nice and sharp, this PR turns off Shaka’s gradient for chapter markers and sticks with FreeTube’s current DOM-based overlay for the ticks.


## Screenshots

**Before:**

https://github.com/user-attachments/assets/28e86677-4991-400c-8eb3-7f35238610dd

**After:**

When hovering over the seek bar on a video with chapters, the preview shows the timestamp and chapter title.

https://github.com/user-attachments/assets/04fbe98b-b6c9-42f2-b84f-93bd987f215b

_Test on simple video (after)_


https://github.com/user-attachments/assets/0fa617fe-6b10-4389-97f4-4fbecc1cd614



## Testing

1. Open a YouTube video that has chapters.
2. Hover over different parts of the seek bar.
3. Check that the seek bar preview shows the timestamp and the matching chapter title.
4. Check that chapter markers still appear on the seek bar and remain sharp.
5. Open a video without chapters and check that the seek bar preview still works normally.
7. Switch between normal, fullscreen, and full window mode and check that the behavior is still correct.

## Desktop
* **OS:** Windows
* **OS Version:** 11
* **FreeTube version:** 0.24.0

## Additional context

The upstream Shaka Player support for showing chapter names in the seek bar preview was added in shaka-project/shaka-player#9413. FreeTube is already using `shaka-player` 5.1.2, which includes that upstream behavior.

The new flow is:

```text
FreeTube gets chapter data from YouTube
        ↓
FreeTube converts the chapters into WebVTT text
        ↓
FreeTube adds that WebVTT file as a Shaka chapter track
        ↓
Shaka reads the chapter track through its own API
        ↓
Shaka displays the chapter name in the seek preview
        ↓
FreeTube keep its own visual chapter ticks so they stay crisp 
```
