### PR TITLE
Combine in-template keydown listeners that call the same handler

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -12,8 +12,7 @@
         role="button"
         tabindex="0"
         @click="showComments = false"
-        @keydown.space.prevent="showComments = false"
-        @keydown.enter.prevent="showComments = false"
+        @keydown.enter.space.prevent="showComments = false"
       >
         {{ $t("Comments.Hide Comments") }}
       </span>
@@ -24,8 +23,7 @@
       role="button"
       tabindex="0"
       @click="getCommentData"
-      @keydown.space.prevent="getCommentData"
-      @keydown.enter.prevent="getCommentData"
+      @keydown.enter.space.prevent="getCommentData"
     >
       {{ $t("Comments.Click to View Comments") }}
     </h4>
@@ -35,8 +33,7 @@
       role="button"
       tabindex="0"
       @click="showComments = true"
-      @keydown.space.prevent="showComments = true"
-      @keydown.enter.prevent="showComments = true"
+      @keydown.enter.space.prevent="showComments = true"
     >
       {{ $t("Comments.Click to View Comments") }}
     </h4>
@@ -161,8 +158,7 @@
             role="button"
             tabindex="0"
             @click="toggleCommentReplies(index)"
-            @keydown.space.prevent="toggleCommentReplies(index)"
-            @keydown.enter.prevent="toggleCommentReplies(index)"
+            @keydown.enter.space.prevent="toggleCommentReplies(index)"
           >
             <span>
               {{ toggleCommentRepliesLinkText(comment) }}
@@ -277,8 +273,7 @@
             role="button"
             tabindex="0"
             @click="getCommentReplies(index)"
-            @keydown.space.prevent="getCommentReplies(index)"
-            @keydown.enter.prevent="getCommentReplies(index)"
+            @keydown.enter.space.prevent="getCommentReplies(index)"
           >
             <span>{{ $t("Comments.Show More Replies") }}</span>
           </div>
@@ -307,8 +302,7 @@
       role="button"
       tabindex="0"
       @click="getMoreComments"
-      @keydown.space.prevent="getMoreComments"
-      @keydown.enter.prevent="getMoreComments"
+      @keydown.enter.space.prevent="getMoreComments"
     >
       {{ $t("Comments.Load More Comments") }}
     </h4>

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
@@ -49,8 +49,7 @@
       tabindex="0"
       role="button"
       @click="revealAnswer = !revealAnswer"
-      @keydown.enter.prevent="revealAnswer = !revealAnswer"
-      @keydown.space.prevent="revealAnswer = !revealAnswer"
+      @keydown.enter.space.prevent="revealAnswer = !revealAnswer"
     >
       <div
         v-if="!revealAnswer"

--- a/src/renderer/components/FtNotificationBanner/FtNotificationBanner.vue
+++ b/src/renderer/components/FtNotificationBanner/FtNotificationBanner.vue
@@ -6,8 +6,7 @@
     :title="message"
     :aria-describedby="id"
     @click="handleClick"
-    @keydown.enter.prevent="handleClick"
-    @keydown.space.prevent="handleClick"
+    @keydown.enter.space.prevent="handleClick"
   >
     <p
       :id="id"

--- a/src/renderer/components/FtPlaylistSelector/FtPlaylistSelector.vue
+++ b/src/renderer/components/FtPlaylistSelector/FtPlaylistSelector.vue
@@ -3,8 +3,7 @@
     class="ft-playlist-selector grid"
     :class="{ selected }"
     @click="toggleSelection"
-    @keydown.enter.prevent="toggleSelection"
-    @keydown.space.prevent="toggleSelection"
+    @keydown.enter.space.prevent="toggleSelection"
   >
     <div
       class="thumbnail"

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -17,8 +17,7 @@
               tabindex="0"
               role="button"
               @click="profileBgColor = color"
-              @keydown.space.prevent="profileBgColor = color"
-              @keydown.enter.prevent="profileBgColor = color"
+              @keydown.enter.space.prevent="profileBgColor = color"
             />
           </FtFlexBox>
           <div class="customColorSection">

--- a/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
+++ b/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
@@ -11,8 +11,7 @@
       :aria-controls="id + 'list'"
       @click="toggleProfileList"
       @mousedown="handleIconMouseDown"
-      @keydown.space.prevent="toggleProfileList"
-      @keydown.enter.prevent="toggleProfileList"
+      @keydown.enter.space.prevent="toggleProfileList"
     >
       <div
         class="initial"

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -8,8 +8,7 @@
       tabindex="0"
       role="status"
       @click="performAction(toast)"
-      @keydown.enter.prevent="performAction(toast)"
-      @keydown.space.prevent="performAction(toast)"
+      @keydown.enter.space.prevent="performAction(toast)"
     >
       <p class="message">
         {{ toast.message }}

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -10,8 +10,7 @@
       aria-labelledby="moreNavLabel"
       :title="$t('More')"
       @click="openMoreOptions = !openMoreOptions"
