### PR TITLE
Bugfix for Subs page

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -736,7 +736,16 @@ export async function getLocalChannelVideos(id) {
     // if the channel doesn't have a videos tab, YouTube returns the home tab instead
     // so we need to check that we got the right tab
     if (videosTab.current_tab?.endpoint.metadata.url?.endsWith('/videos')) {
-      videos = parseLocalChannelVideos(videosTab.videos, channelId, name)
+      let videoItems = videosTab.videos
+
+      // YouTube has started returning LockupView nodes instead of Video nodes
+      // for channel videos tabs. videosTab.videos only includes Video nodes,
+      // so we need to also check for LockupView nodes when the list is empty.
+      if (videoItems.length === 0) {
+        videoItems = extractLockupVideos(videosTab)
+      }
+
+      videos = parseLocalChannelVideos(videoItems, channelId, name)
     } else if (name.endsWith('- Topic') && !!videosTab.metadata.music_artist_name) {
       try {
         const playlist = await innertube.getPlaylist(getChannelPlaylistId(channelId, 'videos', 'newest'))
@@ -797,9 +806,19 @@ export async function getLocalChannelLiveStreams(id) {
       // e.g. https://www.youtube.com/@TWLIVES/streams
 
       let tempVideos = liveStreamsTab.videos
+
+      // YouTube has started returning LockupView nodes instead of Video nodes
+      if (tempVideos.length === 0) {
+        tempVideos = extractLockupVideos(liveStreamsTab)
+      }
+
       while (tempVideos.length === 0 && liveStreamsTab.has_continuation) {
         liveStreamsTab = await liveStreamsTab.getContinuation()
         tempVideos = liveStreamsTab.videos
+
+        if (tempVideos.length === 0) {
+          tempVideos = extractLockupVideos(liveStreamsTab)
+        }
       }
 
       videos = parseLocalChannelVideos(tempVideos, channelId, name)
@@ -1068,7 +1087,18 @@ export function parseLocalChannelHeader(channel, onlyIdNameThumbnail = false) {
 }
 
 /**
- * @param {import('youtubei.js').YTNodes.Video[]} videos
+ * Extracts LockupView nodes with VIDEO content type from a channel tab's memo.
+ * YouTube has started returning LockupView instead of Video nodes for channel tabs.
+ * @param {YT.Channel} channelTab
+ * @returns {import('youtubei.js').YTNodes.LockupView[]}
+ */
+function extractLockupVideos(channelTab) {
+  const lockups = channelTab.memo.get('LockupView') || []
+  return lockups.filter(lockup => lockup.content_type === 'VIDEO')
+}
+
+/**
+ * @param {(import('youtubei.js').YTNodes.Video | import('youtubei.js').YTNodes.LockupView)[]} videos
  * @param {string} channelId
  * @param {string} channelName
  */
@@ -1076,11 +1106,18 @@ export function parseLocalChannelVideos(videos, channelId, channelName) {
   const parsedVideos = []
 
   for (const video of videos) {
-    // `BADGE_STYLE_TYPE_MEMBERS_ONLY` used for both `members only` and `members first` videos
-    if (video.is(YTNodes.Video) && video.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY')) {
-      continue
+    if (video.is(YTNodes.LockupView)) {
+      const parsed = parseLockupView(video, channelId, channelName)
+      if (parsed) {
+        parsedVideos.push(parsed)
+      }
+    } else {
+      // `BADGE_STYLE_TYPE_MEMBERS_ONLY` used for both `members only` and `members first` videos
+      if (video.is(YTNodes.Video) && video.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY')) {
+        continue
+      }
+      parsedVideos.push(parseLocalListVideo(video, channelId, channelName))
     }
-    parsedVideos.push(parseLocalListVideo(video, channelId, channelName))
   }
 
   return parsedVideos
@@ -1622,8 +1659,8 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         type: 'video',
         videoId: lockupView.content_id,
         title: lockupView.metadata.title.text?.trim(),
-        author: lockupView.metadata.metadata?.metadata_rows[0].metadata_parts?.[0].text?.text,
-        authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId,
+        author: lockupView.metadata.metadata?.metadata_rows[0].metadata_parts?.[0].text?.text ?? channelName,
+        authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId ?? channelId,
         viewCount,
         published: calculatePublishedDate(publishedText, liveNow, isUpcoming, premiereDate),
         lengthSeconds,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube changed channel video/live stream tabs to return `lockupViewModel` nodes instead of `videoRenderer` nodes. The   youtubei.js library parses these as `LockupView` objects, but its `.videos` getter doesn't include them, causing       `getLocalChannelVideos()` and `getLocalChannelLiveStreams()` to return empty arrays.                                                                                                                                                            This fix adds a fallback in both functions to extract `LockupView` nodes (with `content_type === 'VIDEO'`) from the     channel tab's memo when `.videos` returns empty. The existing `parseLockupView()` function already handles full VIDEO
parsing, so `parseLocalChannelVideos()` was updated to route `LockupView` items through it alongside traditional        `Video` nodes.

Also adds `channelName`/`channelId` fallbacks in `parseLockupView()`'s VIDEO case, since metadata rows on a channel's   own page contain views/time rather than channel info.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
Currently Release says: "Your subscribed channels currently does not have any videos"
This version fixes this

<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

## Desktop
<!-- Please complete the following information-->
- **OS:** Windos
- **OS Version:** Win 10
- **FreeTube version:** v0.24.0 Beta

## Additional context
<!-- Add any other context about the pull request here. -->
