### PR TITLE
Fix: permanent player tooltip 

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2238,6 +2238,23 @@ export default defineComponent({
       seekBySeconds(dist, true)
     }
 
+    // Blur player buttons to remove :focus-visible state, preventing tooltips from staying visible
+    const buttonWithTooltipClasses = [
+      'shaka-play-button',
+      'shaka-fullscreen-button',
+      'shaka-mute-button',
+      'shaka-pip-button',
+      'full-window-button',
+      'theatre-button',
+      'screenshot-button',
+    ]
+    function blurTooltipButtons() {
+      const element = document.activeElement
+      if (buttonWithTooltipClasses.some(className => element.classList.contains(className))) {
+        element.blur()
+      }
+    }
+
     /**
      * @param {KeyboardEvent} event
      */
@@ -2289,25 +2306,6 @@ export default defineComponent({
       if (event.shiftKey && event.key.toLowerCase() === 'p') {
         emit('skip-to-prev')
         return
-      }
-
-      // Blur player buttons to remove :focus-visible state, preventing tooltips from staying visible
-      const buttonWithTooltipClasses = [
-        'shaka-play-button',
-        'shaka-fullscreen-button',
-        'shaka-mute-button',
-        'shaka-pip-button',
-        'full-window-button',
-        'theatre-button',
-        'screenshot-button',
-      ]
-      function blurTooltipButtons() {
-        for (const buttonClass of buttonWithTooltipClasses) {
-          const button = document.querySelector(`.${buttonClass}`)
-          if (button) {
-            button.blur()
-          }
-        }
       }
 
       switch (event.key.toLowerCase()) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2292,16 +2292,16 @@ export default defineComponent({
       }
 
       // Blur player buttons to remove :focus-visible state, preventing tooltips from staying visible
+      const buttonWithTooltipClasses = [
+        'shaka-play-button',
+        'shaka-fullscreen-button',
+        'shaka-mute-button',
+        'shaka-pip-button',
+        'full-window-button',
+        'theatre-button',
+        'screenshot-button',
+      ]
       function blurTooltipButtons() {
-        const buttonWithTooltipClasses = [
-          'shaka-play-button',
-          'shaka-fullscreen-button',
-          'shaka-mute-button',
-          'shaka-pip-button',
-          'full-window-button',
-          'theatre-button',
-          'screenshot-button'
-        ]
         for (const buttonClass of buttonWithTooltipClasses) {
           const button = document.querySelector(`.${buttonClass}`)
           if (button) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2291,6 +2291,14 @@ export default defineComponent({
         return
       }
 
+      // Clear focus to prevent tooltip from staying visible
+      function blurButton(buttonClass) {
+        const button = document.querySelector(`.${buttonClass}`)
+        if (button) {
+          button.blur()
+        }
+      }
+
       switch (event.key.toLowerCase()) {
         case ' ':
         case 'spacebar': // older browsers might return spacebar instead of a space character
@@ -2298,7 +2306,7 @@ export default defineComponent({
           // Toggle Play/Pause
           event.preventDefault()
           video_.paused ? video_.play() : video_.pause()
-          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
+          blurButton('shaka-play-button')
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_REWIND:
           // Rewind by 2x the time-skip interval (in seconds)
@@ -2326,7 +2334,7 @@ export default defineComponent({
           // Toggle full screen
           event.preventDefault()
           ui.getControls().toggleFullScreen()
-          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
+          blurButton('shaka-fullscreen-button')
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.MUTE:
           // Toggle mute only if metakey is not pressed
@@ -2339,7 +2347,7 @@ export default defineComponent({
             const message = isMuted ? '0%' : `${Math.round(video_.volume * 100)}%`
             showValueChange(message, messageIcon)
           }
-          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
+          blurButton('shaka-mute-button')
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.CAPTIONS: {
           // Toggle caption/subtitles
@@ -2404,7 +2412,7 @@ export default defineComponent({
               controls.togglePiP()
             }
           }
-          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
+          blurButton('shaka-pip-button')
           break
         case '0':
         case '1':
@@ -2490,7 +2498,7 @@ export default defineComponent({
           events.dispatchEvent(new CustomEvent('setFullWindow', {
             detail: !fullWindowEnabled.value
           }))
-          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
+          blurButton('full-window-button')
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.THEATRE_MODE:
           // Toggle theatre mode
@@ -2501,6 +2509,7 @@ export default defineComponent({
               detail: !props.useTheatreMode
             }))
           }
+          blurButton('theatre-button')
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.TAKE_SCREENSHOT:
           if (enableScreenshot.value && props.format !== 'audio') {
@@ -2508,6 +2517,7 @@ export default defineComponent({
             // Take screenshot
             takeScreenshot()
           }
+          blurButton('screenshot-button')
           break
       }
     }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -964,7 +964,7 @@ export default defineComponent({
         classList.contains('shaka-fast-foward-container') ||
         classList.contains('shaka-rewind-container') ||
         classList.contains('shaka-play-button-container') ||
-        classList.contains('sc') ||
+        classList.contains('shaka-play-button') ||
         classList.contains('shaka-controls-container')) {
         //
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2298,6 +2298,7 @@ export default defineComponent({
           // Toggle Play/Pause
           event.preventDefault()
           video_.paused ? video_.play() : video_.pause()
+          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_REWIND:
           // Rewind by 2x the time-skip interval (in seconds)
@@ -2325,6 +2326,7 @@ export default defineComponent({
           // Toggle full screen
           event.preventDefault()
           ui.getControls().toggleFullScreen()
+          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.MUTE:
           // Toggle mute only if metakey is not pressed
@@ -2337,6 +2339,7 @@ export default defineComponent({
             const message = isMuted ? '0%' : `${Math.round(video_.volume * 100)}%`
             showValueChange(message, messageIcon)
           }
+          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.CAPTIONS: {
           // Toggle caption/subtitles
@@ -2401,6 +2404,7 @@ export default defineComponent({
               controls.togglePiP()
             }
           }
+          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
           break
         case '0':
         case '1':
@@ -2486,6 +2490,7 @@ export default defineComponent({
           events.dispatchEvent(new CustomEvent('setFullWindow', {
             detail: !fullWindowEnabled.value
           }))
+          document.activeElement.blur() // Clear focus to prevent tooltip from staying visible
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.THEATRE_MODE:
           // Toggle theatre mode

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -964,7 +964,7 @@ export default defineComponent({
         classList.contains('shaka-fast-foward-container') ||
         classList.contains('shaka-rewind-container') ||
         classList.contains('shaka-play-button-container') ||
-        classList.contains('shaka-play-button') ||
+        classList.contains('sc') ||
         classList.contains('shaka-controls-container')) {
         //
 
@@ -2291,11 +2291,22 @@ export default defineComponent({
         return
       }
 
-      // Clear focus to prevent tooltip from staying visible
-      function blurButton(buttonClass) {
-        const button = document.querySelector(`.${buttonClass}`)
-        if (button) {
-          button.blur()
+      // Blur player buttons to remove :focus-visible state, preventing tooltips from staying visible
+      function blurTooltipButtons() {
+        const buttonWithTooltipClasses = [
+          'shaka-play-button',
+          'shaka-fullscreen-button',
+          'shaka-mute-button',
+          'shaka-pip-button',
+          'full-window-button',
+          'theatre-button',
+          'screenshot-button'
+        ]
+        for (const buttonClass of buttonWithTooltipClasses) {
+          const button = document.querySelector(`.${buttonClass}`)
+          if (button) {
+            button.blur()
+          }
         }
       }
 
@@ -2306,7 +2317,7 @@ export default defineComponent({
           // Toggle Play/Pause
           event.preventDefault()
           video_.paused ? video_.play() : video_.pause()
-          blurButton('shaka-play-button')
+          blurTooltipButtons()
           break
         case KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_REWIND:
           // Rewind by 2x the time-skip interval (in seconds)
@@ -2334,7 +2345,7 @@ export default defineComponent({
           // Toggle full screen
           event.preventDefault()
           ui.getControls().toggleFullScreen()
-          blurButton('shaka-fullscreen-button')
+          blurTooltipButtons()
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.MUTE:
           // Toggle mute only if metakey is not pressed
@@ -2347,7 +2358,7 @@ export default defineComponent({
             const message = isMuted ? '0%' : `${Math.round(video_.volume * 100)}%`
             showValueChange(message, messageIcon)
           }
-          blurButton('shaka-mute-button')
+          blurTooltipButtons()
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.CAPTIONS: {
           // Toggle caption/subtitles
@@ -2412,7 +2423,7 @@ export default defineComponent({
               controls.togglePiP()
             }
           }
-          blurButton('shaka-pip-button')
+          blurTooltipButtons()
           break
         case '0':
         case '1':
@@ -2498,7 +2509,7 @@ export default defineComponent({
           events.dispatchEvent(new CustomEvent('setFullWindow', {
             detail: !fullWindowEnabled.value
           }))
-          blurButton('full-window-button')
+          blurTooltipButtons()
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.THEATRE_MODE:
           // Toggle theatre mode
@@ -2509,7 +2520,7 @@ export default defineComponent({
               detail: !props.useTheatreMode
             }))
           }
-          blurButton('theatre-button')
+          blurTooltipButtons()
           break
         case KeyboardShortcuts.VIDEO_PLAYER.GENERAL.TAKE_SCREENSHOT:
           if (enableScreenshot.value && props.format !== 'audio') {
@@ -2517,7 +2528,7 @@ export default defineComponent({
             // Take screenshot
             takeScreenshot()
           }
-          blurButton('screenshot-button')
+          blurTooltipButtons()
           break
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/8046

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When a button is clicked, it gains `:focus`, and then, when a shortcut is used (it can be any button in the player and the button clicked does not need to be hovered anymore), the `:focus-visible` state becomes `true` and stay like this until the focus is lost by clicking elsewhere. 
According to [Shaka Player's CSS rules](https://github.com/shaka-project/shaka-player/blob/main/ui/less/tooltip.less#L48)), the `:focus-visible` pseudo-class keeps the tooltip visible until focus is removed.

Calling [blur()](https://www.w3schools.com/jsref/met_html_blur.asp) after a keyboard shortcut is triggered removes the  focus by clearing the `:focus-visible` state, hiding the tooltip.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
No visible change to show

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

Scenario 1
1. Click on a player button, eg play/pause
2. Now use the shortcut for it, k
3. Label is now **not** permanently showing and **does not** obstruct other player labels

Scenario 2 (thanks aditya0155)
1. Click on a player button, eg play/pause
2. Now use the shortcut for another one, eg m
3. Label is now **not** permanently showing and **does not** obstruct other player labels
