### PR TITLE
Explicitly configure ad-hoc codesigning after electron-builder changes

### DIFF
--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -96,7 +96,12 @@ export default {
       NSBluetoothPeripheralUsageDescription: undefined,
       NSCameraUsageDescription: undefined,
       NSMicrophoneUsageDescription: undefined,
-    }
+    },
+
+    // Enable ad-hoc signing
+    // If we skip signing entirely, macOS says that the application is damaged, which makes users open bug reports.
+    // With an ad-hoc signature it still refuses to launch by default but with the reason that it cannot verify the signature
+    identity: '-'
   },
   win: {
     icon: '_icons/icon.ico',


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- #9428
- Comments on #9425

## Description

For a while electron-builder was ad-hoc signing by default when no code signing identity was provided but in version [26.15.0](https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.15.0) (PR: https://github.com/electron-userland/electron-builder/pull/9822) they stopped doing that and made it an opt-in thing. Without the ad-hoc codesigning macOS refuses to launch saying that the app is broken, with the ad-hoc code signing it still refuses to launch by default but it only complains about not being able to verify the signature which is a lot less alarming to users and easier to bypass (checking boxes in settings GUIs instead of having to remove the quarantine attribute with a command).

The difference in the dialogs that macOS shows can be seen here: https://github.com/electron-userland/electron-builder/pull/9007

## Testing

Test build here: https://github.com/absidue/FreeTube/actions/runs/29598510452

As I don't have a macOS machine I haven't been able to test it myself but looking at the code changes on the electron-builder side, this should be enough to get us back to how it was before.

## Desktop

- **OS:** Windows
- **OS Version:** 11