### PR TITLE
Add dependabot groups for actions/cache and github/codeql-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,10 @@ updates:
     labels:
       - "PR: waiting for review"
       - "PR: dependencies"
+    groups:
+      "actions/cache":
+        patterns:
+          - "actions/cache/*"
+      "github/codeql-action":
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- #9364
- #9363

## Description

The `github/codeql-action/*` GitHub Actions need to be updated at the same time as the first action creates files with an embedded version that the second one uses and validates that the version matches, so if they are on different versions they fail as shown in #9364 and #9363. This pull request introduces a dependabot group for them, so they always get updated together, while I was at it I also created a group for the `actions/cache/*` actions as they always get released at the same time.

## Testing

These are standard dependabot groups like we already have for the JavaScript dependencies, so they should just work automatically once they are added.

## Desktop

- **OS:** Windows
- **OS Version:** 11