### PR TITLE
Fix: Screenshot in 'Save to Folder' mode isn't working

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -68,11 +68,11 @@ async function restartElectron() {
 
   electronProcess = spawn(electron, [
     path.join(__dirname, '../dist/main.js'),
-    '--enable-logging', // Enable to show logs from all electron processes
+    // '--enable-logging', // Enable to show logs from all electron processes
     remoteDebugging ? '--inspect=9222' : '',
     remoteDebugging ? '--remote-debugging-port=9223' : ''
   ],
-  { stdio: 'inherit' } // required for logs to actually appear in the stdout
+    // { stdio: 'inherit' } // required for logs to actually appear in the stdout
   )
 
   electronProcess.on('exit', (code, _) => {

--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -68,11 +68,11 @@ async function restartElectron() {
 
   electronProcess = spawn(electron, [
     path.join(__dirname, '../dist/main.js'),
-    // '--enable-logging', // Enable to show logs from all electron processes
+    '--enable-logging', // Enable to show logs from all electron processes
     remoteDebugging ? '--inspect=9222' : '',
     remoteDebugging ? '--remote-debugging-port=9223' : ''
   ],
-    // { stdio: 'inherit' } // required for logs to actually appear in the stdout
+  { stdio: 'inherit' } // required for logs to actually appear in the stdout
   )
 
   electronProcess.on('exit', (code, _) => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1446,7 +1446,8 @@ function runApp() {
     const filePath = path.resolve(directory, filename)
 
     // Ensure that we are only writing inside of the expected directory
-    if (path.dirname(filePath) !== directory) {
+    // 'path.dirname' does not return trailing slash, remove it from 'directory' path to ensure consistent comparison
+    if (path.dirname(filePath) !== directory.replace(/\/$/, '')) {
       throw new Error('Invalid save location')
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9337

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
On Linux at least, `index#chooseDefaultFolder` returns a directory path with a trailing slash, however `path.dirname` does not.
When doing the safe check to ensure both path are the same, the additional trailing slash causes the test to fail. 

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
For any OS:
1. Go to Settings and enable Screenshot
2. Change 'Screenshot Mode' dropdown to 'Save to Folder'
3. Play any video and try to take a screenshot
4. Check that the screenshot is correctly saved

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** 0.24.1-beta