### PR TITLE
fix: use authorThumbnail for Invidious comment avatars

### DIFF
--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -616,7 +616,7 @@ function parseInvidiousCommentData(response) {
     return {
       id: comment.commentId,
       authorLink: comment.authorId,
-      authorThumb: youtubeImageUrlToInvidious(comment.authorThumbnails.at(-1).url),
+      authorThumb: youtubeImageUrlToInvidious(comment.authorThumbnail),
       author: comment.author,
       likes: comment.likeCount,
       text: autolinker.link(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstanceUrl())),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #9661

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
comment fail to load while using invidious API because in parseInvidiousCommentData  comment thumbnail read from comment.authorThumbnails.at(-1).url while the Invidious docs "https://docs.invidious.io/api/" say comments API returns thumbnail as authorThumbnail  string.
this mean instead of  comment.authorThumbnails.at(-1).url we simply do comment.authorThumbnail.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
before:
<img width="892" height="779" alt="screenshot" src="https://github.com/user-attachments/assets/d6e10388-bf48-492f-a704-988ad7941b62" />

after:
<img width="1064" height="1331" alt="screenshot" src="https://github.com/user-attachments/assets/97f7dd0c-e3bb-4193-b137-4251f37108bc" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
(A) (without this PR)
    Set the API backend to Invidious in Settings
    Open any video
    Scroll to the comments section
    No comments load; the console shows "TypeError: Cannot read properties of undefined (reading 'at')"

(B) (with this PR)
    Set the API backend to Invidious in Settings
    Open any video
    Scroll to the comments section
    Comments load correctly

## Desktop
<!-- Please complete the following information-->
- **OS:*archlinux*
- **OS Version:*archlinux 7.1.8-arch1-3*
- **FreeTube version:*v0.25.2 Beta*

## Additional context
<!-- Add any other context about the pull request here. -->
