### PR TITLE
Don't crash on invalid external player arguments

### DIFF
--- a/src/main/externalPlayer.js
+++ b/src/main/externalPlayer.js
@@ -84,7 +84,11 @@ export async function handleOpenInExternalPlayer(event, payload) {
   const customArgs = (await settings._findOne('externalPlayerCustomArgs'))?.value || '[]'
 
   if (typeof customArgs === 'string' && customArgs !== '[]') {
-    args.push(...JSON.parse(customArgs))
+    try {
+      args.push(...JSON.parse(customArgs))
+    } catch (error) {
+      console.error('Failed to parse externalPlayerCustomArgs, ignoring it', error)
+    }
   } else if (!ignoreDefaultArgs && Array.isArray(cmdArgs.defaultCustomArguments)) {
     args.push(...cmdArgs.defaultCustomArguments)
   }


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Description
If the custom arguments setting contains invalid JSON (for example
after editing settings.db by hand), the app throws and nothing opens.
Now it logs the error and keeps going.

## Testing
Set `externalPlayerCustomArgs` to `not-json`, open a video in an
external player. Nothing opens, but the app doesn't crash.