### PR TITLE
Recover from rejected SABR PoTokens and restore reload controls

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2393,6 +2393,11 @@ function runApp() {
       {
         label: 'View',
         submenu: [
+          { role: 'reload' },
+          {
+            role: 'forcereload',
+            accelerator: 'CmdOrCtrl+Shift+R'
+          },
           { role: 'toggledevtools' },
           { role: 'toggledevtools', accelerator: 'f12', visible: false },
           {

--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -358,7 +358,7 @@ async function doRequest(
         switch (part.type) {
           case UMPPartId.STREAM_PROTECTION_STATUS: {
             const streamProtectionStatus = decodePart(part, StreamProtectionStatus)
-            if (streamProtectionStatus.status === 3) {
+            if (streamProtectionStatus.status === 2 || streamProtectionStatus.status === 3) {
               invalidPoToken = true
             }
             break
@@ -566,12 +566,17 @@ async function doRequest(
     currentState.abortStatus.finished = false
     return doRequest(operationInputs, currentState)
   } else if (invalidPoToken) {
-    throw new ShakaError(
-      ShakaError.Severity.CRITICAL,
-      ShakaError.Category.NETWORK,
-      ShakaError.Code.HTTP_ERROR,
+    // A rejected token cannot recover within this SABR session. Requesting a
+    // player reload causes the watch page to fetch fresh HTML and generate a
+    // new page-bound token while preserving the current playback timestamp.
+    currentState.sabrStreamState.playerReloadRequested = true
+    if (!currentState.abortController.signal.aborted) {
+      currentState.abortController.abort()
+      currentState.eventEmitter.emit('reload')
+    }
+    throw createRecoverableNetworkError(
+      ShakaError.Code.OPERATION_ABORTED,
       operationInputs.uri,
-      new Error('Invalid PO token'),
       operationInputs.requestType,
     )
   } else if (error) {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

Related to #9066 and #9190.

## Description

This changes how the player handles rejected PoTokens during SABR playback.

When SABR reports stream protection status 2 or 3, FreeTube now treats the current PoToken as invalid. Instead of ending playback with a critical network error, it aborts the affected request and asks the player to reload. This allows the watch page to obtain fresh session and PoToken data while retaining the current playback position.

This also restores Electron's Reload and Force Reload commands in the View menu. The keyboard shortcuts are `Ctrl+R` and `Ctrl+Shift+R`.

## Screenshots

Not applicable. The changes are primarily related to playback recovery.

## Testing

I built and tested the changes on Windows with the Local API enabled.

I tested starting multiple videos, playing through videos, seeking to different positions, and continuing playback after a SABR reload. I also confirmed that the playback position is retained during recovery.

I confirmed that Reload and Force Reload are available in the View menu and that `Ctrl+R` and `Ctrl+Shift+R` work.

The following checks passed:

- `pnpm run lint-all`
- `pnpm run pack`
- `pnpm run build-release`

## Desktop

- **OS:** Windows
- **OS Version:** Windows 10, build 19045
- **FreeTube version:** 0.25.2 Beta

## Additional context

This does not attempt to fix every possible cause of a SABR reload. It specifically changes recovery when SABR reports a rejected PoToken and restores manual reload controls as an additional recovery option.