### PR TITLE
Fix: Opening a playlist from a user playlist reloads the view twice

### DIFF
--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1077,7 +1077,7 @@ export function debounce(func, wait) {
   // Using a fully fledged function here instead of an arrow function
   // so that we can get `this` and pass it onto the original function.
   // Vue components using the options API use `this` alot.
-  return function(...args) {
+  return function (...args) {
     const context = this
 
     clearTimeout(timeout)

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1066,15 +1066,10 @@ export function localizeAndAddKeyboardShortcutToActionTitle(localizedActionTitle
 }
 
 /**
- * @template {Function} U
- * @typedef {{cancel: () => void} & U} ReturnedFunc
- */
-
-/**
  * @template {Function} T
  * @param {T} func
  * @param {number} wait
- * @returns {ReturnedFunc<T>}
+ * @returns {T}
  */
 export function debounce(func, wait) {
   let timeout
@@ -1082,7 +1077,7 @@ export function debounce(func, wait) {
   // Using a fully fledged function here instead of an arrow function
   // so that we can get `this` and pass it onto the original function.
   // Vue components using the options API use `this` alot.
-  function debounceFunc(...args) {
+  return function(...args) {
     const context = this
 
     clearTimeout(timeout)
@@ -1092,13 +1087,6 @@ export function debounce(func, wait) {
       func.apply(context, args)
     }, wait)
   }
-
-  debounceFunc.cancel = function () {
-    clearTimeout(timeout)
-    timeout = null
-  }
-
-  return debounceFunc
 }
 
 /**

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1069,7 +1069,7 @@ export function localizeAndAddKeyboardShortcutToActionTitle(localizedActionTitle
  * @template {Function} T
  * @param {T} func
  * @param {number} wait
- * @returns {T}
+ * @returns {{ (...args: any[]): any, cancel: () => void }}
  */
 export function debounce(func, wait) {
   let timeout
@@ -1077,7 +1077,7 @@ export function debounce(func, wait) {
   // Using a fully fledged function here instead of an arrow function
   // so that we can get `this` and pass it onto the original function.
   // Vue components using the options API use `this` alot.
-  return function (...args) {
+  function debounceFunc(...args) {
     const context = this
 
     clearTimeout(timeout)
@@ -1087,6 +1087,13 @@ export function debounce(func, wait) {
       func.apply(context, args)
     }, wait)
   }
+
+  debounceFunc.cancel = function () {
+    clearTimeout(timeout)
+    timeout = null
+  }
+
+  return debounceFunc
 }
 
 /**

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1066,10 +1066,15 @@ export function localizeAndAddKeyboardShortcutToActionTitle(localizedActionTitle
 }
 
 /**
+ * @template {Function} U
+ * @typedef {{cancel: () => void} & U} ReturnedFunc
+ */
+
+/**
  * @template {Function} T
  * @param {T} func
  * @param {number} wait
- * @returns {{ (...args: any[]): any, cancel: () => void }}
+ * @returns {ReturnedFunc<T>}
  */
 export function debounce(func, wait) {
   let timeout

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -461,7 +461,7 @@ function resetState() {
   playlistThumbnail.value = ''
   viewCount.value = 0
   videoCount.value = 0
-  lastUpdated.value = ''
+  lastUpdated.value = undefined
   channelName.value = ''
   channelThumbnail.value = ''
   channelId.value = ''

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -609,6 +609,12 @@ watch(selectedUserPlaylistVideoCount, async () => {
   // So length is monitored instead
   // Assuming in user playlist video cannot be swapped without length change
 
+  // This watch function can be triggered while a debounced `getPlaylistInfoDebounce`
+  // call is still pending from another watch function. If we let it execute, we'd have
+  // two close calls to fetch playlist info in quick succession.
+  // See https://github.com/FreeTubeApp/FreeTube/issues/9517
+  getPlaylistInfoDebounce.cancel()
+
   // Re-fetch from local store when current user playlist videos updated
   // MUST NOT use `getPlaylistInfoDebounce` as it will cause delay in data update
   // Causing deleted videos to reappear for one frame

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -453,6 +453,23 @@ function getPlaylistInfo() {
 
 const getPlaylistInfoDebounce = debounce(getPlaylistInfo, 100)
 
+function resetState() {
+  isLoading.value = true
+  playlistTitle.value = ''
+  playlistDescription.value = ''
+  firstVideoId.value = ''
+  playlistThumbnail.value = ''
+  viewCount.value = 0
+  videoCount.value = 0
+  lastUpdated.value = ''
+  channelName.value = ''
+  channelThumbnail.value = ''
+  channelId.value = ''
+  infoSource.value = 'local'
+  playlistItems.value = []
+  continuationData.value = null
+}
+
 async function getPlaylistLocal() {
   try {
     const result = await getLocalPlaylist(playlistId.value)
@@ -588,7 +605,10 @@ function parseUserPlaylist(playlist) {
 }
 
 // react to route changes...
-watch(playlistId, getPlaylistInfoDebounce)
+watch(playlistId, () => {
+  resetState()
+  getPlaylistInfoDebounce()
+})
 
 watch(userPlaylistsReady, () => {
   // Fetch from local store when playlist data ready
@@ -598,22 +618,26 @@ watch(userPlaylistsReady, () => {
 })
 
 // Fetch from local store when current user playlist changed
-watch(selectedUserPlaylist, getPlaylistInfoDebounce)
+watch(selectedUserPlaylist, () => {
+  if (!isUserPlaylistRequested.value) { return }
+
+  getPlaylistInfoDebounce()
+})
 
 // Re-fetch from local store when current user playlist updated
-watch(selectedUserPlaylistLastUpdatedAt, getPlaylistInfoDebounce)
+watch(selectedUserPlaylistLastUpdatedAt, () => {
+  if (!isUserPlaylistRequested.value) { return }
+
+  getPlaylistInfoDebounce()
+})
 
 watch(selectedUserPlaylistVideoCount, async () => {
+  if (!isUserPlaylistRequested.value) { return }
+
   // Monitoring `selectedUserPlaylistVideos` makes this function called
   // Even when the same array object is returned
   // So length is monitored instead
   // Assuming in user playlist video cannot be swapped without length change
-
-  // This watch function can be triggered while a debounced `getPlaylistInfoDebounce`
-  // call is still pending from another watch function. If we let it execute, we'd have
-  // two close calls to fetch playlist info in quick succession.
-  // See https://github.com/FreeTubeApp/FreeTube/issues/9517
-  getPlaylistInfoDebounce.cancel()
 
   // Re-fetch from local store when current user playlist videos updated
   // MUST NOT use `getPlaylistInfoDebounce` as it will cause delay in data update


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9517
closes https://github.com/FreeTubeApp/FreeTube/issues/9513 (side effect)

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Early exit from watchers that are triggering redundant calls to `getPlaylistInfo` (debounced or not).
For the fix to work, the state of the playlist needs to be reset, otherwise everyting break on route change. This has the added benefit of fixing issue https://github.com/FreeTubeApp/FreeTube/issues/9513 too.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
**Valid playlist**
1. Open a user playlist
2. Enter a valid playlist URL in the search bar
3. Check that the UI does not reload after the first load and does not cause a flicker

**Invalid playlist**
1. Open a user playlist
2. Enter an invalid playlist URL in the search bar (e.g. https://www.youtube.com/playlist?list=foobar)
3. Check that the UI does not break and display `The playlist currently has no videos.`

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.25.1-beta