### PR TITLE
Fallback to extracting the potoken challenge data and config from the YouTube homepage

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -592,7 +592,10 @@ function runApp() {
         requestHeaders['Sec-Fetch-Site'] = 'same-origin'
         requestHeaders['Sec-Fetch-Mode'] = 'same-origin'
         requestHeaders['X-Youtube-Bootstrap-Logged-In'] = 'false'
-      } else if (url.startsWith('https://www.youtube.com/watch')) {
+      } else if (
+        url.startsWith('https://www.youtube.com/watch') ||
+        (urlObj.origin === 'www.youtube.com' && urlObj.pathname === '/')
+      ) {
         delete requestHeaders.Referer
         delete requestHeaders.Origin
         requestHeaders['Sec-Fetch-Dest'] = 'document'

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -379,12 +379,12 @@ export async function getLocalSearchContinuation(continuationData) {
 }
 
 /**
- * @param {string} videoId
- * @param {(input, init) => Promise<Response>} fetchFunc
+ * @param {string} url
+ * @param {string} kind
  */
-async function getWatchHTMLWatchPage(videoId, fetchFunc) {
+async function getHTMLPage(url, kind) {
   // This returns session/tracking cookies but they get removed in onHeadersReceived in the main process before they are saved by Electron
-  const htmlResponse = await fetch(`https://www.youtube.com/watch?v=${videoId}&bpctr=9999999999&has_verified=1`,
+  const htmlResponse = await fetch(url,
     {
       headers: {
         // We need to be able to parse the localised strings in the /next response data (e.g. view counts and published dates)
@@ -398,7 +398,7 @@ async function getWatchHTMLWatchPage(videoId, fetchFunc) {
   const ytConfigStr = htmlPage.match(/ytcfg\.set\(({.+?})\);/s)?.[1]
   if (!ytConfigStr) {
     // required for botguard
-    throw new Error('Could not find ytcfg in the HTML page')
+    throw new Error(`Could not find ytcfg in the ${kind} HTML page`)
   }
 
   const ytConfig = JSON.parse(ytConfigStr)
@@ -407,7 +407,7 @@ async function getWatchHTMLWatchPage(videoId, fetchFunc) {
 
   if (!initialAttestationDataMatch) {
     // required for botguard
-    throw new Error('Could not find challenge in the HTML page')
+    throw new Error(`Could not find challenge in the ${kind} HTML page`)
   }
 
   let initialAttestationData
@@ -415,42 +415,74 @@ async function getWatchHTMLWatchPage(videoId, fetchFunc) {
   try {
     initialAttestationData = parseLooseJSON(initialAttestationDataMatch[1])
   } catch (e) {
-    const error = new Error('Failed to parse the initial attestation data', { cause: e })
+    const error = new Error(`Failed to parse the ${kind} home page initial attestation data`, { cause: e })
     console.error(error, initialAttestationDataMatch[1])
     throw error
   }
 
-  /** @type {string | undefined} */
   let playerId = ytConfig.PLAYER_JS_URL?.match(/player\/([^/]+)\//)?.[1]
 
   playerId ??= htmlPage.match(/<script[^>]+src="[^">]+player\/([^/]+)\/[^"]+\/base.js"/)?.[1]
 
-  const playerResponseStr = htmlPage.match(/ytInitialPlayerResponse\s*=\s*(\{.+?\});/)?.[1]
-  let playerResponse
-
-  // not fatal if it is missing as we can retrieve it from Innertube ourselves
-  if (playerResponseStr) {
-    try {
-      playerResponse = JSON.parse(playerResponseStr)
-    } catch (e) {
-      console.warn('/player response extracted from the HTML page is invalid JSON', e)
-    }
-  } else {
-    console.warn('Could not find /player response in the HTML page')
+  return {
+    htmlPage,
+    ytConfig,
+    initialAttestationData,
+    playerId
   }
+}
 
-  const nextResponseStr = htmlPage.match(/(?:window\s*\[\s*["']ytInitialData["']\s*\]|ytInitialData)\s*=\s*(\{.+?\});/)?.[1]
-  let nextResponse
+/**
+ * @param {string} videoId
+ * @param {(input, init) => Promise<Response>} fetchFunc
+ */
+async function getWatchHTMLWatchPage(videoId, fetchFunc) {
+  let htmlPage, ytConfig, initialAttestationData
 
-  // not fatal if it is missing as we can retrieve it from Innertube ourselves
-  if (nextResponseStr) {
-    try {
-      nextResponse = JSON.parse(nextResponseStr)
-    } catch (e) {
-      console.warn('/next response extracted from the HTML page is invalid JSON', e)
-    }
+  let playerResponse, nextResponse
+  /** @type {string | undefined} */
+  let playerId
+
+  if (sessionStorage.getItem('playerHtmlHomepageFallback') === '1') {
+    ({ ytConfig, initialAttestationData, playerId } = await getHTMLPage('https://www.youtube.com', 'home'))
   } else {
-    console.warn('Could not find /next response in the HTML page')
+    try {
+      ({ htmlPage, ytConfig, initialAttestationData, playerId } = await getHTMLPage(`https://www.youtube.com/watch?v=${videoId}&bpctr=9999999999&has_verified=1`, 'watch'))
+
+      const playerResponseStr = htmlPage.match(/ytInitialPlayerResponse\s*=\s*(\{.+?\});/)?.[1]
+
+      // not fatal if it is missing as we can retrieve it from Innertube ourselves
+      if (playerResponseStr) {
+        try {
+          playerResponse = JSON.parse(playerResponseStr)
+        } catch (e) {
+          console.warn('/player response extracted from the HTML page is invalid JSON', e)
+        }
+      } else {
+        console.warn('Could not find /player response in the HTML page')
+      }
+
+      const nextResponseStr = htmlPage.match(/(?:window\s*\[\s*["']ytInitialData["']\s*\]|ytInitialData)\s*=\s*(\{.+?\});/)?.[1]
+
+      // not fatal if it is missing as we can retrieve it from Innertube ourselves
+      if (nextResponseStr) {
+        try {
+          nextResponse = JSON.parse(nextResponseStr)
+        } catch (e) {
+          console.warn('/next response extracted from the HTML page is invalid JSON', e)
+        }
+      } else {
+        console.warn('Could not find /next response in the HTML page')
+      }
+    } catch (watchError) {
+      console.warn('Falling back to the YT home page for the rest of the session because of:', watchError)
+
+      // Fall back to the home page for the rest of the session/until FreeTube is restarted
+      // assuming that getting the watch page captcha once is a sign that it will continue happening
+      sessionStorage.setItem('playerHtmlHomepageFallback', '1');
+
+      ({ ytConfig, initialAttestationData, playerId } = await getHTMLPage('https://www.youtube.com', 'home'))
+    }
   }
 
   const session = buildSessionFromYtConfig(ytConfig, fetchFunc)


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix

## Related issue

- closes #9632

## Description

The YouTube home page seems to work when the watch page is returning captchas so lets fallback to extracting the ytconfig, challenge data and player ID from there, with the watch page information coming from the /player and /next Innertube calls that were already added as fallbacks in #9607. This keeps the watch page HTML as the main mechanism as that requires less requests and as a result tends to load the FreeTube watch page faster. 

When the watch page extraction fails we set a session level flag to use the home page for the rest of the FreeTube session, which is stored in session storage rather than vuex so it applies across all windows, the flag will be automatically reset when FreeTube is relaunched.

_I recommend turning on the "hide whitespace" diff view setting to make the diff easier to read, as varous code blocks moved around._

## Testing

1. Find a VPN server or home IP that is currently getting redirected to Google's captcha page and throwing "Could not find ytcfg in the HTML page" errors.
2. Test this pull request
3. If 1 isn't possible for you, you can also force the fallback with `sessionStorage.setItem('playerHtmlHomepageFallback', '1')` and `sessionStorage.removeItem('playerHtmlHomepageFallback')` in the dev tools.

## Desktop

- **OS:** Windows
- **OS Version:** 11