### PR TITLE
Use batched fetching instead of forcing RSS with sub count > N

### DIFF
--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -185,14 +185,7 @@ async function loadVideosForSubscriptionsFromRemote() {
   let channelCount = 0
   isLoading.value = true
 
-  let useRss = useRssFeeds.value
-  if (channelsToLoadFromRemote.length >= 125 && !useRss) {
-    showToast(
-      t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
-      10000
-    )
-    useRss = true
-  }
+  const useRss = useRssFeeds.value
 
   store.commit('setShowProgressBar', true)
   store.commit('setProgressBarPercentage', 0)
@@ -200,8 +193,9 @@ async function loadVideosForSubscriptionsFromRemote() {
 
   errorChannels.value = []
   const subscriptionUpdates = []
+  const videoListFromRemote = []
 
-  const videoListFromRemote = (await Promise.all(channelsToLoadFromRemote.map(async (channel) => {
+  const processChannel = async (channel) => {
     let videos, name, thumbnailUrl
 
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
@@ -238,7 +232,25 @@ async function loadVideosForSubscriptionsFromRemote() {
     }
 
     return videos ?? []
-  }))).flat()
+  }
+
+  if (useRss) {
+    const results = await Promise.all(channelsToLoadFromRemote.map(processChannel))
+    videoListFromRemote.push(...results.flat())
+  } else {
+    const CHUNK_SIZE = 80
+    const CHUNK_DELAY_MS = 2000
+
+    for (let i = 0; i < channelsToLoadFromRemote.length; i += CHUNK_SIZE) {
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, CHUNK_DELAY_MS))
+      }
+
+      const chunk = channelsToLoadFromRemote.slice(i, i + CHUNK_SIZE)
+      const chunkResults = await Promise.all(chunk.map(processChannel))
+      videoListFromRemote.push(...chunkResults.flat())
+    }
+  }
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
   isLoading.value = false

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -190,8 +190,9 @@ async function loadPostsForSubscriptionsFromRemote() {
 
   errorChannels.value = []
   const subscriptionUpdates = []
+  const postListFromRemote = []
 
-  const postListFromRemote = (await Promise.all(channelsToLoadFromRemote.map(async (channel) => {
+  const processChannel = async (channel) => {
     let posts
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
       posts = await getChannelPostsInvidious(channel)
@@ -231,7 +232,20 @@ async function loadPostsForSubscriptionsFromRemote() {
 
     posts = posts.filter(post => !forbiddenTitles.value.some(text => post.author.toLowerCase().includes(text)))
     return posts
-  }))).flat()
+  }
+
+  const CHUNK_SIZE = 80
+  const CHUNK_DELAY_MS = 2000
+
+  for (let i = 0; i < channelsToLoadFromRemote.length; i += CHUNK_SIZE) {
+    if (i > 0) {
+      await new Promise(resolve => setTimeout(resolve, CHUNK_DELAY_MS))
+    }
+
+    const chunk = channelsToLoadFromRemote.slice(i, i + CHUNK_SIZE)
+    const chunkResults = await Promise.all(chunk.map(processChannel))
+    postListFromRemote.push(...chunkResults.flat())
+  }
 
   postListFromRemote.sort((a, b) => {
     return b.publishedTime - a.publishedTime

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -184,14 +184,7 @@ async function loadVideosForSubscriptionsFromRemote() {
   let channelCount = 0
   isLoading.value = true
 
-  let useRss = useRssFeeds.value
-  if (channelsToLoadFromRemote.length >= 125 && !useRss) {
-    showToast(
-      t('Subscriptions["This profile has a large number of subscriptions. Forcing RSS to avoid rate limiting"]'),
-      10000
-    )
-    useRss = true
-  }
+  const useRss = useRssFeeds.value
 
   store.commit('setShowProgressBar', true)
   store.commit('setProgressBarPercentage', 0)
@@ -199,8 +192,9 @@ async function loadVideosForSubscriptionsFromRemote() {
 
   errorChannels.value = []
   const subscriptionUpdates = []
+  const videoListFromRemote = []
 
-  const videoListFromRemote = (await Promise.all(channelsToLoadFromRemote.map(async (channel) => {
+  const processChannel = async (channel) => {
     let videos, name, thumbnailUrl
 
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
@@ -237,7 +231,25 @@ async function loadVideosForSubscriptionsFromRemote() {
     }
 
     return videos ?? []
-  }))).flat()
+  }
+
+  if (useRss) {
+    const results = await Promise.all(channelsToLoadFromRemote.map(processChannel))
+    videoListFromRemote.push(...results.flat())
+  } else {
+    const CHUNK_SIZE = 80
+    const CHUNK_DELAY_MS = 2000
+
+    for (let i = 0; i < channelsToLoadFromRemote.length; i += CHUNK_SIZE) {
+      if (i > 0) {
+        await new Promise(resolve => setTimeout(resolve, CHUNK_DELAY_MS))
+      }
+
+      const chunk = channelsToLoadFromRemote.slice(i, i + CHUNK_SIZE)
+      const chunkResults = await Promise.all(chunk.map(processChannel))
+      videoListFromRemote.push(...chunkResults.flat())
+    }
+  }
 
   videoList.value = updateVideoListAfterProcessing(videoListFromRemote)
   isLoading.value = false

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -157,11 +157,6 @@ const hideSubscriptionsCommunity = computed(() => {
   return store.getters.getHideSubscriptionsCommunity
 })
 
-/** @type {import('vue').ComputedRef<any[]>} */
-const activeSubscriptionList = computed(() => {
-  return store.getters.getActiveProfile.subscriptions
-})
-
 /** @type {import('vue').ComputedRef<boolean>} */
 const useRssFeeds = computed(() => {
   return store.getters.getUseRssFeeds
@@ -196,7 +191,7 @@ const visibleTabs = computed(() => {
   }
 
   // community does not support rss
-  if (!hideSubscriptionsCommunity.value && !useRssFeeds.value && activeSubscriptionList.value.length < 125) {
+  if (!hideSubscriptionsCommunity.value && !useRssFeeds.value) {
     tabs.push('community')
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Taken from https://github.com/FreeTubeApp/FreeTube/pull/9157 without the new setting

closes #9157

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Currently FT forces user to use RSS when subscription count within the current profile is > 125
This PR makes FT just fetch videos, live, community posts in batches of 80 regardless (sub count <= 80 = same as before)
No new setting at all, `Posts` tab can be shown now as sub count shouldn't matter

No idea what batch size/timeout should be used, all taken from https://github.com/FreeTubeApp/FreeTube/pull/9157

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Only shows video one, test the rest yourself

https://github.com/user-attachments/assets/9cfe3658-8c4d-42a7-9434-4c8f60382520

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Preparation: get 125+ subscriptions
- Refresh sub in video tab
- Refresh sub in live tab
- Refresh sub in posts tab (the tab should be visible

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
