### PR TITLE
Fix some broken translations

### DIFF
--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -34,13 +34,13 @@ Global:
 
 # Search Bar
   Counts:
-    Video Count: 1 فيديو | {عدد} مقاطع فيديو
-    Channel Count: 1 قناة | {عدد} قنوات
-    Subscriber Count: 1 مشترك | {عدد} مشتركين
-    View Count: 1 مشاهدة | {عدد} مشاهدات
-    Watching Count: 1 مشاهد | {عدد} مشاهدون
-    Like Count: إعجاب واحد |{عدد} إعجابات
-    Comment Count: تعليق واحد | {عدد} تعليقًا
+    Video Count: 1 فيديو | {count} مقاطع فيديو
+    Channel Count: 1 قناة | {count} قنوات
+    Subscriber Count: 1 مشترك | {count} مشتركين
+    View Count: 1 مشاهدة | {count} مشاهدات
+    Watching Count: 1 مشاهد | {count} مشاهدون
+    Like Count: إعجاب واحد |{count} إعجابات
+    Comment Count: تعليق واحد | {count} تعليقًا
 Search / Go to URL: 'ابحث / اذهب إلى رابط'
   # In Filter Button
 Search Filters:

--- a/static/locales/eo.yaml
+++ b/static/locales/eo.yaml
@@ -784,8 +784,8 @@ Video:
       Bandwidth: 'Kapacito: {bandwidth} kbps'
       Buffered: 'Bufrita: {bufferedPercentage}%'
       Dropped Frames / Total Frames: 'Perditaj bildoj: {droppedFrames} / Tutaj bildoj: {totalFrames}'
-      CodecAudio: 'Kodeko: {audioCodec} ({audioltag})'
-      CodecsVideoAudio: 'Kodekoj: {videoCodec} ({videoltag}) / {audioCodec} ({audioltag})'
+      CodecAudio: 'Kodeko: {audioCodec} ({audioItag})'
+      CodecsVideoAudio: 'Kodekoj: {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
       CodecsVideoAudioNoItags: 'Kodekoj: {videoCodec} / {audioCodec}'
     You appear to be offline: Vi ŝajne ne havas retkonekton.
     Playback will resume automatically when your connection comes back: La ludado ados aŭtomate kiam via retkonekto revenos.

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -143,7 +143,7 @@ User Playlists:
   Remove Watched Videos: Eliminar videos vistos
   Create New Playlist: Crear nueva lista de reproducción
   Add to Playlist: Agregar a la lista de reproducción
-  Add to Favorites: Agregar a Mi Lista Favorita
+  Add to Favorites: Agregar a {playlistName}
   Playlist Description: Descripción de la lista de reproducción
   Edit Playlist Info: Editar información de la lista de reproducción
   Copy Playlist: Copiar lista de reproducción

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -892,7 +892,7 @@ Canceled next video autoplay: 'Peruttiin seuraavan videon toistaminen'
 
 Yes: 'Kyllä'
 No: 'Ei'
-Locale Name: Englanti (US)
+Locale Name: suomi
 The playlist has been reversed: Soittolista on muutettu käänteiseksi
 Profile:
   '{profile} is now the active profile': '{profile} on nyt aktiivinen profiili'

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -972,7 +972,7 @@ Profile:
   Toggle Profile List: Prepnúť zoznam profilov
 Download From Site: Stiahnuť zo stránky
 Version {versionNumber} is now available!  Click for more details: Verzia {versionNumber} je k dispozícii! Kliknite pre viac podrobností
-Locale Name: Angličtina (US)
+Locale Name: Slovenčina
 Playing Next Video Interval: Prehrávanie ďalšieho videa okamžite. Kliknite pre zrušenie. | Prehrávanie ďalšieho videa o {nextVideoInterval} sekundu. Kliknite pre zrušenie. | Prehrávanie ďalšieho videa o {nextVideoInterval} sekúnd. Kliknite pre zrušenie.
 More: Viac
 Unknown YouTube url type, cannot be opened in app: Neznámy typ adresy URL YouTube, nemôže byť otvorený v aplikácii
@@ -1008,7 +1008,7 @@ Search Listing:
 Feed:
   Feed Last Updated: 'Kanál {feedName} naposledy aktualizovaný: {date}'
   Refresh Feed: Obnoviť {subscriptionName}
-Go to page: Prejsť na {stránka}
+Go to page: Prejsť na {page}
 Right-click or hold to see history: Podržte alebo kliknite pravým tlačidlom pre zobrazenie histórie
 KeyboardShortcutPrompt:
   Toggle Developer Tools: Prepnúť nástroje pre vývojárov


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

Corrects some incorrect placeholders and reverts the wrong local names there were introduced in 241aa326b5f0554edc0f3b763079be2f19537fb4 and f8e6d395fbc7f480d045a135b43903f1a778edea.

## Testing

You can check that things show up correctly if you really want to or don't ¯\\_(ツ)_/¯.

## Desktop

- **OS:** Windows
- **OS Version:** 11