### PR TITLE
Fix the channel tab accent color when switching tabs

### DIFF
--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -98,8 +98,8 @@
   border-block-end: 3px solid transparent;
 }
 
-.tab:hover,
-.tab:focus {
+.tab:focus-visible,
+.tab:hover:not(.selectedTab) {
   font-weight: bold;
   border-block-end: 3px solid var(--tertiary-text-color);
 }

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -2333,7 +2333,6 @@ function changeTab(tab) {
 
   if (newTabNode != null) {
     newTabNode.focus()
-    store.commit('setOutlinesHidden', false)
   }
 }
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue
Closes #3204

## Description
Fixes the accent color at the bottom of the tabs that were not being applied correctly.

## Screenshots

https://github.com/user-attachments/assets/896a33b0-b3e7-4302-87d7-01e63b102fb5

## Testing

1. Go to a channel
2. Click on the tabs
3. See the accent color is being applied, and not the hover color

## Desktop
<!-- Please complete the following information-->
- **OS:** MacOS
- **OS Version:** 26
- **FreeTube version:** v0.25.1 Beta