### PR TITLE
fix: getRegions script failing

### DIFF
--- a/_scripts/getRegions.mjs
+++ b/_scripts/getRegions.mjs
@@ -28,6 +28,7 @@ const initialResponse = await scrapeLanguage('en')
 
 /** @type {string[]} */
 const youTubeLanguages = initialResponse.data.actions[0].openPopupAction.popup.multiPageMenuRenderer.sections[0].multiPageMenuSectionRenderer.items[2].compactLinkRenderer.serviceEndpoint.signalServiceEndpoint.actions[0].getMultiPageMenuAction.menu.multiPageMenuRenderer.sections[0].multiPageMenuSectionRenderer.items
+  .filter(({ compactLinkRenderer }) => compactLinkRenderer)
   .map(({ compactLinkRenderer }) => {
     return compactLinkRenderer.serviceEndpoint.signalServiceEndpoint.actions[0].selectLanguageCommand.hl
   })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [X] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Running `pnpm run get-regions` throws `TypeError: Cannot read properties of undefined (reading 'serviceEndpoint')` because the first element of the array is:

```JSON
{
    "messageRenderer": {
        "trackingParams": "CNUBEJY7GAAiEwi0y9KcpLqWAxVlWnoFHdDbO6Y=",
        "subtext": {
            "messageSubtextRenderer": {
                "text": {
                    "runs": [
                        {
                            "text": "Buttons and display text on this browser"
                        }
                    ]
                }
            }
        }
    }
}
```  
which does not contain key `compactLinkRenderer`

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Run `pnpm run get-regions` and checks that it completes successfully
