### PR TITLE
Use .example domain in package.json to resolve build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "author": {
     "name": "FreeTube Team",
-    "email": "FreeTubeApp@protonmail.com",
+    "email": "noreply@example.com",
     "url": "https://github.com/FreeTubeApp/FreeTube"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "author": {
     "name": "FreeTube Team",
+    "email": "FreeTubeApp@protonmail.com",
     "url": "https://github.com/FreeTubeApp/FreeTube"
   },
   "repository": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
https://github.com/FreeTubeApp/FreeTube/pull/9491

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
> electron-builder seems to require an `email` field in `package.json` https://github.com/FreeTubeApp/FreeTube/actions/runs/30201281250/job/89791523696#step:12:125
However, the linked doc indicates that this field is optional https://docs.npmjs.com/cli/v12/configuring-npm/package-json#people-fields-author-contributors
So it seems mandatory for electron-builder, even if it's optional for npm

Taken from https://github.com/FreeTubeApp/FreeTube/pull/9491#issuecomment-5083635412

