### PR TITLE
Add play all button

### DIFF
--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -15,6 +15,8 @@
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+  align-items: baseline;
+  gap: 10px;
   margin-block-end: 10px;
 }
 

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -40,10 +40,10 @@
       />
       <div class="select-container">
         <FtButton
-          v-if="showPlayAllButton"
+          v-if="showViewAllButton"
           style="margin-top: 33px;"
-          :label="$t('Channel.Play All')"
-          @click="router.push(currentTabPlayAllRoute)"
+          :label="$t('Channel.View All')"
+          @click="router.push(currentTabViewAllRoute)"
         />
         <FtSelect
           v-if="showVideoSortBy"
@@ -517,7 +517,7 @@ const tabInfoValues = computed(() => {
   return values
 })
 
-const showPlayAllButton = computed(() => {
+const showViewAllButton = computed(() => {
   switch (currentTab.value) {
     case 'videos': return (videoSortBy.value === 'newest' || videoSortBy.value === 'popular') && (showFetchMoreButton.value || filteredVideos.value.length > 1)
     case 'shorts': return (shortSortBy.value === 'newest' || shortSortBy.value === 'popular') && (showFetchMoreButton.value || filteredShorts.value.length > 1)
@@ -526,7 +526,7 @@ const showPlayAllButton = computed(() => {
   }
 })
 
-const currentTabPlayAllRoute = computed(() => {
+const currentTabViewAllRoute = computed(() => {
   switch (currentTab.value) {
     case 'videos': return `/playlist/${getChannelPlaylistId(id.value, 'videos', videoSortBy.value)}`
     case 'shorts': return `/playlist/${getChannelPlaylistId(id.value, 'shorts', shortSortBy.value)}`

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -39,6 +39,11 @@
         :related-channels="relatedChannels"
       />
       <div class="select-container">
+        <FtButton
+          v-if="showPlayAllButton"
+          :label="$t('Channel.Play All')"
+          @click="router.push(currentTabPlayAllRoute)"
+        />
         <FtSelect
           v-if="showVideoSortBy"
           v-show="currentTab === 'videos' && (showFetchMoreButton || filteredVideos.length > 1)"
@@ -280,6 +285,7 @@ import FtElementList from '../../components/FtElementList/FtElementList.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtLoader from '../../components/FtLoader/FtLoader.vue'
 import FtSelect from '../../components/FtSelect/FtSelect.vue'
+import FtButton from '../../components/FtButton/FtButton.vue'
 
 import store from '../../store/index'
 
@@ -508,6 +514,24 @@ const tabInfoValues = computed(() => {
   }
 
   return values
+})
+
+const showPlayAllButton = computed(() => {
+  switch (currentTab.value) {
+    case 'videos': return (videoSortBy.value === 'newest' || videoSortBy.value === 'popular') && (showFetchMoreButton.value || filteredVideos.value.length > 1)
+    case 'shorts': return (shortSortBy.value === 'newest' || shortSortBy.value === 'popular') && (showFetchMoreButton.value || filteredShorts.value.length > 1)
+    case 'live': return (liveSortBy.value === 'newest' || liveSortBy.value === 'popular') && (showFetchMoreButton.value || filteredLive.value.length > 1)
+    default: return false
+  }
+})
+
+const currentTabPlayAllRoute = computed(() => {
+  switch (currentTab.value) {
+    case 'videos': return `/playlist/${getChannelPlaylistId(id.value, 'videos', videoSortBy.value)}`
+    case 'shorts': return `/playlist/${getChannelPlaylistId(id.value, 'shorts', shortSortBy.value)}`
+    case 'live': return `/playlist/${getChannelPlaylistId(id.value, 'live', liveSortBy.value)}`
+    default: return ''
+  }
 })
 
 watch(route, () => {

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -41,6 +41,7 @@
       <div class="select-container">
         <FtButton
           v-if="showPlayAllButton"
+          style="margin-top: 33px;"
           :label="$t('Channel.Play All')"
           @click="router.push(currentTabPlayAllRoute)"
         />

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -775,6 +775,7 @@ Channel:
   This channel does not allow searching: This channel does not allow searching
   This channel is age-restricted and currently cannot be viewed in FreeTube.: This channel is age-restricted and currently cannot be viewed in FreeTube.
   Channel Tabs: Channel Tabs
+  Play All: Play All
   Videos:
     Videos: Videos
     This channel does not currently have any videos: This channel does not currently

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -775,7 +775,7 @@ Channel:
   This channel does not allow searching: This channel does not allow searching
   This channel is age-restricted and currently cannot be viewed in FreeTube.: This channel is age-restricted and currently cannot be viewed in FreeTube.
   Channel Tabs: Channel Tabs
-  Play All: Play All
+  View All: View All
   Videos:
     Videos: Videos
     This channel does not currently have any videos: This channel does not currently


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #629 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
This PR adds a button to the home tab, videos tab, shorts tab, and live tab of a channel to play all of the respective content based on the sorting selected. It also left justifies the content of the select container.

## Screenshots <!-- If appropriate -->
### Before
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-15-48" src="https://github.com/user-attachments/assets/17513c13-c81b-4895-9526-66ba6a1bbcae" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-15-52" src="https://github.com/user-attachments/assets/e66a179e-22aa-4228-86a8-176ef59691f6" />

### After
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-09" src="https://github.com/user-attachments/assets/52cbb946-0728-4bbe-93e2-21b6759ae680" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-13" src="https://github.com/user-attachments/assets/ec619c86-7590-4df9-a309-d89f7da45b72" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-20" src="https://github.com/user-attachments/assets/f97f1c67-27b5-406e-a18f-1f077ec54487" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-31" src="https://github.com/user-attachments/assets/3f7f363c-af1d-44bf-bfa9-afe261be255a" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-40" src="https://github.com/user-attachments/assets/74ee0bfb-d106-4371-a79a-f2868cc19205" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-46" src="https://github.com/user-attachments/assets/f9507aaf-952b-4a7f-964f-00dfbcc444d3" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-12-56" src="https://github.com/user-attachments/assets/9e21ac50-b5c6-47ca-8587-006c714a401b" />
<img width="2017" height="1029" alt="Grimshot 2026-06-28 13-13-02" src="https://github.com/user-attachments/assets/f7ebf55b-df16-487f-a5d7-cb28e6d9ed2f" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- Requires #9325
- Go to any channel
- Home tab should have a play all button that opens a playlist with all channel content ordered by newest
- Videos, shorts, and live tabs should have a button that works similarly with their respective content and sorting
- The videos, shorts, and live tabs play all button should be hidden when not sorting by newest or most popular as youtube only has playlists for sorting by newest or most popular

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Kernel 7.0.10-zen1-1-zen
- **FreeTube version:** 0.24.1

## Additional context
<!-- Add any other context about the pull request here. -->
