### PR TITLE
Fix: Local Playlist doesn't show upcoming premieres if 'hide upcoming premieres' is enabled

### DIFF
--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -12,6 +12,7 @@
       :layout="displayValue"
       :show-video-with-last-viewed-playlist="showVideoWithLastViewedPlaylist"
       :use-channels-hidden-preference="useChannelsHiddenPreference"
+      :use-hide-upcoming-premieres-preference="useHideUpcomingPremieresPreference"
       :hide-forbidden-titles="hideForbiddenTitles"
       :always-show-add-to-playlist-button="alwaysShowAddToPlaylistButton"
       :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
@@ -66,6 +67,10 @@ const props = defineProps({
     default: false
   },
   useChannelsHiddenPreference: {
+    type: Boolean,
+    default: true,
+  },
+  useHideUpcomingPremieresPreference: {
     type: Boolean,
     default: true,
   },

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -192,6 +192,7 @@ const hideLiveStreams = computed(() => {
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideUpcomingPremieres = computed(() => {
   if (!props.useHideUpcomingPremieresPreference) { return false }
+
   return store.getters.getHideUpcomingPremieres
 })
 

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -103,6 +103,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  useHideUpcomingPremieresPreference: {
+    type: Boolean,
+    default: true,
+  },
   hideForbiddenTitles: {
     type: Boolean,
     default: true
@@ -187,6 +191,7 @@ const hideLiveStreams = computed(() => {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideUpcomingPremieres = computed(() => {
+  if (!props.useHideUpcomingPremieresPreference) { return false }
   return store.getters.getHideUpcomingPremieres
 })
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -80,6 +80,7 @@
             :playlist-type="infoSource"
             :show-video-with-last-viewed-playlist="true"
             :use-channels-hidden-preference="false"
+            :use-hide-upcoming-premieres-preference="false"
             :hide-forbidden-titles="false"
             :always-show-add-to-playlist-button="true"
             :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/8261

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I've used the same pattern as `useChannelsHiddenPreference`. 
The behavior is different when the window is narrowed because grid view uses `FtListLazyWrapper` which implements 'hide upcoming premieres' preference whereas list view uses `FtListVideoNumbered` which does not take into account the setting.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
**Local Playlist**
1. Create a new playlist
2. Find a video marked as "upcoming premiere" (example https://www.youtube.com/watch?v=9dPo4_ALCxQ)  and add it to the playlist
3. Go to Settings > Distraction Free and make sure "Hide Upcoming Premieres" is enabled
4. Open the playlist and check that the upcoming premiere is visible

**Public  Playlist**
1. Create a new YouTube playlist
2. Find a video marked as "upcoming premiere" (example https://www.youtube.com/watch?v=9dPo4_ALCxQ) and add it to the playlist
3. In FreeTube, go to Settings > Distraction Free and make sure "Hide Upcoming Premieres" is enabled
4. Open the YouTube playlist URL inside FreeTube and check that the upcoming premiere is visible