### PR TITLE
chore(eslint): use defineConfig for better editor integration when updating the file

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,9 @@ import eslintPluginPromise from 'eslint-plugin-promise'
 
 import activeLocales from './static/locales/activeLocales.json' with { type: 'json' }
 
-export default [
+import { defineConfig } from 'eslint/config';
+
+export default defineConfig([
   {
     ignores: [
       'build/',
@@ -341,14 +343,13 @@ export default [
       }
     }
   },
-
-  ...eslintPluginJsonc.configs.base,
   {
     files: ['**/*.json'],
     ignores: [
       '_scripts/',
     ],
 
+    extends: [eslintPluginJsonc.configs.base],
     rules: {
       '@stylistic/no-tabs': 'off',
       '@stylistic/comma-spacing': 'off',
@@ -363,14 +364,14 @@ export default [
       },
     },
   },
-
-  ...eslintPluginYml.configs.recommended,
   {
     files: ['**/*.{yml,yaml}'],
     ignores: [
       '.github/',
       '_scripts/'
     ],
+
+    extends: [eslintPluginYml.configs.recommended],
 
     rules: {
       'yml/no-irregular-whitespace': 'off',
@@ -443,4 +444,4 @@ export default [
       'unicorn/prefer-array-index-of': 'error',
     }
   }
-]
+])


### PR DESCRIPTION
## Pull Request Type
- [x] Other

## Description
Since we migrated to eslint flat config, eslint has added `defineConfig` which provides better editor integration with types. They also added `extends`. I've moved the yaml and json configs to `extends` to clean stuff up a bit

## Testing
- `pnpm run lint`

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora Linux
- **OS Version:** 44
- **FreeTube version:** latest nightly


