### PR TITLE
Change Unofficial Downloads section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,29 +115,13 @@ The first build with a green check mark is the latest build.
 > [!IMPORTANT]
 > You will need to have a GitHub account to download these builds.
 
-### Unofficial Downloads
-> [!WARNING]
-> These builds are maintained by the community. While they should be safe, download at your own risk. There may be issues with using these versus the official builds. Any issues specific with these builds should be sent to their respective maintainer. Make sure you always try an [official download](https://github.com/freetubeapp/freetube/#official-downloads) before reporting your issue to us!
-
-* Arch User Repository (AUR): [Download](https://aur.archlinux.org/packages/freetube-bin/)
-
-* Chocolatey: [Download](https://chocolatey.org/packages/freetube/)
-
-* FreeTubeAndroid (FreeTube port for Android and PWA): [Download](https://github.com/MarmadileManteater/FreeTubeAndroid/releases) and [Source Code](https://github.com/MarmadileManteater/FreeTubeAndroid)
+### Projects maintained by individual FreeTube team members
+> [!IMPORTANT]
+> The following are related projects maintained by individual members of the FreeTube team. While they are not part of the main FreeTube project, they may be useful to FreeTube users. There may be issues when using these projects compared to the official builds. Any issues specific to these builds should be reported to their respective maintainers. Make sure you always try an [official download](https://github.com/freetubeapp/freetube/#official-downloads) before reporting your issue to us!
 
 * Homebrew Formulae (Mac only): [Download for Apple Silicon](https://github.com/PikachuEXE/homebrew-FreeTube)
 
-* Nix Packages: [Download](https://search.nixos.org/packages?query=freetube)
-
-* PortableApps (Windows Only): [Download](https://github.com/rddim/FreeTubePortable/releases) and [Source Code](https://github.com/rddim/FreeTubePortable)
-
-* Scoop (Windows Only): [Usage](https://github.com/ScoopInstaller/Scoop)
-
-* Snap: [Download](https://snapcraft.io/freetube) and [Source Code](https://git.launchpad.net/freetube)
-
-* WAPT: [Download](https://wapt.tranquil.it/store/en/tis-freetube)
-
-* Windows Package Manager (winget): [Usage](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
+* FreeTubeAndroid (FreeTube port for Android and PWA): [Download](https://github.com/MarmadileManteater/FreeTubeAndroid/releases) and [Source Code](https://github.com/MarmadileManteater/FreeTubeAndroid)
 
 ## Contributing
 Thank you very much to the [People and Projects](https://docs.freetubeapp.io/credits/) that make FreeTube possible!

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The first build with a green check mark is the latest build.
 > [!IMPORTANT]
 > The following are related projects maintained by individual members of the FreeTube team. While they are not part of the main FreeTube project, they may be useful to FreeTube users. There may be issues when using these projects compared to the official builds. Any issues specific to these builds should be reported to their respective maintainers. Make sure you always try an [official download](https://github.com/freetubeapp/freetube/#official-downloads) before reporting your issue to us!
 
-* Homebrew Formulae (Mac only): [Download for Apple Silicon](https://github.com/PikachuEXE/homebrew-FreeTube)
+* Homebrew FreeTube (Apple Silicon only): [Install](https://github.com/PikachuEXE/homebrew-FreeTube)
 
 * FreeTubeAndroid (FreeTube port for Android and PWA): [Download](https://github.com/MarmadileManteater/FreeTubeAndroid/releases) and [Source Code](https://github.com/MarmadileManteater/FreeTubeAndroid)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Documentation

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTubeApp.io/issues/32

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
For a long time now we have been running into the problem of users reporting issues that are caused by third party maintainers e.g. AUR maintainers creating builds with a newer version of Electron that is full of bugs. This PR renames that section to `Projects maintained by individual FreeTube team members` and only lists projects created by one of us. 

I decided to not remove them in the issue templates so we at least know somebody is using something unofficial.

The Unofficial Downloads section was created to make FreeTube more accessible to a broader audience but unfortunately lead to it being counterproductive as we have seen an uptick in false reports which consumes time we can use on something else.