### PR TITLE
Fix long select labels in settings

### DIFF
--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -24,7 +24,7 @@
 .select {
   position: relative;
   inline-size: 200px;
-  margin-block-start: 30px;
+  margin-block-start: 45px;
 }
 
 .select-text {
@@ -90,23 +90,32 @@
   font-weight: normal;
   position: absolute;
   display: flex;
+  align-items: flex-start;
   column-gap: 6px;
   inset-inline-start: 0;
   inset-block-start: 10px;
+  max-inline-size: 100%;
+  line-height: 1.2;
   transition: 0.2s ease all;
   color: var(--tertiary-text-color);
 }
 
 .select-icon {
+  flex: 0 0 auto;
   inline-size: 14px;
   block-size: 14px;
+}
+
+.select-label-text {
+  min-inline-size: 0;
+  overflow-wrap: anywhere;
 }
 
 /* active state */
 .select-text:focus ~ .select-label,
 .select-text:valid ~ .select-label {
   color: var(--accent-color);
-  inset-block-start: -20px;
+  inset-block-start: -42px;
   transition: 0.2s ease all;
   font-size: 14px;
 }

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -36,7 +36,9 @@
         class="select-icon"
         :color="iconColor"
       />
-      {{ placeholder }}
+      <span class="select-label-text">
+        {{ placeholder }}
+      </span>
     </label>
     <FtTooltip
       v-if="tooltip !== ''"


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue


## Description
Long translated select labels in settings could keep drawing past their own dropdown and into the next one. This keeps the label text inside the select width, lets it wrap, and gives wrapped labels enough room above the dropdown.

## Screenshots
Checked locally in the Player settings with German, Greek, Croatian, and Hungarian. The long blue labels wrap above their own dropdown now instead of crossing into the next one.

## Testing
- `pnpm.cmd exec stylelint src/renderer/components/FtSelect/FtSelect.css`
- `pnpm.cmd exec eslint --config eslint.config.mjs src/renderer/components/FtSelect/FtSelect.vue`
- `pnpm.cmd run pack:web`
- Opened the web build at `http://localhost:9080/#/settings` and checked the Player settings around the widths from the issue screenshots.

## Desktop
- **OS:** Windows
- **OS Version:** 11
- **FreeTube version:** 0.24.0 development

## Additional context