### PR TITLE
Fix the circle getting stretched on quiz posts with multi-line options

### DIFF
--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.css
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.css
@@ -55,11 +55,6 @@
   background-color: #78da71;
 }
 
-.incorrect-option {
-  border-color: #dd4e4e;
-  border-width: 2px;
-}
-
 .reveal-answer {
   justify-content: center;
   cursor: pointer;

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.css
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.css
@@ -12,7 +12,7 @@
   float: inline-start;
   block-size: 10px;
   position: relative;
-  inline-size: 10px;
+  min-inline-size: 10px;
 }
 
 .filled-circle {

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
@@ -12,7 +12,7 @@
     >
       <div
         v-if="data.type === 'quiz'"
-        class="option quiz-option"
+        class="option"
         :class="revealAnswer && choice.isCorrect ? 'correct-option' : ''"
       >
         <span class="empty-circle">
@@ -27,7 +27,7 @@
       </div>
       <div
         v-else
-        class="option poll-option"
+        class="option"
       >
         <span class="empty-circle" />
         <img


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #9599

## Description

Switches from `inline-size` to `min-inline-size` for the circles shown in quiz posts, to avoid it getting squashed when the option text is long or takes up multiple lines. The second commit cleans up unused CSS classes in the FtCommunityPost component.

## Screenshots

_videos of how it looked before were provided in the linked issue_

## Testing

http://youtube.com/post/Ugkxxn2h-vniZa3OH1mh1dB4wXtNuccVurv4

## Desktop

- **OS:** Windows
- **OS Version:** 11