### PR TITLE
Add Shorten view count numbers using K, M, B suffixes

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -163,7 +163,7 @@
           class="viewCount"
         >
           <template v-if="channelId !== null || channelName !== null"> • </template>
-          {{ t('Global.Counts.View Count', { count: isNumberRounded(viewCount) ? formatNumber(viewCount, { notation: 'compact' }) : parsedViewCount }, viewCount) }}
+          {{ t('Global.Counts.View Count', { count: viewCount % 1000 === 0 ? formatNumber(viewCount, { notation: 'compact' }) : parsedViewCount }, viewCount) }}
         </span>
         <span
           v-if="uploadedTime !== '' && !isLive"
@@ -296,8 +296,7 @@ import {
   showToast,
   toDistractionFreeTitle,
   deepCopy,
-  debounce,
-  isNumberRounded
+  debounce
 } from '../../helpers/utils.js'
 import { deArrowData, deArrowThumbnail } from '../../helpers/sponsorblock.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -163,7 +163,7 @@
           class="viewCount"
         >
           <template v-if="channelId !== null || channelName !== null"> • </template>
-          {{ t('Global.Counts.View Count', { count: parsedViewCount }, viewCount) }}
+          {{ t('Global.Counts.View Count', { count: isNumberRounded(viewCount) ? formatNumber(viewCount, { notation: 'compact' }) : parsedViewCount }, viewCount) }}
         </span>
         <span
           v-if="uploadedTime !== '' && !isLive"
@@ -296,7 +296,8 @@ import {
   showToast,
   toDistractionFreeTitle,
   deepCopy,
-  debounce
+  debounce,
+  isNumberRounded
 } from '../../helpers/utils.js'
 import { deArrowData, deArrowThumbnail } from '../../helpers/sponsorblock.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -163,7 +163,7 @@
           class="viewCount"
         >
           <template v-if="channelId !== null || channelName !== null"> • </template>
-          {{ t('Global.Counts.View Count', { count: viewCount % 1000 === 0 ? formatNumber(viewCount, { notation: 'compact' }) : parsedViewCount }, viewCount) }}
+          {{ t('Global.Counts.View Count', { count: compactViewCount }, viewCount) }}
         </span>
         <span
           v-if="uploadedTime !== '' && !isLive"
@@ -1061,6 +1061,33 @@ function parseVideoData() {
     parsedViewCount.value = props.data.viewCountText.replace(' views', '')
   } else {
     hideViews.value = true
+  }
+}
+
+const compactViewCount = computed(() => {
+  if (isNumberRounded(viewCount.value)) {
+    return formatNumber(viewCount.value, { notation: 'compact' })
+  } else {
+    return parsedViewCount.value
+  }
+})
+
+function isNumberRounded(number) {
+  switch (number.toString().length) {
+    case 10:
+      return number % 100000000 === 0
+    case 9:
+    case 8:
+      return number % 1000000 === 0
+    case 7:
+      return number % 100000 === 0
+    case 6:
+    case 5:
+      return number % 1000 === 0
+    case 4:
+      return number % 100 === 0
+    default:
+      return false
   }
 }
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1113,11 +1113,3 @@ export function throttle(func, wait) {
     }
   }
 }
-
-/**
- * @param {number} number
- * @returns {boolean}
- */
-export function isNumberRounded(number) {
-  if (number % 1000 === 0) return true
-}

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1113,3 +1113,11 @@ export function throttle(func, wait) {
     }
   }
 }
+
+/**
+ * @param {number} number
+ * @returns {boolean}
+ */
+export function isNumberRounded(number) {
+  if (number % 1000 === 0) return true
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #9522 

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds a helper function to detect if a number (view count) has been rounded
Calls this function when displaying view counts and shortens the number as per `Intl.NumberFormat` formatting if true

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
Search for any video, see that returned search results view count is not shortened as they contain exact numbers
Watch any video, see recommended videos rounded view count have now been shortened