### PR TITLE
Feat: Implement pagination for playlists when using Invidious API

### DIFF
--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -174,7 +174,7 @@ import {
   parseLocalPlaylistVideo,
   untilEndOfLocalPlayList,
 } from '../../helpers/api/local'
-import { invidiousGetPlaylistInfo } from '../../helpers/api/invidious'
+import { invidiousGetPlaylistInfo, fetchAllInvidiousPlaylistVideos } from '../../helpers/api/invidious'
 import { getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 
 const props = defineProps({
@@ -581,20 +581,22 @@ async function loadCachedPlaylistInformation(cachedPlaylist) {
   channelName.value = cachedPlaylist.channelName
   channelId.value = cachedPlaylist.channelId
 
-  if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious' || cachedPlaylist.continuationData === null) {
-    playlistItems.value = cachedPlaylist.items
-  } else {
-    const videos = cachedPlaylist.items
-
+  const videos = cachedPlaylist.items
+  if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
+    const videoCount = cachedPlaylist.videoCount
+    if (videos.length < videoCount) {
+      const remainingVideos = await fetchAllInvidiousPlaylistVideos(cachedPlaylist.id, videos.length)
+      videos.push(...remainingVideos)
+    }
+  } else if (cachedPlaylist.continuationData !== null) {
     const continuationData = await getLocalCachedFeedContinuation('playlist', cachedPlaylist.continuationData)
     videos.push(...continuationData.items.map(parseLocalPlaylistVideo))
 
     await untilEndOfLocalPlayList(continuationData, (p) => {
       videos.push(...p.items.map(parseLocalPlaylistVideo))
     }, { runCallbackOnceFirst: false })
-
-    playlistItems.value = videos
   }
+  playlistItems.value = videos
 
   isLoading.value = false
 }
@@ -653,7 +655,11 @@ async function getPlaylistInformationInvidious() {
     channelName.value = result.author
     channelId.value = result.authorId
 
-    playlistItems.value = result.videos
+    const videos = result.videos
+    const remainingVideos = await fetchAllInvidiousPlaylistVideos(result.playlistId, videos.length)
+    videos.push(...remainingVideos)
+
+    playlistItems.value = videos
 
     isLoading.value = false
   } catch (err) {

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -284,6 +284,7 @@ export async function searchInvidiousChannel(channelId, query, page) {
 
 /**
  * @param {string} playlistId
+ * @param {number} index
  * @returns {Promise<{
  *  title: string,
  *  playlistId: string,
@@ -307,16 +308,53 @@ export async function searchInvidiousChannel(channelId, query, page) {
  *  }[]
  * }>}
  */
-export async function invidiousGetPlaylistInfo(playlistId) {
+export async function invidiousGetPlaylistInfo(playlistId, index = 0) {
+  // The Invidious API offsets the index by 50 to apply a lookback window
+  // By increasing our offset by 50, we skip those overlapping videos and avoid de-duplicating them from our response
+  // See: https://github.com/iv-org/invidious/blob/66fb829dbc0f96cbf4319798f3b9090bc88a7012/src/invidious/routes/api/v1/misc.cr#L67
+  index += 50
   const playlist = await invidiousAPICall({
     resource: 'playlists',
     id: playlistId,
+    params: {
+      index
+    }
   })
 
   normalizeManyInvidiousVideosAttributes(playlist.videos)
   setMultiplePublishedTimestamps(playlist.videos)
 
   return playlist
+}
+
+/**
+ * @param {string} playlistId
+ * @param {number} initialOffset
+ * @returns {{
+ *    title: string,
+ *    videoId: string,
+ *    author: string,
+ *    authorId: string,
+ *    authorUrl: string,
+ *    videoThumbnails: InvidiousThumbnailObject[],
+ *    index: number,
+ *    lengthSeconds: number
+ *  }[]}
+ */
+export async function fetchAllInvidiousPlaylistVideos(playlistId, initialOffset = 0) {
+  let offset = initialOffset
+  const videos = []
+
+  while (true) {
+    const playlist = await invidiousGetPlaylistInfo(playlistId, offset)
+    if (playlist.videos.length === 0) {
+      break
+    }
+    videos.push(...playlist.videos)
+    offset += playlist.videos.length
+  }
+
+  return videos
 }
 
 /**

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -286,7 +286,7 @@ export async function getLocalPlaylistContinuation(playlist) {
 }
 
 /**
- * Callback for adding two numbers.
+ * Callback for processing a Local playlist.
  *
  * @callback untilEndOfLocalPlayListCallback
  * @param {import('youtubei.js').YT.Playlist} playlist

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -295,9 +295,15 @@ const selectedUserPlaylistVideos = computed(() => selectedUserPlaylist.value?.vi
 const selectedUserPlaylistVideoCount = computed(() => selectedUserPlaylistVideos.value.length)
 
 const moreVideoDataAvailable = computed(() => {
-  return isUserPlaylistRequested.value
-    ? userPlaylistVisibleLimit.value < sometimesFilteredUserPlaylistItems.value.length
-    : continuationData.value !== null
+  if (isUserPlaylistRequested.value) {
+    return userPlaylistVisibleLimit.value < sometimesFilteredUserPlaylistItems.value.length
+  }
+
+  if (infoSource.value === 'invidious') {
+    return playlistItems.value.length < videoCount.value
+  }
+
+  return continuationData.value !== null
 })
 
 const processedVideoSearchQuery = computed(() => videoSearchQuery.value.trim().toLowerCase())
@@ -668,7 +674,7 @@ function getNextPage() {
       isLoadingMore.value = false
     })
   } else if (infoSource.value === 'invidious') {
-    console.error('Playlist pagination is not currently supported when the Invidious backend is selected.')
+    getNextPageInvidious()
   }
 }
 
@@ -701,6 +707,16 @@ async function getNextPageLocal() {
   if (shouldGetNextPage) {
     getNextPageLocal()
   }
+}
+
+async function getNextPageInvidious() {
+  isLoadingMore.value = true
+
+  const index = playlistItems.value.length
+  const result = await invidiousGetPlaylistInfo(playlistId.value, index)
+  playlistItems.value.push(...result.videos)
+
+  isLoadingMore.value = false
 }
 
 const canMoveVideos = computed(() => {
@@ -1075,6 +1091,7 @@ onBeforeRouteLeave((to) => {
       continuationData: continuationData.value
         ? extractLocalCacheablePlaylistContinuation(continuationData.value)
         : null,
+      videoCount: videoCount.value,
     })
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/2333
This is considered to be a bug, but the fix needs implementing a feature.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Add support for Invidious playlists pagination.
Also, fix the video count in the playlist description to display the total count.

There are three ways to implement pagination with Invidious API, two of them are [undocumented](https://docs.invidious.io/api/#get-apiv1playlistsplid):
- `page`: Inconsistent behaviour (see https://github.com/iv-org/invidious/issues/5816) which makes it hard to rely on for caching
- `index`: More consistent than `page`, it is the video index in the playlist. A lookback window of 50 is applied to the value
- `continuation`: Same as `index` but with a `video_id`. It is [commented](https://github.com/iv-org/invidious/blob/66fb829dbc0f96cbf4319798f3b9090bc88a7012/src/invidious/routes/api/v1/misc.cr#L71) as being expensive.

I chose `index`, which is the less expensive and the more consistent. However, I had to compensate for the lookback window which is not useful in our case (I don't know in which scenario it could be useful too...).

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
All tests require `Settings > General > Preferred API Backend` to be set to `Invidious API` with an Invidious instance having its API enabled. 

**Large playlist can be fully loaded**
1. Go a playlist with 200+ videos (e.g. https://youtube.com/playlist?list=PLj3LVjI7cF7k-LmGKRiw6XwbU8SAtQwCF)
2. Check that the playlist description displays the total video count
3. Scroll to the bottom
4. Check that the `Load More Videos` button appears
5. Click and check that more videos are loaded
6. Repeat until reaching the end of the playlist

**Playlist cache is conserved when navigating to watch page**
This one requires some feedback from the code. I would suggest adding a log to the `invidious#invidiousGetPlaylistInfo` function.
1. Complete all the steps in the previous test
2. Click on a video in the playlist
3. Check that `invidiousGetPlaylistInfo` is not called
4. Check that the playlist view on the watch page contains all the videos

**Watch page loads the full playlist**
1. Go a playlist with 200+ videos (e.g. https://youtube.com/playlist?list=PLj3LVjI7cF7k-LmGKRiw6XwbU8SAtQwCF)
2. Click on any video
3. Check that the playlist view on the watch page contains all the videos

**Direct acces to watch page loads the full playlist**
1. Navigate directly to the watch page of a video within a playlist (e.g. https://youtu.be/h5cDiLHs2JM?list=PL47cI9uL16XuIfObjdqaP6HFdyjYcEVyT)
2. Check that the playlist view on the watch page contains all the videos

**Regression**
Check that the behaviour hasn't changed for:
- small playlist using Invididous API
- small and large playlists using Local API
- user playlists

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.25.1-beta
