### PR TITLE
Remove unused GITHUB_TOKEN permissions from the auto-merge workflow

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -13,9 +13,6 @@ jobs:
       (contains(github.event.pull_request.base.ref, 'development') || contains(github.event.pull_request.base.ref, 'RC'))
     runs-on: ubuntu-slim
 
-    permissions:
-      contents: write
-
     steps:
     - name: Auto Merge PR
       shell: bash


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Description

This workflow doesn't use the GITHUB_TOKEN token so it doesn't need any permissions on that token (we already remove all permissions from it at the top of the file `permissions: {}`).

## Testing

Doesn't really need testing as this is just a clean up.