### PR TITLE
Fix: Private video - TypeError: Cannot read properties of undefined (reading 'view_count')

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -476,6 +476,21 @@ export default defineComponent({
         const videoInfo = await getLocalVideoInfo(this.videoId)
         const { info: result, poToken, clientInfo, adEndTimeUnixMs } = videoInfo
 
+        const playabilityStatus = result.playability_status
+        this.playabilityStatus = playabilityStatus.status
+
+        if (playabilityStatus.status === 'LOGIN_REQUIRED' && playabilityStatus.error_screen?.reason?.text === 'Private video') {
+          // Private videos cannot be played in FreeTube, as they require to be logged as the owner of the video
+          // so there is no point continuing or trying any other backends as it will always fail
+          this.errorMessage = this.$t('Video.Private')
+          // TODO: Migrate to use https://github.com/FreeTubeApp/FreeTube/pull/8991 once merged
+          this.thumbnail = 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
+          this.isLoading = false
+          // TODO: Check but it should work after merging 8991 as it will restore videoTitle
+          this.updateTitle()
+          return
+        }
+
         this.adEndTimeUnixMs = adEndTimeUnixMs
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
@@ -627,9 +642,6 @@ export default defineComponent({
         }
 
         this.videoChapters = chapters
-
-        const playabilityStatus = result.playability_status
-        this.playabilityStatus = playabilityStatus.status
 
         // The apostrophe is intentionally that one (char code 8217), because that is the one YouTube uses
         const BOT_MESSAGE = 'Sign in to confirm you’re not a bot'
@@ -1095,6 +1107,18 @@ export default defineComponent({
           this.isLoading = false
         })
         .catch(err => {
+          if (err.message === "Sign in if you've been granted access to this video") {
+            // Private videos cannot be played in FreeTube, as they require to be logged as the owner of the video
+            // so there is no point continuing or trying any other backends as it will always fail
+            this.errorMessage = this.$t('Video.Private')
+            // TODO: Migrate to use https://github.com/FreeTubeApp/FreeTube/pull/8991 once merged
+            this.thumbnail = 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
+            this.isLoading = false
+            // TODO: Check but it should work after merging 8991 as it will restore videoTitle
+            this.updateTitle()
+            return
+          }
+
           console.error(err)
           if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
             const errorMessage = this.$t('Invidious API Error (Click to copy)')

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -483,10 +483,8 @@ export default defineComponent({
           // Private videos cannot be played in FreeTube, as they require to be logged as the owner of the video
           // so there is no point continuing or trying any other backends as it will always fail
           this.errorMessage = this.$t('Video.Private')
-          // TODO: Migrate to use https://github.com/FreeTubeApp/FreeTube/pull/8991 once merged
-          this.thumbnail = 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
+          this.thumbnail = this.getUnavailableVideoThumbnail()
           this.isLoading = false
-          // TODO: Check but it should work after merging 8991 as it will restore videoTitle
           this.updateTitle()
           return
         }
@@ -1107,18 +1105,6 @@ export default defineComponent({
           this.isLoading = false
         })
         .catch(err => {
-          if (err.message === "Sign in if you've been granted access to this video") {
-            // Private videos cannot be played in FreeTube, as they require to be logged as the owner of the video
-            // so there is no point continuing or trying any other backends as it will always fail
-            this.errorMessage = this.$t('Video.Private')
-            // TODO: Migrate to use https://github.com/FreeTubeApp/FreeTube/pull/8991 once merged
-            this.thumbnail = 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
-            this.isLoading = false
-            // TODO: Check but it should work after merging 8991 as it will restore videoTitle
-            this.updateTitle()
-            return
-          }
-
           console.error(err)
           if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
             const errorMessage = this.$t('Invidious API Error (Click to copy)')

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -830,6 +830,7 @@ Video:
   MembersOnly: Members-only videos cannot be watched with FreeTube as they require Google login and paid membership to the uploader's channel.
   AgeRestricted: Age-restricted videos cannot be watched with FreeTube as they require Google login and using an age-verified YouTube account.
   DRMProtected: DRM protected videos cannot be played in FreeTube, as they require proprietary, closed source components. If you want to watch this video please watch it on the official YouTube website in a DRM enabled web browser.
+  Private: Private videos cannot be watched with FreeTube as they require Google login and being the owner of the video.
   More Options: More Options
   Mark As Watched: Mark As Watched
   Remove From History: Remove From History

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -830,7 +830,7 @@ Video:
   MembersOnly: Members-only videos cannot be watched with FreeTube as they require Google login and paid membership to the uploader's channel.
   AgeRestricted: Age-restricted videos cannot be watched with FreeTube as they require Google login and using an age-verified YouTube account.
   DRMProtected: DRM protected videos cannot be played in FreeTube, as they require proprietary, closed source components. If you want to watch this video please watch it on the official YouTube website in a DRM enabled web browser.
-  Private: Private videos cannot be watched with FreeTube as they require Google login and being the owner of the video.
+  Private: Private videos cannot be watched in FreeTube as they require Google login and ownership of the video.
   More Options: More Options
   Mark As Watched: Mark As Watched
   Remove From History: Remove From History


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/7690

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When a video is private, all `result` fields are either null or undefined, leading to the message `TypeError: Cannot read properties of undefined (reading 'view_count')`.

Luckily, we have a reliable way to catch private video errors  with the `playabilityStatus`.

I've spent some times trying to use Invidious API with FreeTube to test the behavior. I'm not sure if I'm misconfiguring something, but all the Invidious instances listed [here](https://api.invidious.io/) fail to load any videos. I've also tested some of them as a regular user without the API, and none of them could play videos, so the issue likely lies with Invidious itself.

If you're aware of any working Invidious instances, I'd be happy to implement this fix for Invidious as well, if possible.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
**Before**
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/77402ea6-fdf4-4224-b502-44afb8997279" />

**After**
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/01b26c59-be68-44f6-9aef-e2b6d2093757" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Private video URL: https://www.youtube.com/watch?v=K97lp7xWPCQ