### PR TITLE
Make SabrSchemePlugin more robust

### DIFF
--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -358,6 +358,8 @@ async function doRequest(
         switch (part.type) {
           case UMPPartId.STREAM_PROTECTION_STATUS: {
             const streamProtectionStatus = decodePart(part, StreamProtectionStatus)
+            if (!streamProtectionStatus) break
+
             if (streamProtectionStatus.status === 3) {
               invalidPoToken = true
             }
@@ -372,7 +374,7 @@ async function doRequest(
           }
           case UMPPartId.SABR_REDIRECT: {
             const sabrRedirect = decodePart(part, SabrRedirect)
-            if (!sabrRedirect) break
+            if (!sabrRedirect?.url) break
 
             currentState.sabrStreamState.sabrUrl = sabrRedirect.url
             shouldRetry = true


### PR DESCRIPTION
Add guards for some rare situations causing video playback to hang.

<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #9726

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The changes are adding some guards for some rare situations causing video playback to hang. Should make SabrSchemePlugin more robust.

One point for discussion might be: what to do with an empty url on a redirect request? Just ignore the whole thing (what this change does)? Or skip setting the empty url but do `shouldRetry = true` so it retries the old url I guess (what v0.25.2 did)?

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Watch a lot of videos
2. Check if video sometimes stops after some minutes with an endless spinner

## Desktop
<!-- Please complete the following information-->
- **OS:** NixOS
- **OS Version:** unstable
- **FreeTube version:** v0.25.3

