### PR TITLE
fix: restore subscription feed broken by YouTube's new channel page f…

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -735,8 +735,14 @@ export async function getLocalChannelVideos(id) {
 
     // if the channel doesn't have a videos tab, YouTube returns the home tab instead
     // so we need to check that we got the right tab
-    if (videosTab.current_tab?.endpoint.metadata.url?.endsWith('/videos')) {
-      videos = parseLocalChannelVideos(videosTab.videos, channelId, name)
+    // YouTube may append query params (e.g. ?view=0&sort=dd&flow=grid) so use includes instead of endsWith
+    if (videosTab.current_tab?.endpoint.metadata.url?.includes('/videos')) {
+      // YouTube's new channel page returns videos as LockupView nodes (lockupVideoRenderer),
+      // but Feed.getVideosFromMemo (used by videosTab.videos) does not include LockupView
+      // in its type search, so those items are invisible to .videos and the array comes back empty.
+      // Pull LockupView items directly from the memo and merge them in.
+      const lockupViewItems = videosTab.memo.getType(YTNodes.LockupView)
+      videos = parseLocalChannelVideos([...videosTab.videos, ...lockupViewItems], channelId, name)
     } else if (name.endsWith('- Topic') && !!videosTab.metadata.music_artist_name) {
       try {
         const playlist = await innertube.getPlaylist(getChannelPlaylistId(channelId, 'videos', 'newest'))
@@ -792,14 +798,16 @@ export async function getLocalChannelLiveStreams(id) {
 
     // if the channel doesn't have a live tab, YouTube returns the home tab instead
     // so we need to check that we got the right tab
-    if (liveStreamsTab.current_tab?.endpoint.metadata.url?.endsWith('/streams')) {
+    // YouTube may append query params so use includes instead of endsWith
+    if (liveStreamsTab.current_tab?.endpoint.metadata.url?.includes('/streams')) {
       // work around YouTube bug where it will return a bunch of responses with only continuations in them
       // e.g. https://www.youtube.com/@TWLIVES/streams
 
-      let tempVideos = liveStreamsTab.videos
+      // Also merge LockupView items from memo (same issue as videos tab — see getLocalChannelVideos)
+      let tempVideos = [...liveStreamsTab.videos, ...liveStreamsTab.memo.getType(YTNodes.LockupView)]
       while (tempVideos.length === 0 && liveStreamsTab.has_continuation) {
         liveStreamsTab = await liveStreamsTab.getContinuation()
-        tempVideos = liveStreamsTab.videos
+        tempVideos = [...liveStreamsTab.videos, ...liveStreamsTab.memo.getType(YTNodes.LockupView)]
       }
 
       videos = parseLocalChannelVideos(tempVideos, channelId, name)
@@ -837,7 +845,8 @@ export async function getLocalChannelCommunity(id) {
 
     // if the channel doesn't have a community tab, YouTube returns the home tab instead
     // so we need to check that we got the right tab
-    if (communityTab.current_tab?.endpoint.metadata.url?.endsWith('/posts')) {
+    // YouTube may append query params so use includes instead of endsWith
+    if (communityTab.current_tab?.endpoint.metadata.url?.includes('/posts')) {
       return parseLocalCommunityPosts(communityTab.posts)
     } else {
       return []
@@ -1080,7 +1089,18 @@ export function parseLocalChannelVideos(videos, channelId, channelName) {
     if (video.is(YTNodes.Video) && video.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY')) {
       continue
     }
-    parsedVideos.push(parseLocalListVideo(video, channelId, channelName))
+
+    // YouTube's new channel page design returns LockupView items instead of Video/GridVideo
+    let parsed
+    if (video.type === 'LockupView') {
+      parsed = parseLockupView(video, channelId, channelName)
+    } else {
+      parsed = parseLocalListVideo(video, channelId, channelName)
+    }
+
+    if (parsed != null) {
+      parsedVideos.push(parsed)
+    }
   }
 
   return parsedVideos
@@ -1586,7 +1606,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
 
           if (lockupView.metadata.metadata?.metadata_rows != null) {
             for (const row of lockupView.metadata.metadata.metadata_rows) {
-              const foundText = row.metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
+              const foundText = row.metadata_parts?.find(part => part.text?.text?.includes('ago'))?.text?.text
               if (foundText != null) {
                 publishedText = foundText
                 break

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -75,6 +75,11 @@ export function calculatePublishedDate(publishedText, isLive = false, isUpcoming
 
   const match = publishedText.match(PUBLISHED_TEXT_REGEX)
 
+  if (!match) {
+    console.error('publishedText did not match the expected format', publishedText)
+    return undefined
+  }
+
   const timeFrame = match[2]
   const timeAmount = parseInt(match[1])
   let timeSpan = null


### PR DESCRIPTION
Fix subscription feed returning empty results for channels using YouTube's new page design. This was coded mostly with Sonnet. It does work though. Take it or leave it as you will.

YouTube's channel pages now return video items as lockupVideoRenderer (parsed by youtubei.js as LockupView) inside richItemRenderer wrappers. Feed.getVideosFromMemo — which powers
Channel.videos — searches for Video, GridVideo, etc. but does not include LockupView, so the result is always an empty array for channels using the new page design.

Fix by pulling LockupView nodes directly from the memo and merging them into the videos/liveStreams arrays before parsing. Also route LockupView items through parseLockupView() in
parseLocalChannelVideos() rather than the legacy parseLocalListVideo() path, which would crash on them.

Additional hardening:
- Use includes() instead of endsWith() for tab URL checks (/videos, /streams, /posts) since YouTube now appends query params to these URLs in its responses, breaking the exact-suffix
match.
- Use includes('ago') instead of endsWith('ago') in parseLockupView's published-date detection for the same reason (YouTube appends a trailing period to relative-time strings in some
locales).
- Add null guard on regex match result in calculatePublishedDate to prevent a TypeError crash on unexpected publishedText formats.


Pull Request Type:
Bugfix

Description:
YouTube silently migrated channel pages to a new format that returns lockupVideoRenderer items (parsed as LockupView by youtubei.js) rather than the legacy Video/GridVideo nodes.
Because Feed.getVideosFromMemo() does not include LockupView in its type search, Channel.videos returns an empty array for any channel on the new format — causing the subscription feed
and channel video tabs to appear completely empty.

Changes in src/renderer/helpers/api/local.js:
- getLocalChannelVideos: pull LockupView items from videosTab.memo and merge with videosTab.videos before passing to parseLocalChannelVideos
- getLocalChannelLiveStreams: same pattern for the streams tab
- parseLocalChannelVideos: dispatch LockupView items to parseLockupView() instead of parseLocalListVideo() (which crashes on them due to missing .author property)
- Tab URL checks (/videos, /streams, /posts): endsWith → includes
- parseLockupView published-date detection: endsWith('ago') → includes('ago')

Changes in src/renderer/helpers/utils.js:
- calculatePublishedDate: add null guard on regex match to prevent TypeError on unexpected publishedText formats


Testing:
1. Open the Subscriptions feed — videos should populate from channels that were previously returning empty.
2. Navigate to any channel → Videos tab — the video grid should load.
3. Navigate to any channel → Live tab — live/upcoming streams should appear.
4. Check the browser console — no TypeError crashes from parseLocalListVideo or calculatePublishedDate.

Desktop

- OS: Linux
- OS Version: Ubuntu (tested on kernel 6.17)
- FreeTube version: 0.24.0 (development branch, built from source)

Additional context:
Root cause confirmed via Chrome DevTools Protocol network interception: raw YouTube browse API responses contain richItemRenderer → lockupVideoRenderer wrappers; youtubei.js parses
these as LockupView nodes but Feed.getVideosFromMemo() never queries for that type. The fix was verified by confirming videosTab.memo.getType(YTNodes.LockupView) returns the expected
items while videosTab.videos returns [] for affected channels.