### PR TITLE
feat: Add default audio selector

### DIFF
--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -103,6 +103,14 @@
         @change="updateDefaultQuality"
       />
       <FtSelect
+        :placeholder="t('Settings.Player Settings.Default Language.Default Language')"
+        :value="defaultAudioLanguage"
+        :select-names="AUDIO_LANGUAGE_NAMES"
+        :select-values="AUDIO_LANGUAGE_VALUES"
+        :icon="['fas', 'language']"
+        @change="updateDefaultAudioLanguage"
+      />
+      <FtSelect
         :placeholder="t('Settings.Player Settings.Video Playback Rate Interval')"
         :value="videoPlaybackRateIntervalString"
         :select-names="PLAYBACK_RATE_INTERVAL_VALUES"
@@ -507,6 +515,113 @@ const defaultQuality = computed(() => {
  */
 function updateDefaultQuality(value) {
   store.dispatch('updateDefaultQuality', value)
+}
+
+const AUDIO_LANGUAGE_VALUES = [
+  'system',
+  'af',
+  'am',
+  'ar',
+  'as',
+  'az',
+  'be',
+  'bg',
+  'bn',
+  'bs',
+  'ca',
+  'cs',
+  'da',
+  'de',
+  'el',
+  'en',
+  'en-GB',
+  'en-IN',
+  'es',
+  'es-419',
+  'es-US',
+  'et',
+  'eu',
+  'fa',
+  'fi',
+  'fil',
+  'fr',
+  'fr-CA',
+  'gl',
+  'gu',
+  'hi',
+  'hr',
+  'hu',
+  'hy',
+  'id',
+  'is',
+  'it',
+  'iw',
+  'ja',
+  'ka',
+  'kk',
+  'km',
+  'kn',
+  'ko',
+  'ky',
+  'lo',
+  'lt',
+  'lv',
+  'mk',
+  'ml',
+  'mn',
+  'mr',
+  'ms',
+  'my',
+  'ne',
+  'nl',
+  'no',
+  'or',
+  'pa',
+  'pl',
+  'pt',
+  'pt-PT',
+  'ro',
+  'ru',
+  'si',
+  'sk',
+  'sl',
+  'sq',
+  'sr',
+  'sr-Latn',
+  'sv',
+  'sw',
+  'ta',
+  'te',
+  'th',
+  'tr',
+  'uk',
+  'ur',
+  'uz',
+  'vi',
+  'zh-CN',
+  'zh-HK',
+  'zh-Hans',
+  'zh-Hant',
+  'zh-TW',
+  'zu'
+]
+
+const AUDIO_LANGUAGE_NAMES = AUDIO_LANGUAGE_VALUES.map((language, index) => {
+  if (index === 0) {
+    return t('Settings.Player Settings.Default Language.System Language')
+  }
+
+  return new Intl.DisplayNames('en', { type: 'language', languageDisplay: 'standard' }).of(language) ?? language
+})
+
+/** @type {import('vue').ComputedRef<string>} */
+const defaultAudioLanguage = computed(() => store.getters.getDefaultAudioLanguage)
+
+/**
+ * @param {string} value
+ */
+function updateDefaultAudioLanguage(value) {
+  store.dispatch('updateDefaultAudioLanguage', value)
 }
 
 const PLAYBACK_RATE_INTERVAL_VALUES = ['0.1', '0.25', '0.5', '1']

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -290,6 +290,33 @@ export default defineComponent({
       return parseInt(value)
     })
 
+    /** @type {import('vue').ComputedRef<string>} */
+    const defaultAudioLanguage = computed(() => store.getters.getDefaultAudioLanguage)
+
+    /** @type {import('vue').ComputedRef<string>} */
+    const preferredAudioLanguage = computed(() => {
+      return defaultAudioLanguage.value === 'system' ? locale.value : defaultAudioLanguage.value
+    })
+
+    /**
+     * Filters the given variants to the user's preferred audio language, falling back to the main audio track.
+     * @param {shaka.extern.Variant[]} variants
+     * @returns {shaka.extern.Variant[]}
+     */
+    function filterVariantsByPreferredLanguage(variants) {
+      const languageVariants = variants.filter((variant) => {
+        return shaka.util.LanguageUtils.areLanguageCompatible(preferredAudioLanguage.value, variant.language)
+      })
+
+      if (languageVariants.length > 0) {
+        const mainVariants = languageVariants.filter(variant => variant.audioRoles.includes('main'))
+        return mainVariants.length > 0 ? mainVariants : languageVariants
+      }
+
+      const mainVariants = variants.filter(variant => variant.audioRoles.includes('main'))
+      return mainVariants.length > 0 ? mainVariants : variants
+    }
+
     /** @type {import('vue').ComputedRef<boolean>} */
     const enterFullscreenOnDisplayRotate = computed(() => {
       return store.getters.getEnterFullscreenOnDisplayRotate
@@ -634,7 +661,11 @@ export default defineComponent({
         // Electron doesn't like YouTube's vp9 VR video streams and throws:
         // "CHUNK_DEMUXER_ERROR_APPEND_FAILED: Projection element is incomplete; ProjectionPoseYaw required."
         // So use the AV1 and h264 codecs instead which it doesn't reject
-        preferredVideoCodecs: typeof props.vrProjection === 'string' ? ['av01', 'avc1'] : []
+        preferredVideoCodecs: typeof props.vrProjection === 'string' ? ['av01', 'avc1'] : [],
+
+        // The default language to prefer for the audio track.
+        // 'system' uses FreeTube's active locale, which shaka-player matches by prefix.
+        preferredAudioLanguage: preferredAudioLanguage.value
       }
     }
 
@@ -1462,12 +1493,7 @@ export default defineComponent({
       if (label) {
         variants = variants.filter(variant => variant.label === label)
       } else if (hasMultipleAudioTracks.value) {
-        // default audio track
-        const filteredVariants = variants.filter(variant => variant.audioRoles.includes('main'))
-        // Sometimes there is nothing marked as main, don't filter in this case
-        if (filteredVariants.length > 0) {
-          variants = filteredVariants
-        }
+        variants = filterVariantsByPreferredLanguage(variants)
       }
 
       const isPortrait = variants[0].height > variants[0].width
@@ -2906,8 +2932,7 @@ export default defineComponent({
               let variants = player.getVariantTracks()
 
               if (hasMultipleAudioTracks.value) {
-                // default audio track
-                variants = variants.filter(variant => variant.audioRoles.includes('main'))
+                variants = filterVariantsByPreferredLanguage(variants)
               }
 
               const highestBandwidth = Math.max(...variants.map(variant => variant.audioBandwidth))
@@ -3164,12 +3189,7 @@ export default defineComponent({
                 if (label) {
                   variants = variants.filter(variant => variant.label === label)
                 } else if (variants.length > 1) {
-                  // default audio track
-                  const filteredVariants = variants.filter(variant => variant.audioRoles.includes('main'))
-                  // Sometimes there is nothing marked as main, don't filter in this case
-                  if (filteredVariants.length > 0) {
-                    variants = filteredVariants
-                  }
+                  variants = filterVariantsByPreferredLanguage(variants)
                 }
 
                 let chosenVariant

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -168,6 +168,7 @@ const state = {
   mainColor: 'Red',
   secColor: 'Blue',
   defaultAutoplayInterruptionIntervalHours: 3,
+  defaultAudioLanguage: 'system',
   defaultCaptionSettings: '{}',
   defaultInterval: 5,
   defaultPlayback: 1,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -479,6 +479,9 @@ Settings:
       1440p: 1440p
       4k: 4k
       8k: 8k
+    Default Language:
+      Default Language: Default Audio Language
+      System Language: Use System Locale
     Screenshot:
       Enable: Enable Screenshot
       Mode: Screenshot Mode


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
open #4291

## Description
Add an option to set the default audio language

## Screenshots
<img width="1407" height="651" alt="2026-08-12-233205_1407x651_scrot" src="https://github.com/user-attachments/assets/951b2f8e-1b67-4f80-86f8-c0c40c37f003" />

## Testing
Select a language and open a video with multiple audio tracks. For example, one of MrBeast’s recent videos.

It was also tested with the Invidious API using a locally hosted server, since the online instances either don’t expose the API or are offline.

## Desktop
<!-- Please complete the following information-->
- **OS:** GNU/Linux
- **OS Version:** Linux debian 6.12.95+deb13-amd64
- **FreeTube version:** v0.25.2 Beta

## Additional context
The list of languages and their codes was obtained using the YouTube API through the [i18nLanguages.list ](https://developers.google.com/youtube/v3/docs/i18nLanguages/list) endpoint, and the values `zh-Hans` for Simplified Chinese and `zh-Hant` for Traditional Chinese were added, as indicated in the `relevanceLanguage` section of [search.list](https://developers.google.com/youtube/v3/docs/search/list).