### PR TITLE
Add move to top/bottom to playlist

### DIFF
--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -131,7 +131,16 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
+const emit = defineEmits([
+  'move-dragged-video',
+  'move-video-down',
+  'move-video-up',
+  'move-video-to-the-top',
+  'move-video-to-the-bottom',
+  'remove-from-playlist',
+  'drag-video',
+  'drag-video-end'
+])
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const listType = computed(() => {

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -31,6 +31,8 @@
       @drag-video-end="afterDrag"
       @move-video-up="moveVideoUp"
       @move-video-down="moveVideoDown"
+      @move-video-to-the-top="moveVideoToTheTop"
+      @move-video-to-the-bottom="moveVideoToTheBottom"
       @remove-from-playlist="removeFromPlaylist"
     />
   </FtAutoGrid>
@@ -129,7 +131,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
+const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const listType = computed(() => {
@@ -155,6 +157,22 @@ function moveVideoUp(videoId, playlistItemId) {
  */
 function moveVideoDown(videoId, playlistItemId) {
   emit('move-video-down', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheTop(videoId, playlistItemId) {
+  emit('move-video-to-the-top', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheBottom(videoId, playlistItemId) {
+  emit('move-video-to-the-bottom', videoId, playlistItemId)
 }
 
 /**

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -33,6 +33,8 @@
         :show-grab-bar="isDraggable && layout === 'grid'"
         @move-video-up="moveVideoUp"
         @move-video-down="moveVideoDown"
+        @move-video-to-the-top="moveVideoToTheTop"
+        @move-video-to-the-bottom="moveVideoToTheBottom"
         @remove-from-playlist="removeFromPlaylist"
       />
       <FtListChannel
@@ -162,7 +164,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
+const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
 
 const inUserPlaylist = props.playlistType === 'user'
 const isDraggable = computed(() => inUserPlaylist && props.isSortOrderCustom && (props.canMoveVideoUp || props.canMoveVideoDown))
@@ -326,6 +328,22 @@ function moveVideoUp(videoId, playlistItemId) {
  */
 function moveVideoDown(videoId, playlistItemId) {
   emit('move-video-down', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheTop(videoId, playlistItemId) {
+  emit('move-video-to-the-top', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheBottom(videoId, playlistItemId) {
+  emit('move-video-to-the-bottom', videoId, playlistItemId)
 }
 
 /**

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -164,7 +164,16 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
+const emit = defineEmits([
+  'move-dragged-video',
+  'move-video-down',
+  'move-video-up',
+  'move-video-to-the-top',
+  'move-video-to-the-bottom',
+  'remove-from-playlist',
+  'drag-video',
+  'drag-video-end'
+])
 
 const inUserPlaylist = props.playlistType === 'user'
 const isDraggable = computed(() => inUserPlaylist && props.isSortOrderCustom && (props.canMoveVideoUp || props.canMoveVideoDown))

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -373,7 +373,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['move-video-down', 'move-video-up', 'pause-player', 'remove-from-playlist'])
+const emit = defineEmits(['move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'pause-player', 'remove-from-playlist'])
 
 const { locale, t } = useI18n()
 const route = useRoute()
@@ -486,8 +486,25 @@ const dropdownOptions = computed(() => {
         ? t('Video.Remove From History')
         : t('Video.Mark As Watched'),
       value: 'history'
-    }
+    },
   ]
+  if (inUserPlaylist.value && (props.canMoveVideoUp || props.canMoveVideoDown)) {
+    options.push({
+      type: 'divider'
+    })
+  }
+  if (props.canMoveVideoUp && inUserPlaylist.value) {
+    options.push({
+      label: t('User Playlists.Move Video to the Top'),
+      value: 'moveVideoTop'
+    })
+  }
+  if (props.canMoveVideoDown && inUserPlaylist.value) {
+    options.push({
+      label: t('User Playlists.Move Video to the Bottom'),
+      value: 'moveVideoBottom'
+    })
+  }
   if (!hideSharingActions.value) {
     options.push(
       {
@@ -613,6 +630,12 @@ function handleOptionsClick(option) {
       } else {
         markAsWatched()
       }
+      break
+    case 'moveVideoTop':
+      moveVideoToTheTop()
+      break
+    case 'moveVideoBottom':
+      moveVideoToTheBottom()
       break
     case 'copyYoutube': {
       let videoUrl = `https://youtu.be/${id.value}`
@@ -1052,6 +1075,14 @@ function removeFromWatched() {
   store.dispatch('removeFromHistory', id.value)
 
   showToast(t('Video.Video has been removed from your history'))
+}
+
+function moveVideoToTheTop() {
+  emit('move-video-to-the-top', id.value, props.playlistItemId)
+}
+
+function moveVideoToTheBottom() {
+  emit('move-video-to-the-bottom', id.value, props.playlistItemId)
 }
 
 function togglePlaylistPrompt() {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -373,7 +373,14 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'pause-player', 'remove-from-playlist'])
+const emit = defineEmits([
+  'move-video-down',
+  'move-video-up',
+  'move-video-to-the-top',
+  'move-video-to-the-bottom',
+  'pause-player',
+  'remove-from-playlist'
+])
 
 const { locale, t } = useI18n()
 const route = useRoute()
@@ -488,22 +495,24 @@ const dropdownOptions = computed(() => {
       value: 'history'
     },
   ]
-  if (inUserPlaylist.value && (props.canMoveVideoUp || props.canMoveVideoDown)) {
-    options.push({
-      type: 'divider'
-    })
-  }
-  if (props.canMoveVideoUp && inUserPlaylist.value) {
-    options.push({
-      label: t('User Playlists.Move Video to the Top'),
-      value: 'moveVideoTop'
-    })
-  }
-  if (props.canMoveVideoDown && inUserPlaylist.value) {
-    options.push({
-      label: t('User Playlists.Move Video to the Bottom'),
-      value: 'moveVideoBottom'
-    })
+  if (inUserPlaylist.value) {
+    if (props.canMoveVideoUp || props.canMoveVideoDown) {
+      options.push({
+        type: 'divider'
+      })
+    }
+    if (props.canMoveVideoUp) {
+      options.push({
+        label: t('User Playlists.Move Video to the Top'),
+        value: 'moveVideoTop'
+      })
+    }
+    if (props.canMoveVideoDown) {
+      options.push({
+        label: t('User Playlists.Move Video to the Bottom'),
+        value: 'moveVideoBottom'
+      })
+    }
   }
   if (!hideSharingActions.value) {
     options.push(

--- a/src/renderer/components/FtListVideoLazy.vue
+++ b/src/renderer/components/FtListVideoLazy.vue
@@ -160,7 +160,14 @@ function onVisibilityChanged(isVisible) {
   }
 }
 
-const emit = defineEmits(['pause-player', 'move-video-up', 'move-video-down', 'move-video-to-the-top', 'move-video-to-the-bottom', 'remove-from-playlist'])
+const emit = defineEmits([
+  'pause-player',
+  'move-video-up',
+  'move-video-down',
+  'move-video-to-the-top',
+  'move-video-to-the-bottom',
+  'remove-from-playlist'
+])
 
 function pausePlayer() {
   emit('pause-player')

--- a/src/renderer/components/FtListVideoLazy.vue
+++ b/src/renderer/components/FtListVideoLazy.vue
@@ -22,6 +22,8 @@
       :can-move-video-up="canMoveVideoUp"
       :can-move-video-down="canMoveVideoDown"
       :can-remove-from-playlist="canRemoveFromPlaylist"
+      @move-video-to-the-top="moveVideoToTheTop"
+      @move-video-to-the-bottom="moveVideoToTheBottom"
       @pause-player="pausePlayer"
       @move-video-up="moveVideoUp"
       @move-video-down="moveVideoDown"
@@ -158,10 +160,26 @@ function onVisibilityChanged(isVisible) {
   }
 }
 
-const emit = defineEmits(['pause-player', 'move-video-up', 'move-video-down', 'remove-from-playlist'])
+const emit = defineEmits(['pause-player', 'move-video-up', 'move-video-down', 'move-video-to-the-top', 'move-video-to-the-bottom', 'remove-from-playlist'])
 
 function pausePlayer() {
   emit('pause-player')
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheTop(videoId, playlistItemId) {
+  emit('move-video-to-the-top', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheBottom(videoId, playlistItemId) {
+  emit('move-video-to-the-bottom', videoId, playlistItemId)
 }
 
 /**

--- a/src/renderer/components/FtListVideoNumbered/FtListVideoNumbered.vue
+++ b/src/renderer/components/FtListVideoNumbered/FtListVideoNumbered.vue
@@ -157,7 +157,17 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'pause-player', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
+const emit = defineEmits([
+  'move-dragged-video',
+  'move-video-down',
+  'move-video-up',
+  'move-video-to-the-top',
+  'move-video-to-the-bottom',
+  'pause-player',
+  'remove-from-playlist',
+  'drag-video',
+  'drag-video-end'
+])
 const visible = ref(props.initialVisibleState)
 
 const inUserPlaylist = props.playlistType === 'user'

--- a/src/renderer/components/FtListVideoNumbered/FtListVideoNumbered.vue
+++ b/src/renderer/components/FtListVideoNumbered/FtListVideoNumbered.vue
@@ -58,6 +58,8 @@
         @pause-player="pausePlayer"
         @move-video-up="moveVideoUp"
         @move-video-down="moveVideoDown"
+        @move-video-to-the-top="moveVideoToTheTop"
+        @move-video-to-the-bottom="moveVideoToTheBottom"
         @remove-from-playlist="removeFromPlaylist"
       />
     </template>
@@ -155,7 +157,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'pause-player', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
+const emit = defineEmits(['move-dragged-video', 'move-video-down', 'move-video-up', 'move-video-to-the-top', 'move-video-to-the-bottom', 'pause-player', 'remove-from-playlist', 'drag-video', 'drag-video-end'])
 const visible = ref(props.initialVisibleState)
 
 const inUserPlaylist = props.playlistType === 'user'
@@ -215,6 +217,22 @@ function moveVideoUp(videoId, playlistItemId) {
  */
 function moveVideoDown(videoId, playlistItemId) {
   emit('move-video-down', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheTop(videoId, playlistItemId) {
+  emit('move-video-to-the-top', videoId, playlistItemId)
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheBottom(videoId, playlistItemId) {
+  emit('move-video-to-the-bottom', videoId, playlistItemId)
 }
 
 function onDragVideo(event) {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -801,7 +801,7 @@ function moveVideoToTheTop(videoId, playlistItemId) {
   }
 
   if (index === 0) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved to the top."]'))
+    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved up."]'))
     return
   }
 
@@ -842,7 +842,7 @@ function moveVideoToTheBottom(videoId, playlistItemId) {
   }
 
   if (index === playlistItems_.length - 1) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved to the bottom."]'))
+    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved down."]'))
     return
   }
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -96,6 +96,8 @@
             @move-dragged-video="moveDraggedVideoTemporarilyThrottled"
             @move-video-up="moveVideoUp"
             @move-video-down="moveVideoDown"
+            @move-video-to-the-top="moveVideoToTheTop"
+            @move-video-to-the-bottom="moveVideoToTheBottom"
             @remove-from-playlist="removeVideoFromPlaylist"
           />
           <TransitionGroup
@@ -129,6 +131,8 @@
               @move-dragged-video="moveDraggedVideoTemporarilyThrottled"
               @move-video-up="moveVideoUp"
               @move-video-down="moveVideoDown"
+              @move-video-to-the-top="moveVideoToTheTop"
+              @move-video-to-the-bottom="moveVideoToTheBottom"
               @remove-from-playlist="removeVideoFromPlaylist"
             />
           </TransitionGroup>
@@ -714,6 +718,10 @@ function moveVideoUp(videoId, playlistItemId) {
     return video.videoId === videoId && video.playlistItemId === playlistItemId
   })
 
+  if (index === -1) {
+    return
+  }
+
   if (index === 0) {
     showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved up."]'))
     return
@@ -749,12 +757,98 @@ function moveVideoDown(videoId, playlistItemId) {
     return video.videoId === videoId && video.playlistItemId === playlistItemId
   })
 
+  if (index === -1) {
+    return
+  }
+
   if (index + 1 >= playlistItems_.length) {
     showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved down."]'))
     return
   }
 
   [playlistItems_[index], playlistItems_[index + 1]] = [playlistItems_[index + 1], playlistItems_[index]]
+
+  const playlist = {
+    playlistName: playlistTitle.value,
+    protected: selectedUserPlaylist.value.protected,
+    description: playlistDescription.value,
+    videos: deepCopy(playlistItems_),
+    _id: playlistId.value
+  }
+
+  try {
+    store.dispatch('updatePlaylist', playlist)
+    playlistItems.value = playlistItems_
+  } catch (e) {
+    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    console.error(e)
+  }
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheTop(videoId, playlistItemId) {
+  const playlistItems_ = playlistItems.value.slice()
+
+  const index = playlistItems_.findIndex((video) => {
+    return video.videoId === videoId && video.playlistItemId === playlistItemId
+  })
+
+  if (index === -1) {
+    return
+  }
+
+  if (index === 0) {
+    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved to the top."]'))
+    return
+  }
+
+  const videoObject = playlistItems_[index]
+  playlistItems_.splice(index, 1)
+  playlistItems_.unshift(videoObject)
+
+  const playlist = {
+    playlistName: playlistTitle.value,
+    protected: selectedUserPlaylist.value.protected,
+    description: playlistDescription.value,
+    videos: deepCopy(playlistItems_),
+    _id: playlistId.value
+  }
+
+  try {
+    store.dispatch('updatePlaylist', playlist)
+    playlistItems.value = playlistItems_
+  } catch (e) {
+    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    console.error(e)
+  }
+}
+
+/**
+ * @param {string} videoId
+ * @param {string} playlistItemId
+ */
+function moveVideoToTheBottom(videoId, playlistItemId) {
+  const playlistItems_ = playlistItems.value.slice()
+
+  const index = playlistItems_.findIndex((video) => {
+    return video.videoId === videoId && video.playlistItemId === playlistItemId
+  })
+
+  if (index === -1) {
+    return
+  }
+
+  if (index === playlistItems_.length - 1) {
+    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved to the bottom."]'))
+    return
+  }
+
+  const videoObject = playlistItems_[index]
+  playlistItems_.splice(index, 1)
+  playlistItems_.push(videoObject)
 
   const playlist = {
     playlistName: playlistTitle.value,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -164,6 +164,8 @@ User Playlists:
   Add to Favorites: Add to {playlistName}
   Remove from Favorites: Remove from {playlistName}
 
+  Move Video to the Top: Move Video to the Top
+  Move Video to the Bottom: Move Video to the Bottom
   Move Video Up: Move Video Up
   Move Video Down: Move Video Down
   Remove from Playlist: Remove from Playlist
@@ -208,6 +210,8 @@ User Playlists:
     Toast:
       This video cannot be moved up.: This video cannot be moved up.
       This video cannot be moved down.: This video cannot be moved down.
+      This video cannot be moved to the top.: This video cannot be moved to the top.
+      This video cannot be moved to the bottom.: This video cannot be moved to the bottom.
       Video has been removed: Video has been removed
       Video has been removed. Click here to undo.: Video has been removed. Click here to undo.
       There was a problem with removing this video: There was a problem with removing this video

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -210,8 +210,6 @@ User Playlists:
     Toast:
       This video cannot be moved up.: This video cannot be moved up.
       This video cannot be moved down.: This video cannot be moved down.
-      This video cannot be moved to the top.: This video cannot be moved to the top.
-      This video cannot be moved to the bottom.: This video cannot be moved to the bottom.
       Video has been removed: Video has been removed
       Video has been removed. Click here to undo.: Video has been removed. Click here to undo.
       There was a problem with removing this video: There was a problem with removing this video


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
closes #4603 

## Description
This PR introduces an option to move videos to the top or to the bottom of a playlist when the sorting is set to Custom.

## Screenshots

https://github.com/user-attachments/assets/257aed77-5d04-4146-bbe8-10c8e4be3326


## Testing

1. Open a saved playlist from the playlists tab
2. Set sorting type to Custom
3. Click on the three dots
4. Click on Move video to the top or Move video to the bottom

## Desktop

- **OS:** MacOS
- **OS Version:** 26
- **FreeTube version:** v0.25.0 Beta