### PR TITLE
Fix lazy rendering on channel home pages

### DIFF
--- a/src/renderer/components/ChannelHome/ChannelHome.vue
+++ b/src/renderer/components/ChannelHome/ChannelHome.vue
@@ -44,6 +44,7 @@
           :data="shelf.content"
           :use-channels-hidden-preference="false"
           :display="shelf.isCommunity ? 'list' : ''"
+          :render-all-items-lazily="index > 2"
         />
       </details>
     </div>

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -8,7 +8,7 @@
       appearance="result"
       :data="result"
       :data-type="dataType || result.type"
-      :first-screen="index < 16"
+      :first-screen="!renderAllItemsLazily && index < 16"
       :layout="displayValue"
       :show-video-with-last-viewed-playlist="showVideoWithLastViewedPlaylist"
       :use-channels-hidden-preference="useChannelsHiddenPreference"
@@ -51,6 +51,10 @@ const props = defineProps({
   dataType: {
     type: String,
     default: null,
+  },
+  renderAllItemsLazily: {
+    type: Boolean,
+    default: false
   },
   display: {
     type: String,


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [x] Performance improvement

## Description

FtElementList renders up to 16 items and lazy loads the rest, as lazy loading something that is already on screen is a bit of an unpleasant experience as it can cause flickering and layout shifts, 16 is not enough when you have FreeTube fullscreened on a big screen and is too much on FreeTubeAndroid on a phone but was picked as a decent middle ground. That works quite well when there is only one FtElementList on screen (subscriptions, playlists, search results, etc) but on channel home pages there is one FtElementList per section and as the sections usually have less than 16 items each, that means we are rendering everything in one go when the user opens the channel home tab.

The system VR channel (`@360` https://www.youtube.com/channel/UCzuqhhs6NWbgTzMuM09WKDQ) is one of, if not the slowest, channels to open in FreeTube, apart from the response itself being slow (seems to be pretty heavy on YouTube's servers too), it also takes an really long time to render in FreeTube once the response has been returned (about 18 seconds on my machine) and the entire window is frozen for that time. It has about 127 sections and with about 12 videos per section, that works out to about 1540 videos to render, that is a lot of DOM elements to create but also lots of number formatting, translations to look up and format, conditional rendering to do, font awesome icons to look up and render. This pull request switches to overriding that auto-render decision only allowing it for the first 2 sections on a channel home page and forcing the rest of them to lazy-render all of their items, which takes the render time for that channel down to less than 2 seconds on my machine. 🥳 It will also help with all other channels that have more than 2 sections, it just won't be as noticable.

## Testing

1. Open the dev tools network panel
2. Open the system VR channel: `@360` (https://www.youtube.com/channel/UCzuqhhs6NWbgTzMuM09WKDQ)
3. Only start counting when the first browse request has actually finished (seems like that channel is pretty heavy on YouTube's servers too).
4. It should appear a lot sooner and the window should become responsive a lot faster too.

## Desktop

- **OS:** Windows
- **OS Version:** 11