### PR TITLE
Fix: Duplicates when click spam loading elements in FT (1/3)

### DIFF
--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -230,7 +230,7 @@
           </p>
         </FtFlexBox>
         <FtAutoLoadNextPageWrapper
-          v-if="showFetchMoreButton"
+          v-if="showFetchMoreButton && !isFetchMoreLoading"
           @load-next-page="handleFetchMore"
         >
           <div
@@ -338,6 +338,7 @@ let mayContainContentFromOtherChannels = false
 const isLoading = ref(true)
 const isElementListLoading = ref(false)
 const isSearchTabLoading = ref(false)
+const isFetchMoreLoading = ref(false)
 const currentTab = ref('videos')
 
 const isCurrentTabLoading = computed(() => {
@@ -2225,74 +2226,80 @@ const showFetchMoreButton = computed(() => {
   }
 })
 
-function handleFetchMore() {
+async function handleFetchMore() {
+  if (isFetchMoreLoading.value) return
+
+  isFetchMoreLoading.value = true
+
   switch (currentTab.value) {
     case 'videos':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelVideosLocalMore()
+        await getChannelVideosLocalMore()
       } else {
-        channelInvidiousVideos()
+        await channelInvidiousVideos()
       }
       break
     case 'shorts':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelShortsLocalMore()
+        await getChannelShortsLocalMore()
       } else {
-        channelInvidiousShorts()
+        await channelInvidiousShorts()
       }
       break
     case 'live':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelLiveLocalMore()
+        await getChannelLiveLocalMore()
       } else {
-        channelInvidiousLive()
+        await channelInvidiousLive()
       }
       break
     case 'releases':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelReleasesLocalMore()
+        await getChannelReleasesLocalMore()
       } else {
-        channelInvidiousReleasesMore()
+        await channelInvidiousReleasesMore()
       }
       break
     case 'podcasts':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelPodcastsLocalMore()
+        await getChannelPodcastsLocalMore()
       } else {
-        channelInvidiousPodcastsMore()
+        await channelInvidiousPodcastsMore()
       }
       break
     case 'courses':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelCoursesLocalMore()
+        await getChannelCoursesLocalMore()
       } else {
-        channelInvidiousCoursesMore()
+        await channelInvidiousCoursesMore()
       }
       break
     case 'playlists':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getChannelPlaylistsLocalMore()
+        await getChannelPlaylistsLocalMore()
       } else {
-        getPlaylistsInvidiousMore()
+        await getPlaylistsInvidiousMore()
       }
       break
     case 'search':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        searchChannelLocal()
+        await searchChannelLocal()
       } else {
-        searchChannelInvidious()
+        await searchChannelInvidious()
       }
       break
     case 'community':
       if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
-        getCommunityPostsLocalMore()
+        await getCommunityPostsLocalMore()
       } else {
-        getCommunityPostsInvidious()
+        await getCommunityPostsInvidious()
       }
       break
     default:
       console.error(currentTab.value)
   }
+
+  isFetchMoreLoading.value = false
 }
 
 function changeTab(tab) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
partially addresses https://github.com/FreeTubeApp/FreeTube/issues/3541 (channel tabs)

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
There are no safeguards to prevent multiple queries from being sent simultaneously with the same data, which causes duplicate results to be displayed.

Most components already have `isLoading` bools, but they have side effects on page content. They're designed to detect initial loading rather than any loading state, which is why I opted for a separate variable.

I also chose to hide the button during loading, but we could alternatively disable it with CSS or display a loading icon. It won't make much difference here since the request usually completes too quickly for it to appear, but that won't be the case for the other two fixes.

I considered grouping all three fixes in one MR, but some are more complex and would probably need a separate MR for easier review.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
The following video is recorded with a 2s delay applied to each request.
https://github.com/user-attachments/assets/8fe0b174-2cca-402a-90b4-d63a439d821d

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Testing can be simplified by simulating a slow connection. To do this, simply add `await new Promise((resolve) => setTimeout(resolve, 2000))` to the `Channel#handleFetchMore` method after `isFetchMoreLoading.value = true`

1. Open any channel with enough videos/shorts/playlists to display "Fetch more results"
2. Click very fast on the "Fetch more results" button in any of the tab
3. Check that the button disappears when the results are loading 
4. Check that no duplicated videos/shorts/playlists are shown once loaded

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** 0.24.1-beta