### PR TITLE
Fix: default playlists not being created on app starts

### DIFF
--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -1,5 +1,6 @@
 import { DBPlaylistHandlers } from '../../../datastores/handlers/index'
 import { generateRandomUniqueId, processToBeAddedPlaylistVideo } from '../../helpers/playlists'
+import { deepCopy } from '../../helpers/utils'
 
 function generateRandomPlaylistId() {
   return `ft-playlist--${generateRandomUniqueId()}`
@@ -237,7 +238,7 @@ const actions = {
       if (payload.length === 0) {
         // Not using `addPlaylists` to ensure required attributes with dynamic values added
         state.defaultPlaylists.forEach(playlist => {
-          dispatch('addPlaylist', playlist)
+          dispatch('addPlaylist', deepCopy(playlist))
         })
       } else {
         const dateNow = Date.now()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
I've based my fix on this MR: https://github.com/FreeTubeApp/FreeTube/pull/8993
After deleting all playlists, FreeTube should recreate two default playlists the next time it starts up. 
This was not currently the case due to an exception.

<img width="606" height="96" alt="image" src="https://github.com/user-attachments/assets/0858c069-73ae-42ad-ab9a-33a4be722f27" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to `Settings > Privacy > Remove All Playlists`
2. Close FreeTube
3. Open it again 
4. Go to `Playlists`
5. Check that `Favorites` and `Watch Later` have been created

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.25.1-beta