### PR TITLE
Style context menus as light or dark depending on the base theme

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -262,6 +262,32 @@ const MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT = 4
 // Displayed on the about page and used in the main.js file to only allow bitcoin URLs with this wallet address to be opened
 const ABOUT_BITCOIN_ADDRESS = '1Lih7Ho5gnxb1CwPD4o59ss78pwo2T91eS'
 
+const LIGHT_BASE_THEMES = [
+  'light',
+  'pastelPink',
+  'catppuccinLatte',
+  'everforestLightHard',
+  'everforestLightMedium',
+  'everforestLightLow',
+  'gruvboxLight',
+  'solarizedLight'
+]
+
+const DARK_BASE_THEMES = [
+  'dark',
+  'black',
+  'nordic',
+  'hotPink',
+  'catppuccinFrappe',
+  'catppuccinMocha',
+  'dracula',
+  'everforestDarkHard',
+  'everforestDarkMedium',
+  'everforestDarkLow',
+  'gruvboxDark',
+  'solarizedDark',
+]
+
 export {
   IpcChannels,
   DBActions,
@@ -276,4 +302,6 @@ export {
   SEARCH_RESULTS_DISPLAY_LIMIT,
   MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT,
   ABOUT_BITCOIN_ADDRESS,
+  LIGHT_BASE_THEMES,
+  DARK_BASE_THEMES,
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -270,7 +270,7 @@ const LIGHT_BASE_THEMES = [
   'everforestLightMedium',
   'everforestLightLow',
   'gruvboxLight',
-  'solarizedLight'
+  'solarizedLight',
 ]
 
 const DARK_BASE_THEMES = [

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -14,6 +14,8 @@ import {
   ABOUT_BITCOIN_ADDRESS,
   KeyboardShortcuts,
   SEARCH_CHAR_LIMIT,
+  LIGHT_BASE_THEMES,
+  DARK_BASE_THEMES,
 } from '../constants'
 import * as baseHandlers from '../datastores/handlers/base'
 import { extractExpiryTimestamp, ImageCache } from './ImageCache'
@@ -735,6 +737,14 @@ function runApp() {
       // --- end of `if experimentsDisableDiskCache` ---
     }
 
+    try {
+      const baseTheme = await baseHandlers.settings._findOne('baseTheme')
+
+      if (baseTheme?.value) {
+        updateThemeSource(baseTheme.value)
+      }
+    } catch {}
+
     await createWindow()
 
     if (isDebug) {
@@ -973,7 +983,6 @@ function runApp() {
       // It will be shown later when ready via `ready-to-show` event
       show: showWindowNow,
       backgroundColor: windowBackground,
-      darkTheme: nativeTheme.shouldUseDarkColors,
       icon: process.env.NODE_ENV === 'development'
         ? path.join(__dirname, '../../_icons/iconColor.png')
         : path.join(__dirname, '../_icons/iconColor.png'),
@@ -1623,6 +1632,14 @@ function runApp() {
     }
   })
 
+  function updateThemeSource(baseTheme) {
+    nativeTheme.themeSource = LIGHT_BASE_THEMES.includes(baseTheme)
+      ? 'light'
+      : (DARK_BASE_THEMES.includes(baseTheme)
+          ? 'dark'
+          : 'system')
+  }
+
   // ************************************************* //
   // DB related IPC calls
   // *********** //
@@ -1671,6 +1688,9 @@ function runApp() {
                 trayOnMinimize = data.value
                 if (!trayOnMinimize) { showHiddenWindows() }
               }
+              break
+            case 'baseTheme':
+              updateThemeSource(data.value)
               break
 
             default:


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Description

Currently the context menus in FreeTube follow the system level dark/light mode, which means you can get dark menus with a light theme selected in FreeTube or get flashbanged by white menus when you have a dark theme set in FreeTube. With this pull request FreeTube overrides [Electron's `themeSource` setting](https://www.electronjs.org/docs/latest/api/native-theme#nativethemethemesource) to `"dark"`, `"light"` or `"system"` as appropriate. It also affects the dev tools and has some operating system specific effects such as changing the title bar and/or app menu colours, so most parts of the Electron UI should match as well as operating system level UI that Electron is able to override.

## Screenshots

### Black theme
<img width="237" height="131" alt="black theme with dark context menu" src="https://github.com/user-attachments/assets/881d3ec4-953e-4848-b187-723fb4c5f8cd" />

### Solarized Light theme
<img width="238" height="128" alt="solarized light them with light context menu" src="https://github.com/user-attachments/assets/b9b74fea-44a5-4833-a1cb-2f0dec56a187" />

## Testing

Test various themes in FreeTube and check that the context menu and devtools theming matches, additionally confirm that it correctly switched back to the operating system theme when the system theme is selected in FreeTube.

## Desktop

- **OS:** Windows
- **OS Version:** 11