### PR TITLE
Compact the datastores hourly

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -400,6 +400,19 @@ function compactAllDatastores() {
   ])
 }
 
+const COMPACTION_INTERVAL_MS = 60 * 60 * 1000
+
+/** Compact the datastores every hour so they don't grow forever. */
+function scheduleDatastoreCompaction() {
+  const timer = setInterval(() => {
+    compactAllDatastores()
+  }, COMPACTION_INTERVAL_MS)
+
+  timer.unref?.()
+
+  return timer
+}
+
 export {
   Settings as settings,
   History as history,
@@ -410,4 +423,5 @@ export {
 
   loadDatastores,
   compactAllDatastores,
+  scheduleDatastoreCompaction,
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -46,6 +46,7 @@ if (process.argv.includes('--version')) {
     app.exit()
   } else {
     baseHandlers.loadDatastores()
+    baseHandlers.scheduleDatastoreCompaction()
     runApp()
   }
 }


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix

## Description
NeDB keeps deleted/updated entries as tombstones. On a long-lived
install (history, playlists) the datafiles grow forever. Compact them
once an hour, like the existing compaction on quit.

## Testing
Run the app, check the datastore files shrink after an hour of use
(compaction is also run on quit, as before).