### PR TITLE
[Bug]: catppuccinMocha: Color contrast for owner comments is too low

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -309,7 +309,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
   --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --secondary-card-bg-color: #313244;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION


Changes the `--secondary-card-bg-color` for the `catppuccinMocha` theme from `#1e1e2e` (base) to `#313244` (surface0). This provides noticeably better contrast against `--card-bg-color: #181825` (mantle) when used as the owner comment highlight background, while staying within the official Catppuccin palette.

Before: `#1e1e2e` on `#181825` → 1.07:1 contrast ratio
After: `#313244` on `#181825` → improved contrast