### PR TITLE
Fix 'expand side bar by default' setting appearing always disabled

### DIFF
--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -225,7 +225,7 @@ function updateSecColor(value) {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const expandSideBar = computed(() => {
-  return store.getters.getexpandSideBar
+  return store.getters.getExpandSideBar
 })
 
 /** @type {import('vue').ComputedRef<boolean>} */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None found

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
`expandSideBar` computed value had a typo in `ThemeSettings.vue`, making the setting always appearing as disabled no matter the actual value.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Enable "Expand Side Bar by Default"
2. Restart the app
3. Check that the value is still enabled in settings

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** 0.24.0

## Additional context
<!-- Add any other context about the pull request here. -->
