### PR TITLE
Update release workflow to use GH CLI instead of deprecated action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ name: Upload Release
 on:
   workflow_dispatch:
     inputs:
-      releaseId:
+      tag:
         type: string
         required: true
-        description: Release ID
+        description: Tag
 
 permissions: {}
 
@@ -130,355 +130,259 @@ jobs:
         zsyncmake -u "freetube-${VERSION}-beta-${APPIMAGE_ARCH}.AppImage" ./FreeTube-${VERSION}*.AppImage
 
     - name: Upload Linux .zip x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-x64-portable.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-x64-portable.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-x64-portable.zip"
 
     - name: Upload Linux .7z x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-x64-portable.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-x64-portable.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-x64-portable.7z"
 
     - name: Upload Linux .zip ARMv7l Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-armv7l-portable.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-armv7l-portable.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-armv7l-portable.zip"
 
     - name: Upload Linux .7z ARMv7l Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-armv7l-portable.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-armv7l.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-armv7l-portable.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-armv7l-portable.7z"
 
     - name: Upload Linux .zip ARM64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-arm64-portable.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-arm64-portable.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-arm64-portable.zip"
 
     - name: Upload Linux .7z ARM64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-arm64-portable.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-arm64-portable.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-linux-arm64-portable.7z"
 
     - name: Upload Linux .deb x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_beta_amd64.deb
-        asset_path: build/freetube_${{ steps.getPackageInfo.outputs.version }}_amd64.deb
-        asset_content_type: application/vnd.debian.binary-package
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube_${{ steps.getPackageInfo.outputs.version }}_amd64.deb" -Destination "freetube_${{ steps.getPackageInfo.outputs.version }}_beta_amd64.deb" && gh release upload "${{ inputs.tag }}" "freetube_${{ steps.getPackageInfo.outputs.version }}_beta_amd64.deb"
 
     - name: Upload Linux .deb ARMv7l Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_beta_armv7l.deb
-        asset_path: build/freetube_${{ steps.getPackageInfo.outputs.version }}_armv7l.deb
-        asset_content_type: application/vnd.debian.binary-package
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube_${{ steps.getPackageInfo.outputs.version }}_armv7l.deb" -Destination "freetube_${{ steps.getPackageInfo.outputs.version }}_beta_armv7l.deb" && gh release upload "${{ inputs.tag }}" "freetube_${{ steps.getPackageInfo.outputs.version }}_beta_armv7l.deb"
 
     - name: Upload Linux .deb ARM64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube_${{ steps.getPackageInfo.outputs.version }}_beta_arm64.deb
-        asset_path: build/freetube_${{ steps.getPackageInfo.outputs.version }}_arm64.deb
-        asset_content_type: application/vnd.debian.binary-package
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube_${{ steps.getPackageInfo.outputs.version }}_arm64.deb" -Destination "freetube_${{ steps.getPackageInfo.outputs.version }}_beta_arm64.deb" && gh release upload "${{ inputs.tag }}" "freetube_${{ steps.getPackageInfo.outputs.version }}_beta_arm64.deb"
 
     - name: Upload AppImage x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage
-        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage
-        asset_content_type: application/vnd.appimage
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage"
 
     - name: Upload AppImage .zsync x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage.zsync
-        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage.zsync
-        asset_content_type: application/x-zsync
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube-${{ steps.getPackageInfo.outputs.version }}.AppImage.zsync" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage.zsync" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage.zsync"
 
     - name: Upload AppImage ARMv7l Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-armv7l.AppImage
-        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-armv7l.AppImage
-        asset_content_type: application/vnd.appimage
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-armv7l.AppImage" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-armv7l.AppImage" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-armv7l.AppImage"
 
     - name: Upload AppImage .zsync ARMv7l Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-armv7l.AppImage.zsync
-        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-armv7l.AppImage.zsync
-        asset_content_type: application/x-zsync
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-armv7l.AppImage.zsync" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-armv7l.AppImage.zsync" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-armv7l.AppImage.zsync"
 
     - name: Upload AppImage ARM64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage
