### PR TITLE
A11y: add missing labels to improve accessibility of buttons

### DIFF
--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -240,6 +240,7 @@
           v-if="showSearchBar"
           ref="searchBar"
           :placeholder="$t('Channel.Search Channel')"
+          :action-button-label="$t('Search Bar.Search')"
           :value="query"
           :show-clear-text-button="true"
           class="channelSearch"

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -125,7 +125,7 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 const props = defineProps({
   title: {
     type: String,
-    default: ''
+    required: true,
   },
   icon: {
     type: Array,

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -66,6 +66,8 @@
           enabled: inputDataPresent,
           withLabel: showLabel
         }"
+        :aria-label="actionButtonLabel"
+        :title="actionButtonLabel"
         @click="handleClick"
       >
         <FontAwesomeIcon
@@ -153,6 +155,10 @@ const props = defineProps({
   showActionButton: {
     type: Boolean,
     default: true
+  },
+  actionButtonLabel: {
+    type: String,
+    default: '',
   },
   forceActionButtonIconName: {
     type: Array,

--- a/src/renderer/components/FtInputTags/FtInputTags.vue
+++ b/src/renderer/components/FtInputTags/FtInputTags.vue
@@ -18,6 +18,7 @@
       :tooltip="tooltip"
       :show-action-button="true"
       :select-on-focus="true"
+      :action-button-label="t('Settings.Distraction Free Settings.Add')"
       :force-action-button-icon-name="['fas', 'arrow-right']"
       @click="updateTags"
     />
@@ -69,6 +70,8 @@
           <button
             v-if="!disabled"
             class="removeTagButton"
+            :title="t('Settings.Distraction Free Settings.Remove')"
+            :aria-label="t('Settings.Distraction Free Settings.Remove')"
             @click="removeTag(tag)"
           >
             <FontAwesomeIcon

--- a/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
+++ b/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
@@ -38,6 +38,7 @@
       <FtIconButton
         class="profileSettings"
         :icon="['fas', 'sliders-h']"
+        :title="$t('Profile.Go To Profile Manager')"
         @click="openProfileSettings"
       />
       <div

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -46,6 +46,8 @@
       <button
         v-if="!hideSearchBar"
         class="navSearchButton navButton"
+        :aria-label="t('Search Bar.Open Search Container')"
+        :title="t('Search Bar.Open Search Container')"
         @click="toggleSearchContainer"
       >
         <FontAwesomeIcon
@@ -91,6 +93,7 @@
           :placeholder="t('Search / Go to URL')"
           class="searchInput"
           is-search
+          :action-button-label="t('Search Bar.Search')"
           :data-list="activeDataList"
           :data-list-properties="activeDataListProperties"
           show-clear-text-button

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -59,6 +59,8 @@ Search / Go to URL: Search / Go to URL
 Search Bar:
   Clear Input: Clear Input
   Remove: Remove
+  Open Search Container: Open Search Container
+  Search: Search
 Search character limit: Search query is over the {searchCharacterLimit} character limit
 Search Listing:
   Label:
@@ -591,6 +593,8 @@ Settings:
     Hide Subscriptions Live: Hide Subscriptions Live
     Hide Subscriptions Posts: Hide Subscriptions Posts
     Show Added Items: Show Added Items
+    Add: Add
+    Remove: Remove
   Data Settings:
     Data Settings: Data
     Select Export Type: Select Export Type
@@ -776,6 +780,7 @@ Profile:
     from any other profile.
   Close Profile Dropdown: Close Profile Dropdown
   Open Profile Dropdown: Open Profile Dropdown
+  Go To Profile Manager: Go to Profile Manager
 #On Channel Page
 Channel:
   Subscribe: Subscribe


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
- [x] Bugfix

## Related issue
#9690

## Description
This PR fixes some issues where some of our buttons were unlabeled and weren't accessible for folks using screen readers

## Screenshots <!-- If appropriate -->
Title for profile manager button
<img width="458" height="179" alt="A screenshot with the profile menu expanded and a tooltip is showing on the icon button for going to the profile manager" src="https://github.com/user-attachments/assets/dd034783-da5a-4d09-8684-352e2ef09794" />

Search button:
<img width="492" height="105" alt="the main search bar's search button has a tooltip" src="https://github.com/user-attachments/assets/23ea4fe9-8927-4129-abb5-e43eac0e2f07" />

Tag add:
<img width="882" height="175" alt="Hiding videos from a channel has a new add button" src="https://github.com/user-attachments/assets/9c9af250-e27c-4d23-80a4-1e16cf1cccca" />

Tag remove:
<img width="859" height="207" alt="Unhiding videos from a channel has a remove button" src="https://github.com/user-attachments/assets/f96dc4c3-0dbb-4c85-acf0-de20842b27be" />

## Testing
The buttons now expose aria-label and title attributes. You can test the title by hovering on the buttons.
I tested with Orca screen reader on Linux using `orca` in the command line. NVDA is probably the best bet on Windows (since it's open source) if you wish to test with a screen reader as well

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora Linux 
- **OS Version:** 44
- **FreeTube version:** 0.25.3 (latest nightly)


