### PR TITLE
Fix: Live chat error overflow

### DIFF
--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -34,7 +34,7 @@
   color: var(--tertiary-text-color);
   padding: 0;
   margin: 0;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 :deep(.liveChatEmoji) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/6312

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
An explanation for the regression and the fix is here: https://github.com/FreeTubeApp/FreeTube/issues/6312#issuecomment-4712914382

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="2690" height="1524" alt="image" src="https://github.com/user-attachments/assets/50bf3c97-9dc4-4270-88ea-8c18c3fff5a8" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Same steps as https://github.com/FreeTubeApp/FreeTube/pull/6327

## Additional context
<!-- Add any other context about the pull request here. -->
Additional properties were changed from `word-break` to `word-wrap` [here](https://github.com/FreeTubeApp/FreeTube/commit/23c39404d9507fb152cb6509fefa753ab9ee1381#diff-e065bbaa847ebfdda7db955b5039a54e849246e6ea412e441cdd11629135cf31L37), but it may be the only place where it actually causes a regression, as it is a single long word (URL).