### PR TITLE
Add local development flatpak target to ebuilder.config.mjs, update linux category metadata

### DIFF
--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -50,7 +50,7 @@ export default {
     }
   },
   linux: {
-    category: 'AudioVideo;Video;Player;Network',
+    category: 'AudioVideo;Video;Player;Feed;Network',
     icon: '_icons/icon.svg',
     target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'], // 'flatpak'],
   },

--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -81,6 +81,10 @@ export default {
   toolsets: {
     appimage: '1.0.3'
   },
+
+  // NOTE: this exists purely for local development builds, we will not provide support for flatpaks built this way!
+  // This is here if unofficial builds need to be made
+  /*
   flatpak: {
     // install flatpak builder
     // install electron app from flathub. Ex: flatpak install flathub org.electronjs.Electron2.BaseApp/x86_64/25.08
@@ -101,6 +105,7 @@ export default {
     runtimeVersion: '25.08',
     baseVersion: '25.08',
   },
+  */
   mac: {
     category: 'public.app-category.utilities',
     icon: '_icons/iconMac.icns',

--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -53,11 +53,6 @@ export default {
     category: 'AudioVideo;Video;Player;Network',
     icon: '_icons/icon.svg',
     target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman', 'flatpak'],
-    // desktop: {
-    //   entry: {
-    //     'Comment[fr]': ''
-    //   }
-    // },
   },
   // See the following issues for more information
   // https://github.com/jordansissel/fpm/issues/1503

--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -52,7 +52,7 @@ export default {
   linux: {
     category: 'AudioVideo;Video;Player;Network',
     icon: '_icons/icon.svg',
-    target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman', 'flatpak'],
+    target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'], // 'flatpak'],
   },
   // See the following issues for more information
   // https://github.com/jordansissel/fpm/issues/1503

--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -50,9 +50,14 @@ export default {
     }
   },
   linux: {
-    category: 'Network',
+    category: 'AudioVideo;Video;Player;Network',
     icon: '_icons/icon.svg',
-    target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'],
+    target: ['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman', 'flatpak'],
+    // desktop: {
+    //   entry: {
+    //     'Comment[fr]': ''
+    //   }
+    // },
   },
   // See the following issues for more information
   // https://github.com/jordansissel/fpm/issues/1503
@@ -75,6 +80,26 @@ export default {
   },
   toolsets: {
     appimage: '1.0.3'
+  },
+  flatpak: {
+    // install flatpak builder
+    // install electron app from flathub. Ex: flatpak install flathub org.electronjs.Electron2.BaseApp/x86_64/25.08
+    finishArgs: [
+      '--device=dri',
+      '--share=ipc',
+      '--socket=wayland',
+      '--socket=fallback-x11',
+      '--socket=pulseaudio',
+      '--share=network',
+      '--own-name=org.mpris.MediaPlayer2.chromium.*',
+      '--own-name=org.mpris.MediaPlayer2.freetube',
+      '--talk-name=org.freedesktop.PowerManagement',
+      '--talk-name=org.freedesktop.ScreenSaver',
+      '--talk-name=org.gnome.SessionManager',
+      '--talk-name=org.gnome.SettingsDaemon'
+    ],
+    runtimeVersion: '25.08',
+    baseVersion: '25.08',
   },
   mac: {
     category: 'public.app-category.utilities',


### PR DESCRIPTION
## Pull Request Type
- [x] Other - maintenance chore

## Description

The main purpose for adding this to `ebuilder.config.mjs` is so I can create builds to easily test on my Steamdeck and postmarketOS phone.

This PR adds configuration necessary for Flatpak in `ebuilder.config.mjs`. I didn't add this to `_scripts/build.mjs` but it could potentially be useful for Flathub users (especially ones on immutable distros like the Steam Deck or Bazzite) to test specific PRs (we'd need to make special builds for them)

## Testing

On a linux machine:
- Apply this patch:
```patch
index 1617f1ad5..dae9cb8ba 100644
--- a/_scripts/build.mjs
+++ b/_scripts/build.mjs
@@ -34,7 +34,7 @@ if (platform === 'darwin') {
     arch = Arch.armv7l
   }
 
-  targets = Platform.LINUX.createTarget(['deb', 'zip', '7z', 'rpm', 'AppImage', 'pacman'], arch)
+  targets = Platform.LINUX.createTarget(['flatpak'], arch)
 }
 
 const output = await build({ targets, config, publish: 'never' })

```
- Uncomment the flatpak section in `ebuilder.config.mjs`
- run `pnpm run build`.

I had an issue when I first ran at and was able to debug by patching `@malept/flatpak-bundler` with the changes in this PR: https://github.com/malept/flatpak-bundler/pull/60

Essentially you'll need flathub setup, the runtimes installed and flatpak-builder installed

## Desktop

- **OS:** Fedora Linux 
- **OS Version:** 44
- **FreeTube version:** latest nightly

