### PR TITLE
Fix: tooltip not being aligned with dropdown arrow

### DIFF
--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -80,7 +80,8 @@
 .selectTooltip {
   position: absolute;
   inset-block-start: -22px;
-  inset-inline-end: 13px;
+  inset-inline-end: 10px;
+  border-inline-end: 6px solid transparent;
 }
 
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9601

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The tooltip above dropdown menu in the settings page is now centered again with the triangle below.

`selectTooltip` now has an aligned right border with `iconSelect`

```
.iconSelect {
  position: absolute;
  inset-block-start: 10px;
  inset-inline-end: 10px;

  /* Styling the down arrow */
  padding: 0;
  content: '';
  border-inline-start: 6px solid transparent;
  border-inline-end: 6px solid transparent;
  pointer-events: none;
  color: var(--tertiary-text-color);
}
```

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
<img width="1209" height="656" alt="image" src="https://github.com/user-attachments/assets/0273156d-ac52-48cd-a2ea-1182efeed33f" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Go to settings page and zoom in and out to check that the arrow and the tooltip icon keep being aligned

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** v0.25.3-beta