### PR TITLE
Retry Invidious requests once without auth on 401/403

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -40,7 +40,7 @@ export function getProxyUrl(uri) {
 export async function invidiousFetch(url, retried = false) {
   const authorization = store.getters.getCurrentInvidiousInstanceAuthorization
 
-  const init = authorization
+  const init = authorization && !retried
     ? {
         headers: {
           Authorization: authorization

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -35,19 +35,28 @@ export function getProxyUrl(uri) {
 
 /**
  * @param {string | URL} url
+ * @param {boolean} [retried] internal, used to prevent infinite retries
  */
-export function invidiousFetch(url) {
+export async function invidiousFetch(url, retried = false) {
   const authorization = store.getters.getCurrentInvidiousInstanceAuthorization
 
-  if (authorization) {
-    return fetch(url, {
-      headers: {
-        Authorization: authorization
+  const init = authorization
+    ? {
+        headers: {
+          Authorization: authorization
+        }
       }
-    })
-  } else {
-    return fetch(url)
+    : undefined
+
+  const response = await fetch(url, init)
+
+  // A bad auth token can cause 401/403, so retry once without it
+  if (!retried && (response.status === 401 || response.status === 403) && String(url).includes('/api/v1/')) {
+    console.warn('Invidious API auth failure, retrying once without authorization', response.status)
+    return await invidiousFetch(url, true)
   }
+
+  return response
 }
 
 function invidiousAPICall({ resource, id = '', params = {}, doLogError = true, subResource = '' }) {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Description
When a saved Invidious instance token stops working (instance changed,
token expired), every API call returns 401/403 and the user is stuck.
Retry once without the auth header so anonymous access still works.

## Testing
Add a bad token to an instance, load a channel. It falls back to
anonymous instead of showing nothing.