### PR TITLE
style: check for course pointer to determine if a device is touch screen

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -20,7 +20,7 @@
 }
 
 // If touch screen device, always show grab bar.
-@media (hover: none) {
+@media (hover: none) or (any-pointer: coarse) {
   .draggable:not(.draggable:only-child) .grabBar {
     display: revert;
   }

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
@@ -28,7 +28,7 @@
 }
 
 /* prevent hover styling from showing on title click for mobile */
-@media (hover: hover) {
+@media (hover: hover) and (not (any-pointer: coarse)) {
   .title:hover {
     color: var(--primary-text-color);
   }

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -402,7 +402,7 @@ $watched-transition-duration: 0.5s;
     opacity: $thumbnail-overlay-opacity;
   }
 
-  @media (hover: hover) {
+  @media (hover: hover) and (not (any-pointer: coarse)) {
     &:hover .quickBookmarkVideoIcon:not(.alwaysVisible),
     .quickBookmarkVideoIcon.bookmarked:not(.alwaysVisible),
     &:hover .addToPlaylistIcon:not(.alwaysVisible),


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
#9002 

## Description
This PR updates our checks to see if a device is touch screen to also check for a course pointer (which is often a touch device)
https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/any-pointer#coarse

## Screenshots

_TODO_: add FreeTube screenshots from Steam Deck

## Testing

I created a codesandbox to easily test this on multiple devices (here: https://codesandbox.io/p/sandbox/beautiful-field-mttppr )

On my computer (no touchscreen) it shows:
<img width="638" height="220" alt="image" src="https://github.com/user-attachments/assets/984f0b60-1cb5-429a-b3ac-f0d98e35307f" />

On my android phone, it shows:
<img width="383" height="343" alt="image" src="https://github.com/user-attachments/assets/a09f09a4-7b31-4f14-af1f-376f669db0c6" />

On my Steam Deck, it shows:
<img width="330" height="510" alt="image" src="https://github.com/user-attachments/assets/b8b4b3bf-bc57-4a50-8b78-ef519b011cc1" />
- Course pointer
- Fine Pointer
- Mobile

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 44
- **FreeTube version:** 0.25.1 (latest nightly)