-      @keydown.space.prevent="openMoreOptions = !openMoreOptions"
-      @keydown.enter.prevent="openMoreOptions = !openMoreOptions"
+      @keydown.enter.space.prevent="openMoreOptions = !openMoreOptions"
     >
       <FontAwesomeIcon
         :icon="['fas', 'ellipsis-h']"

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -38,8 +38,7 @@
           :aria-selected="index === currentIndex"
           :class="{ current: index === currentIndex }"
           @click="changeChapter(index)"
-          @keydown.space.stop.prevent="changeChapter(index)"
-          @keydown.enter.stop.prevent="changeChapter(index)"
+          @keydown.enter.space.stop.prevent="changeChapter(index)"
         >
           <!-- Setting the aspect ratio avoids layout shifts when the images load -->
           <img

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -9,8 +9,7 @@
       role="button"
       tabindex="0"
       @click="expandDescription"
-      @keydown.space.prevent="expandDescription"
-      @keydown.enter.prevent="expandDescription"
+      @keydown.enter.space.prevent="expandDescription"
     >
       {{ $t("Description.Expand Description") }}
     </span>
@@ -34,8 +33,7 @@
       role="button"
       tabindex="0"
       @click="collapseDescription"
-      @keydown.space.prevent="collapseDescription"
-      @keydown.enter.prevent="collapseDescription"
+      @keydown.enter.space.prevent="collapseDescription"
     >
       {{ $t("Description.Collapse Description") }}
     </span>

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -81,8 +81,7 @@
           role="button"
           tabindex="0"
           @click="showSuperChatComment(comment)"
-          @keydown.space.prevent="showSuperChatComment(comment)"
-          @keydown.enter.prevent="showSuperChatComment(comment)"
+          @keydown.enter.space.prevent="showSuperChatComment(comment)"
         >
           <img
             :src="comment.author.thumbnailUrl"
@@ -107,8 +106,7 @@
         role="button"
         tabindex="0"
         @click="hideSuperChat"
-        @keydown.space.prevent="hideSuperChat"
-        @keydown.enter.prevent="hideSuperChat"
+        @keydown.enter.space.prevent="hideSuperChat"
       >
         <div
           class="superChatMessage"
@@ -233,8 +231,7 @@
         role="button"
         tabindex="0"
         @click="scrollToBottom"
-        @keydown.space.prevent="scrollToBottom"
-        @keydown.enter.prevent="scrollToBottom"
+        @keydown.enter.space.prevent="scrollToBottom"
       >
         <FontAwesomeIcon
           class="icon"

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -244,8 +244,7 @@
             role="button"
             tabindex="0"
             @click="handleFetchMore"
-            @keydown.space.prevent="handleFetchMore"
-            @keydown.enter.prevent="handleFetchMore"
+            @keydown.enter.space.prevent="handleFetchMore"
           >
             <FontAwesomeIcon :icon="['fas', 'search']" /> {{ $t("Search Filters.Fetch more results") }}
           </div>

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -39,8 +39,7 @@
           role="button"
           tabindex="0"
           @click="handleFetchMore"
-          @keydown.space.prevent="handleFetchMore"
-          @keydown.enter.prevent="handleFetchMore"
+          @keydown.enter.space.prevent="handleFetchMore"
         >
           <FontAwesomeIcon :icon="['fas', 'search']" /> {{ $t("Search Filters.Fetch more results") }}
         </div>

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -27,8 +27,7 @@
           role="button"
           tabindex="0"
           @click="nextPage"
-          @keydown.enter.prevent="nextPage"
-          @keydown.space.prevent="nextPage"
+          @keydown.enter.space.prevent="nextPage"
         >
           <FontAwesomeIcon :icon="['fas', 'search']" /> {{ t("Search Filters.Fetch more results") }}
         </div>


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

When we write multiple keydown listeners for different keys in a Vue template that call the same handler (e.g. spacebar and enter), the Vue compiler is clever enough to recognise that it is the same event and only registers a single keydown event listener in the DOM but doesn't recognise that they call the same handler, instead looping over the filters and handlers. This pull request combines those cases in the template so that the Vue compiler generates a single filter and handler call, we already use that pattern in various places in the code base (e.g. channel and trending tabs), so this just expands it to the remaining places.

## Screenshots

Formatted snippet of the `dist/renderer.js` file showing the before and after difference for the search page fetch more results button when running `pnpm run pack:renderer` (`w` is our `nextPage` function).

```diff
  xo(
    "div",
    {
      class: "getNextPage",
      role: "button",
      tabindex: "0",
      onClick: w,
-     onKeydown: [
-       tc(Ql(w, ["prevent"]), ["enter"]),
-       tc(Ql(w, ["prevent"]), ["space"]),
-     ],
+     onKeydown: tc(Ql(w, ["prevent"]), ["enter", "space"]),
    },
    [
      Eo(Vt($g), { icon: ["fas", "search"] }),
      Mo(" " + ie(Vt(t)("Search Filters.Fetch more results")), 1),
    ],
    40,
    JX
  )
```

## Testing

Try various buttons that were affected by the changes in this pull request such as expanding and collapsing video descriptions or selecting chapters in the chapter selector.

## Desktop

- **OS:** Windows
- **OS Version:** 11