### PR TITLE
Fix: Default quality setting isnt applied

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1472,7 +1472,11 @@ export default defineComponent({
       const isPortrait = variants[0].height > variants[0].width
 
       let matches = variants.filter(variant => {
-        return quality === (isPortrait ? variant.width : variant.height)
+        const { width, height } = variant
+        const [primary, secondary] = isPortrait ? [width, height] : [height, width]
+        const aspectRatio = secondary / primary
+        const resolution = aspectRatio > 16 / 9 ? Math.round(secondary * 9 / 16) : primary
+        return quality === resolution
       })
 
       if (matches.length === 0) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/6653

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fix default quality settings not being applied for video with aspect ratio differents than 16/9 or 9/16.

I've based my fix directly on what [shaka-player](https://github.com/shaka-project/shaka-player/blob/bbc759c77677c86c9a94627c70503eaac8e73647/ui/resolution_selection.js#L459) does to display the `Resolution` setting.
FreeTube's resolution detection is now similar to what shaka-player does, allowing to better match resolutions.

There is still one little difference, shaka-player resolution [takes `pixelAspectRatio` into account](https://github.com/shaka-project/shaka-player/blob/bbc759c77677c86c9a94627c70503eaac8e73647/ui/resolution_selection.js#L445), but I didn't include it as I don't have a reliable way to test those cases, but that could be a bug too.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Set Default Quality to 1080p
2. Navigate to https://youtu.be/wgqs33CVaCI
3. See that quality is set to 1080p
4. Change the video format to audio
5. Change the video format back to dash (another code path that leads to `setDashQuality` with different branching) 
6. See that quality is set to 1080p

It should work the same with portrait videos with non-9/16 aspect ratio, but I can't find any.
And of course, previous behaviour should be the same for all standard aspect-ratio.