### PR TITLE
Fix: Remove add/remove channel buttons from profile view if unsubscribe setting is toggled

### DIFF
--- a/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
+++ b/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
@@ -5,7 +5,7 @@
         {{ $t("Profile.Subscription List") }}
       </h2>
       <p
-        v-if="!hideUnsubscribeButton"
+        v-if="showUnsubscribeButton"
         class="selectedCount"
       >
         {{ selectedText }}
@@ -17,13 +17,13 @@
           :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
-          :selectable="!hideUnsubscribeButton"
+          :selectable="showUnsubscribeButton"
           :selected="selected.has(channel.id)"
           @change="handleChannelToggle(channel.id)"
         />
       </FtFlexBox>
       <FtFlexBox
-        v-if="!hideUnsubscribeButton"
+        v-if="showUnsubscribeButton"
       >
         <FtButton
           :label="$t('Profile.Select All')"
@@ -108,8 +108,8 @@ const intlCollator = computed(() => {
 })
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const hideUnsubscribeButton = computed(() => {
-  return store.getters.getHideUnsubscribeButton
+const showUnsubscribeButton = computed(() => {
+  return !store.getters.getHideUnsubscribeButton
 })
 
 /** @type {import('vue').ShallowRef<Profile['subscriptions']>} */

--- a/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
+++ b/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
@@ -4,7 +4,10 @@
       <h2>
         {{ $t("Profile.Subscription List") }}
       </h2>
-      <p class="selectedCount">
+      <p
+        v-if="!hideUnsubscribeButton"
+        class="selectedCount"
+      >
         {{ selectedText }}
       </p>
       <FtFlexBox>
@@ -14,12 +17,14 @@
           :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
-          :selectable="true"
+          :selectable="!hideUnsubscribeButton"
           :selected="selected.has(channel.id)"
           @change="handleChannelToggle(channel.id)"
         />
       </FtFlexBox>
-      <FtFlexBox>
+      <FtFlexBox
+        v-if="!hideUnsubscribeButton"
+      >
         <FtButton
           :label="$t('Profile.Select All')"
           @click="selectAll"
@@ -100,6 +105,11 @@ const currentInvidiousInstanceUrl = computed(() => {
 
 const intlCollator = computed(() => {
   return new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' })
+})
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideUnsubscribeButton = computed(() => {
+  return store.getters.getHideUnsubscribeButton
 })
 
 /** @type {import('vue').ShallowRef<Profile['subscriptions']>} */

--- a/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
+++ b/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
@@ -15,7 +15,7 @@
         />
       </FtFlexBox>
       <p
-        v-if="!hideUnsubscribeButton"
+        v-if="showUnsubscribeButton"
         class="selected"
       >
         {{ selectedText }}
@@ -27,13 +27,13 @@
           :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
-          :selectable="!hideUnsubscribeButton"
+          :selectable="showUnsubscribeButton"
           :selected="selected.has(channel.id)"
           @change="handleChannelToggle(channel.id)"
         />
       </FtFlexBox>
       <FtFlexBox
-        v-if="!hideUnsubscribeButton"
+        v-if="showUnsubscribeButton"
       >
         <FtButton
           :label="$t('Profile.Select All')"
@@ -117,8 +117,8 @@ const intlCollator = computed(() => {
 })
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const hideUnsubscribeButton = computed(() => {
-  return store.getters.getHideUnsubscribeButton
+const showUnsubscribeButton = computed(() => {
+  return !store.getters.getHideUnsubscribeButton
 })
 
 const filteredProfileIndex = ref(0)

--- a/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
+++ b/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
@@ -14,7 +14,10 @@
           @change="handleProfileFilterChange"
         />
       </FtFlexBox>
-      <p class="selected">
+      <p
+        v-if="!hideUnsubscribeButton"
+        class="selected"
+      >
         {{ selectedText }}
       </p>
       <FtFlexBox>
@@ -24,12 +27,14 @@
           :channel-id="channel.id"
           :channel-name="channel.name"
           :channel-thumbnail="channel.thumbnail"
-          :selectable="true"
+          :selectable="!hideUnsubscribeButton"
           :selected="selected.has(channel.id)"
           @change="handleChannelToggle(channel.id)"
         />
       </FtFlexBox>
-      <FtFlexBox>
+      <FtFlexBox
+        v-if="!hideUnsubscribeButton"
+      >
         <FtButton
           :label="$t('Profile.Select All')"
           @click="selectAll"
@@ -109,6 +114,11 @@ const currentInvidiousInstanceUrl = computed(() => {
 
 const intlCollator = computed(() => {
   return new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' })
+})
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideUnsubscribeButton = computed(() => {
+  return store.getters.getHideUnsubscribeButton
 })
 
 const filteredProfileIndex = ref(0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/3501

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Those changes aim to address the issue described in https://github.com/FreeTubeApp/FreeTube/issues/3501.
When the channel bubbles are not selectable, they are clickable, which could be subject to debate as it is a different behavior from when the "Hide Unsubscribe Button" is not toggled, but I think it is useful, so I left it like that.


## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
**Before**
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/249d53cb-49a9-4f15-b4fa-f203cab72869" />

**After**
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/fd6d16a3-2677-4c40-b7e1-d33bdaf9459f" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Enable "Settings / Parental Control / Hide Unsubscribe Button"
2. Open Profile Manager and click on a profile
3. Check that text "0 selected" and all buttons related to selection, addition and deletion of channels are hidden
4. Check that clicking on a channel open the channel page

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.24.0