### PR TITLE
Feature: Add fallback behavior for RSS ratelimiting 

### DIFF
--- a/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
+++ b/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
@@ -24,6 +24,13 @@
           compact
           @change="updateUnsubscriptionPopupStatus"
         />
+        <FtToggleSwitch
+          :label="$t('Settings.Subscription Settings.Limit Request Fallback Without RSS')"
+          :default-value="limitRequestFallbackWithoutRss"
+          :tooltip="$t('Tooltips.Subscription Settings.Limit Request Fallback Without RSS')"
+          compact
+          @change="updateLimitRequestFallbackWithoutRss"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -85,6 +92,16 @@ const unsubscriptionPopupStatus = computed(() => store.getters.getUnsubscription
  */
 function updateUnsubscriptionPopupStatus(value) {
   store.dispatch('updateUnsubscriptionPopupStatus', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const limitRequestFallbackWithoutRss = computed(() => store.getters.getLimitRequestFallbackWithoutRss)
+
+/**
+ * @param {boolean} value
+ */
+function updateLimitRequestFallbackWithoutRss(value) {
+  store.dispatch('updateLimitRequestFallbackWithoutRss', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -55,6 +55,9 @@ const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCache
 const useRssFeeds = computed(() => store.getters.getUseRssFeeds)
 
 /** @type {import('vue').ComputedRef<boolean>} */
+const limitRequestFallbackWithoutRss = computed(() => store.getters.getLimitRequestFallbackWithoutRss)
+
+/** @type {import('vue').ComputedRef<boolean>} */
 const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSubscriptionsAutomatically)
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
@@ -185,14 +188,22 @@ async function loadVideosForSubscriptionsFromRemote() {
   let channelCount = 0
   isLoading.value = true
 
-  let useRss = useRssFeeds.value
-  if (channelsToLoadFromRemote.length >= 125 && !useRss) {
-    showToast(
-      t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
-      10000
-    )
-    useRss = true
-  }
+  const useRss = limitRequestFallbackWithoutRss.value
+    ? useRssFeeds.value
+    : (() => {
+        let rss = useRssFeeds.value
+        if (channelsToLoadFromRemote.length >= 125 && !rss) {
+          showToast(
+            t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
+            10000
+          )
+          rss = true
+        }
+        return rss
+      })()
+
+  const CHUNK_SIZE = 80
+  const CHUNK_DELAY_MS = 2000
 
   store.commit('setShowProgressBar', true)
   store.commit('setProgressBarPercentage', 0)
@@ -200,8 +211,9 @@ async function loadVideosForSubscriptionsFromRemote() {
 
   errorChannels.value = []
   const subscriptionUpdates = []
+  const videoListFromRemote = []
 
-  const videoListFromRemote = (await Promise.all(channelsToLoadFromRemote.map(async (channel) => {
+  const processChannel = async (channel) => {
     let videos, name, thumbnailUrl
 
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
@@ -238,7 +250,22 @@ async function loadVideosForSubscriptionsFromRemote() {
     }
 
     return videos ?? []
-  }))).flat()
+  }
+
+  if (limitRequestFallbackWithoutRss.value && !useRss) {
+    for (let i = 0; i < channelsToLoadFromRemote.length; i += CHUNK_SIZE) {
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, CHUNK_DELAY_MS))
+      }
+
+      const chunk = channelsToLoadFromRemote.slice(i, i + CHUNK_SIZE)
+      const chunkResults = await Promise.all(chunk.map(processChannel))
+      videoListFromRemote.push(...chunkResults.flat())
+    }
+  } else {
+    const results = await Promise.all(channelsToLoadFromRemote.map(processChannel))
+    videoListFromRemote.push(...results.flat())
+  }
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
   isLoading.value = false

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -55,6 +55,9 @@ const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCache
 const useRssFeeds = computed(() => store.getters.getUseRssFeeds)
 
 /** @type {import('vue').ComputedRef<boolean>} */
+const limitRequestFallbackWithoutRss = computed(() => store.getters.getLimitRequestFallbackWithoutRss)
+
+/** @type {import('vue').ComputedRef<boolean>} */
 const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSubscriptionsAutomatically)
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
@@ -184,14 +187,22 @@ async function loadVideosForSubscriptionsFromRemote() {
   let channelCount = 0
   isLoading.value = true
 
-  let useRss = useRssFeeds.value
-  if (channelsToLoadFromRemote.length >= 125 && !useRss) {
-    showToast(
-      t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
-      10000
-    )
-    useRss = true
-  }
+  const useRss = limitRequestFallbackWithoutRss.value
+    ? useRssFeeds.value
+    : (() => {
+        let rss = useRssFeeds.value
+        if (channelsToLoadFromRemote.length >= 125 && !rss) {
+          showToast(
+            t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
+            10000
+          )
+          rss = true
+        }
+        return rss
+      })()
+
+  const CHUNK_SIZE = 80
+  const CHUNK_DELAY_MS = 2000
 
   store.commit('setShowProgressBar', true)
   store.commit('setProgressBarPercentage', 0)
@@ -199,8 +210,9 @@ async function loadVideosForSubscriptionsFromRemote() {
 
   errorChannels.value = []
   const subscriptionUpdates = []
+  const videoListFromRemote = []
 
-  const videoListFromRemote = (await Promise.all(channelsToLoadFromRemote.map(async (channel) => {
+  const processChannel = async (channel) => {
     let videos, name, thumbnailUrl
 
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
@@ -237,7 +249,22 @@ async function loadVideosForSubscriptionsFromRemote() {
     }
 
     return videos ?? []
-  }))).flat()
+  }
+
+  if (limitRequestFallbackWithoutRss.value && !useRss) {
+    for (let i = 0; i < channelsToLoadFromRemote.length; i += CHUNK_SIZE) {
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, CHUNK_DELAY_MS))
+      }
+
+      const chunk = channelsToLoadFromRemote.slice(i, i + CHUNK_SIZE)
+      const chunkResults = await Promise.all(chunk.map(processChannel))
+      videoListFromRemote.push(...chunkResults.flat())
+    }
+  } else {
+    const results = await Promise.all(channelsToLoadFromRemote.map(processChannel))
+    videoListFromRemote.push(...results.flat())
+  }
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
   isLoading.value = false

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -280,6 +280,7 @@ const state = {
   useProxy: false,
   userPlaylistSortOrder: 'date_added_descending',
   useRssFeeds: false,
+  limitRequestFallbackWithoutRss: false,
   useSponsorBlock: false,
   videoVolumeMouseScroll: false,
   videoPlaybackRateMouseScroll: false,

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -167,6 +167,11 @@ const useRssFeeds = computed(() => {
   return store.getters.getUseRssFeeds
 })
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const limitRequestFallbackWithoutRss = computed(() => {
+  return store.getters.getLimitRequestFallbackWithoutRss
+})
+
 /** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'community' | null>} */
 const currentTab = ref('videos')
 
@@ -196,7 +201,7 @@ const visibleTabs = computed(() => {
   }
 
   // community does not support rss
-  if (!hideSubscriptionsCommunity.value && !useRssFeeds.value && activeSubscriptionList.value.length < 125) {
+  if (!hideSubscriptionsCommunity.value && !useRssFeeds.value && (limitRequestFallbackWithoutRss.value || activeSubscriptionList.value.length < 125)) {
     tabs.push('community')
   }
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -537,6 +537,7 @@ Settings:
     'Limit the number of videos displayed for each channel': 'Limit the number of videos displayed for each channel'
     To: To
     Confirm Before Unsubscribing: Confirm Before Unsubscribing
+    Limit Request Fallback Without RSS: Limit Request Fallback Without RSS
   Distraction Free Settings:
     Distraction Free Settings: Distraction Free
     Sections:
@@ -1086,6 +1087,10 @@ Tooltips:
       but doesn't provide certain information like video duration, live status or posts
     Fetch Automatically: When enabled, FreeTube will automatically fetch
       your subscription feed on startup and when a new window is opened.
+    Limit Request Fallback Without RSS: When enabled, FreeTube will split
+      subscription requests into smaller chunks instead of forcing RSS for large
+      subscription lists. This prevents rate limiting while preserving video duration,
+      live status and other metadata that RSS does not provide
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
[8653](https://github.com/FreeTubeApp/FreeTube/issues/8653)

## Description
this add's a toggle in the subscription section of the settings page (default off) witch when enabled will change the behavior when fetching subscriptions for large (above 125) lists. instead of falling back to RSS witch often has problems as YT's rss goes down often it will instead chunk fetch requests in chunk's of 80 separated by 2 seconds (2000 ms) to avoid rate limiting without relying on rss. 

## Screenshots <!-- If appropriate -->
<img width="863" height="717" alt="image" src="https://github.com/user-attachments/assets/0fa0171d-0e6d-4fc3-a2e0-1c0a18915fe2" />

## Testing
1 launch app and refresh a large subscription list. the RSS fetch should still work.
2 go to settings tab and the subscription subsection and check "limit request fallback without RSS" 
3 go back to subscriptions and refresh. you should notice the bottom loading bar stopping for 2 sec then resuming (and stopping again since it fetches in chunk's of 80) a few times.
4 once all subscriptions are fetched they should all have timestamps confirming it worked without rss.  

## Desktop
<!-- Please complete the following information-->
- **OS:Cachyos
- **OS Version:X86_64
- **FreeTube version:v0.24.0 Beta

## Additional context
i originally created a proof of concept for this about a month ago and posted the diff in the original feature request thread here https://github.com/FreeTubeApp/FreeTube/issues/8653#issuecomment-4315729687 . i have been running that fix daily on my computers (and some friends) since then and it work's without problem.
English is a second language for me and i am not a developer by trade. this is the second pull request i have made (the first was for a one line fix for another most likely abandoned project). i have tried to the best of my ability to follow the guidelines in the "Code Contributions" file. 
