### PR TITLE
Fix: 'Copy YouTube Link' generates malformed URL when video is part of a playlist

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -651,7 +651,7 @@ function handleOptionsClick(option) {
 
       if (playlistSharable.value) {
         // `index` seems can be ignored
-        videoUrl += `&list=${playlistIdFinal.value}`
+        videoUrl += `?list=${playlistIdFinal.value}`
       }
 
       copyToClipboard(videoUrl, { messageOnSuccess: t('Share.YouTube URL copied to clipboard') })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9693

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
It is not exactly the same issue.  
This MR fixes the malformed URL generated by FreeTube that led to the discovery of the related issue.  
It does not fix the fact that FreeTube does not support those malformed URLs while YouTube does, but it does not feel like it should.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to a playlist
2. In a video dropdown menu,  use "Copy YouTube Link"
3. Paste the link in the search bar 
4. Check that the video is loaded with its playlist 
5. Check that this URL works for YouTube in a browser too 

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.25.2-beta