### PR TITLE
Fix parsing view counts in shorts-only playlists

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1330,7 +1330,7 @@ export function parseLocalPlaylistVideo(video) {
     if (shortsLockupView.accessibility_text) {
       // the `.*\s+` at the start of the regex, ensures we match the last occurence
       // just in case the video title also contains that pattern
-      const match = shortsLockupView.accessibility_text.match(/.*\s+(\d+(?:[,.]\d+)?\s?(?:[BKMbkm]|million)?|no)\s+views?/)
+      const match = shortsLockupView.accessibility_text.match(/.*\s+(\d+(?:[,.]\d+)?\s?(?:[BKMbkm]|thousand|[bm]illion)?|no)\s+views?/)
 
       if (match) {
         const count = match[1]
@@ -2098,7 +2098,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
  * @param {string} text
  */
 export function parseLocalSubscriberCount(text) {
-  const match = text.match(/(\d+)(?:[,.](\d+))?\s?([BKMbkm]|million)\b/)
+  const match = text.match(/(\d+)(?:[,.](\d+))?\s?([BKMbkm]|thousand|[bm]illion)\b/)
 
   if (match) {
     let multiplier = 0
@@ -2106,6 +2106,7 @@ export function parseLocalSubscriberCount(text) {
     switch (match[3]) {
       case 'K':
       case 'k':
+      case 'thousand':
         multiplier = 3
         break
       case 'M':
@@ -2115,6 +2116,7 @@ export function parseLocalSubscriberCount(text) {
         break
       case 'B':
       case 'b':
+      case 'billion':
         multiplier = 9
         break
     }


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

This pull request fixes the view count parsing in shorts only playlists. As they shorts in playlists don't have the view count overlay that shorts on channel pages do, FreeTube extracts the view count from the accessibility text which uses full words instead of abbreviations. The current extraction code only supported "million", this pull request adds "thousand" and "billion" to it too.

Shorts only playlists were not affected by the recent YouTube changes so this can be tested without having to wait for the YouTube.js update to be merged :).

## Screenshots

### Before

<img width="629" height="700" alt="before thousands" src="https://github.com/user-attachments/assets/ad870a95-5485-4927-9be5-87abaab1b477" />

<img width="626" height="704" alt="before billions" src="https://github.com/user-attachments/assets/cc34d402-b9c5-4933-bc4f-bb54f7588534" />

### After

<img width="628" height="699" alt="after thousands" src="https://github.com/user-attachments/assets/4bf42da7-5b60-4089-b79b-2fdb6b6fe521" />

<img width="630" height="706" alt="after billions" src="https://github.com/user-attachments/assets/22201992-741b-47ac-8041-04c7e88140c7" />

## Testing

- shorts playlist with some thousand view counts: https://youtube.com/playlist?list=UUSHXuqSBlHAE6Xw-yeJA0Tunw (LTT auto-generated shorts playlist)
- shorts playist with some billion view counts: https://www.youtube.com/playlist?list=PLNc3mV34rpBkX50Sng9WdWFxIFEFua-f4 (found by searching for various things a long the line of "most viewed shorts playlists" in my search engine of choice)

## Desktop

- **OS:** Windows
- **OS Version:** 11