-        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage
-        asset_content_type: application/vnd.appimage
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage"
 
     - name: Upload AppImage .zsync ARM64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage.zsync
-        asset_path: build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage.zsync
-        asset_content_type: application/x-zsync
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage.zsync" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage.zsync" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage.zsync"
 
     - name: Upload Linux .rpm x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta.amd64.rpm
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.x86_64.rpm
-        asset_content_type: application/x-rpm
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}.x86_64.rpm" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta.amd64.rpm" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta.amd64.rpm"
 
       # rpm are not built for armv7l
 
     - name: Upload Linux .rpm ARM64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta.arm64.rpm
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.aarch64.rpm
-        asset_content_type: application/x-rpm
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}.aarch64.rpm" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta.arm64.rpm" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta.arm64.rpm"
 
     - name: Upload Pacman .pacman x64 Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.pacman
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.pacman
-        asset_content_type: application/x-zstd-compressed-tar
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}.pacman" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.pacman" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.pacman"
 
     - name: Upload Windows x64 .exe Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-setup-x64.exe
-        asset_path: build/freetube Setup ${{ steps.getPackageInfo.outputs.version }}.exe
-        asset_content_type: application/x-ms-dos-executable
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube Setup ${{ steps.getPackageInfo.outputs.version }}.exe" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-setup-x64.exe" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-setup-x64.exe"
 
     - name: Upload Windows x64 portable Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.exe
-        asset_path: build/FreeTube ${{ steps.getPackageInfo.outputs.version }}.exe
-        asset_content_type: application/x-ms-dos-executable
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube ${{ steps.getPackageInfo.outputs.version }}.exe" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.exe" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.exe"
 
     - name: Upload Windows x64 .zip Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-win.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-win.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.zip"
 
     - name: Upload Windows x64 .7z Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-win.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-win.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-x64-portable.7z"
 
     - name: Upload Windows arm64 .exe Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-setup-arm64.exe
-        asset_path: build/freetube Setup ${{ steps.getPackageInfo.outputs.version }}.exe
-        asset_content_type: application/x-ms-dos-executable
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube Setup ${{ steps.getPackageInfo.outputs.version }}.exe" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-setup-arm64.exe" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-setup-arm64.exe"
 
     - name: Upload Windows arm64 portable Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.exe
-        asset_path: build/FreeTube ${{ steps.getPackageInfo.outputs.version }}.exe
-        asset_content_type: application/x-ms-dos-executable
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/FreeTube ${{ steps.getPackageInfo.outputs.version }}.exe" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.exe" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.exe"
 
     - name: Upload Windows arm64 .zip Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-win.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-win.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.zip"
 
     - name: Upload Windows arm64 .7z Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'windows') && startsWith(matrix.runtime, 'win-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-win.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-win.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-win-arm64-portable.7z"
 
     - name: Upload Mac x64 .dmg Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.dmg
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}.dmg
-        asset_content_type: application/x-apple-diskimage
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}.dmg" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.dmg" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.dmg"
 
     - name: Upload Mac x64 .zip Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-mac.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-mac.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.zip"
 
     - name: Upload Mac x64 .7z Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-x64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-mac.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-mac.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-x64.7z"
 
     - name: Upload Mac arm64 .dmg Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.dmg
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.dmg
-        asset_content_type: application/x-apple-diskimage
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64.dmg" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.dmg" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.dmg"
 
     - name: Upload Mac arm64 .zip Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-arm64')
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.zip
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-mac.zip
-        asset_content_type: application/x-apple-diskimage
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-mac.zip" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.zip" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.zip"
 
     - name: Upload Mac arm64 .7z Release
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
       if: startsWith(matrix.os, 'macos') && startsWith(matrix.runtime, 'osx-arm64')
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: https://uploads.github.com/repos/FreeTubeApp/FreeTube/releases/${{ inputs.releaseId }}/assets{?name,label}
-        asset_name: freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.7z
-        asset_path: build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-mac.7z
-        asset_content_type: application/x-7z-compressed
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+      shell: pwsh
+      run: Move-Item -Path "build/freetube-${{ steps.getPackageInfo.outputs.version }}-arm64-mac.7z" -Destination "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.7z" && gh release upload "${{ inputs.tag }}" "freetube-${{ steps.getPackageInfo.outputs.version }}-beta-mac-arm64.7z"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "electron": "^42.5.2",
-    "electron-builder": "^26.15.3",
+    "electron-builder": "^26.15.7",
     "eslint": "^10.6.0",
     "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-jsdoc": "^63.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^42.5.2
         version: 42.5.2
       electron-builder:
