### PR TITLE
Fix: Channel with unavailable clips throws 'Cannot read properties of null'

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1654,6 +1654,11 @@ export function parseLocalListVideo(item, channelId, channelName) {
     /** @type {import('youtubei.js').YTNodes.GridVideo} */
     const video = item
 
+    // This can happen for unavailable clip on channel home page
+    if (!video.video_id) {
+      return null
+    }
+
     let publishedText
 
     if (video.published != null && !video.published.isEmpty()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9760

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
If a channel home page contains clips that have been deleted, it will throw when trying to parse them.
There is an example with this channel: https://www.youtube.com/channel/UCCFqUJYKT97UerMmb6DM0bw
<img width="1378" height="284" alt="image" src="https://github.com/user-attachments/assets/343f391f-33c8-4c19-a649-73932d7dfb9f" />

".." and "fsd" have been deleted but YouTube still displays them for some reason
Clicking on them displays a popup
<img width="638" height="167" alt="image" src="https://github.com/user-attachments/assets/1571c85e-3e05-4edb-bd39-cee54e95ebe6" />

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to a channel with deleted clips (e.g. https://www.youtube.com/channel/UCCFqUJYKT97UerMmb6DM0bw)
2. Check that it is correctly loading without errors

For regression testing, I think this is pretty safe, because I don't imagine a valid scenario where we would try to parse a video with no ID