### PR TITLE
Fix: Watch time progress bar inconsistency

### DIFF
--- a/src/renderer/components/ft-list-video/ft-list-video.js
+++ b/src/renderer/components/ft-list-video/ft-list-video.js
@@ -252,7 +252,7 @@ export default defineComponent({
       if (typeof this.lengthSeconds !== 'number' || this.lengthSeconds === 0) {
         return 0
       }
-      const percentage = (this.watchProgress / this.lengthSeconds) * 100
+      const percentage = (Math.ceil(this.watchProgress) / this.lengthSeconds) * 100
       return Math.min(percentage, 100)
     },
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/3530

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Playlist video information is gathered from Innertube with duration precision in seconds (see the references in [YouTube.js](https://github.com/LuanRT/YouTube.js/blob/main/src/parser/classes/PlaylistVideo.ts#L59) and [FreeTube](https://github.com/FreeTubeApp/FreeTube/blob/development/src/renderer/components/ft-list-video/ft-list-video.js#L738)). However, when [watch progress](https://github.com/FreeTubeApp/FreeTube/blob/development/src/renderer/views/Watch/Watch.js#L1866) is saved to the database, it uses the Shaka player's `getCurrentTime()` method, which has millisecond precision. When calculating the watch progress percentage, the calculation divides milliseconds by seconds, for example, 1.412 / 2, which always results in a value less than 100% due to the unit mismatch.

This introduces a small regression, but I have checked and it is exactly the same behaviour on YouTube: if you watch a video with a duration of 1.4s during 1s and close the video, it will be considered as fully watched. It is the same for all video durations, a second started is a second considered fully watched.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/9c0c04d8-3900-4705-877a-98b9ad46263b" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
See reproduction steps in https://github.com/FreeTubeApp/FreeTube/issues/3530
