### PR TITLE
Build static runtime AppImages with electron-builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,22 +154,6 @@ jobs:
       shell: bash
       run: pnpm run build:arm64
 
-    - name: Convert X64 AppImage to static runtime
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
-      shell: bash
-      env:
-        VERSION: ${{ steps.versionNumber.outputs.version }}
-      run: |
-        sudo apt install desktop-file-utils
-        cd build
-        appimage="FreeTube-${VERSION}.AppImage"
-        wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
-        chmod +x ./"$appimage" ./appimagetool.AppImage
-        ./"$appimage" --appimage-extract && rm -f ./"$appimage"
-        ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
-          -n ./squashfs-root ./"$appimage"
-        rm -rf ./squashfs-root ./appimagetool.AppImage
-
     - name: Upload Linux .zip x64 Artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,15 @@ jobs:
         include:
         - runtime: linux-x64
           os: ubuntu-latest
+          appimage-arch: amd64
 
         - runtime: linux-armv7l
           os: ubuntu-latest
+          appimage-arch: armv7l
 
         - runtime: linux-arm64
           os: ubuntu-latest
+          appimage-arch: arm64
 
         - runtime: osx-x64
           os: macOS-latest
@@ -107,58 +110,24 @@ jobs:
       shell: bash
       run: pnpm run build:arm64
 
-    - name: Convert X64 AppImage to static runtime and add update information
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
+    - name: Add update information to AppImage
+      if: startsWith(matrix.os, 'ubuntu')
       shell: bash
       env:
         VERSION: ${{ steps.getPackageInfo.outputs.version }}
+        APPIMAGE_ARCH: ${{ matrix.appimage-arch }}
       run: |
-        sudo apt install desktop-file-utils
-        cd build
-        appimage="FreeTube-${VERSION}.AppImage"
-        wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
-        chmod +x ./"$appimage" ./appimagetool.AppImage
-        update_information='gh-releases-zsync|FreeTubeApp|FreeTube|latest-all|freetube-*-amd64.AppImage.zsync'
-        ./"$appimage" --appimage-extract && rm -f ./"$appimage"
-        ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
-          -u "$update_information" -n ./squashfs-root ./"$appimage"
-        rm -rf ./squashfs-root ./appimagetool.AppImage
+        update_info="gh-releases-zsync|FreeTubeApp|FreeTube|latest-all|freetube-*-${APPIMAGE_ARCH}.AppImage.zsync"
 
-    - name: Convert ARMv7l AppImage to static runtime and add update information
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
-      shell: bash
-      env:
-        VERSION: ${{ steps.getPackageInfo.outputs.version }}
-      run: |
-        sudo apt install desktop-file-utils
         cd build
-        appimage="FreeTube-${VERSION}-armv7l.AppImage"
-        wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
-        wget "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64" -O runtime
-        chmod +x ./"$appimage" ./appimagetool.AppImage ./runtime
-        update_information='gh-releases-zsync|FreeTubeApp|FreeTube|latest-all|freetube-*-armv7l.AppImage.zsync'
-        TARGET_APPIMAGE="$appimage" ./runtime --appimage-extract && rm -f ./"$appimage"
-        ARCH=armhf ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
-          -u "$update_information" -n ./squashfs-root ./"$appimage"
-        rm -rf ./squashfs-root ./appimagetool.AppImage ./runtime
 
-    - name: Convert ARM64 AppImage to static runtime and add update information
-      if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
-      shell: bash
-      env:
-        VERSION: ${{ steps.getPackageInfo.outputs.version }}
-      run: |
-        sudo apt install desktop-file-utils
-        cd build
-        appimage="FreeTube-${VERSION}-arm64.AppImage"
-        wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -O ./appimagetool.AppImage
-        wget "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64" -O runtime
-        chmod +x ./"$appimage" ./appimagetool.AppImage ./runtime
-        update_information='gh-releases-zsync|FreeTubeApp|FreeTube|latest-all|freetube-*-arm64.AppImage.zsync'
-        TARGET_APPIMAGE="$appimage" ./runtime --appimage-extract && rm -f ./"$appimage"
-        ARCH=aarch64 ./appimagetool.AppImage --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
-          -u "$update_information" -n ./squashfs-root ./"$appimage"
-        rm -rf ./squashfs-root ./appimagetool.AppImage ./runtime
+        section_offset_hex="$(objdump --section-headers ./FreeTube-${VERSION}*.AppImage | awk '$2 == ".upd_info" { printf $6 }')"
+
+        script='const fd = fs.openSync(process.argv[3], "r+"); fs.writeSync(fd, process.argv[2], parseInt(process.argv[1], 16)); fs.closeSync(fd)'
+
+        node -e "$script" $section_offset_hex "$update_info" ./FreeTube-${VERSION}*.AppImage
+
+        zsyncmake -u "freetube-${VERSION}-beta-${APPIMAGE_ARCH}.AppImage" ./FreeTube-${VERSION}*.AppImage
 
     - name: Upload Linux .zip x64 Release
       uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2

--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -73,6 +73,9 @@ export default {
       'libsecret-1-0'
     ]
   },
+  toolsets: {
+    appimage: '1.0.3'
+  },
   mac: {
     category: 'public.app-category.utilities',
     icon: '_icons/iconMac.icns',


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

Currently we build AppImages with the old AppImage runtime with electron-builder, then in a second step we unpack those appimages and recreate them with the static runtime using appimagetool. There are a few issues with that approach firstly recent-ish releases of electron-builder received support for building AppImages with the static runtime itself (will be the default in electron-builder 27), secondly appimagetool doesn't have versionsed releases so we are currently just downloading whichever the latest version is when the workflow runs in the build and release workflows, which is not great for security and lastly it means that if you build FreeTube locally you need to manually perform those extra steps to get a static runtime AppImage of FreeTube.

This pull request switches to telling electron-builder to create static runtime AppImages and removes the extra unpack and rebuild steps. In the release workflow we were also using appimagetool to inject the AppImageUpdate update information, as that is just writing to a specific offset in the binary and calling zsyncmake it didn't seem worth keeping appimagetool just for that, so I replicated it with a few bash commands (find the offset of the `.upd_info` section, open the file, write the info to that offset, close the file, run zsyncmake). Even with doing those steps ourselves in bash it still speeds up the workflow as that only takes 1 second, whereas the previous extra steps averaged around 40 seconds).

Also yes the node eval call is a bit silly but I did try to use `objcopy` and `dd` to write the update information but both resulted in appimageupdatetool saying that the AppImage was corrupted, so I went with that node JavaScript line instead.

## Testing

- Release workflow run before (with appimageupdatetool debugging): https://github.com/absidue/FreeTube/actions/runs/28318560107
- Release workflow run afterwards (with appimageupdatetool debugging): https://github.com/absidue/FreeTube/actions/runs/28326479155
- Build workflow run afterwards: https://github.com/absidue/FreeTube/actions/runs/28327514309

I don't have a Linux machine to test if the AppImage runs correctly (I would assume so but it is probably still worth testing), so if someone with a Linux VM could test the AppImage (just check if it launches) from the linked build workflow that would be very helpful.

## Desktop

- **OS:** Windows
- **OS Version:** 11