### PR TITLE
feat: add subtitle style controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "googlevideo": "^4.1.1",
     "marked": "^18.0.11",
     "process": "^0.11.10",
-    "shaka-player": "^5.1.12",
+    "shaka-player": "^5.2.8",
     "swiper": "^14.1.0",
     "vue": "^3.5.41",
     "vue-i18n": "^11.4.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.11.10
         version: 0.11.10
       shaka-player:
-        specifier: ^5.1.12
-        version: 5.1.12
+        specifier: ^5.2.8
+        version: 5.2.8
       swiper:
         specifier: ^14.1.0
         version: 14.1.0
@@ -4516,8 +4516,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shaka-player@5.1.12:
-    resolution: {integrity: sha512-luGIzJ/H201aY0Hobs5853vY1eRJXPHH+u3oSWiTAYoufq5s/yIbRZS1QwCsj3f3Fyxc2C3HfptfI0brjE+RIQ==}
+  shaka-player@5.2.8:
+    resolution: {integrity: sha512-CLverPUQCw/ouNsVVo6SVPBNt31Tf6H9h3aZqWaILe9y/WE4Ok5scImkHSriOFo5udm/OShPOH3YNH3Sb3quEA==}
     engines: {node: '>=18'}
 
   shallow-clone@3.0.1:
@@ -9792,7 +9792,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shaka-player@5.1.12: {}
+  shaka-player@5.2.8: {}
 
   shallow-clone@3.0.1:
     dependencies:

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -33,6 +33,7 @@ import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 
 /** @typedef {import('../../helpers/sponsorblock').SponsorBlockCategory} SponsorBlockCategory */
+/** @typedef {{ fontScaleFactor?: number, positionArea?: shaka.config.PositionArea }} CaptionStyleConfig */
 
 // The UTF-8 characters "h", "t", "t", and "p".
 const HTTP_IN_HEX = 0x68747470
