### PR TITLE
`Fetch Feed Automatically` will now auto-fetch each profile's feed once per session, not just the first profile viewed

### DIFF
--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -59,6 +59,8 @@ const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSub
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
 
+const activeProfileId = computed(() => store.getters.getActiveProfile._id)
+
 const cacheEntriesForAllActiveProfileChannels = computed(() => {
   const liveCache = store.getters.getLiveCache
   const entries = []
@@ -140,22 +142,25 @@ function loadVideosFromRemoteFirstPerWindowSometimes() {
 
   alreadyLoadedRemotely = true
   loadVideosForSubscriptionsFromRemote()
-  store.commit('setSubscriptionForLiveStreamsFirstAutoFetchRun')
+  store.commit('setSubscriptionForLiveStreamsFirstAutoFetchRun', activeProfileId.value)
 }
 
 function loadVideosFromCacheSometimes() {
   // Can only load reliably when cache ready
   if (!subscriptionCacheReady.value) { return }
 
-  // This method is called on view visible
-  if (videoCacheForAllActiveProfileChannelsPresent.value) {
-    loadVideosFromCacheForAllActiveProfileChannels()
+  // Check if this profile needs to be auto-fetched for the first time
+  if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForLiveStreamsFirstAutoFetchRun) {
+    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+    alreadyLoadedRemotely = true
+    loadVideosForSubscriptionsFromRemote()
+    store.commit('setSubscriptionForLiveStreamsFirstAutoFetchRun', activeProfileId.value)
     return
   }
 
-  if (fetchSubscriptionsAutomatically.value) {
-    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
-    loadVideosForSubscriptionsFromRemote()
+  // This method is called on view visible
+  if (videoCacheForAllActiveProfileChannelsPresent.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
     return
   }
 

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -151,10 +151,20 @@ function loadVideosFromCacheSometimes() {
 
   // Check if this profile needs to be auto-fetched for the first time
   if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForLiveStreamsFirstAutoFetchRun) {
-    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
     alreadyLoadedRemotely = true
-    loadVideosForSubscriptionsFromRemote()
     store.commit('setSubscriptionForLiveStreamsFirstAutoFetchRun', activeProfileId.value)
+
+    const liveCache = store.getters.getLiveCache
+    const channelsMissingFromCache = activeSubscriptionList.value.filter((channel) => liveCache[channel.id] == null)
+
+    if (channelsMissingFromCache.length === 0) {
+      // Every channel already has a cache entry from another profile this session, nothing to fetch
+      loadVideosFromCacheForAllActiveProfileChannels()
+      return
+    }
+
+    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+    loadVideosForSubscriptionsFromRemote(channelsMissingFromCache)
     return
   }
 
@@ -179,14 +189,13 @@ function loadVideosFromCacheForAllActiveProfileChannels() {
   isLoading.value = false
 }
 
-async function loadVideosForSubscriptionsFromRemote() {
+async function loadVideosForSubscriptionsFromRemote(channelsToLoadFromRemote = activeSubscriptionList.value) {
   if (activeSubscriptionList.value.length === 0) {
     isLoading.value = false
     videoList.value = []
     return
   }
 
-  const channelsToLoadFromRemote = activeSubscriptionList.value
   let channelCount = 0
   isLoading.value = true
 
@@ -245,7 +254,15 @@ async function loadVideosForSubscriptionsFromRemote() {
     return videos ?? []
   }))).flat()
 
-  videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
+  // When only fetching the channels missing from the session cache (e.g. on profile switch),
+  // merge in the already-cached videos for the channels that weren't just fetched
+  const liveCache = store.getters.getLiveCache
+  const fetchedChannelIds = new Set(channelsToLoadFromRemote.map((channel) => channel.id))
+  const cachedVideosForUnfetchedChannels = activeSubscriptionList.value
+    .filter((channel) => !fetchedChannelIds.has(channel.id))
+    .flatMap((channel) => liveCache[channel.id]?.videos ?? [])
+
+  videoList.value = updateVideoListAfterProcessing([...videoListFromRemote, ...cachedVideosForUnfetchedChannels])
   isLoading.value = false
   store.commit('setShowProgressBar', false)
   lastRemoteRefreshSuccessTimestamp.value = Date.now()

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -49,6 +49,8 @@ const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSub
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
 
+const activeProfileId = computed(() => store.getters.getActiveProfile._id)
+
 const cacheEntriesForAllActiveProfileChannels = computed(() => {
   const postsCache = store.getters.getPostsCache
   const entries = []
@@ -130,22 +132,25 @@ function loadPostsFromRemoteFirstPerWindowSometimes() {
 
   alreadyLoadedRemotely = true
   loadPostsForSubscriptionsFromRemote()
-  store.commit('setSubscriptionForPostsFirstAutoFetchRun')
+  store.commit('setSubscriptionForPostsFirstAutoFetchRun', activeProfileId.value)
 }
 
 function loadPostsFromCacheSometimes() {
   // Can only load reliably when cache ready
   if (!subscriptionCacheReady.value) { return }
 
-  // This method is called on view visible
-  if (postCacheForAllActiveProfileChannelsPresent.value) {
-    loadPostsFromCacheForAllActiveProfileChannels()
+  // Check if this profile needs to be auto-fetched for the first time
+  if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForPostsFirstAutoFetchRun) {
+    // `isLoading.value = false` is called inside `loadPostsForSubscriptionsFromRemote` when needed
+    alreadyLoadedRemotely = true
+    loadPostsForSubscriptionsFromRemote()
+    store.commit('setSubscriptionForPostsFirstAutoFetchRun', activeProfileId.value)
     return
   }
 
-  if (fetchSubscriptionsAutomatically.value) {
-    // `isLoading.value = false` is called inside `loadPostsForSubscriptionsFromRemote` when needed
-    loadPostsForSubscriptionsFromRemote()
+  // This method is called on view visible
+  if (postCacheForAllActiveProfileChannelsPresent.value) {
+    loadPostsFromCacheForAllActiveProfileChannels()
     return
   }
 

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -141,10 +141,20 @@ function loadPostsFromCacheSometimes() {
 
   // Check if this profile needs to be auto-fetched for the first time
   if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForPostsFirstAutoFetchRun) {
-    // `isLoading.value = false` is called inside `loadPostsForSubscriptionsFromRemote` when needed
     alreadyLoadedRemotely = true
-    loadPostsForSubscriptionsFromRemote()
     store.commit('setSubscriptionForPostsFirstAutoFetchRun', activeProfileId.value)
+
+    const postsCache = store.getters.getPostsCache
+    const channelsMissingFromCache = activeSubscriptionList.value.filter((channel) => postsCache[channel.id] == null)
+
+    if (channelsMissingFromCache.length === 0) {
+      // Every channel already has a cache entry from another profile this session, nothing to fetch
+      loadPostsFromCacheForAllActiveProfileChannels()
+      return
+    }
+
+    // `isLoading.value = false` is called inside `loadPostsForSubscriptionsFromRemote` when needed
+    loadPostsForSubscriptionsFromRemote(channelsMissingFromCache)
     return
   }
 
@@ -178,14 +188,13 @@ function loadPostsFromCacheForAllActiveProfileChannels() {
   isLoading.value = false
 }
 
-async function loadPostsForSubscriptionsFromRemote() {
+async function loadPostsForSubscriptionsFromRemote(channelsToLoadFromRemote = activeSubscriptionList.value) {
   if (activeSubscriptionList.value.length === 0) {
     isLoading.value = false
     postList.value = []
     return
   }
 
-  const channelsToLoadFromRemote = activeSubscriptionList.value
   let channelCount = 0
   isLoading.value = true
 
@@ -238,11 +247,22 @@ async function loadPostsForSubscriptionsFromRemote() {
     return posts
   }))).flat()
 
-  postListFromRemote.sort((a, b) => {
+  // When only fetching the channels missing from the session cache (e.g. on profile switch),
+  // merge in the already-cached posts for the channels that weren't just fetched
+  const postsCache = store.getters.getPostsCache
+  const fetchedChannelIds = new Set(channelsToLoadFromRemote.map((channel) => channel.id))
+  const cachedPostsForUnfetchedChannels = activeSubscriptionList.value
+    .filter((channel) => !fetchedChannelIds.has(channel.id))
+    .flatMap((channel) => postsCache[channel.id]?.posts ?? [])
+    .filter((post) => !forbiddenTitles.value.some((text) => post.author.toLowerCase().includes(text)))
+
+  const postListMerged = [...postListFromRemote, ...cachedPostsForUnfetchedChannels]
+
+  postListMerged.sort((a, b) => {
     return b.publishedTime - a.publishedTime
   })
 
-  postList.value = postListFromRemote
+  postList.value = postListMerged
   isLoading.value = false
   store.commit('setShowProgressBar', false)
   lastRemoteRefreshSuccessTimestamp.value = Date.now()

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -55,6 +55,8 @@ const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSub
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
 
+const activeProfileId = computed(() => store.getters.getActiveProfile._id)
+
 const cacheEntriesForAllActiveProfileChannels = computed(() => {
   const shortsCache = store.getters.getShortsCache
   const entries = []
@@ -135,22 +137,25 @@ function loadVideosFromRemoteFirstPerWindowSometimes() {
 
   alreadyLoadedRemotely = true
   loadVideosForSubscriptionsFromRemote()
-  store.commit('setSubscriptionForShortsFirstAutoFetchRun')
+  store.commit('setSubscriptionForShortsFirstAutoFetchRun', activeProfileId.value)
 }
 
 function loadVideosFromCacheSometimes() {
   // Can only load reliably when cache ready
   if (!subscriptionCacheReady.value) { return }
 
-  // This method is called on view visible
-  if (videoCacheForAllActiveProfileChannelsPresent.value) {
-    loadVideosFromCacheForAllActiveProfileChannels()
+  // Check if this profile needs to be auto-fetched for the first time
+  if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForShortsFirstAutoFetchRun) {
+    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+    alreadyLoadedRemotely = true
+    loadVideosForSubscriptionsFromRemote()
+    store.commit('setSubscriptionForShortsFirstAutoFetchRun', activeProfileId.value)
     return
   }
 
-  if (fetchSubscriptionsAutomatically.value) {
-    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
-    loadVideosForSubscriptionsFromRemote()
+  // This method is called on view visible
+  if (videoCacheForAllActiveProfileChannelsPresent.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
     return
   }
 

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -146,10 +146,20 @@ function loadVideosFromCacheSometimes() {
 
   // Check if this profile needs to be auto-fetched for the first time
   if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForShortsFirstAutoFetchRun) {
-    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
     alreadyLoadedRemotely = true
-    loadVideosForSubscriptionsFromRemote()
     store.commit('setSubscriptionForShortsFirstAutoFetchRun', activeProfileId.value)
+
+    const shortsCache = store.getters.getShortsCache
+    const channelsMissingFromCache = activeSubscriptionList.value.filter((channel) => shortsCache[channel.id] == null)
+
+    if (channelsMissingFromCache.length === 0) {
+      // Every channel already has a cache entry from another profile this session, nothing to fetch
+      loadVideosFromCacheForAllActiveProfileChannels()
+      return
+    }
+
+    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+    loadVideosForSubscriptionsFromRemote(channelsMissingFromCache)
     return
   }
 
@@ -174,14 +184,13 @@ function loadVideosFromCacheForAllActiveProfileChannels() {
   isLoading.value = false
 }
 
-async function loadVideosForSubscriptionsFromRemote() {
+async function loadVideosForSubscriptionsFromRemote(channelsToLoadFromRemote = activeSubscriptionList.value) {
   if (activeSubscriptionList.value.length === 0) {
     isLoading.value = false
     videoList.value = []
     return
   }
 
-  const channelsToLoadFromRemote = activeSubscriptionList.value
   let channelCount = 0
   isLoading.value = true
   store.commit('setShowProgressBar', true)
@@ -221,7 +230,15 @@ async function loadVideosForSubscriptionsFromRemote() {
     return videos ?? []
   }))).flat()
 
-  videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
+  // When only fetching the channels missing from the session cache (e.g. on profile switch),
+  // merge in the already-cached videos for the channels that weren't just fetched
+  const shortsCache = store.getters.getShortsCache
+  const fetchedChannelIds = new Set(channelsToLoadFromRemote.map((channel) => channel.id))
+  const cachedVideosForUnfetchedChannels = activeSubscriptionList.value
+    .filter((channel) => !fetchedChannelIds.has(channel.id))
+    .flatMap((channel) => shortsCache[channel.id]?.videos ?? [])
+
+  videoList.value = updateVideoListAfterProcessing([...videoListFromRemote, ...cachedVideosForUnfetchedChannels])
   isLoading.value = false
   store.commit('setShowProgressBar', false)
   lastRemoteRefreshSuccessTimestamp.value = Date.now()

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -59,6 +59,8 @@ const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSub
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
 
+const activeProfileId = computed(() => store.getters.getActiveProfile._id)
+
 const cacheEntriesForAllActiveProfileChannels = computed(() => {
   const videoCache = store.getters.getVideoCache
   const entries = []
@@ -139,22 +141,25 @@ function loadVideosFromRemoteFirstPerWindowSometimes() {
 
   alreadyLoadedRemotely = true
   loadVideosForSubscriptionsFromRemote()
-  store.commit('setSubscriptionForVideosFirstAutoFetchRun')
+  store.commit('setSubscriptionForVideosFirstAutoFetchRun', activeProfileId.value)
 }
 
 function loadVideosFromCacheSometimes() {
   // Can only load reliably when cache ready
   if (!subscriptionCacheReady.value) { return }
 
-  // This method is called on view visible
-  if (videoCacheForAllActiveProfileChannelsPresent.value) {
-    loadVideosFromCacheForAllActiveProfileChannels()
+  // Check if this profile needs to be auto-fetched for the first time
+  if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForVideosFirstAutoFetchRun) {
+    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+    alreadyLoadedRemotely = true
+    loadVideosForSubscriptionsFromRemote()
+    store.commit('setSubscriptionForVideosFirstAutoFetchRun', activeProfileId.value)
     return
   }
 
-  if (fetchSubscriptionsAutomatically.value) {
-    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
-    loadVideosForSubscriptionsFromRemote()
+  // This method is called on view visible
+  if (videoCacheForAllActiveProfileChannelsPresent.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
     return
   }
 

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -150,10 +150,20 @@ function loadVideosFromCacheSometimes() {
 
   // Check if this profile needs to be auto-fetched for the first time
   if (fetchSubscriptionsAutomatically.value && !store.getters.getSubscriptionForVideosFirstAutoFetchRun) {
-    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
     alreadyLoadedRemotely = true
-    loadVideosForSubscriptionsFromRemote()
     store.commit('setSubscriptionForVideosFirstAutoFetchRun', activeProfileId.value)
+
+    const videoCache = store.getters.getVideoCache
+    const channelsMissingFromCache = activeSubscriptionList.value.filter((channel) => videoCache[channel.id] == null)
+
+    if (channelsMissingFromCache.length === 0) {
+      // Every channel already has a cache entry from another profile this session, nothing to fetch
+      loadVideosFromCacheForAllActiveProfileChannels()
+      return
+    }
+
+    // `isLoading.value = false` is called inside `loadVideosForSubscriptionsFromRemote` when needed
+    loadVideosForSubscriptionsFromRemote(channelsMissingFromCache)
     return
   }
 
@@ -178,14 +188,13 @@ function loadVideosFromCacheForAllActiveProfileChannels() {
   isLoading.value = false
 }
 
-async function loadVideosForSubscriptionsFromRemote() {
+async function loadVideosForSubscriptionsFromRemote(channelsToLoadFromRemote = activeSubscriptionList.value) {
   if (activeSubscriptionList.value.length === 0) {
     isLoading.value = false
     videoList.value = []
     return
   }
 
-  const channelsToLoadFromRemote = activeSubscriptionList.value
   let channelCount = 0
   isLoading.value = true
 
@@ -244,7 +253,15 @@ async function loadVideosForSubscriptionsFromRemote() {
     return videos ?? []
   }))).flat()
 
-  videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
+  // When only fetching the channels missing from the session cache (e.g. on profile switch),
+  // merge in the already-cached videos for the channels that weren't just fetched
+  const videoCache = store.getters.getVideoCache
+  const fetchedChannelIds = new Set(channelsToLoadFromRemote.map((channel) => channel.id))
+  const cachedVideosForUnfetchedChannels = activeSubscriptionList.value
+    .filter((channel) => !fetchedChannelIds.has(channel.id))
+    .flatMap((channel) => videoCache[channel.id]?.videos ?? [])
+
+  videoList.value = updateVideoListAfterProcessing([...videoListFromRemote, ...cachedVideosForUnfetchedChannels])
   isLoading.value = false
   store.commit('setShowProgressBar', false)
   lastRemoteRefreshSuccessTimestamp.value = Date.now()

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -49,10 +49,10 @@ const state = {
     podcasts: ''
   },
   subscriptionFirstAutoFetchRunData: {
-    videos: false,
-    liveStreams: false,
-    shorts: false,
-    posts: false,
+    videos: new Set(),
+    liveStreams: new Set(),
+    shorts: new Set(),
+    posts: new Set(),
   },
   appTitle: '',
   openPrompts: new Set()
@@ -159,17 +159,21 @@ const getters = {
     return state.lastPopularRefreshTimestamp
   },
 
-  getSubscriptionForVideosFirstAutoFetchRun(state) {
-    return state.subscriptionFirstAutoFetchRunData.videos === true
+  getSubscriptionForVideosFirstAutoFetchRun: (state, getters, rootState, rootGetters) => {
+    const activeProfileId = rootGetters.getActiveProfile._id
+    return state.subscriptionFirstAutoFetchRunData.videos.has(activeProfileId)
   },
-  getSubscriptionForLiveStreamsFirstAutoFetchRun (state) {
-    return state.subscriptionFirstAutoFetchRunData.liveStreams === true
+  getSubscriptionForLiveStreamsFirstAutoFetchRun: (state, getters, rootState, rootGetters) => {
+    const activeProfileId = rootGetters.getActiveProfile._id
+    return state.subscriptionFirstAutoFetchRunData.liveStreams.has(activeProfileId)
   },
-  getSubscriptionForShortsFirstAutoFetchRun (state) {
-    return state.subscriptionFirstAutoFetchRunData.shorts === true
+  getSubscriptionForShortsFirstAutoFetchRun: (state, getters, rootState, rootGetters) => {
+    const activeProfileId = rootGetters.getActiveProfile._id
+    return state.subscriptionFirstAutoFetchRunData.shorts.has(activeProfileId)
   },
-  getSubscriptionForPostsFirstAutoFetchRun (state) {
-    return state.subscriptionFirstAutoFetchRunData.posts === true
+  getSubscriptionForPostsFirstAutoFetchRun: (state, getters, rootState, rootGetters) => {
+    const activeProfileId = rootGetters.getActiveProfile._id
+    return state.subscriptionFirstAutoFetchRunData.posts.has(activeProfileId)
   },
   getAppTitle (state) {
     return state.appTitle
@@ -787,17 +791,17 @@ const mutations = {
     state.openPrompts.delete(id)
   },
 
-  setSubscriptionForVideosFirstAutoFetchRun (state) {
-    state.subscriptionFirstAutoFetchRunData.videos = true
+  setSubscriptionForVideosFirstAutoFetchRun (state, profileId) {
+    state.subscriptionFirstAutoFetchRunData.videos.add(profileId)
   },
-  setSubscriptionForLiveStreamsFirstAutoFetchRun (state) {
-    state.subscriptionFirstAutoFetchRunData.liveStreams = true
+  setSubscriptionForLiveStreamsFirstAutoFetchRun (state, profileId) {
+    state.subscriptionFirstAutoFetchRunData.liveStreams.add(profileId)
   },
-  setSubscriptionForShortsFirstAutoFetchRun (state) {
-    state.subscriptionFirstAutoFetchRunData.shorts = true
+  setSubscriptionForShortsFirstAutoFetchRun (state, profileId) {
+    state.subscriptionFirstAutoFetchRunData.shorts.add(profileId)
   },
-  setSubscriptionForPostsFirstAutoFetchRun (state) {
-    state.subscriptionFirstAutoFetchRunData.posts = true
+  setSubscriptionForPostsFirstAutoFetchRun (state, profileId) {
+    state.subscriptionFirstAutoFetchRunData.posts.add(profileId)
   }
 }
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1085,7 +1085,8 @@ Tooltips:
       method for grabbing your subscription feed. RSS is faster and prevents IP blocking,
       but doesn't provide certain information like video duration, live status or posts
     Fetch Automatically: When enabled, FreeTube will automatically fetch
-      your subscription feed on startup and when a new window is opened.
+      your subscription feed on startup, when a new window is opened, and the
+      first time each profile is viewed in a session.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:


### PR DESCRIPTION
# Pull Request Type

- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Closes #6089, #7262

## Description

The `Fetch Feed Automatically` setting is described as fetching the subscription feed "on startup and when a new window is opened". Since #5743 (first shipped in v0.22.0, which matches the "Last Known Working Version: v0.21.0" in the linked issue), the flag tracking whether the first automatic fetch has already run is a single boolean per window. The consequence: only the profile you view first ever gets an automatic fetch. When you switch to another profile, the flag is already consumed, so that profile silently shows whatever is in the persistent disk cache (which can be days old) and its feed is never automatically fetched at all during that session.

The issue was closed with the reasoning that showing cached results is intended, but I believe that misses what's actually going wrong. This is not about wanting a re-fetch on every profile switch - the problem is that for every profile except the first one, the automatic fetch promised by the setting never happens, not even once. If a profile's feed is never fetched automatically, then `Fetch Feed Automatically` simply isn't doing what its name and tooltip promise for that profile, and it's a regression from v0.21.0 where each profile got one automatic fetch per session.

This PR scopes the "first auto-fetch has run" tracking per profile (a `Set` of profile ids per tab type, instead of a boolean). Each profile now receives exactly one automatic remote fetch per session, the first time its feed is viewed. It deliberately does **not** re-fetch on every switch: returning to an already-fetched profile still shows the session cache, so the caching behaviour is preserved and there are no additional network requests compared to v0.21.0.

The one-time-fetch check was also moved above the cache-presence check in `loadVideosFromCacheSometimes` / `loadPostsFromCacheSometimes`, mirroring what #5743 did for the new-window path - otherwise the persistent disk cache would again take priority over the first automatic fetch.

## Screenshots

N/A - no visual changes.

## Testing

## Testing

1. Create two profiles, A and B, with overlapping subscriptions: A subscribed to channels 1 and 2, B subscribed to channel 1 only.
2. Enable Settings > Subscription Settings > `Fetch Feed Automatically`.
3. Restart FreeTube with profile A active and open the Subscriptions page: channels 1 and 2 are fetched from remote as before.
4. Switch to profile B:

   - Without this PR: the page shows the stale feed from the disk cache and no fetch happens; B's feed is never fetched automatically for the rest of the session.

   - With this PR: B's feed is fetched once, and channel 1 is served from the session cache populated by profile A's fetch rather than being re-fetched from remote.
5. Switch back to profile A, then to profile B again: both load instantly from the session cache - no re-fetching on subsequent switches, and no re-fetching of channel 1 despite the overlap.
6. Repeat on the Shorts, Live and Posts tabs; each tab tracks its first fetch per profile independently, and each avoids re-fetching channels already cached by another profile.
7. As a control, create a third profile C with no overlap with A or B (e.g. channel 3) and switch to it: confirm channel 3 is fetched from remote normally, same as before this PR.