### PR TITLE
Fix: "Hide videos from channels" doesn't work for collab videos (local API)

### DIFF
--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -258,8 +258,9 @@ const showResult = computed(() => {
     }
 
     const lowerCaseAuthor = props.data.author?.toLowerCase()
-
-    if (channelsHidden.value.some(ch => ch.name === props.data.authorId) || channelsHidden.value.some(ch => ch.name === props.data.author) || (forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text)))) {
+    if (channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
+    channelsHidden.value.some(ch => ch.name === props.data.author) ||
+    forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text))) {
       // hide videos by author
       return false
     }

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -258,7 +258,7 @@ const showResult = computed(() => {
     }
 
     const lowerCaseAuthor = props.data.author?.toLowerCase()
-    if (channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
+    if (channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds?.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
     channelsHidden.value.some(ch => ch.name === props.data.author) ||
     forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text))) {
       // hide videos by author

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -258,7 +258,7 @@ const showResult = computed(() => {
     }
 
     const lowerCaseAuthor = props.data.author?.toLowerCase()
-    if (channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds?.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
+    if (channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaborators?.length > 0 && ch.name === props.data.collaborators[0].id)) ||
     channelsHidden.value.some(ch => ch.name === props.data.author) ||
     forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text))) {
       // hide videos by author

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -411,6 +411,7 @@ const id = ref('')
 const title = ref('')
 const channelName = ref(null)
 const channelId = ref(null)
+const collaborators = ref([])
 const viewCount = ref(0)
 const parsedViewCount = ref('')
 const uploadedTime = ref('')
@@ -715,12 +716,16 @@ function handleOptionsClick(option) {
     case 'openInvidiousChannel':
       openExternalLink(getInvidiousChannelUrl())
       break
-    case 'hideChannel':
-      hideChannel(channelName.value, channelId.value)
+    case 'hideChannel': {
+      const name = collaborators.value.length > 0 ? collaborators.value[0].name : channelName.value
+      hideChannel(name, channelId.value)
       break
-    case 'unhideChannel':
-      unhideChannel(channelName.value, channelId.value)
+    }
+    case 'unhideChannel': {
+      const name = collaborators.value.length > 0 ? collaborators.value[0].name : channelName.value
+      unhideChannel(name, channelId.value)
       break
+    }
   }
 }
 
