### PR TITLE
Fix proxy config not working on startup

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -541,9 +541,7 @@ function runApp() {
     if (useProxy) {
       proxyUrl = `${proxyProtocol}://${proxyHostname}:${proxyPort}`
 
-      session.defaultSession.setProxy({
-        proxyRules: proxyUrl
-      })
+      app.commandLine.appendSwitch('proxy-server', proxyUrl)
     }
 
     const fixedUserAgent = session.defaultSession.getUserAgent()


### PR DESCRIPTION
i built it for .deb only and it worked, on my system atleast (No reason this shouldnt work on other systems.)
i did not see an existing issue for this, therefore i cannot link one

## Pull Request Type
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
session.setProxy() was being used to configure the proxy during app startup, but it doesn't reliably take effect because electrons network service isn't always ready at that point, So, i switched it to app.commandLine.appendSwitch which sets the proxy at the chromium level before any weird electrion networking happens.

The runtime proxy toggle (settings page) still uses session.setProxy() and that works fine because the network service is already running atp..

## Testing
Setup a (atleast in my usage) a microsocks proxy, 
configure it in the settings, 
close the app, re open it, it should fail to connect to the youtube api. 
go to the settings, 
change the proxy setting, click "test", (it wont work if setting are invalid) 
change them back, then it should work.

## Desktop
- **OS: Linux Mint 22.2 x86_64 **
- **OS Version: 6.18.21-x64v3-xanmod1 **
- **FreeTube version: 0.24.1**