-        specifier: ^26.15.3
-        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+        specifier: ^26.15.7
+        version: 26.15.7(electron-builder-squirrel-windows@26.15.7)
       eslint:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -1782,12 +1782,12 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  app-builder-lib@26.15.3:
-    resolution: {integrity: sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==}
+  app-builder-lib@26.15.7:
+    resolution: {integrity: sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 26.15.3
-      electron-builder-squirrel-windows: 26.15.3
+      dmg-builder: 26.15.7
+      electron-builder-squirrel-windows: 26.15.7
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -2341,8 +2341,8 @@ packages:
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
 
-  dmg-builder@26.15.3:
-    resolution: {integrity: sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==}
+  dmg-builder@26.15.7:
+    resolution: {integrity: sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -2406,11 +2406,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@26.15.3:
-    resolution: {integrity: sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==}
+  electron-builder-squirrel-windows@26.15.7:
+    resolution: {integrity: sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==}
 
-  electron-builder@26.15.3:
-    resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
+  electron-builder@26.15.7:
+    resolution: {integrity: sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -7007,7 +7007,7 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -7028,11 +7028,11 @@ snapshots:
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      dmg-builder: 26.15.7(electron-builder-squirrel-windows@26.15.7)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)
+      electron-builder-squirrel-windows: 26.15.7(dmg-builder@26.15.7)
       electron-publish: 26.15.3
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
@@ -7600,9 +7600,9 @@ snapshots:
       minimatch: 3.1.5
       p-limit: 3.1.0
 
-  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+  dmg-builder@26.15.7(electron-builder-squirrel-windows@26.15.7):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.3.0
@@ -7685,23 +7685,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
+  electron-builder-squirrel-windows@26.15.7(dmg-builder@26.15.7):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+  electron-builder@26.15.7(electron-builder-squirrel-windows@26.15.7):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.7(dmg-builder@26.15.7)(electron-builder-squirrel-windows@26.15.7)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
       ci-info: 4.4.0
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      dmg-builder: 26.15.7(electron-builder-squirrel-windows@26.15.7)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
This PR includes https://github.com/FreeTubeApp/FreeTube/pull/9460 so that assets can be tested properly
That PR should be merged first

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Spotted deprecation message in last run - https://github.com/FreeTubeApp/FreeTube/actions/runs/29556083929
Found `gh release upload` - https://github.com/marketplace/actions/publish-release (bottom, example included)
Doc for command & env var:
- https://cli.github.com/manual/gh_release_create
- https://cli.github.com/manual/gh_help_environment
No rename/upload with different name option yet so rename using powershell needed (found in https://stackoverflow.com/questions/70515210/can-i-use-a-github-action-to-rename-a-file

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Build log screenshot (only the changed part
<img width="1701" height="1123" alt="image" src="https://github.com/user-attachments/assets/172fc7cb-9f24-4b55-a4c9-898333287492" />


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Download assets (all versions, archive and installer) for each OS to see if app can be extracted/installed and run
https://github.com/PikachuEXE/FreeTube/releases/tag/v0.25.0-beta-release-test-202607201605
Assets uploaded by https://github.com/PikachuEXE/FreeTube/actions/runs/29726731446

In addition you might want to test https://github.com/FreeTubeApp/FreeTube/pull/9444 & https://github.com/FreeTubeApp/FreeTube/pull/9460

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->

Already tested macos x64 + arm64 on m1 mac w/ macOS 15.7.7
