### PR TITLE
feat: add subtitle size and position controls

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -32,7 +32,7 @@ import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 
 /** @typedef {import('../../helpers/sponsorblock').SponsorBlockCategory} SponsorBlockCategory */
-/** @typedef {{ fontScaleFactor: number, positionArea: string }} CaptionStyleConfig */
+/** @typedef {{ fontScaleFactor: number, positionArea: shaka.config.PositionArea }} CaptionStyleConfig */
 
 // The UTF-8 characters "h", "t", "t", and "p".
 const HTTP_IN_HEX = 0x68747470
@@ -647,7 +647,7 @@ export default defineComponent({
     }
 
     /**
-     * @returns {{ fontScaleFactor?: number, positionArea?: string }}
+     * @returns {{ fontScaleFactor?: number, positionArea?: shaka.config.PositionArea }}
      */
     function getSavedCaptionStyleConfig() {
       let captionSettings
@@ -662,7 +662,7 @@ export default defineComponent({
         return {}
       }
 
-      /** @type {{ fontScaleFactor?: number, positionArea?: string }} */
+      /** @type {{ fontScaleFactor?: number, positionArea?: shaka.config.PositionArea }} */
       const captionStyleConfig = {}
       const { fontScaleFactor, positionArea } = captionSettings
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -32,6 +32,7 @@ import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 
 /** @typedef {import('../../helpers/sponsorblock').SponsorBlockCategory} SponsorBlockCategory */
+/** @typedef {{ fontScaleFactor: number, positionArea: string }} CaptionStyleConfig */
 
 // The UTF-8 characters "h", "t", "t", and "p".
 const HTTP_IN_HEX = 0x68747470
@@ -209,6 +210,9 @@ export default defineComponent({
     const startInFullwindow = props.startInFullwindow
     let startInFullscreen = props.startInFullscreen
     let startInPip = props.startInPip
+
+    /** @type {CaptionStyleConfig|null} */
+    let activeCaptionStyleConfig = null
 
     /** @type {number|null} */
     let restoreCaptionIndex = null
@@ -596,7 +600,10 @@ export default defineComponent({
      * @returns {shaka.extern.PlayerConfiguration}
      */
     function getPlayerConfig(format, useAutoQuality = false) {
-      return {
+      const captionStyleConfig = activeCaptionStyleConfig ?? getSavedCaptionStyleConfig()
+
+      /** @type {shaka.extern.PlayerConfiguration} */
+      const playerConfig = {
         // YouTube uses these values and they seem to work well in FreeTube too,
         // so we might as well use them
         streaming: {
@@ -631,6 +638,108 @@ export default defineComponent({
         // So use the AV1 and h264 codecs instead which it doesn't reject
         preferredVideoCodecs: typeof props.vrProjection === 'string' ? ['av01', 'avc1'] : []
       }
+
+      if (Object.keys(captionStyleConfig).length > 0) {
+        playerConfig.textDisplayer = captionStyleConfig
+      }
+
+      return playerConfig
+    }
+
+    /**
+     * @returns {{ fontScaleFactor?: number, positionArea?: string }}
+     */
+    function getSavedCaptionStyleConfig() {
+      let captionSettings
+
+      try {
+        captionSettings = JSON.parse(store.getters.getDefaultCaptionSettings)
+      } catch {
+        return {}
+      }
+
+      if (typeof captionSettings !== 'object' || captionSettings === null || Array.isArray(captionSettings)) {
+        return {}
+      }
+
+      /** @type {{ fontScaleFactor?: number, positionArea?: string }} */
+      const captionStyleConfig = {}
+      const { fontScaleFactor, positionArea } = captionSettings
+
+      if (typeof fontScaleFactor === 'number' && Number.isFinite(fontScaleFactor) && fontScaleFactor > 0) {
+        captionStyleConfig.fontScaleFactor = fontScaleFactor
+      }
+
+      if (Object.values(shaka.config.PositionArea).includes(positionArea)) {
+        captionStyleConfig.positionArea = positionArea
+      }
+
+      return captionStyleConfig
+    }
+
+    /**
+     * @returns {CaptionStyleConfig|null}
+     */
+    function getCaptionStyleConfig() {
+      if (!player) {
+        return null
+      }
+
+      const textDisplayerConfig = player.getConfiguration().textDisplayer
+      if (!textDisplayerConfig) {
+        return null
+      }
+
+      const { fontScaleFactor, positionArea } = textDisplayerConfig
+
+      if (typeof fontScaleFactor !== 'number' || !Number.isFinite(fontScaleFactor) || fontScaleFactor <= 0 ||
+        !Object.values(shaka.config.PositionArea).includes(positionArea)) {
+        return null
+      }
+
+      return {
+        fontScaleFactor,
+        positionArea
+      }
+    }
+
+    function saveCaptionStyleSettings() {
+      const captionStyleConfig = getCaptionStyleConfig()
+      if (!captionStyleConfig || captionStyleConfigsAreEqual(captionStyleConfig, activeCaptionStyleConfig)) {
+        return
+      }
+
+      activeCaptionStyleConfig = captionStyleConfig
+
+      store.dispatch('updateDefaultCaptionSettings', JSON.stringify({
+        ...getSavedCaptionSettings(),
+        ...captionStyleConfig
+      }))
+    }
+
+    /**
+     * @returns {Record<string, unknown>}
+     */
+    function getSavedCaptionSettings() {
+      try {
+        const captionSettings = JSON.parse(store.getters.getDefaultCaptionSettings)
+
+        if (typeof captionSettings === 'object' && captionSettings !== null && !Array.isArray(captionSettings)) {
+          return captionSettings
+        }
+      } catch { }
+
+      return {}
+    }
+
+    /**
+     * @param {CaptionStyleConfig|null} a
+     * @param {CaptionStyleConfig|null} b
+     * @returns {boolean}
+     */
+    function captionStyleConfigsAreEqual(a, b) {
+      return a?.fontScaleFactor === b?.fontScaleFactor &&
+        a?.positionArea === b?.positionArea
     }
 
     /**
@@ -822,6 +931,8 @@ export default defineComponent({
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
           'playback_rate',
           'captions',
+          'captions-position',
+          'captions-size',
           'ft_audio_tracks',
           'loop',
           'ft_screenshot',
@@ -848,6 +959,8 @@ export default defineComponent({
         uiConfig.overflowMenuButtons.push(
           'ft_audio_tracks',
           'captions',
+          'captions-position',
+          'captions-size',
           'playback_rate',
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
           'loop',
@@ -900,7 +1013,11 @@ export default defineComponent({
         const firstTimeConfig = {
           addSeekBar: seekingIsPossible.value,
           customContextMenu: true,
-          contextMenuElements: ['ft_stats'],
+          contextMenuElements: [
+            'captions-position',
+            'captions-size',
+            'ft_stats'
+          ],
           enableTooltips: true,
           seekBarColors: {
             played: 'var(--primary-color)'
@@ -2712,6 +2829,8 @@ export default defineComponent({
       player.addEventListener('error', event => handleError(event.detail, 'shaka error handler'))
 
       player.configure(getPlayerConfig(props.format, defaultQuality.value === 'auto'))
+      activeCaptionStyleConfig = getCaptionStyleConfig()
+      player.addEventListener('configurationchanged', saveCaptionStyleSettings)
 
       if (process.env.SUPPORTS_LOCAL_API) {
         player.getNetworkingEngine().registerRequestFilter(requestFilter)
@@ -3153,6 +3272,8 @@ export default defineComponent({
       document.removeEventListener('keydown', keyboardShortcutHandler)
       document.removeEventListener('fullscreenchange', fullscreenChangeHandler)
 
+      player?.removeEventListener('configurationchanged', saveCaptionStyleSettings)
+
       if (containerResizeObserver) {
         containerResizeObserver.disconnect()
         containerResizeObserver = null
@@ -3211,6 +3332,8 @@ export default defineComponent({
       ignoreErrors = true
 
       let uiState = { startNextVideoInFullscreen: false, startNextVideoInFullwindow: false, startNextVideoInPip: false }
+
+      player?.removeEventListener('configurationchanged', saveCaptionStyleSettings)
 
       if (ui) {
         if (ui.getControls()) {


### PR DESCRIPTION


## Pull Request Type
- [x] Feature

## Related Issue
Partially closes #968 (check additional context)

## Description

This PR brings Shaka’s built-in subtitle style controls directly into FreeTube’s video player.

After this PR, when you’re watching a video, you can tweak the subtitle size and move the subtitles up or down—straight from the player menu. To keep things solid, this uses Shaka’s native `captions-position` and `captions-size` controls.

Also, FreeTube saves your preferences. So if you change the subtitle size or reposition them, FreeTube remembers what you picked by saving `fontScaleFactor` and `positionArea` in your `defaultCaptionSettings`. Next time you watch a video or restart the player, your subtitles will look just how you left them.

And to make sure nothing breaks, the app double-checks your saved settings before loading them. If anything is corrupt or doesn’t make sense, the player just skips it and keeps working as usual.

## Screenshots

**Before:**

https://github.com/user-attachments/assets/046f7857-3a2f-4830-a8c3-28814c9a12d1


**After:**


https://github.com/user-attachments/assets/74ab731a-2d35-4a06-a3b5-0c14ad6db780


## Testing

1. Open any video that has subtitles available.
2. Turn the subtitles on.
3. Open the player menu.
4. Check that the new subtitle size and position controls are showing up.
5. Change the subtitle size (e.g., to `150%`), and make sure the subtitles actually get bigger.
6. Change the subtitle position (e.g., to `Center Right`), and confirm they move over.
7. Open a different video and check that your new size and position settings carried over.
8. Reopen the menus to make sure the right options are still checked.
9. Test a video without captions to make sure the player still behaves normally.


## Desktop

- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.24.0

## Additional Context

**Update on Hover Previews**: I’ve sent an upstream PR to Shaka Player ([shaka-project/shaka-player#10077](https://github.com/shaka-project/shaka-player/pull/10077)) to add live hover previews for subtitle styles. Having this in Shaka itself means FreeTube doesn’t need to change around with the DOM anymore. Once Shaka merges that PR and FreeTube updates its Shaka version, #968 will be natively fixed.

(requiring only a one line configuration toggle in FreeTube to enable the native preview) 

