### PR TITLE
Fix: import history from youtube adding trailing space to title

### DIFF
--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -892,6 +892,10 @@ async function importYouTubeWatchHistory(historyData) {
   // remove 'Watched' and translated variants from start of title
   // so we get the common string prefix for all the titles
   const getCommonStart = (allTitles) => {
+    if (allTitles.length < 2) {
+      return ''
+    }
+
     let commonStart = allTitles[0]
     for (let i = 1; i < allTitles.length; i++) {
       while (!allTitles[i].startsWith(commonStart)) {

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -892,17 +892,17 @@ async function importYouTubeWatchHistory(historyData) {
   // remove 'Watched' and translated variants from start of title
   // so we get the common string prefix for all the titles
   const getCommonStart = (allTitles) => {
-    const watchedTitle = allTitles[0].split(' ')
-    allTitles.forEach((title) => {
-      const splitTitle = title.split(' ')
-      for (let wtIndex = 0; wtIndex <= watchedTitle.length; wtIndex++) {
-        if (!splitTitle.includes(watchedTitle[wtIndex])) {
-          watchedTitle.splice(wtIndex, watchedTitle.length - wtIndex)
+    let commonStart = allTitles[0]
+    for (let i = 1; i < allTitles.length; i++) {
+      while (!allTitles[i].startsWith(commonStart)) {
+        commonStart = commonStart.slice(0, -1)
+        if (commonStart === '') {
+          return ''
         }
       }
-    })
+    }
 
-    return watchedTitle.join(' ')
+    return commonStart
   }
 
   const commonStart = getCommonStart(filteredHistoryData.map(e => e.title))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When importing watch history from YouTube, FreeTube tries to guess the common start of titles to remove it. It does this by splitting words using spaces. The issue is that by doing this, spaces aren't counted as being part of the start of the title. This leads to extra trailing spaces being added to titles when importing, and these spaces are also present when exporting.
For example, "Watched My Cool Video" will match "Watched" as the starting string, leading to title being " My Cool Video".

Also, if the history only contained one video, the whole title was considered as common, leading to the title being empty once cleaned.
There is still one small issue: if there is only one video in the history, the title will be imported with the common start string, but it can't be fixed with the current approach.

The fix consists of iterating over all titles and removing the last character of the first title while the others do not start with the same string. It doesn't seem like it when reading it, but this approach is faster than the previous one.
_Previously:_ For 4,746 videos in history, average `getCommonStart` time of 2.5ms
_Now:_ For 4,746 videos in history, average `getCommonStart` time of 0.4ms

I didn't just use `title: [{ importKey: 'title', predicate: item => item.slice(commonStart.length + 1) }]` because some languages probably don't have a space between the start string and the title.

I tested extensively with import/export history and behavior in FreeTube, and I didn't find any regression caused by the title change (after removing the trailing space).

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Remove watch history
2. Import history from YouTube export (sample in additional context section)
3. Check that the "history.db" file does not contain a title field with a trailing space
4. Export history as YouTube format
5. Check that the resulting exported file does not contain an extra space between "Watched" and the video title

## Additional context
<!-- Add any other context about the pull request here. -->
YouTube export sample, to save in a ".json" file:
```
[{
  "header": "YouTube",
  "title": "Vous avez regardé The Bald Paradox 🤔 (explained)",
  "titleUrl": "https://www.youtube.com/watch?v\u003dgjR-Z2oSFWI",
  "subtitles": [{
    "name": "Zack D. Films",
    "url": "https://www.youtube.com/channel/UCvz84_Q0BbvZThy75mbd-Dg"
  }],
  "time": "2026-05-27T20:50:42.333Z",
  "products": ["YouTube"],
  "activityControls": ["Historique des vidéos regardées sur YouTube"]
}]
```