### PR TITLE
[Bug]: In some languages, an extra scrollbar appears in the settings

### DIFF
--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -3,6 +3,10 @@
   gap: 20px;
 }
 
+.settingsContent {
+  min-inline-size: 0;
+}
+
 .settingsSections,
 .switchRow {
   overflow-x: hidden;


### PR DESCRIPTION


The `.settingsContent` flex item lacked `min-inline-size: 0`, which prevented it from shrinking below the intrinsic width of its children. In languages with long words (German, Turkish, etc.), the flex item stayed wide and caused an extra scrollbar.

Adding `min-inline-size: 0` to `.settingsContent` allows it to shrink properly within the flex layout, matching the available viewport width.