### PR TITLE
chore: Add `globals` to our eslint dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
           - "neostandard"
           - "@intlify/eslint-plugin-vue-i18n"
           - "@stylistic/eslint-plugin"
+          - "globals"
       stylelint:
         patterns:
           - "stylelint"


### PR DESCRIPTION
## Pull Request Type
- [x] Other

## Description
We only use globals for eslint, I think we should include globals in our eslint dependabot group :smile: 

## Desktop
- **OS:** Fedora Linux
- **OS Version:** 44
- **FreeTube version:** latest nightly
