### PR TITLE
Preconnect to YouTube origins

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -5,6 +5,11 @@
     <meta charset="utf-8" />
     <meta name="viewport"
           content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://www.youtube.com">
+    <link rel="preconnect" href="https://i.ytimg.com">
+    <link rel="dns-prefetch" href="https://www.youtube.com">
+    <link rel="dns-prefetch" href="https://i.ytimg.com">
+    <link rel="dns-prefetch" href="https://www.googlevideo.com">
     <% if (!process.env.IS_ELECTRON) { %>
     <link rel="manifest" href="static/manifest.json" />
     <% } %>


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation

## Description
Preconnect and dns-prefetch youtube.com, i.ytimg.com and
googlevideo.com, so first playback starts a bit faster.

## Testing
App loads and plays videos normally; no console errors.