### PR TITLE
Fix Disable Channel Links in Channel Sidenav Menu

### DIFF
--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -152,6 +152,10 @@
   block-size: 1.3em;
 }
 
+.disabledIcon {
+  pointer-events: none;
+}
+
 @media only screen and (width > 680px) {
   ::-webkit-scrollbar {
     inline-size: 10px;

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -186,7 +186,8 @@
         v-if="!hideActiveSubscriptions"
         class="mobileHidden"
       >
-        <router-link
+        <component
+          :is="enableChannelLinks ? 'router-link' : 'span'"
           v-for="channel in activeSubscriptions"
           :key="channel.id"
           :to="`/channel/${channel.id}`"
@@ -219,7 +220,7 @@
           >
             {{ channel.name }}
           </p>
-        </router-link>
+        </component>
       </div>
     </div>
   </FtFlexBox>
@@ -348,6 +349,8 @@ const settingsTitle = computed(() => {
     KeyboardShortcuts.APP.GENERAL.NAVIGATE_TO_SETTINGS
   )
 })
+
+const enableChannelLinks = computed(() => !store.getters.getDisableChannelLinks)
 </script>
 
 <style scoped src="./SideNav.css" />

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -191,6 +191,7 @@
           v-for="channel in activeSubscriptions"
           :key="channel.id"
           :to="`/channel/${channel.id}`"
+          :class="enableChannelLinks ? '' : 'disabledIcon'"
           class="navChannel channelLink mobileHidden"
           :title="channel.name"
           role="button"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -36,7 +36,8 @@
             :key="channel.id"
             class="channel"
           >
-            <router-link
+            <component
+              :is="enableChannelLinks ? 'router-link' : 'span'"
               tabindex="-1"
               class="thumbnailContainer"
               :to="`/channel/${channel.id}`"
@@ -53,15 +54,16 @@
                 class="channelThumbnail"
                 :icon="['fas', 'circle-user']"
               />
-            </router-link>
-            <router-link
+            </component>
+            <component
+              :is="enableChannelLinks ? 'router-link' : 'span'"
               class="channelName"
               dir="auto"
               :title="channel.name"
               :to="`/channel/${channel.id}`"
             >
               {{ channel.name }}
-            </router-link>
+            </component>
             <div
               v-if="!hideUnsubscribeButton"
               class="unsubscribeContainer"
@@ -288,5 +290,8 @@ onMounted(() => {
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', keyboardShortcutHandler)
 })
+
+const enableChannelLinks = computed(() => !store.getters.getDisableChannelLinks)
+
 </script>
 <style scoped src="./SubscribedChannels.css" />


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
relates to #8502

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
These links were missed in the original PR, so this disables them as originally intended

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Go to Settings -> Parental Control -> Enabled "Disable Channel Link on Videos"
Go to Channels sidenav item, see links are disabled for Channel thumbnail and name