### PR TITLE
Handle compact published dates e.g. 1w ago in LockupViews

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1533,8 +1533,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
 }
 
 const VIEWS_OR_WATCHING_REGEX = /views?|watching|waiting/i
-const WAITING_REGEX = /waiting/i
-const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[km]?$/i
+const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[bkm]?$/i
 const PREMIERES_TIME_REGEX = /^(premieres|scheduled for) /i
 // Sometimes got `Streamed N (unit) ago`
 const PUBLISH_TIME_REGEX = /^(streamed )?\d+ ?\w+? ago/i
@@ -1546,15 +1545,6 @@ function isViewCountText(text) {
   if (typeof text !== 'string') { return false }
 
   return VIEWS_OR_WATCHING_REGEX.test(text) || VIEWS_IN_NUMBER_ONLY.test(text)
-}
-
-/**
- * @param {string | undefined} text
- */
-function isViewOrWaitingCountText(text) {
-  if (typeof text !== 'string') { return false }
-
-  return WAITING_REGEX.test(text) || isViewCountText(text)
 }
 
 /**
@@ -1688,7 +1678,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
 
       const maybeAuthorText = lockupView.metadata.metadata?.metadata_rows[0].metadata_parts?.[0].text?.text
       let author = channelName
-      if (maybeAuthorText && !isViewOrWaitingCountText(maybeAuthorText) && !isPremieresTimeText(maybeAuthorText)) {
+      if (maybeAuthorText && !isViewCountText(maybeAuthorText) && !isPremieresTimeText(maybeAuthorText)) {
         author = maybeAuthorText
       }
 

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1537,7 +1537,7 @@ const WAITING_REGEX = /waiting/i
 const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[km]?$/i
 const PREMIERES_TIME_REGEX = /^(premieres|scheduled for) /i
 // Sometimes got `Streamed N (unit) ago`
-const PUBLISH_TIME_REGEX = /^(streamed )?\d+ \w+? ago/i
+const PUBLISH_TIME_REGEX = /^(streamed )?\d+ ?\w+? ago/i
 
 /**
  * @param {string | undefined} text


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Description

YouTube is currently A/B testing compact published dates in the up next section e.g. "1 week ago" -> "1w ago". The fix was just making the space in the regex optional.

While I was at it I also removed the `isViewOrWaitingCountText` function which was only used in one place, as that checked for "watching" and then called `isViewCountText` which checked for `watching` and various other things, in favour of just calling `isViewCountText` directly and added `b` for billions in the `VIEWS_IN_NUMBER_ONLY` regex. Those changes seemed minor enough to not be worth sticking in their own pull request.

## Testing

If you are unable to get it on your side after lots of tries, try setting your VPN to France or the Netherlands as it seems to appear more often in those two locations.

## Desktop

- **OS:** Windows
- **OS Version:** 11