### PR TITLE
Fix: publishedText is missing but the video isn't live or upcoming

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -69,7 +69,6 @@ export function calculatePublishedDate(publishedText, isLive = false, isUpcoming
   }
 
   if (!publishedText) {
-    console.error("publishedText is missing but the video isn't live or upcoming")
     return undefined
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/8085

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
It is a valid state to have an empty `publishedText` when the video is not live/premiere/upcoming.  

A good example is the [paramountplus channel](https://www.youtube.com/@paramountplus) when using an IP located in USA:

**YouTube:**
<img width="1420" height="827" alt="image" src="https://github.com/user-attachments/assets/460c08cb-4720-4a5f-b11b-9ec2dad960bf" />

**FreeTube:**
<img width="1511" height="812" alt="image" src="https://github.com/user-attachments/assets/70c8eecb-ffd0-4be6-85a0-7870cc9b0431" />

Differentiating valid and unvalid cases does not seem possible. It does not break FreeTube UI and does not impact the user when a video is returned without `publishedText`, so I suggest to remove the log.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to [paramountplus channel](https://www.youtube.com/@paramountplus) using an IP located in USA
2. Check that there is no error