### PR TITLE
Use page-bound attestation data for Web PoTokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@fortawesome/vue-fontawesome": "^3.3.3",
     "@seald-io/nedb": "^4.1.2",
     "autolinker": "^4.1.5",
-    "bgutils-js": "^4.0.2",
+    "bgutils-js": "^4.0.3",
     "dompurify": "^3.4.12",
     "electron-context-menu": "^4.1.2",
     "googlevideo": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       bgutils-js:
-        specifier: ^4.0.2
-        version: 4.0.2
+        specifier: ^4.0.3
+        version: 4.0.3
       dompurify:
         specifier: ^3.4.12
         version: 3.4.12
@@ -1901,8 +1901,8 @@ packages:
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
 
-  bgutils-js@4.0.2:
-    resolution: {integrity: sha512-PyZRxSkwC2MyVtIidD0DejgeNQfb9p3N/wY/d9sa3zAFeMTg6nDMv99wPYoUMU8JhzgG22ZVTnCzAcbfzKPVfQ==}
+  bgutils-js@4.0.3:
+    resolution: {integrity: sha512-nvhrzqRYqFcC3AJbf1fENc/jzyMk95wH9UC9ruQzTZCq+itYWuHi2a9leK/bC1lLfi+R4a28wJZxpD5KiTFf+w==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
@@ -7160,7 +7160,7 @@ snapshots:
 
   batch@0.6.1: {}
 
-  bgutils-js@4.0.2: {}
+  bgutils-js@4.0.3: {}
 
   birpc@2.9.0: {}
 

--- a/src/botGuardScript.js
+++ b/src/botGuardScript.js
@@ -1,5 +1,5 @@
 import { BotGuardClient } from 'bgutils-js/botguard'
-import { buildURL, GOOG_API_KEY } from 'bgutils-js/utils'
+import { buildURL, GOOG_API_KEY, parseLooseJSON } from 'bgutils-js/utils'
 import { WebPoMinter } from 'bgutils-js/webpo'
 
 // This script has it's own webpack config, as it gets passed as a string to Electron's evaluateJavaScript function
@@ -8,34 +8,33 @@ import { WebPoMinter } from 'bgutils-js/webpo'
 /**
  * Based on: https://github.com/LuanRT/BgUtils/blob/main/examples/node/innertube-challenge-fetcher-example.ts
  * @param {string} videoId
- * @param {import('youtubei.js').Session['context']} context
  */
-export default async function (videoId, context) {
+export default async function (videoId) {
   const requestKey = 'O43z0dpjhgX20SCx4KAo'
 
-  const challengeResponse = await fetch(
-    'https://www.youtube.com/youtubei/v1/att/get?prettyPrint=false&alt=json',
-    {
-      method: 'POST',
-      headers: {
-        Accept: '*/*',
-        'Content-Type': 'application/json',
-        'X-Goog-Visitor-Id': context.client.visitorData,
-        'X-Youtube-Client-Version': context.client.clientVersion,
-        'X-Youtube-Client-Name': '1'
-      },
-      body: JSON.stringify({
-        engagementType: 'ENGAGEMENT_TYPE_UNBOUND',
-        context
-      }),
+  // YouTube binds WEB attestation challenges to the page's yt.config_.EVENT_ID.
+  const pageResponse = await fetch('https://www.youtube.com/', {
+    headers: {
+      Accept: '*/*',
+      'Accept-Language': 'en-US,en;q=0.7'
     }
-  )
+  })
 
-  if (!challengeResponse.ok) {
-    throw new Error(`Request to ${challengeResponse.url} failed with status ${challengeResponse.status}\n${await challengeResponse.text()}`)
+  if (!pageResponse.ok) {
+    throw new Error(`Request to ${pageResponse.url} failed with status ${pageResponse.status}`)
   }
 
-  const challengeData = await challengeResponse.json()
+  const pageHtml = await pageResponse.text()
+  const ytConfigText = pageHtml.match(/ytcfg\.set\(({.+?})\);/s)?.[1]
+  const initialAttestationText = pageHtml.match(/window\.ytAtN\(\s*({[\s\S]*?})\s*\)/)?.[1]
+
+  if (!ytConfigText || !initialAttestationText) {
+    throw new Error('Could not find the page-bound attestation data')
+  }
+
+  window.yt = { config_: JSON.parse(ytConfigText) }
+
+  const challengeData = parseLooseJSON(initialAttestationText).R
 
   if (!challengeData.bgChallenge) {
     throw new Error('Failed to get BotGuard challenge')

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1274,9 +1274,9 @@ function runApp() {
     })
   })
 
-  ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (event, videoId, context) => {
+  ipcMain.handle(IpcChannels.GENERATE_PO_TOKEN, (event, videoId) => {
     if (isFreeTubeUrl(event.senderFrame.url)) {
-      return generatePoToken(videoId, context, proxyUrl)
+      return generatePoToken(videoId, proxyUrl)
     }
   })
 

--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -43,11 +43,10 @@ let firstTime = true
  * as the BotGuard stuff accesses the global `document` and `window` objects and also requires making some requests.
  * So we definitely don't want it running in the same places as the rest of the FreeTube code with the user data.
  * @param {string} videoId
- * @param {string} context
  * @param {string|undefined} proxyUrl
  * @returns {Promise<string>}
  */
-export function generatePoToken(videoId, context, proxyUrl) {
+export function generatePoToken(videoId, proxyUrl) {
   if (firstTime) {
     firstTime = false
     enqueueAsyncFunction(sharedInit)
@@ -65,7 +64,7 @@ export function generatePoToken(videoId, context, proxyUrl) {
   // - https://github.com/FreeTubeApp/FreeTube/issues/8640
   // - https://github.com/electron/electron/pull/46131
   // - https://github.com/electron/electron/commit/bac2f46ba981cc1763c0485cec44813c1d07fa18
-  const potokenPromise = enqueueAsyncFunction(internalGeneratePotoken, videoId, context, proxyUrl)
+  const potokenPromise = enqueueAsyncFunction(internalGeneratePotoken, videoId, proxyUrl)
 
   // schedule the cleanup separately,
   // so that we can return the potoken without having to wait until the cleanup is done
@@ -145,11 +144,10 @@ async function sharedInit() {
 
 /**
  * @param {string} videoId
- * @param {string} context
  * @param {string|undefined} proxyUrl
  * @returns {Promise<string>}
  */
-async function internalGeneratePotoken(videoId, context, proxyUrl) {
+async function internalGeneratePotoken(videoId, proxyUrl) {
   let webContentsView
 
   try {
@@ -203,7 +201,7 @@ async function internalGeneratePotoken(videoId, context, proxyUrl) {
       }
     })
 
-    const script = cachedScript.replace('FT_PARAMS', `"${videoId}",${context}`)
+    const script = cachedScript.replace('FT_PARAMS', `"${videoId}"`)
 
     return await webContentsView.webContents.executeJavaScript(script)
   } finally {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -118,11 +118,10 @@ export default {
 
   /**
    * @param {string} videoId
-   * @param {string} context
    * @returns {Promise<string>}
    */
-  generatePoToken: (videoId, context) => {
-    return ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKEN, videoId, context)
+  generatePoToken: (videoId) => {
+    return ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKEN, videoId)
   },
 
   chooseDefaultFolder: () => {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -445,10 +445,7 @@ export async function getLocalVideoInfo(id) {
 
   if (process.env.IS_ELECTRON) {
     try {
-      contentPoToken = await window.ftElectron.generatePoToken(
-        id,
-        JSON.stringify(webInnertube.session.context)
-      )
+      contentPoToken = await window.ftElectron.generatePoToken(id)
 
       webInnertube.session.player.po_token = contentPoToken
     } catch (error) {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Relates to  (I couldn't comment on the issues since they're locked)

## Description

FreeTube currently generates a content-bound Web PoToken before playback using a challenge from `/youtubei/v1/att/get`.

According to [BgUtils PR #44](https://github.com/LuanRT/BgUtils/pull/44), YouTube is rolling out an experiment that binds the initial attestation challenge to the `EVENT_ID` in the same page's `yt.config_`. Sessions placed in this experiment therefore do not accept the token currently generated from the standalone challenge, so YouTube returns `StreamProtectionStatus` 2 in those sessions. This seems to explain the intermittent/random nature of the bug and may explain how it seems to show up more with certain videos over others.

Now at this point FreeTube currently doesn't handle the status 2 responses well which is what results in the bad behavior, but this PR doesn't address that.
The status 2 responses allow a limited amount of media using the cold-start allowance, but FreeTube does not replace the token after receiving it, so once the allowance runs out, YouTube returns zero-backoff request policies without more media. FreeTube receives each zero-backoff policy response and immediately sends another request with the same token. After following 100 of these policy responses, FreeTube reloads the player, and this can become a loop if you repeatedly land on the experiment. I thought this should be addressed separately.

This change:
- Gets the initial challenge and `yt.config_` from the same YouTube page.
- Generates the content-bound PoToken with the matching `EVENT_ID`.
- Updates `bgutils-js` to 4.0.3 for its `window.ytAtN(...)` parser.
- Removes the Innertube context previously passed through the renderer, preload, and main process for `/att/get`.

## Testing

I first reproduced the reload loop naturally with video ID `nylKaW1ZMRA`. Then I slopped out a test harness that repeatedly opened the same video in fresh sessions while keeping the FreeTube process, profile, and IP unchanged. The harness captured the SABR traffic and decoded `StreamProtectionStatus` directly from the UMP responses.

With the existing `/att/get` implementation:

- 13 of 24 sessions returned status 2.
- 11 of 24 sessions returned status 1 and played normally.

With the challenge and `EVENT_ID` taken from the same page:

- 12 of 12 sessions returned status 1.

As a control, I kept the page challenge but deliberately changed only its `EVENT_ID`:

- 5 of 8 sessions returned status 2.
- 3 of 8 sessions returned status 1.


If you want to test manually without a harness, just find a video that happens to hit the experiment and exhibit the bad behavior, reload a bunch to see if you can reproduce it (I would wait at least a minute each time), then try with this version to see if you can reproduce again.

## Desktop

- **OS:** Linux
- **OS Version:** Kernel 6.18.38
- **FreeTube version:** 0.25.1 development
