### PR TITLE
Fix SABR redirect handling not updating SABR URL which is actually used

### DIFF
--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -374,7 +374,7 @@ async function doRequest(
             const sabrRedirect = decodePart(part, SabrRedirect)
             if (!sabrRedirect) break
 
-            currentState.sabrUrl = sabrRedirect.url
+            currentState.sabrStreamState.sabrUrl = sabrRedirect.url
             shouldRetry = true
             break
           }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://github.com/FreeTubeApp/FreeTube/issues/9677

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
SABR set received URL but not to a property used in code

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
N/A

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
No idea since redirect happens rarely but you can try those provided in comments in https://github.com/FreeTubeApp/FreeTube/issues/9677

## Desktop
<!-- Please complete the following information-->
- **OS:**
- **OS Version:**
- **FreeTube version:**

## Additional context
<!-- Add any other context about the pull request here. -->
