### PR TITLE
Fix: occasional error with age-restricted videos

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1625,7 +1625,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       if (thumbnailBottomOverlayView) {
         if (thumbnailBottomOverlayView.badges.some(badge => badge.badge_style === 'THUMBNAIL_OVERLAY_BADGE_STYLE_LIVE')) {
           liveNow = true
-        } else if (thumbnailBottomOverlayView.badges.some(badge => badge.text.toLowerCase() === 'upcoming')) {
+        } else if (thumbnailBottomOverlayView.badges.some(badge => badge.text?.toLowerCase() === 'upcoming')) {
           isUpcoming = true
 
           for (const row of lockupView.metadata.metadata.metadata_rows) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I've had a hard time reproducing this issue to investigate. 
From time to time I was getting `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` while refreshing my subscription feed.
It seems that videos with an age restriction can have a badge with no text:
```
{
    "type": "ThumbnailBottomOverlayView",
    "progress_bar": null,
    "badges": [
        {
            "type": "ThumbnailBadgeView",
            "text": "0:37",
            "badge_style": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT"
        },
        {
            "type": "ThumbnailBadgeView",
            "icon_name": "PLAY_DISABLED",
            "badge_style": "THUMBNAIL_OVERLAY_BADGE_STYLE_DEFAULT"
        }
    ]
}
```
However, I've tried subscribing to the only channel containing this video and spamming refresh, I can't consistently reproduce.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Low reproduction rate but:
1. Subscribe to a channel with an age restricted video
2. Refresh subscriptions videos several times
3. Observe that no TypeError occurres

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** 0.25.0-beta