### PR TITLE
Fix: Clicking outside the search bar does not close search suggestions/history

### DIFF
--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -372,6 +372,7 @@ function handleOptionClick(index) {
   }
 
   searchState.showOptions = false
+  searchState.isPointerInList = false
   inputData.value = visibleDataList.value[index]
   emit('input', inputData.value)
   handleClick()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/7768

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When we click on an element in the list, the `<ul>` element responsible to update `isPointerInList`  is closed without triggering `mouseleave` event, leaving `isPointerInList` to true. When the user clicks in the search bar again, erases the text and clicks elsewhere, `handleInputBlur` is called with `isPointerInList` still being true, not setting `showOptions` to false.

The fix is to manually set `isPointerInList` to false when an element is selected.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Click in the search bar 
2. Click on any element in search history
3. Click in the search bar again
4. Erase the text with keyboard 
5. Click outside the search bar, without hovering any elements in the history list
6. Check that the suggestions are correctly closed

I've done the same test with keyboard navigation, pressing enter instead of clicking the history, some stress tests, everything works fine. 
