### PR TITLE
Pass chapters to shaka-player

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -158,15 +158,6 @@
 
 :deep(.sponsorBlockMarker) {
   background-color: var(--primary-color);
-}
-
-:deep(.chapterMarker) {
-  width: 2px;
-  background-color: #000;
-}
-
-:deep(.sponsorBlockMarker),
-:deep(.chapterMarker) {
   position: absolute;
   opacity: 0.6;
   height: 100%;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -158,6 +158,15 @@
 
 :deep(.sponsorBlockMarker) {
   background-color: var(--primary-color);
+}
+
+:deep(.chapterMarker) {
+  width: 2px;
+  background-color: #000;
+}
+
+:deep(.sponsorBlockMarker),
+:deep(.chapterMarker) {
   position: absolute;
   opacity: 0.6;
   height: 100%;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -103,6 +103,10 @@ export default defineComponent({
       type: Number,
       default: 0
     },
+    chaptersSrc: {
+      type: String,
+      default: ''
+    },
     storyboardSrc: {
       type: String,
       default: ''
@@ -787,22 +791,18 @@ export default defineComponent({
 
     const uiConfig = computed(() => {
       const controlPanelElements = [
+        'ft_skip_previous',
         'play_pause',
+        'ft_skip_next',
         'mute',
         'volume',
         'time_and_duration',
         'spacer'
       ]
-      const controlPanelElementsWithSkipButtons = [
-        ...controlPanelElements.slice(0, 1),
-        'ft_skip_previous',
-        'ft_skip_next',
-        ...controlPanelElements.slice(1)
-      ]
 
       /** @type {shaka.extern.UIConfiguration} */
       const uiConfig = {
-        controlPanelElements: props.watchingPlaylist ? controlPanelElementsWithSkipButtons : controlPanelElements,
+        controlPanelElements: controlPanelElements,
         overflowMenuButtons: [],
 
         // only set this to label when we actually have labels, so that the warning doesn't show up
@@ -824,6 +824,7 @@ export default defineComponent({
           'playback_rate',
           'captions',
           'ft_audio_tracks',
+          'chapter',
           'loop',
           'ft_screenshot',
           'picture_in_picture',
@@ -851,6 +852,7 @@ export default defineComponent({
           'captions',
           'playback_rate',
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
+          'chapter',
           'loop',
           'recenter_vr',
           'toggle_stereoscopic',
@@ -884,6 +886,15 @@ export default defineComponent({
         removeFromArrayIfExists(uiConfig.overflowMenuButtons, 'toggle_stereoscopic')
       }
 
+      if (!props.watchingPlaylist) {
+        removeFromArrayIfExists(uiConfig.controlPanelElements, 'ft_skip_previous')
+        removeFromArrayIfExists(uiConfig.controlPanelElements, 'ft_skip_next')
+      }
+
+      if (props.chapters.length === 0) {
+        removeFromArrayIfExists(uiConfig.overflowMenuButtons, 'chapter')
+      }
+
       return uiConfig
     })
 
@@ -904,6 +915,7 @@ export default defineComponent({
           contextMenuElements: ['ft_stats'],
           enableTooltips: true,
           seekBarColors: {
+            chapters: '#000',
             played: 'var(--primary-color)'
           },
           showAudioCodec: false,
@@ -1021,10 +1033,6 @@ export default defineComponent({
       fullscreenTitleOverlay.className = 'playerFullscreenTitleOverlay'
       fullscreenTitleOverlay.dir = 'auto'
       controlsContainer.appendChild(fullscreenTitleOverlay)
-
-      if (hasLoaded.value && props.chapters.length > 0) {
-        createChapterMarkers()
-      }
 
       if (useSponsorBlock.value && sponsorBlockSegments.length > 0) {
         let duration
@@ -2588,34 +2596,6 @@ export default defineComponent({
       )
     }
 
-    function createChapterMarkers() {
-      const { start, end } = player.seekRange()
-      const duration = end - start
-
-      /**
-       * @type {{
-       *   title: string,
-       *   timestamp: string,
-       *   startSeconds: number,
-       *   endSeconds: number,
-       *   thumbnail?: string
-       * }[]}
-       */
-      const chapters = props.chapters
-
-      addMarkers(
-        chapters.map(chapter => {
-          const markerDiv = document.createElement('div')
-
-          markerDiv.title = chapter.title
-          markerDiv.className = 'chapterMarker'
-          markerDiv.style.left = `calc(${(chapter.startSeconds / duration) * 100}% - 1px)`
-
-          return markerDiv
-        })
-      )
-    }
-
     /**
      * @param {HTMLDivElement[]} markers
      */
@@ -2885,7 +2865,7 @@ export default defineComponent({
         sabrManifest = player.getManifest()
       }
 
-      // For SABR we include the thumbnails and subtitles in the manifest
+      // For SABR we include the thumbnails, chapters and subtitles in the manifest
       if (!process.env.SUPPORTS_LOCAL_API || props.format === 'legacy' || props.manifestMimeType !== MANIFEST_TYPE_SABR) {
         const promises = []
 
@@ -2958,6 +2938,15 @@ export default defineComponent({
           )
         }
 
+        if (!isLive.value && props.chaptersSrc.length > 0) {
+          promises.push(
+            // Only log the error, as the chapters are a nice to have (we have our own UI outside of the player too)
+            // If an error occurs with them, it is not critical
+            player.addChaptersTrack(props.chaptersSrc, 'und', 'text/vtt')
+              .catch(error => logShakaError(error, 'addChaptersTrack', props.videoId, props.chaptersSrc))
+          )
+        }
+
         await Promise.all(promises)
       }
 
@@ -2970,10 +2959,6 @@ export default defineComponent({
         if (textTrack) {
           player.selectTextTrack(textTrack)
         }
-      }
-
-      if (props.chapters.length > 0) {
-        createChapterMarkers()
       }
 
       if (startInFullscreen && process.env.IS_ELECTRON) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -915,7 +915,10 @@ export default defineComponent({
           contextMenuElements: ['ft_stats'],
           enableTooltips: true,
           seekBarColors: {
-            chapters: '#000',
+            // shaka-player's chapter markers only show up part of the time for the DASH and audio formats
+            // the issue is clearly on the FreeTube side as shaka-player's demo page works fine and they show up all the time for the legacy formats.
+            // As I have spent way too much time debugging it and still cannot make sense of it, we'll stick with FreeTube's own chapter markers for now.
+            chapters: 'transparent',
             played: 'var(--primary-color)'
           },
           showAudioCodec: false,
@@ -1033,6 +1036,10 @@ export default defineComponent({
       fullscreenTitleOverlay.className = 'playerFullscreenTitleOverlay'
       fullscreenTitleOverlay.dir = 'auto'
       controlsContainer.appendChild(fullscreenTitleOverlay)
+
+      if (hasLoaded.value && props.chapters.length > 0) {
+        createChapterMarkers()
+      }
 
       if (useSponsorBlock.value && sponsorBlockSegments.length > 0) {
         let duration
@@ -2596,6 +2603,34 @@ export default defineComponent({
       )
     }
 
+    function createChapterMarkers() {
+      const { start, end } = player.seekRange()
+      const duration = end - start
+
+      /**
+       * @type {{
+       *   title: string,
+       *   timestamp: string,
+       *   startSeconds: number,
+       *   endSeconds: number,
+       *   thumbnail?: string
+       * }[]}
+       */
+      const chapters = props.chapters
+
+      addMarkers(
+        chapters.map(chapter => {
+          const markerDiv = document.createElement('div')
+
+          markerDiv.title = chapter.title
+          markerDiv.className = 'chapterMarker'
+          markerDiv.style.left = `calc(${(chapter.startSeconds / duration) * 100}% - 1px)`
+
+          return markerDiv
+        })
+      )
+    }
+
     /**
      * @param {HTMLDivElement[]} markers
      */
@@ -2959,6 +2994,10 @@ export default defineComponent({
         if (textTrack) {
           player.selectTextTrack(textTrack)
         }
+      }
+
+      if (props.chapters.length > 0) {
+        createChapterMarkers()
       }
 
       if (startInFullscreen && process.env.IS_ELECTRON) {

--- a/src/renderer/helpers/player/SabrManifestParser.js
+++ b/src/renderer/helpers/player/SabrManifestParser.js
@@ -55,6 +55,16 @@ import { parseMp4SegmentIndex } from './Mp4SegmentIndexParser'
  *     thumbnailHeight: number,
  *     storyboardCount: number,
  *     interval: number
+ *   }[],
+ *   chapters: {
+ *     title: string,
+ *     startSeconds: number,
+ *     endSeconds: number,
+ *     thumbnail?: {
+ *       url: string,
+ *       width: number,
+ *       height: number
+ *     }
  *   }[]
  * }} SabrManifest
  */
@@ -237,6 +247,9 @@ class SabrManifestParser {
     currentId += textStreams.length
 
     const imageStreams = /** @__NOINLINE__ */ createImageStreams(manifestData.storyboards, presentationTimeline, currentId)
+    currentId += imageStreams.length
+
+    const chapterStreams = /** @__NOINLINE__ */ createChapterStreams(manifestData.chapters, currentId)
 
     /** @type {shaka.extern.Manifest} */
     const manifest = {
@@ -245,7 +258,7 @@ class SabrManifestParser {
       variants,
       textStreams,
       imageStreams,
-      chapterStreams: [],
+      chapterStreams,
       presentationTimeline,
 
       gapCount: 0,
@@ -610,6 +623,84 @@ function createImageStreams(storyboards, presentationTimeline, currentId) {
 
     return stream
   })
+}
+
+/**
+ * @param {SabrManifest['chapters']} chapters
+ * @param {number} currentId
+ */
+function createChapterStreams(chapters, currentId) {
+  if (chapters.length === 0) {
+    return []
+  }
+
+  /** @type {shaka.media.SegmentReference[]} */
+  const references = []
+
+  for (const chapter of chapters) {
+    const reference = new shaka.media.SegmentReference(
+      chapter.startSeconds,
+      chapter.endSeconds,
+      () => [],
+      /* startByte= */ 0,
+      /* endByte= */ null,
+      /* initSegmentReference= */ null,
+      /* timestampOffset= */ 0,
+      /* appendWindowStart= */ 0,
+      /* appendWindowEnd= */ Infinity
+    )
+
+    reference.setMetadata({
+      title: chapter.title,
+      images: chapter.thumbnail
+        ? [{
+            url: chapter.thumbnail.url,
+            width: chapter.thumbnail.width,
+            height: chapter.thumbnail.height,
+          }]
+        : []
+    })
+
+    references.push(reference)
+  }
+
+  /** @type {shaka.extern.Stream} */
+  const stream = {
+    id: currentId,
+    originalId: null,
+    groupId: null,
+    createSegmentIndex: () => Promise.resolve(),
+    segmentIndex: new shaka.media.SegmentIndex(references),
+    mimeType: 'text/plain',
+    codecs: '',
+    supplementalCodecs: '',
+    kind: '',
+    encrypted: false,
+    drmInfos: [],
+    keyIds: new Set(),
+    language: 'und',
+    originalLanguage: 'und',
+    label: null,
+    type: 'chapter',
+    primary: false,
+    trickModeVideo: null,
+    dependencyStream: null,
+    emsgSchemeIdUris: null,
+    roles: [],
+    forced: false,
+    channelsCount: null,
+    audioSamplingRate: null,
+    spatialAudio: false,
+    closedCaptions: null,
+    accessibilityPurpose: null,
+    external: true,
+    fastSwitching: false,
+    fullMimeTypes: new Set(['text/plain']),
+    isAudioMuxedInVideo: false,
+    baseOriginalId: null
+  }
+
+  return [stream]
 }
 
 /**

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -161,6 +161,36 @@ export function buildVTTFileLocally(storyboard, videoLengthSeconds) {
   return vttString
 }
 
+/**
+ * @param {{ startSeconds: number, endSeconds: number, title: string }[]} chapters
+ */
+export function buildChaptersVttFile(chapters) {
+  const blocks = ['WEBVTT']
+
+  for (const chapter of chapters) {
+    blocks.push(`\
+${secondsToVttTimestamp(chapter.startSeconds)} --> ${secondsToVttTimestamp(chapter.endSeconds)}
+${chapter.title.trim()}`)
+  }
+
+  return blocks.join('\n\n') + '\n'
+}
+
+/**
+ * @param {number} seconds
+ */
+function secondsToVttTimestamp(seconds) {
+  const formattedHours = Math.trunc(seconds / 3600).toFixed(0).padStart(2, '0')
+  seconds %= 3600
+
+  const formattedMinutes = Math.trunc(seconds / 60).toFixed(0).padStart(2, '0')
+  seconds %= 60
+
+  const formattedSeconds = seconds.toFixed(3).padStart(6, '0')
+
+  return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`
+}
+
 export const ToastEventBus = new EventTarget()
 
 /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -14,6 +14,7 @@ import WatchVideoPlaylist from '../../components/WatchVideoPlaylist/WatchVideoPl
 import WatchVideoRecommendations from '../../components/WatchVideoRecommendations/WatchVideoRecommendations.vue'
 import FtAgeRestricted from '../../components/FtAgeRestricted/FtAgeRestricted.vue'
 import {
+  buildChaptersVttFile,
   buildVTTFileLocally,
   copyToClipboard,
   extractNumberFromString,
@@ -313,6 +314,16 @@ export default defineComponent({
       // `this.$refs.player?.hasLoaded` cannot be used in computed property
       return !this.isLoading
     },
+
+    chaptersSrc() {
+      if (this.videoChapters.length > 0) {
+        const vttText = buildChaptersVttFile(this.videoChapters)
+
+        return `data:text/vtt,${encodeURIComponent(vttText)}`
+      } else {
+        return ''
+      }
+    }
   },
   watch: {
     async $route() {
@@ -531,6 +542,7 @@ export default defineComponent({
         }
 
         let chapters = []
+        let chaptersKind = 'chapters'
         if (!this.hideChapters) {
           const rawChapters = result.player_overlays?.decorated_player_bar?.player_bar?.markers_map
             ?.find(marker => marker.marker_key === 'DESCRIPTION_CHAPTERS')?.value.chapters
@@ -564,7 +576,7 @@ export default defineComponent({
                   })
                 }
               }
-              this.videoChaptersKind = 'keyMoments'
+              chaptersKind = 'keyMoments'
             } else {
               chapters = this.extractChaptersFromDescription(result.basic_info.short_description ?? result.secondary_info.description.text)
             }
@@ -582,6 +594,7 @@ export default defineComponent({
         }
 
         this.videoChapters = chapters
+        this.videoChaptersKind = chaptersKind
 
         const playabilityStatus = result.playability_status
         this.playabilityStatus = playabilityStatus.status
@@ -978,6 +991,7 @@ export default defineComponent({
             }
           }
           this.videoChapters = chapters
+          this.videoChaptersKind = 'chapters'
 
           if (this.isLive || this.isPostLiveDvr) {
             // The live DASH manifest is currently unusable as it returns 403s after 1 minute of playback
@@ -1446,9 +1460,6 @@ export default defineComponent({
 
     handleRouteChange: function () {
       this.abortAutoplayCountdown(true)
-      this.videoChapters = []
-      this.videoChaptersKind = 'chapters'
-
       this.handleWatchProgressAutoSave()
     },
 
@@ -1596,6 +1607,7 @@ export default defineComponent({
           colorPrimaries: format.color_info?.primaries
         })),
         captions: this.captions,
+        chapters: this.videoChapters,
         storyboards
       }
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -31,6 +31,7 @@
           :video-id="videoId"
           :chapters="videoChapters"
           :current-chapter-index="videoCurrentChapterIndex"
+          :chapters-src="chaptersSrc"
           :title="videoTitle"
           :theatre-possible="theatrePossible"
           :use-theatre-mode="useTheatreMode"


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue

- closes #2829

## Description

As mentioned in #8772 shaka-player v5 added better support for chapters. This pull request passes the chapters to shaka-player so that chapter name appears when you hover over the seekbar and making it possible to use their in-player chapters menu (not a replacement for the main chapters menu, it just lets you easily change chapters in full screen and full window modes).

Unfortunately I ran into some issues while trying to use shaka-player markers, on short videos with few chapters such as Me at the Zoo, they displayed fine, but on longer videos with lots of chapters such as the WAN show they were a blurry mess, so this pull request still uses FreeTube's own chapter markers on the seek bar. As far as I could tell from my experimentation it seems like CSS linear-gradients were designed to either be used with only percentages or absolute pixel values, trying to combine both with calc like shaka-player does causes the blurring issues.

## Screenshots

<img width="233" height="284" alt="player menu with chapters button" src="https://github.com/user-attachments/assets/b0c13199-7391-445a-9641-e0d8e90485e9" />

<img width="209" height="230" alt="open chapters menu inside the player menu" src="https://github.com/user-attachments/assets/7c307f30-02fa-4182-9112-00aa8dfbc1be" />

<img width="184" height="140" alt="chapter title shown on seek bar hover" src="https://github.com/user-attachments/assets/8c39fea1-b2d9-4983-a4fa-04f11798cac4" />

## Testing

Open a video with chapters and check that the chapters show up on the seek bar as markers, in the tooltip when you hover over the seek bar and as a menu option in the player overflow menu. Check that all 3 things happen for audio, dash and legacy formats.

## Desktop

- **OS:** Windows
- **OS Version:** 11