### PR TITLE
Fix publish time parsing

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1537,6 +1537,8 @@ const VIEWS_OR_WATCHING_REGEX = /views?|watching|waiting/i
 const WAITING_REGEX = /waiting/i
 const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[km]?$/i
 const PREMIERES_TIME_REGEX = /^(premieres|scheduled for) /i
+// Sometimes got `Streamed N (unit) ago`
+const PUBLISH_TIME_REGEX = /^(streamed+ )?\d+ \w+? ago/i
 
 /**
  * @param {string | undefined} text
@@ -1563,6 +1565,15 @@ function isPremieresTimeText(text) {
   if (typeof text !== 'string') { return false }
 
   return PREMIERES_TIME_REGEX.test(text)
+}
+
+/**
+ * @param {string | undefined} text
+ */
+function isPublishTimeText(text) {
+  if (typeof text !== 'string') { return false }
+
+  return PUBLISH_TIME_REGEX.test(text)
 }
 
 /**
@@ -1644,7 +1655,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
 
           if (lockupView.metadata.metadata?.metadata_rows != null) {
             for (const row of lockupView.metadata.metadata.metadata_rows) {
-              const foundText = row.metadata_parts?.find(part => part.text?.text?.endsWith('ago'))?.text?.text
+              const foundText = row.metadata_parts?.find(part => isPublishTimeText(part.text?.text))?.text?.text
               if (foundText != null) {
                 publishedText = foundText
                 break

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1538,7 +1538,7 @@ const WAITING_REGEX = /waiting/i
 const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[km]?$/i
 const PREMIERES_TIME_REGEX = /^(premieres|scheduled for) /i
 // Sometimes got `Streamed N (unit) ago`
-const PUBLISH_TIME_REGEX = /^(streamed+ )?\d+ \w+? ago/i
+const PUBLISH_TIME_REGEX = /^(streamed )?\d+ \w+? ago/i
 
 /**
  * @param {string | undefined} text


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/9279

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fix publish time parsing due to using `endsWith('ago')` is possible to match with some video titles

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
N/A

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- https://www.youtube.com/channel/UCeSRjhfeeqIgr--AcP9qhyg
- Ensure no error, all videos (plus live) publish time look right

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
Included https://github.com/FreeTubeApp/FreeTube/pull/9309 due to merge conflict, maybe merge that one first