@@ -1023,7 +1028,16 @@ function parseVideoData() {
   title.value = props.data.title
 
   channelName.value = props.data.author ?? null
-  channelId.value = props.data.authorId ?? null
+  collaborators.value = props.data.collaborators ?? []
+
+  if (props.data.authorId) {
+    channelId.value = props.data.authorId
+  } else if (collaborators.value.length > 0) {
+    // When video has collaborators, authorId is null and the first element in the collaborator array is the main author
+    channelId.value = collaborators.value[0].id
+  } else {
+    channelId.value = null
+  }
 
   if ((props.data.lengthSeconds === '' || props.data.lengthSeconds === '0:00') && historyEntryExists.value) {
     lengthSeconds.value = historyEntry.value.lengthSeconds

--- a/src/renderer/components/FtListVideoLazy.vue
+++ b/src/renderer/components/FtListVideoLazy.vue
@@ -143,7 +143,7 @@ const shouldBeVisible = computed(() => {
   const lowerCaseTitle = props.data.title?.toLowerCase()
   const lowerCaseAuthor = props.data.author?.toLowerCase()
 
-  return !(channelsHidden.value.some(ch => ch.name === props.data.authorId) ||
+  return !(channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
     channelsHidden.value.some(ch => ch.name === props.data.author) ||
     (lowerCaseTitle && forbiddenTitles.value.some((text) => lowerCaseTitle.includes(text))) ||
     (hideChannelsBasedOnText.value && lowerCaseAuthor && forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text))))

--- a/src/renderer/components/FtListVideoLazy.vue
+++ b/src/renderer/components/FtListVideoLazy.vue
@@ -143,7 +143,7 @@ const shouldBeVisible = computed(() => {
   const lowerCaseTitle = props.data.title?.toLowerCase()
   const lowerCaseAuthor = props.data.author?.toLowerCase()
 
-  return !(channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
+  return !(channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds?.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
     channelsHidden.value.some(ch => ch.name === props.data.author) ||
     (lowerCaseTitle && forbiddenTitles.value.some((text) => lowerCaseTitle.includes(text))) ||
     (hideChannelsBasedOnText.value && lowerCaseAuthor && forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text))))

--- a/src/renderer/components/FtListVideoLazy.vue
+++ b/src/renderer/components/FtListVideoLazy.vue
@@ -143,7 +143,7 @@ const shouldBeVisible = computed(() => {
   const lowerCaseTitle = props.data.title?.toLowerCase()
   const lowerCaseAuthor = props.data.author?.toLowerCase()
 
-  return !(channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaboratorIds?.length > 0 && ch.name === props.data.collaboratorIds[0])) ||
+  return !(channelsHidden.value.some(ch => ch.name === props.data.authorId || (props.data.collaborators?.length > 0 && ch.name === props.data.collaborators[0].id)) ||
     channelsHidden.value.some(ch => ch.name === props.data.author) ||
     (lowerCaseTitle && forbiddenTitles.value.some((text) => lowerCaseTitle.includes(text))) ||
     (hideChannelsBasedOnText.value && lowerCaseAuthor && forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text))))

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1733,6 +1733,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author.name !== 'N/A' ? video.author.name : channelName,
       authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
+      collaboratorIds: video.author.collaborators.map(collaborator => collaborator.id),
       description: video.description,
       viewCount,
       published,

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1911,12 +1911,9 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         author = lockupView.metadata?.metadata?.metadata_rows[0].metadata_parts?.[0].avatar_stack.text?.text
       }
 
-      const maybeCollaborators = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.command?.inline_content?.custom_content?.items
+      const maybeCollaboratorIds = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.command?.inline_content?.custom_content?.items
         .filter(item => item.renderer_context?.command_context?.on_tap?.metadata?.page_type === 'WEB_PAGE_TYPE_CHANNEL')
-      let collaboratorIds = []
-      if (maybeCollaborators) {
-        collaboratorIds = maybeCollaborators.map(item => item.renderer_context?.command_context?.on_tap?.payload?.browseId)
-      }
+        .map(item => item.renderer_context?.command_context?.on_tap?.payload?.browseId)
 
       return {
         type: 'video',
@@ -1924,7 +1921,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         title: lockupView.metadata.title.text?.trim(),
         author,
         authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId ?? channelId,
-        collaboratorIds,
+        collaboratorIds: maybeCollaboratorIds ?? [],
         viewCount,
         published: calculatePublishedDate(publishedText, liveNow, isUpcoming, premiereDate),
         lengthSeconds,

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1675,7 +1675,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author?.name ?? channelName,
       authorId: (video.author?.id != null && video.author.id !== 'N/A') ? video.author.id : channelId,
-      collaboratorIds: video.author?.collaborators.map(collaborator => collaborator.renderer_context?.command_context?.on_tap?.payload?.browseId) ?? [],
+      collaborators: video.author == null ? [] : parseLocalCollaborators(video.author.collaborators),
       viewCount: video.views.text == null ? null : extractNumberFromString(video.views.text),
       published,
       lengthSeconds: isLive ? '' : Utils.timeToSeconds(video.duration.text),
@@ -1734,7 +1734,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author.name !== 'N/A' ? video.author.name : channelName,
       authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
-      collaboratorIds: video.author.collaborators.map(collaborator => collaborator.renderer_context?.command_context?.on_tap?.payload?.browseId),
+      collaborators: parseLocalCollaborators(video.author.collaborators),
       description: video.description,
       viewCount,
       published,
@@ -1911,9 +1911,12 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         author = lockupView.metadata?.metadata?.metadata_rows[0].metadata_parts?.[0].avatar_stack.text?.text
       }
 
-      const maybeCollaboratorIds = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.command?.inline_content?.custom_content?.items
+      let collaborators = []
+      const maybeCollaborators = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.command?.inline_content?.custom_content?.items
         .filter(item => item.renderer_context?.command_context?.on_tap?.metadata?.page_type === 'WEB_PAGE_TYPE_CHANNEL')
-        .map(item => item.renderer_context?.command_context?.on_tap?.payload?.browseId)
+      if (maybeCollaborators) {
+        collaborators = parseLocalCollaborators(maybeCollaborators)
+      }
 
       return {
         type: 'video',
@@ -1921,7 +1924,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         title: lockupView.metadata.title.text?.trim(),
         author,
         authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId ?? channelId,
-        collaboratorIds: maybeCollaboratorIds ?? [],
+        collaborators,
         viewCount,
         published: calculatePublishedDate(publishedText, liveNow, isUpcoming, premiereDate),
         lengthSeconds,
@@ -2476,6 +2479,16 @@ function parseLocalAttachment(attachment) {
     console.error(`Unknown Local community post type: ${attachment.type}`)
     console.error(attachment)
   }
+}
+
+/**
+ * @param {import('youtubei.js').YTNodes.ListItemView[]} collaborators
+ */
+function parseLocalCollaborators(collaborators) {
+  return collaborators.map(collaborator => ({
+    id: collaborator.renderer_context?.command_context?.on_tap?.payload?.browseId,
+    name: collaborator.title?.text,
+  }))
 }
 
 export async function getHashtagLocal(hashtag) {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1909,12 +1909,20 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         author = lockupView.metadata?.metadata?.metadata_rows[0].metadata_parts?.[0].avatar_stack.text?.text
       }
 
+      const maybeCollaborators = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.command?.inline_content?.custom_content?.items
+      let collaboratorIds = []
+      if (maybeCollaborators) {
+        collaboratorIds = maybeCollaborators.map(item => item.renderer_context?.command_context?.on_tap?.payload?.browseId)
+          .filter(collabChannelId => collabChannelId)
+      }
+
       return {
         type: 'video',
         videoId: lockupView.content_id,
         title: lockupView.metadata.title.text?.trim(),
         author,
         authorId: lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload.browseId ?? channelId,
+        collaboratorIds,
         viewCount,
         published: calculatePublishedDate(publishedText, liveNow, isUpcoming, premiereDate),
         lengthSeconds,

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1675,6 +1675,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author?.name ?? channelName,
       authorId: (video.author?.id != null && video.author.id !== 'N/A') ? video.author.id : channelId,
+      collaboratorIds: video.author?.collaborators ?? [],
       viewCount: video.views.text == null ? null : extractNumberFromString(video.views.text),
       published,
       lengthSeconds: isLive ? '' : Utils.timeToSeconds(video.duration.text),

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1675,7 +1675,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author?.name ?? channelName,
       authorId: (video.author?.id != null && video.author.id !== 'N/A') ? video.author.id : channelId,
-      collaboratorIds: video.author?.collaborators ?? [],
+      collaboratorIds: video.author?.collaborators.map(collaborator => collaborator.renderer_context?.command_context?.on_tap?.payload?.browseId) ?? [],
       viewCount: video.views.text == null ? null : extractNumberFromString(video.views.text),
       published,
       lengthSeconds: isLive ? '' : Utils.timeToSeconds(video.duration.text),
@@ -1734,7 +1734,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author.name !== 'N/A' ? video.author.name : channelName,
       authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
-      collaboratorIds: video.author.collaborators.map(collaborator => collaborator.id),
+      collaboratorIds: video.author.collaborators.map(collaborator => collaborator.renderer_context?.command_context?.on_tap?.payload?.browseId),
       description: video.description,
       viewCount,
       published,
@@ -1912,6 +1912,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       }
 
       const maybeCollaborators = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.command?.inline_content?.custom_content?.items
+        .filter(item => item.renderer_context?.command_context?.on_tap?.metadata?.page_type === 'WEB_PAGE_TYPE_CHANNEL')
       let collaboratorIds = []
       if (maybeCollaborators) {
         collaboratorIds = maybeCollaborators.map(item => item.renderer_context?.command_context?.on_tap?.payload?.browseId)

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1915,7 +1915,6 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       let collaboratorIds = []
       if (maybeCollaborators) {
         collaboratorIds = maybeCollaborators.map(item => item.renderer_context?.command_context?.on_tap?.payload?.browseId)
-          .filter(collabChannelId => collabChannelId)
       }
 
       return {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1930,7 +1930,7 @@ export default defineComponent({
     },
 
     isHiddenVideo: function (forbiddenTitles, channelsHidden, video) {
-      return channelsHidden.some(ch => ch.name === video.authorId && (video.author.collaboratorIds?.length > 0 && ch.name === video.author.collaboratorIds[0])) ||
+      return channelsHidden.some(ch => ch.name === video.authorId && (video.author.collaborators?.length > 0 && ch.name === video.author.collaborators[0].id)) ||
         channelsHidden.some(ch => ch.name === video.author) ||
         forbiddenTitles.some((text) => video.title?.toLowerCase().includes(text)) ||
         forbiddenTitles.some((text) => video.author?.toLowerCase().includes(text))

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1930,7 +1930,7 @@ export default defineComponent({
     },
 
     isHiddenVideo: function (forbiddenTitles, channelsHidden, video) {
-      return channelsHidden.some(ch => ch.name === video.authorId) ||
+      return channelsHidden.some(ch => ch.name === video.authorId && (video.author.collaboratorIds.length > 0 && ch.name === video.author.collaboratorIds[0])) ||
         channelsHidden.some(ch => ch.name === video.author) ||
         forbiddenTitles.some((text) => video.title?.toLowerCase().includes(text)) ||
         forbiddenTitles.some((text) => video.author?.toLowerCase().includes(text))

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1930,7 +1930,7 @@ export default defineComponent({
     },
 
     isHiddenVideo: function (forbiddenTitles, channelsHidden, video) {
-      return channelsHidden.some(ch => ch.name === video.authorId && (video.author.collaboratorIds.length > 0 && ch.name === video.author.collaboratorIds[0])) ||
+      return channelsHidden.some(ch => ch.name === video.authorId && (video.author.collaboratorIds?.length > 0 && ch.name === video.author.collaboratorIds[0])) ||
         channelsHidden.some(ch => ch.name === video.author) ||
         forbiddenTitles.some((text) => video.title?.toLowerCase().includes(text)) ||
         forbiddenTitles.some((text) => video.author?.toLowerCase().includes(text))


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Addresses https://github.com/FreeTubeApp/FreeTube/issues/7871 (only for local API).
This does not fix the issue for Invidious API as collaborators are not supported yet: https://github.com/iv-org/invidious/issues/5507

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
**Fix "Hide videos from channels" setting not working with videos having collaborators.**
Videos with collaborators are now hidden correctly for:
- search results 
- recommended videos
- next recommended video
- trending page

**Fix "Hide channel" option not appearing in the dropdown menu for videos with collaborators.**

**Fix video's author not having clickable URL when they have collaborators (redirect to the main author)**

Tested with both Local API and Invidious

## Testing
I don't know this channel but [KSI](https://www.youtube.com/channel/UCGmnsW623G1r-Chmo5RB4Yw) does a **lot** of collaborations, it's easier to test.
All of these tests assume that no channels are hidden by default.

**Search**
1. Search for "KSI"
2. On a video with collaborators, click on the three dots and "Hide Channel"
3. Check that the toast message is correct
4. Check that all videos from KSI are correctly hidden

 **Recommended videos and next recommended video**
1. Search for "KSI"
2. Click on any videos from him
3. In the "Up Next" section, search for a KSI collab video, click on the three dots, and "Hide channel"
5. Check that the toast message is correct
6. Go back and forth (hiding a channel in the "Up Next" section does not refresh automatically) 
7. Check that all videos from KSI are correctly hidden

**Trending page**
1. Go to "Trending"
2. Search for a video with collaborators
3. Click on the three dots and "Hide channel"
4. Check that the toast message is correct
5. Check that the video is correctly hidden

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** 0.24.2-beta

## Additional Information 
`local#parseLocalCollaborators` could be completed using the sample in https://github.com/LuanRT/YouTube.js/pull/1203 if https://github.com/FreeTubeApp/FreeTube/issues/7872 is implemented.
Also, the title for https://github.com/FreeTubeApp/FreeTube/issues/7872 is "Show at least one channel link for videos with multiple collaborators", which is implemented in this MR, however, the description talks about displaying **all** the authors.