### PR TITLE
[Bug]: Avoid collision of "desriptions" with pulldown menues

### DIFF
--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -93,6 +93,10 @@
   column-gap: 6px;
   inset-inline-start: 0;
   inset-block-start: 10px;
+  inline-size: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   transition: 0.2s ease all;
   color: var(--tertiary-text-color);
 }


### PR DESCRIPTION


The `.select-label` element inside `FtSelect` is absolutely positioned without a width constraint. When the label text is long (common in German, Greek, Croatian, Hungarian, etc.), it overflows the 200px select container and collides with adjacent UI elements.

Adding `inline-size: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` constrains the label to the select container's width and truncates overflow with an ellipsis, preventing visual collision.