### PR TITLE
Feat: Do not show unavailable videos in playlist using Invidious backend

### DIFF
--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -638,9 +638,9 @@ async function loadCachedPlaylistInformation(cachedPlaylist) {
 
   const videos = cachedPlaylist.items
   if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
-    const videoCount = cachedPlaylist.videoCount
-    if (videos.length < videoCount) {
-      const remainingVideos = await fetchAllInvidiousPlaylistVideos(cachedPlaylist.id, videos.length)
+    const nextIndex = cachedPlaylist.nextIndex
+    if (nextIndex !== -1) {
+      const remainingVideos = await fetchAllInvidiousPlaylistVideos(cachedPlaylist.id, nextIndex)
       videos.push(...remainingVideos)
     }
   } else if (cachedPlaylist.continuationData !== null) {
@@ -704,14 +704,14 @@ async function getPlaylistInformationInvidious() {
   isLoading.value = true
 
   try {
-    const result = await invidiousGetPlaylistInfo(props.playlistId)
+    const { playlist: result, nextIndex } = await invidiousGetPlaylistInfo(props.playlistId)
 
     playlistTitle.value = result.title
     channelName.value = result.author
     channelId.value = result.authorId
 
     const videos = result.videos
-    const remainingVideos = await fetchAllInvidiousPlaylistVideos(result.playlistId, videos.length)
+    const remainingVideos = await fetchAllInvidiousPlaylistVideos(result.playlistId, nextIndex)
     videos.push(...remainingVideos)
 
     playlistItems.value = videos

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -286,50 +286,59 @@ export async function searchInvidiousChannel(channelId, query, page) {
  * @param {string} playlistId
  * @param {number} index
  * @returns {Promise<{
- *  title: string,
- *  playlistId: string,
- *  author: string,
- *  authorId: string,
- *  authorThumbnails: InvidiousImageObject[],
- *  description: string,
- *  descriptionHtml: string,
- *  videoCount: number,
- *  viewCount: number,
- *  updated: number,
- *  videos: {
+ *  playlist: {
  *    title: string,
- *    videoId: string,
+ *    playlistId: string,
  *    author: string,
  *    authorId: string,
- *    authorUrl: string,
- *    videoThumbnails: InvidiousThumbnailObject[],
- *    index: number,
- *    lengthSeconds: number
- *  }[]
+ *    authorThumbnails: InvidiousImageObject[],
+ *    description: string,
+ *    descriptionHtml: string,
+ *    videoCount: number,
+ *    viewCount: number,
+ *    updated: number,
+ *    videos: {
+ *      title: string,
+ *      videoId: string,
+ *      author: string,
+ *      authorId: string,
+ *      authorUrl: string,
+ *      videoThumbnails: InvidiousThumbnailObject[],
+ *      index: number,
+ *      lengthSeconds: number
+ *    }[]
+ *  },
+ *  nextIndex: number | -1
  * }>}
  */
 export async function invidiousGetPlaylistInfo(playlistId, index = 0) {
   // The Invidious API offsets the index by 50 to apply a lookback window
-  // By increasing our offset by 50, we skip those overlapping videos and avoid de-duplicating them from our response
+  // By increasing the index by 50, we skip those overlapping videos and avoid de-duplicating them from the response
   // See: https://github.com/iv-org/invidious/blob/66fb829dbc0f96cbf4319798f3b9090bc88a7012/src/invidious/routes/api/v1/misc.cr#L67
-  index += 50
+  const offsetIndex = index + 50
   const playlist = await invidiousAPICall({
     resource: 'playlists',
     id: playlistId,
     params: {
-      index
+      index: offsetIndex
     }
   })
 
+  let nextIndex = index + playlist.videos.length
+  if (nextIndex >= playlist.videoCount) {
+    nextIndex = -1
+  }
+
+  playlist.videos = filterUnavailableInvidiousVideos(playlist.videos)
   normalizeManyInvidiousVideosAttributes(playlist.videos)
   setMultiplePublishedTimestamps(playlist.videos)
 
-  return playlist
+  return { playlist, nextIndex }
 }
 
 /**
  * @param {string} playlistId
- * @param {number} initialOffset
+ * @param {number} index
  * @returns {{
  *    title: string,
  *    videoId: string,
@@ -341,17 +350,14 @@ export async function invidiousGetPlaylistInfo(playlistId, index = 0) {
  *    lengthSeconds: number
  *  }[]}
  */
-export async function fetchAllInvidiousPlaylistVideos(playlistId, initialOffset = 0) {
-  let offset = initialOffset
+export async function fetchAllInvidiousPlaylistVideos(playlistId, index = 0) {
+  let currentIndex = index
   const videos = []
 
-  while (true) {
-    const playlist = await invidiousGetPlaylistInfo(playlistId, offset)
-    if (playlist.videos.length === 0) {
-      break
-    }
+  while (currentIndex !== -1) {
+    const { playlist, nextIndex } = await invidiousGetPlaylistInfo(playlistId, currentIndex)
     videos.push(...playlist.videos)
-    offset += playlist.videos.length
+    currentIndex = nextIndex
   }
 
   return videos
@@ -1008,6 +1014,17 @@ export function mapInvidiousLegacyFormat(format) {
     width: parseInt(stringWidth),
     url: format.url
   }
+}
+
+/**
+ * @param {{
+ *  title: string,
+ *  author: string,
+ *  authorId: string | null
+ * }[]} videos
+ */
+function filterUnavailableInvidiousVideos(videos) {
+  return videos.filter(video => video.title !== '' && video.author !== '' && video.authorId !== null)
 }
 
 /**

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -239,6 +239,7 @@ const draggedVideo = ref({ videoId: null, playlistItemId: null })
 const userPlaylistVisibleLimit = ref(100)
 /** @type {import('vue').ShallowRef<import('youtubei.js').YT.Playlist | null>} */
 const continuationData = shallowRef(null)
+const nextIndex = ref(-1)
 const isLoadingMore = ref(false)
 const playlistInEditMode = ref(false)
 const forceListView = ref(false)
@@ -302,7 +303,7 @@ const moreVideoDataAvailable = computed(() => {
   }
 
   if (infoSource.value === 'invidious') {
-    return playlistItems.value.length < videoCount.value
+    return nextIndex.value !== -1
   }
 
   return continuationData.value !== null
@@ -546,7 +547,7 @@ async function getPlaylistLocal() {
 
 async function getPlaylistInvidious() {
   try {
-    const result = await invidiousGetPlaylistInfo(playlistId.value)
+    const { playlist: result, nextIndex: nextIndexValue } = await invidiousGetPlaylistInfo(playlistId.value)
 
     playlistTitle.value = result.title
     playlistDescription.value = result.description
@@ -568,6 +569,7 @@ async function getPlaylistInvidious() {
     lastUpdated.value = dateString.toLocaleDateString(locale.value, { year: 'numeric', month: 'short', day: 'numeric' })
 
     playlistItems.value = result.videos
+    nextIndex.value = nextIndexValue
 
     updatePageTitle()
 
@@ -744,9 +746,9 @@ async function getNextPageLocal() {
 async function getNextPageInvidious() {
   isLoadingMore.value = true
 
-  const index = playlistItems.value.length
-  const result = await invidiousGetPlaylistInfo(playlistId.value, index)
+  const { playlist: result, nextIndex: nextIndexValue } = await invidiousGetPlaylistInfo(playlistId.value, nextIndex.value)
   playlistItems.value.push(...result.videos)
+  nextIndex.value = nextIndexValue
 
   isLoadingMore.value = false
 }
@@ -1127,7 +1129,7 @@ onBeforeRouteLeave((to) => {
       continuationData: continuationData.value
         ? extractLocalCacheablePlaylistContinuation(continuationData.value)
         : null,
-      videoCount: videoCount.value,
+      nextIndex: nextIndex.value,
     })
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9606

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Filter out videos that don't have any useful data other than `videoId` (see https://github.com/FreeTubeApp/FreeTube/issues/9606#issuecomment-5259102345)
This is similar to how the Local API works. Invidious API may still return videos that are not viewable but have valid data (members only, age restricted...). Those are not filtered, thus the difference that could happen when comparing a playlist with Local API or with Invidious API. 

This merge request does **not** completely close https://github.com/FreeTubeApp/FreeTube/issues/9606.
As described in https://github.com/FreeTubeApp/FreeTube/issues/9606#issuecomment-5705591352, the real issue comes from Invidious API. With this MR applied, the risk of FreeTube becoming unresponsive is greatly reduced, but it is not zero. It would still be possible to encounter thumbnails that return a 404 error in various places, and after six such errors, the same issue would happen.

I see two options:
- We consider that this MR is a feature request that does not solve the initial issue, and that the issue could only be solved with Invidious fixing their bug
- We consider that we can't be impacted by the Invidious issue if we don't try to parse invalid data that Invidious returns to us, so it's both a feature request and a fix

@efb4f5ff-1298-471a-8973-3d47447115dc and I chose the second option, but that's open to debate.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Set `Preferred API Backend` to I`nvidiou API`
2. Set a valid `Current Invidious Instance`
3. Go to https://youtube.com/playlist?list=PLvMVt4c68EeXRV2R1fdieei9HwpuUKXKL
4. Scroll down and load the full playlist
5. Check that all listed videos are valid (but not necessarily viewable)

**Regressions**
All tests listed in https://github.com/FreeTubeApp/FreeTube/pull/9564 should still apply 
I've tested all of them myself

## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora
- **OS Version:** 44
- **FreeTube version:** v0.25.2-beta