### PR TITLE
Set @parcel/watcher to false in the pnpm allowBuilds setting

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@
 
 # https://pnpm.io/next/settings#allowbuilds
 allowBuilds:
+  '@parcel/watcher': false # Only required when you want to build @parcel/watcher from source
   electron-winstaller: false # We build NSIS installers on Windows, not squirrel ones
   lefthook: true # Installing git hooks
   unrs-resolver: false # Works around an npm specific optional dependencies bug, so we don't need it with pnpm


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

`@parcel/watcher` now has an install script that compiles it from source if the `npm_config_build_from_source` npm setting is enabled, as we are fine using the pre-built binaries we can disable that postinstall script (also stops pnpm complaining about it).

- https://npmx.dev/package-code/@parcel/watcher/v/2.5.6/package.json#L35
- https://npmx.dev/package-code/@parcel/watcher/v/2.5.6/scripts%2Fbuild-from-source.js

## Testing

1. `pnpm install`
2. `pnpm run dev`

If the pnpm install works and the dev server starts correctly this change works and doesn't break anything.

## Desktop

- **OS:** Windows
- **OS Version:** 11