### PR TITLE
Add mix-blend-mode to improve sponsorBlock visibility

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -158,6 +158,7 @@
 
 :deep(.sponsorBlockMarker) {
   background-color: var(--primary-color);
+  mix-blend-mode: screen;
 }
 
 :deep(.chapterMarker) {


### PR DESCRIPTION
## Pull Request Type

- [x] Other

## Related issue
Closes #9095

## Description
Adds the mix-blend-mode CSS rule to make the video buffer visible when there is a sponsorBlock segment.

## Screenshots <!-- If appropriate -->
Before
<img width="506" height="204" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/eaa237f2-cbb0-4136-ac07-d7c4162d336d" />
After
<img width="506" height="204" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/22d59f1f-66be-4cca-9985-dc92bc09b5c2" />
Before
<img width="278" height="100" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/b1de3ab0-6dad-4a9c-baba-e161e4cf312a" />
After
<img width="278" height="100" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/34386118-da03-4191-a6a1-456db070cb53" />


## Testing

1. Enable sponsor block in settings
2. Open a video with sponsored segments (https://youtu.be/M51asSwRLxA)
3. Look at the video buffer indicator when it is on the sponsored segments

## Desktop

- **OS:** MacOS
- **OS Version:** 26
- **FreeTube version:**  v0.25.1 Beta

## Additional context
I tested the other solutions suggested by the issue author and I think modifying just the CSS is the simplest approach here. It does not change the visuals too much nor adds new code logic.