### PR TITLE
Fix SABR infinite reload loop

### DIFF
--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -55,6 +55,7 @@ const ShakaError = shaka.util.Error
  * @property {number} cumulativeBackOffTimeMs
  * @property {number} cumulativeBackOffRequested
  * @property {number} cumulativeRetryDueToNextRequestPolicy
+ * @property {number} cumulativeRedirectRetries
  */
 /**
  * @typedef SabrStreamState
@@ -294,6 +295,7 @@ async function doRequest(
   let segmentComplete = false
   let shouldRetry = false
   let shouldRetryDueToNextRequestPolicy = false
+  let shouldRetryDueToRedirect = false
 
   let invalidPoToken = false
   let error
@@ -326,7 +328,11 @@ async function doRequest(
         shouldReloadDueToBackoffLoop = true
       }
     }
-    if (shouldReloadDueToBackoffLoop || currentState.cumulativeRetryDueToNextRequestPolicy >= 100) {
+    if (
+      shouldReloadDueToBackoffLoop ||
+      currentState.cumulativeRetryDueToNextRequestPolicy >= 100 ||
+      currentState.cumulativeRedirectRetries >= 100
+    ) {
       // Fire fake reload event due to detecting retry loop
       currentState.sabrStreamState.playerReloadRequested = true
       if (!currentState.abortController.signal.aborted) {
@@ -374,8 +380,9 @@ async function doRequest(
             const sabrRedirect = decodePart(part, SabrRedirect)
             if (!sabrRedirect) break
 
-            currentState.sabrUrl = sabrRedirect.url
+            currentState.sabrStreamState.sabrUrl = sabrRedirect.url
             shouldRetry = true
+            shouldRetryDueToRedirect = true
             break
           }
           case UMPPartId.MEDIA_HEADER: {
@@ -535,6 +542,10 @@ async function doRequest(
     if (shouldRetryDueToNextRequestPolicy) {
       // Only count on actual retry to avoid counting false positive (when segmentComplete
       currentState.cumulativeRetryDueToNextRequestPolicy += 1
+    }
+    if (shouldRetryDueToRedirect) {
+      // Same false-positive guard as above, applied to SABR_REDIRECT so redirect chains can't retry forever uncounted
+      currentState.cumulativeRedirectRetries += 1
     }
 
     const { sabrContexts, unsentSabrContexts } = prepareSabrContexts(currentState.sabrStreamState)
@@ -829,6 +840,7 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
       cumulativeBackOffTimeMs: 0,
       cumulativeBackOffRequested: 0,
       cumulativeRetryDueToNextRequestPolicy: 0,
+      cumulativeRedirectRetries: 0,
     }
 
     const pendingRequest = doRequest(opInputs, currentState)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -58,6 +58,9 @@ import { useI18n } from 'vue-i18n'
 
 const MANIFEST_TYPE_DASH = 'application/dash+xml'
 const MANIFEST_TYPE_HLS = 'application/x-mpegurl'
+// Cap on consecutive SABR-triggered player reloads for the same video, to avoid reloading forever
+// when the underlying SABR error keeps recurring on every fresh session (e.g. YouTube-side issue, VPN misroute)
+const MAX_CONSECUTIVE_SABR_RELOADS = 5
 const UNAVAILABLE_VIDEO_THUMBNAILS = {
   light: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video.png',
   dark: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video_dark_theme.png'
@@ -101,6 +104,8 @@ export default defineComponent({
       startNextVideoInPip: false,
       isLoading: true,
       firstLoad: true,
+      // Consecutive reloads triggered by onPlayerReloadRequested for the current video, reset once it plays successfully
+      sabrReloadCount: 0,
       useTheatreMode: false,
       videoPlayerLoaded: false,
       isFamilyFriendly: false,
@@ -1321,6 +1326,9 @@ export default defineComponent({
     },
 
     handleVideoLoaded: function () {
+      // Playback recovered, so this is no longer a reload loop
+      this.sabrReloadCount = 0
+
       // Only used one time = remove after use
       this.oneTimeTimestamp = null
 
@@ -1953,6 +1961,18 @@ export default defineComponent({
     },
 
     async onPlayerReloadRequested() {
+      this.sabrReloadCount++
+
+      if (this.sabrReloadCount > MAX_CONSECUTIVE_SABR_RELOADS) {
+        if (this.$refs.player) {
+          await this.destroyPlayer()
+        }
+
+        this.errorMessage = this.t('Video.SabrReloadLoop')
+        this.customErrorIcon = ['fas', 'arrows-rotate']
+        return
+      }
+
       showToast('Reloading player according to SABR request')
 
       const timestamp = this.getTimestamp()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Related to #8932, #9526

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When SABR playback hits a retry loop, two different failure modes could
cause the player to reload forever:

1. In `SabrSchemePlugin.js`, retries triggered by `SABR_REDIRECT` were
   never counted, so a redirect loop had no exit condition.
2. Even when a single reload attempt succeeded, `Watch.js` had no limit
   on how many times `onPlayerReloadRequested` could fire in a row. If
   the underlying SABR error kept recurring on every fresh session
   (e.g. a YouTube-side issue or a misrouted request), the player would
   keep reloading indefinitely instead of surfacing an error.

- Added a `cumulativeRedirectRetries` counter to `SabrStreamState`,
  incremented only on an actual `SABR_REDIRECT` retry (same
  false-positive guard already used for
  `cumulativeRetryDueToNextRequestPolicy`). Once it reaches 100, the
  existing reload-trigger logic fires instead of retrying forever.
- Added `sabrReloadCount` in `Watch.js`, incremented on each
  `onPlayerReloadRequested` call and reset once playback actually
  recovers (`handleVideoLoaded`). If it exceeds
  `MAX_CONSECUTIVE_SABR_RELOADS` (5), the player is destroyed and an
  error message is shown instead of reloading again.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
**`SabrSchemePlugin.js` — retry/cap logic (isolated, real production code)**

Verified `doRequest()` directly in a Node harness (shaka-player stubbed out; all UMP/protobuf encoding used the real `googlevideo` library, no mocks there):

- Simulated a server that returns a genuine UMP-encoded `SABR_REDIRECT` part on every response. Confirmed `sabrStreamState.sabrUrl` is updated on every hop (previously it was written to a nonexistent field and silently dropped), `cumulativeRedirectRetries` counts every hop, the chain is capped at the same ~100-retry threshold as the existing `NEXT_REQUEST_POLICY` path, exactly one `reload` event fires, and the operation terminates cleanly (`OPERATION_ABORTED`) instead of looping forever.
- Simulated a single legitimate redirect (not a loop). Confirmed it does **not** false-positive: counter stays at 1, no reload event, no premature cap trip.

**`Watch.js` — reload cap / error UI (manual, real app)**

Ran the actual Electron dev build and drove it via the Chrome DevTools Protocol:

- Loaded a real YouTube video end-to-end over the SABR pipeline and confirmed normal playback (`<video>.currentTime` advancing).
- Triggered `onPlayerReloadRequested()` from a fresh state: count increments 0 → 1 on a single reload, does **not** trip the cap, and resets back to 0 once playback recovers (`handleVideoLoaded`) — confirming normal, occasional reloads are unaffected.
- Pre-seeded the counter to 5 and triggered one more reload: count reaches 6, the cap fires, the player is torn down (`destroyPlayer`), and the UI switches to the new error screen instead of reloading again.
- Confirmed the new `Video.SabrReloadLoop` string renders correctly in the UI (screenshot taken) — an earlier pass caught this string not showing up because the locale addition hadn't actually landed in `en-US.yaml`; fixed and reverified.

**Not covered:** reproducing the original bug against a real misbehaving YouTube SABR endpoint (not controllable on demand) — the redirect-loop scenario above is a faithful stand-in, exercising the exact same code paths a real loop would hit.

## Desktop
<!-- Please complete the following information-->
- **OS:** Gentoo Linux
- **OS Version:** 6.18.41-gentoo
- **FreeTube version:** v0.25.2


