### PR TITLE
Fix: Incomplete history import for marked as watched videos

### DIFF
--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -818,7 +818,6 @@ async function importFreeTubeWatchHistory(textDecode) {
   const requiredKeys = [
     'author',
     'authorId',
-    'description',
     'isLive',
     'lengthSeconds',
     'published',
@@ -836,6 +835,7 @@ async function importFreeTubeWatchHistory(textDecode) {
     'lastViewedPlaylistItemId',
     'lastViewedPlaylistType',
     'viewCount',
+    'description',
   ]
 
   const ignoredKeys = [
@@ -868,6 +868,9 @@ async function importFreeTubeWatchHistory(textDecode) {
       showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
       console.error('Missing Keys: ', missingKeys, historyData)
     } else {
+      // FreeTube history export does not have this data if the video was marked as watched manually, setting default value
+      historyObject.description = ''
+
       historyItems.set(historyObject.videoId, historyObject)
     }
   })

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -869,7 +869,7 @@ async function importFreeTubeWatchHistory(textDecode) {
       console.error('Missing Keys: ', missingKeys, historyData)
     } else {
       // FreeTube history export does not have this data if the video was marked as watched manually, setting default value
-      historyObject.description = ''
+      historyObject.description = historyObject.description ?? ''
 
       historyItems.set(historyObject.videoId, historyObject)
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9021

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
[When video data are parsed](https://github.com/FreeTubeApp/FreeTube/blob/development/src/renderer/components/ft-list-video/ft-list-video.js#L745) from video list, 'description' seems to always be undefined. When the video is marked as watched manually, [the same data is used](https://github.com/FreeTubeApp/FreeTube/blob/124faed3f2739828537f1f4456859e94d40e386d/src/renderer/components/ft-list-video/ft-list-video.js#L792) to insert it in the watch history database. This leads to 'description' field not being part of the exported data. However, it is a [required field](https://github.com/FreeTubeApp/FreeTube/blob/124faed3f2739828537f1f4456859e94d40e386d/src/renderer/components/DataSettings/DataSettings.vue#L821) when importing, leading to the exception.

The fix is to mark this 'description' field as optional. It is [already the case when importing from YouTube watch history](https://github.com/FreeTubeApp/FreeTube/blob/124faed3f2739828537f1f4456859e94d40e386d/src/renderer/components/DataSettings/DataSettings.vue#L957).

Also, I didn't find where this 'description' field was used, if used.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to trending or subscription page
2. Mark a video as watched
3. Export history
4. Check that the exported history contains the video with an empty "description" field
5. Delete watch history
6. Import history
7. Check that the video is correctly part of the history 

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.24.0-beta