### PR TITLE
fix: opening invalid playlist does not update the window title

### DIFF
--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -496,6 +496,7 @@ function resetState() {
   showUnavailableVideosAlert.value = false
   playlistItems.value = []
   continuationData.value = null
+  updatePageTitle()
 }
 
 async function getPlaylistLocal() {
@@ -560,6 +561,7 @@ async function getPlaylistLocal() {
       console.warn('Falling back to Invidious API')
       getPlaylistInvidious()
     } else {
+      updatePageTitle()
       isLoading.value = false
     }
   }
@@ -600,6 +602,7 @@ async function getPlaylistInvidious() {
       console.warn('Error getting data with Invidious, falling back to local backend')
       getPlaylistLocal()
     } else {
+      updatePageTitle()
       isLoading.value = false
       // TODO: Show toast with error message
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes https://github.com/FreeTubeApp/FreeTube/issues/9761

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Update the title of the  window after an error occurred or when the state is reset.

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
1. Go to any FreeTube page (e.g. Subscriptions)
2. Enter an invalid playlist URL (e.g. https://www.youtube.com/playlist?list=foobar)
3. Check that the window's title is "FreeTube"

## Desktop
<!-- Please complete the following information-->
- **OS:** Bazzite
- **OS Version:**
- **FreeTube version:** 0.25.3-beta

## Additional context
<!-- Add any other context about the pull request here. -->
I've  used the same logic as the `Watch.js` file, i.e.  updating when `isLoading` becomes false, or when resetting the state.