### PR TITLE
Set screen width instead of time zone

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -480,7 +480,7 @@ function buildSessionFromYtConfig(ytConfig, fetchFunc) {
   context.client.screenDensityFloat ??= 1
   context.client.screenHeightPoints ??= 1440
   context.client.screenPixelDensity ??= 1
-  context.client.timeZone ??= 2560
+  context.client.screenWidthPoints ??= 2560
   context.client.utcOffsetMinutes ??= -Math.floor((new Date()).getTimezoneOffset())
   context.client.memoryTotalKbytes ??= '8000000'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Description
Set screen width to 2560 instead of setting timeZone to 2560.

## Testing
I haven't tested this. But timeZone is defined as a `string`:
https://github.com/LuanRT/YouTube.js/blob/a6f8a772cbcae54aa109b7cd0730949bae32e901/protos/generated/youtube/api/pfiinnertube/client_info.ts#L71 , is already set slightly higher up:
https://github.com/FreeTubeApp/FreeTube/blob/459412d51eb894e444e8322529cbe27ccc24a1dd/src/renderer/helpers/api/local.js#L479
and I'm pretty sure this is a typo that was intended to set width to 2560 (to end up with 2560x1440).
