### PR TITLE
Fix premierDate parsing in subscription

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1677,12 +1677,16 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       }
 
       const maybeAuthorText = lockupView.metadata.metadata?.metadata_rows[0].metadata_parts?.[0].text?.text
+      let author = channelName
+      if (maybeAuthorText && !isViewOrWaitingCountText(maybeAuthorText) && !isPremieresTimeText(maybeAuthorText)) {
+        author = maybeAuthorText
+      }
 
       return {
         type: 'video',
         videoId: lockupView.content_id,
         title: lockupView.metadata.title.text?.trim(),
-        author: maybeAuthorText && !isViewOrWaitingCountText(maybeAuthorText) ? maybeAuthorText : channelName,
+        author,
         authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId ?? channelId,
         viewCount,
         published: calculatePublishedDate(publishedText, liveNow, isUpcoming, premiereDate),

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1536,7 +1536,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
 const VIEWS_OR_WATCHING_REGEX = /views?|watching|waiting/i
 const WAITING_REGEX = /waiting/i
 const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[km]?$/i
-const PREMIERES_TIME_REGEX = /^premieres /i
+const PREMIERES_TIME_REGEX = /^(premieres|scheduled for) /i
 
 /**
  * @param {string | undefined} text


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Not seeing upcoming time in subscription so this PR should fix it
Also fixed channel name detection for upcoming videos in channel live tab

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
YT
<img width="453" height="379" alt="image" src="https://github.com/user-attachments/assets/a0bc2703-7e68-4135-b0f5-4c3c0e713518" />
After fix
<img width="305" height="387" alt="image" src="https://github.com/user-attachments/assets/93b18fe2-3ff7-4dc0-b44b-527805fa1757" />
Before
<img width="308" height="336" alt="image" src="https://github.com/user-attachments/assets/2536e977-5239-4b36-9d12-e4d43e07b9f8" />


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
A. Upcoming in subscription
Copied from https://github.com/FreeTubeApp/FreeTube/pull/3358

- Find a stream on https://www.youtube.com/@live (click on the live now header to see all of them that are currently live) that is live but is marked as premiere (scrolling down to load more and CTRL+F is your friend), you may have to use the 3 dots menu in the top right of the website to change location if there aren't any listed for your current location.
- Subscribe to that channel and refresh subscription

B. Channel name parsing for upcoming in channel live tab
Same as above I use https://www.youtube.com/channel/UC15WpoPYPPiZREOlT6KD_QQ

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
Not sure if 