@@ -214,6 +215,9 @@ export default defineComponent({
     const startInFullwindow = props.startInFullwindow
     let startInFullscreen = props.startInFullscreen
     let startInPip = props.startInPip
+
+    /** @type {CaptionStyleConfig|null} */
+    let activeCaptionStyleConfig = null
 
     /** @type {number|null} */
     let restoreCaptionIndex = null
@@ -601,7 +605,10 @@ export default defineComponent({
      * @returns {shaka.extern.PlayerConfiguration}
      */
     function getPlayerConfig(format, useAutoQuality = false) {
-      return {
+      const captionStyleConfig = activeCaptionStyleConfig ?? getSavedCaptionStyleConfig()
+
+      /** @type {shaka.extern.PlayerConfiguration} */
+      const playerConfig = {
         // YouTube uses these values and they seem to work well in FreeTube too,
         // so we might as well use them
         streaming: {
@@ -636,6 +643,89 @@ export default defineComponent({
         // So use the AV1 and h264 codecs instead which it doesn't reject
         preferredVideoCodecs: typeof props.vrProjection === 'string' ? ['av01', 'avc1'] : []
       }
+
+      if (Object.keys(captionStyleConfig).length > 0) {
+        playerConfig.textDisplayer = captionStyleConfig
+      }
+
+      return playerConfig
+    }
+
+    /**
+     * @returns {CaptionStyleConfig}
+     */
+    function getSavedCaptionStyleConfig() {
+      const { fontScaleFactor, positionArea } = getSavedCaptionSettings()
+      /** @type {CaptionStyleConfig} */
+      const captionStyleConfig = {}
+
+      if (typeof fontScaleFactor === 'number' && Number.isFinite(fontScaleFactor) && fontScaleFactor > 0) {
+        captionStyleConfig.fontScaleFactor = fontScaleFactor
+      }
+
+      if (Object.values(shaka.config.PositionArea).includes(positionArea)) {
+        captionStyleConfig.positionArea = positionArea
+      }
+
+      return captionStyleConfig
+    }
+
+    /**
+     * @returns {CaptionStyleConfig|null}
+     */
+    function getCaptionStyleConfig() {
+      if (!player) {
+        return null
+      }
+
+      const { fontScaleFactor, positionArea } = player.getConfiguration().textDisplayer
+
+      if (typeof fontScaleFactor !== 'number' || !Number.isFinite(fontScaleFactor) || fontScaleFactor <= 0 ||
+        !Object.values(shaka.config.PositionArea).includes(positionArea)) {
+        return null
+      }
+
+      return { fontScaleFactor, positionArea }
+    }
+
+    function saveCaptionStyleSettings() {
+      const captionStyleConfig = getCaptionStyleConfig()
+
+      if (!captionStyleConfig || captionStyleConfigsAreEqual(captionStyleConfig, activeCaptionStyleConfig)) {
+        return
+      }
+
+      activeCaptionStyleConfig = captionStyleConfig
+
+      store.dispatch('updateDefaultCaptionSettings', JSON.stringify({
+        ...getSavedCaptionSettings(),
+        ...captionStyleConfig
+      }))
+    }
+
+    /**
+     * @returns {Record<string, unknown>}
+     */
+    function getSavedCaptionSettings() {
+      try {
+        const captionSettings = JSON.parse(store.getters.getDefaultCaptionSettings)
+
+        if (typeof captionSettings === 'object' && captionSettings !== null && !Array.isArray(captionSettings)) {
+          return captionSettings
+        }
+      } catch { }
+
+      return {}
+    }
+
+    /**
+     * @param {CaptionStyleConfig|null} a
+     * @param {CaptionStyleConfig|null} b
+     * @returns {boolean}
+     */
+    function captionStyleConfigsAreEqual(a, b) {
+      return a?.fontScaleFactor === b?.fontScaleFactor &&
+        a?.positionArea === b?.positionArea
     }
 
     /**
@@ -823,6 +913,8 @@ export default defineComponent({
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
           'playback_rate',
           'captions',
+          'captions-position',
+          'captions-size',
           'ft_audio_tracks',
           'chapter',
           'loop',
@@ -850,6 +942,8 @@ export default defineComponent({
         uiConfig.overflowMenuButtons.push(
           'ft_audio_tracks',
           'captions',
+          'captions-position',
+          'captions-size',
           'playback_rate',
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
           'chapter',
@@ -912,7 +1006,11 @@ export default defineComponent({
         const firstTimeConfig = {
           addSeekBar: seekingIsPossible.value,
           customContextMenu: true,
-          contextMenuElements: ['ft_stats'],
+          contextMenuElements: [
+            'captions-position',
+            'captions-size',
+            'ft_stats'
+          ],
           enableTooltips: true,
           seekBarColors: {
             // shaka-player's chapter markers only show up part of the time for the DASH and audio formats
@@ -944,6 +1042,7 @@ export default defineComponent({
           enableFullscreenOnRotation: enterFullscreenOnDisplayRotate.value,
           playbackRates: playbackRates.value,
           tapSeekDistance: defaultSkipInterval.value,
+          captionsStyles: true,
 
           // we have our own ones (shaka-player's ones are quite limited)
           enableKeyboardPlaybackControls: false,
@@ -2775,6 +2874,8 @@ export default defineComponent({
       player.addEventListener('error', event => handleError(event.detail, 'shaka error handler'))
 
       player.configure(getPlayerConfig(props.format, defaultQuality.value === 'auto'))
+      activeCaptionStyleConfig = getCaptionStyleConfig()
+      player.addEventListener('configurationchanged', saveCaptionStyleSettings)
 
       if (process.env.SUPPORTS_LOCAL_API) {
         player.getNetworkingEngine().registerRequestFilter(requestFilter)
@@ -3225,6 +3326,8 @@ export default defineComponent({
       document.removeEventListener('keydown', keyboardShortcutHandler)
       document.removeEventListener('fullscreenchange', fullscreenChangeHandler)
 
+      player?.removeEventListener('configurationchanged', saveCaptionStyleSettings)
+
       if (containerResizeObserver) {
         containerResizeObserver.disconnect()
         containerResizeObserver = null
@@ -3283,6 +3386,8 @@ export default defineComponent({
       ignoreErrors = true
 
       let uiState = { startNextVideoInFullscreen: false, startNextVideoInFullwindow: false, startNextVideoInPip: false }
+
+      player?.removeEventListener('configurationchanged', saveCaptionStyleSettings)
 
       if (ui) {
         if (ui.getControls()) {


### PR DESCRIPTION
 ## Pull Request Type

  - [x] Feature

  ## Related Issue

  Closes #968
  Closes #5072

  ## Description

continuation of https://github.com/FreeTubeApp/FreeTube/pull/9120 

  This PR adds subtitle size and position controls to FreeTube's Shaka video player.

  When subtitles are enabled, the player menu includes **Subtitle Size** and **Subtitle Position** controls. Users can
  change the subtitle size and position directly from the player menu.

This PR updates Shaka Player to version 5.2.8, which includes subtitle preview support from my PR [shaka-project/shaka-player#10077](https://github.com/shaka-project/shaka-player/pull/10077). 

When users hover over or focus an option with the keyboard, they can preview the change without saving it. Changes are saved only after an option is selected.

  FreeTube saves the selected subtitle size (`fontScaleFactor`) and position (`positionArea`) in `defaultCaptionSettings`. 
Settings stay the same when the player restarts or you watch another video. Other caption settings are not changed.

  Saved values are validated before they are applied. Invalid values are ignored safely.

  ## Testing

Before: 

https://github.com/user-attachments/assets/07f36971-2662-4499-aa3b-aa38bcf89359



After:


https://github.com/user-attachments/assets/874abc40-760d-4fff-abea-17a4d511c460



  1. Open a video with subtitles and enable them.
  2. Open the player menu and confirm **Subtitle Size** and **Subtitle Position** are visible.
  3. Check that both controls work and preview changes on hover/focus.
  4. Select a size and position, then confirm they persist after opening another video.
  5. Reopen the menus and confirm the selected options are checked.
  6. Test without subtitles and confirm the controls are hidden.
  7. Confirm both controls also appear in the context menu.

  ## Desktop

  - **OS:** Windows
  - **OS Version:** 11
  - **FreeTube version:** 0.25.3

  ## Additional Context

  The hover and keyboard-focus subtitle previews were added upstream in [shaka-project/shaka-player#10077](https://
  github.com/shaka-project/shaka-player/pull/10077), which has been merged and is included through the Shaka Player
  5.2.8 upgrade in this PR.

  The controls use Shaka Player's built-in `captions-size` and `captions-position` elements. This keeps the
  implementation aligned with Shaka's released UI and preview behavior.