### PR TITLE
Change: Add information about current/default invidious instance

### DIFF
--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1059,7 +1059,7 @@ Tooltips:
     Thumbnail Preference: All thumbnails throughout FreeTube will be replaced with
       a frame of the video, blurred or hidden instead of the default thumbnail.
     Invidious Instance: The Invidious instance that FreeTube will connect to for API
-      calls.
+      calls. This setting applies to the current window only, other windows use the default instance.
     Region for Trending: The region of trends allows you to pick which country's trending
       videos you want to have displayed.
     External Link Handling: |

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1059,7 +1059,7 @@ Tooltips:
     Thumbnail Preference: All thumbnails throughout FreeTube will be replaced with
       a frame of the video, blurred or hidden instead of the default thumbnail.
     Invidious Instance: The Invidious instance that FreeTube will connect to for API
-      calls. Changes to this setting apply to the current window only, unless set as default.
+      calls. Changes to this setting apply only to the current window unless you set this instance as the default.
     Region for Trending: The region of trends allows you to pick which country's trending
       videos you want to have displayed.
     External Link Handling: |

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1059,7 +1059,7 @@ Tooltips:
     Thumbnail Preference: All thumbnails throughout FreeTube will be replaced with
       a frame of the video, blurred or hidden instead of the default thumbnail.
     Invidious Instance: The Invidious instance that FreeTube will connect to for API
-      calls. This setting applies to the current window only, other windows use the default instance.
+      calls. Changes to this setting apply to the current window only, unless set as default.
     Region for Trending: The region of trends allows you to pick which country's trending
       videos you want to have displayed.
     External Link Handling: |


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [X] Other

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I've been confused about the difference between the current Invidious instance and the default one for a while.
I'm proposing to clarify this distinction in the tooltip.

I may be the only one confused about this, and it may not be worth adding it. In this case, feel free to close this MR!

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="778" height="235" alt="image" src="https://github.com/user-attachments/assets/c65a4615-6c0f-405f-98ab-2ce058e13051" />
