### PR TITLE
Fix: Translated video titles do not depend on user locale

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -11,6 +11,7 @@ import {
   getChannelPlaylistId,
   getRelativeTimeFromDate,
 } from '../utils'
+import i18n from '../../i18n'
 
 const TRACKING_PARAM_NAMES = [
   'utm_source',
@@ -95,6 +96,7 @@ async function createInnertube({ withPlayer = false, location = undefined, safet
 
     retrieve_player: !!withPlayer,
     location: location,
+    lang: i18n.global.locale,
     enable_safety_mode: !!safetyMode,
     client_type: clientType,
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
~~https://github.com/FreeTubeApp/FreeTube/issues/2049~~
This is, in fact, two separate issues. I will create an issue to link to if you think that this change could be useful.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This merge request is a bit rough, but it's more a way to ask questions and show a bit of a proof-of-concept ~~because the concerned issue is locked https://github.com/FreeTubeApp/FreeTube/issues/2049~~

~~As I read issues on Youtube.js repo, I've found that absidue already knew that this 'lang' field existed, however, it didn't seem to be discussed as a solution for issue 2049. My main question is then: did I miss something? I've read all the thread, multiple times, but I may have missed something subtle indicating why it couldn't be fixed using the 'lang' field. The trending page is already returning the videos with their original titles, so it should be fine for subscription page too (also, the trending page is using 'location', which does not work for the subscription page and I can't really explain it).~~

~~The following questions will be irrelevant depending on the previous answer but I will go on:~~

- Do we want to have the innertube lang always depend on the current FreeTube locale? My implementation is doing so but it could be a parameter
- If YouTube does not support the specified 'lang', it will return error 400. This is currently not handled in the initial state of this MR as I wanted to keep things simple for a first draft, but we could imagine that either FreeTube will not support more langs than YouTube already does, or we could have a hardcoded list of supported langs by YouTube and check against it, defaulting to English.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- Define FreeTube locale as english
- Go to this channel with FreeTube (https://www.youtube.com/channel/UCCMxHHciWRBBouzk-PGzmtQ)
- Check that the first video is in english (WHO KILLED THE RTS?)
- Define FreeTube locale as french
- Check that the first video is in french (QUI A TUE LES RTS ?)

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
