### PR TITLE
Display different message when comments are turned off

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -335,11 +335,8 @@ async function getCommentDataLocal(more = false) {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
-    // region Comments disabled detection
     // No comment related info when video info requested earlier in parent component
     if (err?.message?.includes('The comments page did not have any content')) {
-      // For videos with comments disabled
-      // e.g. https://youtu.be/87DyyMV0kCY
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
@@ -348,7 +345,6 @@ async function getCommentDataLocal(more = false) {
       localCommentsInstance = undefined
       return
     }
-    // endregion Comments disabled detection
 
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
@@ -382,11 +378,8 @@ async function getCommentDataInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
-    // region Comments disabled detection
     // No comment related info when video info requested earlier in parent component
     if (err?.message?.includes('Comments not found')) {
-      // For videos with comments disabled
-      // e.g. https://youtu.be/87DyyMV0kCY
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
@@ -394,7 +387,6 @@ async function getCommentDataInvidious() {
       areCommentsDisabled.value = true
       return
     }
-    // endregion Comments disabled detection
 
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
@@ -424,7 +416,6 @@ async function getPostCommentsInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
-    // region Comments disabled detection
     if (err?.message?.includes('Comments not found')) {
       commentData.value = []
       nextPageToken.value = null
@@ -433,7 +424,6 @@ async function getPostCommentsInvidious() {
       areCommentsDisabled.value = true
       return
     }
-    // endregion Comments disabled detection
 
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -67,7 +67,13 @@
       v-else-if="showComments && !isLoading"
     >
       <h3
-        v-if="isPostComments"
+        v-if="areCommentsDisabled"
+        class="noCommentMsg"
+      >
+        {{ $t("Comments.Comments are turned off") }}
+      </h3>
+      <h3
+        v-else-if="isPostComments"
         class="noCommentMsg"
       >
         {{ $t("Comments.There are no comments available for this post") }}
@@ -166,6 +172,7 @@ function onTimestamp(timestamp) {
 const isLoading = ref(false)
 const isMoreCommentsLoading = ref(false)
 const showComments = ref(false)
+const areCommentsDisabled = ref(false)
 const nextPageToken = shallowRef(null)
 
 /** @type {import('vue').ShallowRef<import('../FtComment/FtComment.vue').Comment[]>} */
@@ -250,11 +257,13 @@ function handleSortChange() {
   sortNewest.value = !sortNewest.value
   commentData.value = []
   nextPageToken.value = null
+  areCommentsDisabled.value = false
   getCommentData()
 }
 
 function getCommentData() {
   isLoading.value = true
+  areCommentsDisabled.value = false
 
   if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
     if (!props.isPostComments) {
@@ -326,19 +335,20 @@ async function getCommentDataLocal(more = false) {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
-    // region No comment detection
+    // region Comments disabled detection
     // No comment related info when video info requested earlier in parent component
-    if (err.message.includes('The comments page did not have any content')) {
-      // For videos without any comment (comment disabled?)
-      // e.g. https://youtu.be/8NBSwDEf8a8
+    if (err?.message?.includes('The comments page did not have any content')) {
+      // For videos with comments disabled
+      // e.g. https://youtu.be/87DyyMV0kCY
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
       showComments.value = true
+      areCommentsDisabled.value = true
       localCommentsInstance = undefined
       return
     }
-    // endregion No comment detection
+    // endregion Comments disabled detection
 
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
@@ -372,18 +382,19 @@ async function getCommentDataInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
-    // region No comment detection
+    // region Comments disabled detection
     // No comment related info when video info requested earlier in parent component
-    if (err.message.includes('Comments not found')) {
-      // For videos without any comment (comment disabled?)
-      // e.g. https://youtu.be/8NBSwDEf8a8
+    if (err?.message?.includes('Comments not found')) {
+      // For videos with comments disabled
+      // e.g. https://youtu.be/87DyyMV0kCY
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
       showComments.value = true
+      areCommentsDisabled.value = true
       return
     }
-    // endregion No comment detection
+    // endregion Comments disabled detection
 
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
@@ -413,6 +424,17 @@ async function getPostCommentsInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
+    // region Comments disabled detection
+    if (err?.message?.includes('Comments not found')) {
+      commentData.value = []
+      nextPageToken.value = null
+      isLoading.value = false
+      showComments.value = true
+      areCommentsDisabled.value = true
+      return
+    }
+    // endregion Comments disabled detection
+
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
     showToast(`${errorMessage}: ${err}`, 10000, () => {

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -334,8 +334,11 @@ async function getCommentDataLocal(more = false) {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
+    // region No comment detection
     // No comment related info when video info requested earlier in parent component
     if (err.message.includes('The comments page did not have any content')) {
+      // For videos without any comment (comment disabled?)
+      // e.g. https://youtu.be/8NBSwDEf8a8
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
@@ -344,6 +347,7 @@ async function getCommentDataLocal(more = false) {
       localCommentsInstance = undefined
       return
     }
+    // endregion No comment detection
 
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
@@ -377,8 +381,11 @@ async function getCommentDataInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
+    // region No comment detection
     // No comment related info when video info requested earlier in parent component
     if (err.message.includes('Comments not found')) {
+      // For videos without any comment (comment disabled?)
+      // e.g. https://youtu.be/8NBSwDEf8a8
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
@@ -386,6 +393,7 @@ async function getCommentDataInvidious() {
       areCommentsDisabled.value = true
       return
     }
+    // endregion No comment detection
 
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -257,7 +257,6 @@ function handleSortChange() {
   sortNewest.value = !sortNewest.value
   commentData.value = []
   nextPageToken.value = null
-  areCommentsDisabled.value = false
   getCommentData()
 }
 
@@ -336,7 +335,7 @@ async function getCommentDataLocal(more = false) {
     showComments.value = true
   } catch (err) {
     // No comment related info when video info requested earlier in parent component
-    if (err?.message?.includes('The comments page did not have any content')) {
+    if (err.message.includes('The comments page did not have any content')) {
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
@@ -379,7 +378,7 @@ async function getCommentDataInvidious() {
     showComments.value = true
   } catch (err) {
     // No comment related info when video info requested earlier in parent component
-    if (err?.message?.includes('Comments not found')) {
+    if (err.message.includes('Comments not found')) {
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false
@@ -416,7 +415,7 @@ async function getPostCommentsInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
-    if (err?.message?.includes('Comments not found')) {
+    if (err.message.includes('Comments not found')) {
       commentData.value = []
       nextPageToken.value = null
       isLoading.value = false

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1048,6 +1048,7 @@ Comments:
   There are no comments available for this video: There are no comments available
     for this video
   There are no comments available for this post: There are no comments available for this post
+  Comments are turned off: Comments are turned off
   Load More Comments: Load More Comments
   Pinned by: Pinned by
   Member: Member


### PR DESCRIPTION
## Pull Request Type

- [x] Feature Implementation

## Related issue
closes #9657

## Description
Shows a message for when comments are turned off instead of the same message for no comments.

## Screenshots

<img width="739" height="540" alt="image" src="https://github.com/user-attachments/assets/54187c31-6a3b-4205-8533-4e5304fa47cb" />
<img width="739" height="540" alt="image" src="https://github.com/user-attachments/assets/3d6fd945-7f3b-4dd4-988e-8595591b1950" />


## Testing

1. Open https://youtu.be/3uAIqqg8ZHo
2. Click on the button to load comments
3. Open https://youtu.be/0GNeqN0sWlc
4. See that the message is different
5. Open https://www.youtube.com/post/UgkxaotJMxw_9fCQQ7Nc3C1N94IlUty6AxMD
6. See it shows the new message for posts as well.

## Desktop

- **OS:** MacOS
- **OS Version:** 27
- **FreeTube version:** v0.25.3 Beta
