### PR TITLE
Add button to collapse playlist when watching a video

### DIFF
--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -183,7 +183,6 @@
   flex: 1;
   min-inline-size: 0;
   margin: 0;
-  padding-block-start: 8px;
 }
 
 .playlistIcon {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -13,13 +13,18 @@
 .channelName {
   font-size: 15px;
   position: relative;
-  inset-block-end: 15px;
+  inset-block-end: 0;
 }
 
 .playlistIndex {
   position: relative;
-  inset-block-end: 15px;
+  inset-block-end: 0;
   color: var(--tertiary-text-color);
+}
+
+.playlistIndex.isCollapsed {
+  display: block;
+  margin-block-end: -6px;
 }
 
 .playlistProgressBarContainer {
@@ -153,6 +158,31 @@
   stroke-width: 10;
   stroke: var(--accent-color-hover);
   transition: background 0.2s ease-in;
+}
+
+.playlistHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-block-end: 4px;
+}
+
+.playlistHeader .playlistCollapseButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  inline-size: 32px;
+  block-size: 32px;
+  margin-block-start: 0;
+  font-size: 16px;
+}
+
+.playlistHeader .playlistTitle {
+  flex: 1;
+  min-inline-size: 0;
+  margin: 0;
 }
 
 .playlistIcon {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -166,6 +166,7 @@
   align-items: center;
   gap: 10px;
   margin-block-end: 4px;
+  padding-block-start: 8px;
 }
 
 .playlistHeader .playlistCollapseButton {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -183,6 +183,7 @@
   flex: 1;
   min-inline-size: 0;
   margin: 0;
+  padding-block-start: 8px;
 }
 
 .playlistIcon {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -1,25 +1,42 @@
 <template>
-  <FtCard class="relative">
+  <FtCard
+    class="relative"
+    :class="{ isCollapsed }"
+  >
     <FtLoader
       v-if="isLoading"
     />
     <div
       v-else
     >
-      <h3
-        class="playlistTitle"
-        :title="playlistTitle"
-      >
-        <RouterLink
-          class="playlistTitleLink"
-          dir="auto"
-          :to="playlistPageLinkTo"
+      <div class="playlistHeader">
+        <h3
+          class="playlistTitle"
+          :title="playlistTitle"
         >
-          {{ playlistTitle }}
-        </RouterLink>
-      </h3>
+          <RouterLink
+            class="playlistTitleLink"
+            dir="auto"
+            :to="playlistPageLinkTo"
+          >
+            {{ playlistTitle }}
+          </RouterLink>
+        </h3>
+        <button
+          class="playlistButton playlistCollapseButton"
+          :aria-label="isCollapsed ? t('Video.Expand Playlist') : t('Video.Collapse Playlist')"
+          :aria-expanded="!isCollapsed"
+          :title="isCollapsed ? t('Video.Expand Playlist') : t('Video.Collapse Playlist')"
+          @click="toggleCollapse"
+        >
+          <FontAwesomeIcon
+            class="playlistIcon"
+            :icon="['fas', isCollapsed ? 'angle-down' : 'angle-up']"
+          />
+        </button>
+      </div>
       <template
-        v-if="channelName !== ''"
+        v-if="!isCollapsed && channelName !== ''"
       >
         <RouterLink
           v-if="channelId"
@@ -38,6 +55,7 @@
       </template>
       <span
         class="playlistIndex"
+        :class="{ isCollapsed }"
       >
         <label for="playlistProgressBar">
           {{ currentVideoIndexOneBased }} / {{ playlistVideoCount }}
@@ -45,7 +63,7 @@
 
         <!-- eslint-disable vuejs-accessibility/mouse-events-have-key-events, vuejs-accessibility/click-events-have-key-events -->
         <div
-          v-if="!shuffleEnabled && !reversePlaylist"
+          v-if="!isCollapsed && !shuffleEnabled && !reversePlaylist"
           class="playlistProgressBarContainer"
           @mouseenter="showProgressBarPreview = true"
           @mouseleave="showProgressBarPreview = false"
@@ -85,7 +103,10 @@
           </div>
         </div>
       </span>
-      <div class="playlistButtons">
+      <div
+        v-show="!isCollapsed"
+        class="playlistButtons"
+      >
         <button
           class="playlistButton"
           :class="{ playlistButtonActive: loopEnabled }"
@@ -128,6 +149,7 @@
       </div>
       <div
         v-if="!isLoading"
+        v-show="!isCollapsed"
         ref="playlistItemsWrapper"
         class="playlistItemsWrapper"
       >
@@ -206,6 +228,7 @@ const { locale, t } = useI18n()
 const router = useRouter()
 
 const isLoading = ref(false)
+const isCollapsed = ref(false)
 const shuffleEnabled = ref(false)
 const loopEnabled = ref(false)
 const reversePlaylist = ref(false)
@@ -447,6 +470,10 @@ function getPlaylistInfoWithDelay() {
   } else {
     getPlaylistInformationLocal()
   }
+}
+
+function toggleCollapse() {
+  isCollapsed.value = !isCollapsed.value
 }
 
 function toggleLoop() {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -241,6 +241,8 @@ const showProgressBarPreview = ref(false)
 const previewPosition = ref(0)
 const previewVideoIndex = ref(1)
 const windowWidth = ref(window.innerWidth)
+const savedScrollTop = ref(0)
+const lastScrolledVideoId = ref(null)
 
 let prevVideoBeforeDeletion = null
 let getPlaylistInfoRun = false
@@ -357,6 +359,10 @@ watch(selectedUserPlaylistLastUpdatedAt, () => {
 })
 
 watch(() => props.videoId, (newId, oldId) => {
+  if (!isCollapsed.value) {
+    nextTick(scrollToCurrentVideo)
+  }
+
   // Check if next video is from the shuffled list or if the user clicked a different video
   if (shuffleEnabled.value) {
     const newVideoIndex = randomizedPlaylistItems.value.findIndex((item) => {
@@ -471,6 +477,29 @@ function getPlaylistInfoWithDelay() {
     getPlaylistInformationLocal()
   }
 }
+
+function saveScrollState() {
+  if (playlistItemsWrapper.value) {
+    savedScrollTop.value = playlistItemsWrapper.value.scrollTop
+    lastScrolledVideoId.value = props.videoId
+  }
+}
+
+function restoreScrollState() {
+  if (lastScrolledVideoId.value !== props.videoId) {
+    scrollToCurrentVideo()
+  } else if (playlistItemsWrapper.value) {
+    playlistItemsWrapper.value.scrollTop = savedScrollTop.value
+  }
+}
+
+watch(isCollapsed, (collapsed) => {
+  if (collapsed) {
+    saveScrollState()
+  } else {
+    nextTick(restoreScrollState)
+  }
+})
 
 function toggleCollapse() {
   isCollapsed.value = !isCollapsed.value
@@ -762,6 +791,7 @@ function scrollToVideo(index) {
 }
 
 function scrollToCurrentVideo() {
+  if (isCollapsed.value) return
   scrollToVideo(currentVideoIndexZeroBased.value)
 }
 

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -241,9 +241,8 @@ const showProgressBarPreview = ref(false)
 const previewPosition = ref(0)
 const previewVideoIndex = ref(1)
 const windowWidth = ref(window.innerWidth)
-const savedScrollTop = ref(0)
-const lastScrolledVideoId = ref(null)
-
+let savedScrollTop = 0
+let lastScrolledVideoId = null
 let prevVideoBeforeDeletion = null
 let getPlaylistInfoRun = false
 
@@ -480,16 +479,16 @@ function getPlaylistInfoWithDelay() {
 
 function saveScrollState() {
   if (playlistItemsWrapper.value) {
-    savedScrollTop.value = playlistItemsWrapper.value.scrollTop
-    lastScrolledVideoId.value = props.videoId
+    savedScrollTop = playlistItemsWrapper.value.scrollTop
+    lastScrolledVideoId = props.videoId
   }
 }
 
 function restoreScrollState() {
-  if (lastScrolledVideoId.value !== props.videoId) {
+  if (lastScrolledVideoId !== props.videoId) {
     scrollToCurrentVideo()
   } else if (playlistItemsWrapper.value) {
-    playlistItemsWrapper.value.scrollTop = savedScrollTop.value
+    playlistItemsWrapper.value.scrollTop = savedScrollTop
   }
 }
 

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -175,8 +175,9 @@
       margin-block: auto;
     }
 
-    @media (width <= 768px) {
+    @media (width <= 1050px) {
       block-size: auto;
+      margin-inline: 0;
     }
   }
 

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -167,6 +167,10 @@
   }
 
   .watchVideoPlaylist {
+    &.isCollapsed {
+      block-size: auto;
+    }
+
     :deep(.videoThumbnail) {
       margin-block: auto;
     }

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -874,6 +874,8 @@ Video:
   Loop Playlist: Loop Playlist
   Shuffle Playlist: Shuffle Playlist
   Reverse Playlist: Reverse Playlist
+  Collapse Playlist: Collapse Playlist
+  Expand Playlist: Expand Playlist
   Previous: Previous
   Next: Next
   Watched: Watched


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
Closes #1356

## Description
Add a button to collapse the playlist when watching a video.

## Screenshots
<img width="1295" height="693" alt="Capture d’écran 2026-07-26 à 15 23 58" src="https://github.com/user-attachments/assets/83408d78-2dda-4670-a5a5-75770bb2b565" />
<img width="1295" height="693" alt="Capture d’écran 2026-07-26 à 15 24 05" src="https://github.com/user-attachments/assets/52ca770d-0f53-400e-8e34-21a562a27a34" />
<img width="986" height="859" alt="Capture d’écran 2026-07-26 à 15 24 22" src="https://github.com/user-attachments/assets/9a392626-f037-4dc4-8e91-329a39a63c9e" />
<img width="986" height="859" alt="Capture d’écran 2026-07-26 à 15 24 27" src="https://github.com/user-attachments/assets/5ad361b0-dd89-416f-a058-c02412e6c4a7" />
<img width="705" height="942" alt="Capture d’écran 2026-07-26 à 15 34 23" src="https://github.com/user-attachments/assets/5ce97c79-aa58-4f77-859c-384df823d2ff" />
<img width="705" height="942" alt="Capture d’écran 2026-07-26 à 15 34 20" src="https://github.com/user-attachments/assets/c0e32058-40b9-4f73-a0a9-d6d2ea9e1037" />

## Testing

1. Go to a playlist
2. Click on a video
3. Click on the button to collapse the playlist

## Desktop

- **OS:** MacOS
- **OS Version:** 26 
- **FreeTube version:** v0.25.1 Beta
