### PR TITLE
Hoist some v-ifs and use v-else and v-else-if

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -25,7 +25,6 @@
         class="banner-wrapper"
       >
         <FtNotificationBanner
-          v-if="showUpdatesBanner"
           class="banner"
           :message="updateBannerMessage"
           role="link"

--- a/src/renderer/components/ExternalPlayerSettings.vue
+++ b/src/renderer/components/ExternalPlayerSettings.vue
@@ -31,32 +31,33 @@
         @change="updateExternalPlayerIgnoreDefaultArgs"
       />
     </FtFlexBox>
-    <FtFlexBox
-      v-if="externalPlayer !== ''"
-      class="settingsFlexStart460px"
-    >
-      <FtInput
-        :placeholder="$t('Settings.External Player Settings.Custom External Player Executable')"
-        :show-action-button="false"
-        :show-label="true"
-        :value="externalPlayerExecutable"
-        :tooltip="$t('Tooltips.External Player Settings.Custom External Player Executable')"
-        @input="updateExternalPlayerExecutable"
-      />
-    </FtFlexBox>
-    <FtFlexBox
+    <template
       v-if="externalPlayer !== ''"
     >
-      <FtInputTags
-        :label="$t('Settings.External Player Settings.Custom External Player Arguments')"
-        :tag-name-placeholder="$t('Settings.External Player Settings.Custom External Player Arguments')"
-        :tag-list="externalPlayerCustomArgs"
-        :tooltip="externalPlayerCustomArgsTooltip"
-        :show-tags="showAddedExternalPlayerCustomArgs"
-        @change="handleExternalPlayerCustomArgs"
-        @toggle-show-tags="handleAddedExternalPayerCustomArgs"
-      />
-    </FtFlexBox>
+      <FtFlexBox
+        class="settingsFlexStart460px"
+      >
+        <FtInput
+          :placeholder="$t('Settings.External Player Settings.Custom External Player Executable')"
+          :show-action-button="false"
+          :show-label="true"
+          :value="externalPlayerExecutable"
+          :tooltip="$t('Tooltips.External Player Settings.Custom External Player Executable')"
+          @input="updateExternalPlayerExecutable"
+        />
+      </FtFlexBox>
+      <FtFlexBox>
+        <FtInputTags
+          :label="$t('Settings.External Player Settings.Custom External Player Arguments')"
+          :tag-name-placeholder="$t('Settings.External Player Settings.Custom External Player Arguments')"
+          :tag-list="externalPlayerCustomArgs"
+          :tooltip="externalPlayerCustomArgsTooltip"
+          :show-tags="showAddedExternalPlayerCustomArgs"
+          @change="handleExternalPlayerCustomArgs"
+          @toggle-show-tags="handleAddedExternalPayerCustomArgs"
+        />
+      </FtFlexBox>
+    </template>
   </FtSettingsSection>
 </template>
 

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -78,7 +78,7 @@
       </swiper-slide>
     </swiper-container>
     <div
-      v-if="postType === 'image' && postContent.content.length > 0"
+      v-else-if="postType === 'image' && postContent.content.length > 0"
     >
       <img
         :src="getBestQualityImage(postContent.content)"
@@ -87,7 +87,7 @@
       >
     </div>
     <div
-      v-if="postType === 'video'"
+      v-else-if="postType === 'video'"
     >
       <FtListVideo
         v-if="!hideVideo"
@@ -102,12 +102,12 @@
       </p>
     </div>
     <div
-      v-if="postType === 'poll' || postType === 'quiz'"
+      v-else-if="postType === 'poll' || postType === 'quiz'"
     >
       <FtCommunityPoll :data="postContent" />
     </div>
     <div
-      v-if="postType === 'playlist'"
+      v-else-if="postType === 'playlist'"
       class="playlistWrapper"
     >
       <FtListPlaylist

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -10,53 +10,55 @@
         playlistCount: selectedPlaylistCount,
       }, selectedPlaylistCount) }}
     </p>
-    <div
+    <template
       v-if="allPlaylists.length > 1"
-      class="searchInputsRow"
-    >
-      <FtInput
-        ref="searchBar"
-        :placeholder="t('User Playlists.AddVideoPrompt.Search in Playlists')"
-        :show-clear-text-button="true"
-        :show-action-button="false"
-        :maxlength="255"
-        @input="updateQueryDebounce"
-        @clear="updateQueryDebounce('')"
-      />
-    </div>
-    <div
-      v-if="allPlaylists.length > 1"
-      class="optionsRow"
     >
       <div
-        class="tightOptions"
+        class="searchInputsRow"
       >
-        <FtToggleSwitch
-          class="matchingVideoToggle"
-          :label="t('User Playlists.Playlists with Matching Videos')"
-          :compact="true"
-          :default-value="doSearchPlaylistsWithMatchingVideos"
-          @change="doSearchPlaylistsWithMatchingVideos = !doSearchPlaylistsWithMatchingVideos"
-        />
-        <FtToggleSwitch
-          v-if="anyPlaylistContainsVideosToBeAdded"
-          class="allowDuplicateToggle"
-          :label="t('User Playlists.AddVideoPrompt.Allow Adding Duplicate Video(s)')"
-          :compact="true"
-          :default-value="addingDuplicateVideosEnabled"
-          @change="addingDuplicateVideosEnabled = !addingDuplicateVideosEnabled"
+        <FtInput
+          ref="searchBar"
+          :placeholder="t('User Playlists.AddVideoPrompt.Search in Playlists')"
+          :show-clear-text-button="true"
+          :show-action-button="false"
+          :maxlength="255"
+          @input="updateQueryDebounce"
+          @clear="updateQueryDebounce('')"
         />
       </div>
-      <FtSelect
-        class="sortSelect"
-        :value="sortBy"
-        :select-names="sortBySelectNames"
-        :select-values="SORT_BY_SELECT_VALUES"
-        :placeholder="t('Global.Sort By')"
-        :icon="sortBySelectIcon"
-        @change="sortBy = $event"
-      />
-    </div>
+      <div
+        class="optionsRow"
+      >
+        <div
+          class="tightOptions"
+        >
+          <FtToggleSwitch
+            class="matchingVideoToggle"
+            :label="t('User Playlists.Playlists with Matching Videos')"
+            :compact="true"
+            :default-value="doSearchPlaylistsWithMatchingVideos"
+            @change="doSearchPlaylistsWithMatchingVideos = !doSearchPlaylistsWithMatchingVideos"
+          />
+          <FtToggleSwitch
+            v-if="anyPlaylistContainsVideosToBeAdded"
+            class="allowDuplicateToggle"
+            :label="t('User Playlists.AddVideoPrompt.Allow Adding Duplicate Video(s)')"
+            :compact="true"
+            :default-value="addingDuplicateVideosEnabled"
+            @change="addingDuplicateVideosEnabled = !addingDuplicateVideosEnabled"
+          />
+        </div>
+        <FtSelect
+          class="sortSelect"
+          :value="sortBy"
+          :select-names="sortBySelectNames"
+          :select-values="SORT_BY_SELECT_VALUES"
+          :placeholder="t('Global.Sort By')"
+          :icon="sortBySelectIcon"
+          @change="sortBy = $event"
+        />
+      </div>
+    </template>
     <div class="playlists-container">
       <FtFlexBox>
         <div

--- a/src/renderer/components/FtShareButton/FtShareButton.vue
+++ b/src/renderer/components/FtShareButton/FtShareButton.vue
@@ -46,24 +46,26 @@
           :label="t('Share.Open Link')"
           @click="openYoutube"
         />
-        <FtButton
+        <template
           v-if="isVideo || isPlaylist"
-          class="action"
-          aria-describedby="youtubeShareImage"
-          background-color="var(--accent-color-active)"
-          :icon="['fas', 'copy']"
-          :label="t('Share.Copy Embed')"
-          @click="copyYoutubeEmbed"
-        />
-        <FtButton
-          v-if="isVideo || isPlaylist"
-          class="action"
-          aria-describedby="youtubeShareImage"
-          background-color="var(--accent-color-active)"
-          :icon="['fas', 'globe']"
-          :label="t('Share.Open Embed')"
-          @click="openYoutubeEmbed"
-        />
+        >
+          <FtButton
+            class="action"
+            aria-describedby="youtubeShareImage"
+            background-color="var(--accent-color-active)"
+            :icon="['fas', 'copy']"
+            :label="t('Share.Copy Embed')"
+            @click="copyYoutubeEmbed"
+          />
+          <FtButton
+            class="action"
+            aria-describedby="youtubeShareImage"
+            background-color="var(--accent-color-active)"
+            :icon="['fas', 'globe']"
+            :label="t('Share.Open Embed')"
+            @click="openYoutubeEmbed"
+          />
+        </template>
       </div>
 
       <template v-if="showInvidiousOptions">
@@ -91,24 +93,26 @@
             :label="t('Share.Open Link')"
             @click="openInvidious"
           />
-          <FtButton
+          <template
             v-if="isVideo || isPlaylist"
-            aria-describedby="invidiousShare"
-            class="action"
-            background-color="var(--accent-color-active)"
-            :icon="['fas', 'copy']"
-            :label="t('Share.Copy Embed')"
-            @click="copyInvidiousEmbed"
-          />
-          <FtButton
-            v-if="isVideo || isPlaylist"
-            aria-describedby="invidiousShare"
-            class="action"
-            background-color="var(--accent-color-active)"
-            :icon="['fas', 'globe']"
-            :label="t('Share.Open Embed')"
-            @click="openInvidiousEmbed"
-          />
+          >
+            <FtButton
+              aria-describedby="invidiousShare"
+              class="action"
+              background-color="var(--accent-color-active)"
+              :icon="['fas', 'copy']"
+              :label="t('Share.Copy Embed')"
+              @click="copyInvidiousEmbed"
+            />
+            <FtButton
+              aria-describedby="invidiousShare"
+              class="action"
+              background-color="var(--accent-color-active)"
+              :icon="['fas', 'globe']"
+              :label="t('Share.Open Embed')"
+              @click="openInvidiousEmbed"
+            />
+          </template>
         </div>
       </template>
     </div>

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -164,14 +164,14 @@
               theme="secondary"
               @click="enterEditMode"
             />
-            <FtIconButton
-              v-if="videoCount > 0 && showPlaylists"
-              :title="$t('User Playlists.Copy Playlist')"
-              :icon="['fas', 'copy']"
-              theme="secondary"
-              @click="toggleCopyVideosPrompt"
-            />
           </template>
+          <FtIconButton
+            v-if="videoCount > 0 && showPlaylists && !editMode"
+            :title="$t('User Playlists.Copy Playlist')"
+            :icon="['fas', 'copy']"
+            theme="secondary"
+            @click="toggleCopyVideosPrompt"
+          />
           <FtIconButton
             v-if="exportPlaylistButtonVisible"
             :title="$t('User Playlists.Export Playlist')"

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -130,44 +130,48 @@
 
       <div class="playlistOptionsAndSearch">
         <div class="playlistOptions">
-          <FtIconButton
+          <template
             v-if="editMode"
-            :title="$t('User Playlists.Save Changes')"
-            :disabled="playlistPersistenceDisabled"
-            :icon="['fas', 'save']"
-            theme="secondary"
-            @click="savePlaylistInfo"
-          />
-          <FtIconButton
-            v-if="editMode"
-            :title="$t('User Playlists.Cancel')"
-            :icon="['fas', 'times']"
-            theme="secondary"
-            @click="exitEditMode"
-          />
-          <FtIconButton
-            v-if="!editMode && isUserPlaylist"
-            :title="markedAsQuickBookmarkTarget ? $t('User Playlists.Quick Bookmark Enabled') : $t('User Playlists.Enable Quick Bookmark With This Playlist')"
-            :icon="markedAsQuickBookmarkTarget ? ['fas', 'bookmark'] : ['far', 'bookmark']"
-            :disabled="markedAsQuickBookmarkTarget"
-            :theme="markedAsQuickBookmarkTarget ? 'secondary' : 'base-no-default'"
-            @disabled-click="handleQuickBookmarkEnabledDisabledClick"
-            @click="enableQuickBookmarkForThisPlaylist"
-          />
-          <FtIconButton
-            v-if="!editMode && isUserPlaylist"
-            :title="$t('User Playlists.Edit Playlist Info')"
-            :icon="['fas', 'edit']"
-            theme="secondary"
-            @click="enterEditMode"
-          />
-          <FtIconButton
-            v-if="videoCount > 0 && showPlaylists && !editMode"
-            :title="$t('User Playlists.Copy Playlist')"
-            :icon="['fas', 'copy']"
-            theme="secondary"
-            @click="toggleCopyVideosPrompt"
-          />
+          >
+            <FtIconButton
+              :title="$t('User Playlists.Save Changes')"
+              :disabled="playlistPersistenceDisabled"
+              :icon="['fas', 'save']"
+              theme="secondary"
+              @click="savePlaylistInfo"
+            />
+            <FtIconButton
+              :title="$t('User Playlists.Cancel')"
+              :icon="['fas', 'times']"
+              theme="secondary"
+              @click="exitEditMode"
+            />
+          </template>
+          <template
+            v-else-if="isUserPlaylist"
+          >
+            <FtIconButton
+              :title="markedAsQuickBookmarkTarget ? $t('User Playlists.Quick Bookmark Enabled') : $t('User Playlists.Enable Quick Bookmark With This Playlist')"
+              :icon="markedAsQuickBookmarkTarget ? ['fas', 'bookmark'] : ['far', 'bookmark']"
+              :disabled="markedAsQuickBookmarkTarget"
+              :theme="markedAsQuickBookmarkTarget ? 'secondary' : 'base-no-default'"
+              @disabled-click="handleQuickBookmarkEnabledDisabledClick"
+              @click="enableQuickBookmarkForThisPlaylist"
+            />
+            <FtIconButton
+              :title="$t('User Playlists.Edit Playlist Info')"
+              :icon="['fas', 'edit']"
+              theme="secondary"
+              @click="enterEditMode"
+            />
+            <FtIconButton
+              v-if="videoCount > 0 && showPlaylists"
+              :title="$t('User Playlists.Copy Playlist')"
+              :icon="['fas', 'copy']"
+              theme="secondary"
+              @click="toggleCopyVideosPrompt"
+            />
+          </template>
           <FtIconButton
             v-if="exportPlaylistButtonVisible"
             :title="$t('User Playlists.Export Playlist')"

--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -88,7 +88,7 @@
         v-if="isLoading"
       />
       <div
-        v-if="!isLoading && dataAvailable"
+        v-else-if="dataAvailable"
         class="center"
       >
         <h3>

--- a/src/renderer/components/SponsorBlockSettings.vue
+++ b/src/renderer/components/SponsorBlockSettings.vue
@@ -48,7 +48,6 @@
         v-if="useDeArrowThumbnails"
       >
         <FtInput
-          v-if="useDeArrowThumbnails"
           ref="deArrowThumbnailGeneratorUrl"
           :placeholder="$t('Settings.SponsorBlock Settings[\'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)\']')"
           :show-action-button="false"

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -3,61 +3,65 @@
     <FtLoader
       v-if="isLoading"
     />
-    <div
-      v-if="!isLoading && errorChannels.length !== 0"
+    <template
+      v-else
     >
-      <h3> {{ $t("Subscriptions.Error Channels") }}</h3>
-      <FtFlexBox>
-        <FtChannelBubble
-          v-for="channel in errorChannels"
-          :key="channel.id"
-          :channel-name="channel.name"
-          :channel-id="channel.id"
-          :channel-thumbnail="channel.thumbnail"
-        />
+      <div
+        v-if="errorChannels.length !== 0"
+      >
+        <h3> {{ $t("Subscriptions.Error Channels") }}</h3>
+        <FtFlexBox>
+          <FtChannelBubble
+            v-for="channel in errorChannels"
+            :key="channel.id"
+            :channel-name="channel.name"
+            :channel-id="channel.id"
+            :channel-thumbnail="channel.thumbnail"
+          />
+        </FtFlexBox>
+      </div>
+      <FtFlexBox
+        v-if="activeVideoList.length === 0"
+      >
+        <p
+          v-if="!activeProfileHasSubscriptions"
+          class="message"
+        >
+          {{ $t("Subscriptions['Your Subscription list is currently empty. Start adding subscriptions to see them here.']") }}
+        </p>
+        <p
+          v-else-if="!fetchSubscriptionsAutomatically && !attemptedFetch"
+          class="message"
+        >
+          {{ $t("Subscriptions.Disabled Automatic Fetching") }}
+        </p>
+        <p
+          v-else
+          class="message"
+        >
+          {{ isCommunity ? $t("Subscriptions.Empty Posts") : $t("Subscriptions.Empty Channels") }}
+        </p>
       </FtFlexBox>
-    </div>
-    <FtFlexBox
-      v-if="!isLoading && activeVideoList.length === 0"
-    >
-      <p
-        v-if="!activeProfileHasSubscriptions"
-        class="message"
-      >
-        {{ $t("Subscriptions['Your Subscription list is currently empty. Start adding subscriptions to see them here.']") }}
-      </p>
-      <p
-        v-else-if="!fetchSubscriptionsAutomatically && !attemptedFetch"
-        class="message"
-      >
-        {{ $t("Subscriptions.Disabled Automatic Fetching") }}
-      </p>
-      <p
+      <FtElementList
         v-else
-        class="message"
+        :data="activeVideoList"
+        :use-channels-hidden-preference="false"
+        :display="isCommunity ? 'list' : ''"
+      />
+      <FtAutoLoadNextPageWrapper
+        v-if="videoList.length > dataLimit"
+        @load-next-page="increaseLimit"
       >
-        {{ isCommunity ? $t("Subscriptions.Empty Posts") : $t("Subscriptions.Empty Channels") }}
-      </p>
-    </FtFlexBox>
-    <FtElementList
-      v-if="!isLoading && activeVideoList.length > 0"
-      :data="activeVideoList"
-      :use-channels-hidden-preference="false"
-      :display="isCommunity ? 'list' : ''"
-    />
-    <FtAutoLoadNextPageWrapper
-      v-if="!isLoading && videoList.length > dataLimit"
-      @load-next-page="increaseLimit"
-    >
-      <FtFlexBox>
-        <FtButton
-          :label="isCommunity ? $t('Subscriptions.Load More Posts') : $t('Subscriptions.Load More Videos')"
-          background-color="var(--primary-color)"
-          text-color="var(--text-with-main-color)"
-          @click="increaseLimit"
-        />
-      </FtFlexBox>
-    </FtAutoLoadNextPageWrapper>
+        <FtFlexBox>
+          <FtButton
+            :label="isCommunity ? $t('Subscriptions.Load More Posts') : $t('Subscriptions.Load More Videos')"
+            background-color="var(--primary-color)"
+            text-color="var(--text-with-main-color)"
+            @click="increaseLimit"
+          />
+        </FtFlexBox>
+      </FtAutoLoadNextPageWrapper>
+    </template>
 
     <FtRefreshWidget
       :disable-refresh="isLoading || !activeProfileHasSubscriptions"

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -21,17 +21,16 @@
         @clear="() => handleQueryChange('')"
       />
       <div
+        v-if="fullData.length > 1"
         class="optionsRow"
       >
         <FtToggleSwitch
-          v-if="fullData.length > 1"
           :label="t('History.Case Sensitive Search')"
           :compact="true"
           :default-value="doCaseSensitiveSearch"
           @change="doCaseSensitiveSearch = !doCaseSensitiveSearch"
         />
         <FtSelect
-          v-if="fullData.length > 1"
           class="sortSelect"
           :placeholder="t('Global.Sort By')"
           :value="sortBy"

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -12,138 +12,104 @@
       v-if="isLoading"
       :fullscreen="true"
     />
-    <div
-      v-if="!isLoading"
-      class="playlistInfoContainer"
-      :class="{
-        promptOpen,
-      }"
+    <template
+      v-else
     >
-      <PlaylistInfo
-        :id="playlistId"
-        :first-video-id="firstVideoId"
-        :first-video-playlist-item-id="firstVideoPlaylistItemId"
-        :playlist-thumbnail="playlistThumbnail"
-        :title="playlistTitle"
-        :channel-name="channelName"
-        :channel-thumbnail="channelThumbnail"
-        :channel-id="channelId"
-        :last-updated="lastUpdated"
-        :description="playlistDescription"
-        :video-count="shownVideoCount"
-        :videos="shownPlaylistItems"
-        :sorted-videos="sortedPlaylistItems"
-        :view-count="viewCount"
-        :total-playlist-duration="totalPlaylistDuration"
-        :is-duration-approximate="isDurationApproximate"
-        :info-source="infoSource"
-        :more-video-data-available="moreVideoDataAvailable"
-        :search-video-mode-allowed="isUserPlaylistRequested && shownVideoCount > 1"
-        :search-query-text="searchQueryTextRequested"
-        :theme="listType === 'list' ? 'base' : 'top-bar'"
-        class="playlistInfo"
-        @dragstart.prevent
-        @enter-edit-mode="playlistInEditMode = true"
-        @exit-edit-mode="playlistInEditMode = false"
-        @search-video-query-change="handleVideoSearchQueryChange"
-        @prompt-open="promptOpen = true"
-        @prompt-close="promptOpen = false"
-      />
-    </div>
-
-    <FtCard
-      v-if="!isLoading"
-      class="playlistItemsCard"
-    >
-      <FtFlexBox
-        v-if="showUnavailableVideosAlert"
-        class="alertBox"
+      <div
+        class="playlistInfoContainer"
+        :class="{
+          promptOpen,
+        }"
       >
-        <p class="alertLabel">
-          {{ t("Playlist.Unavailable videos are hidden") }}
-        </p>
-        <button
-          class="alertButton"
-          :aria-label="t('Close')"
-          :title="t('Close')"
-          @click="handleCloseAlert"
-        >
-          <FontAwesomeIcon
-            :icon="['fas', 'times']"
-          />
-        </button>
-      </FtFlexBox>
-      <template
-        v-if="shownPlaylistItems.length > 0"
-      >
-        <FtSelect
-          v-if="isUserPlaylistRequested && shownPlaylistItems.length > 1"
-          class="sortSelect"
-          :value="sortOrder"
-          :select-names="sortBySelectNames"
-          :select-values="SORT_BY_SELECT_VALUES"
-          :placeholder="t('Global.Sort By')"
-          :icon="sortOrderIcon"
-          @change="updateUserPlaylistSortOrder"
+        <PlaylistInfo
+          :id="playlistId"
+          :first-video-id="firstVideoId"
+          :first-video-playlist-item-id="firstVideoPlaylistItemId"
+          :playlist-thumbnail="playlistThumbnail"
+          :title="playlistTitle"
+          :channel-name="channelName"
+          :channel-thumbnail="channelThumbnail"
+          :channel-id="channelId"
+          :last-updated="lastUpdated"
+          :description="playlistDescription"
+          :video-count="shownVideoCount"
+          :videos="shownPlaylistItems"
+          :sorted-videos="sortedPlaylistItems"
+          :view-count="viewCount"
+          :total-playlist-duration="totalPlaylistDuration"
+          :is-duration-approximate="isDurationApproximate"
+          :info-source="infoSource"
+          :more-video-data-available="moreVideoDataAvailable"
+          :search-video-mode-allowed="isUserPlaylistRequested && shownVideoCount > 1"
+          :search-query-text="searchQueryTextRequested"
+          :theme="listType === 'list' ? 'base' : 'top-bar'"
+          class="playlistInfo"
+          @dragstart.prevent
+          @enter-edit-mode="playlistInEditMode = true"
+          @exit-edit-mode="playlistInEditMode = false"
+          @search-video-query-change="handleVideoSearchQueryChange"
+          @prompt-open="promptOpen = true"
+          @prompt-close="promptOpen = false"
         />
-        <AutoScrollWrapper
-          v-if="visiblePlaylistItems.length > 0"
-          :hot-zone-enabled="isSortOrderCustom && isVideoDragging"
+      </div>
+
+      <FtCard
+        class="playlistItemsCard"
+      >
+        <FtFlexBox
+          v-if="showUnavailableVideosAlert"
+          class="alertBox"
         >
-          <FtElementList
-            v-if="listType === 'grid'"
-            :data="visiblePlaylistItems"
-            display="grid"
-            :playlist-id="playlistId"
-            :playlist-type="infoSource"
-            :show-video-with-last-viewed-playlist="true"
-            :use-channels-hidden-preference="false"
-            :use-hide-upcoming-premieres-preference="false"
-            :hide-forbidden-titles="false"
-            :always-show-add-to-playlist-button="true"
-            :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
-            :can-move-video-up="canMoveVideos"
-            :can-move-video-down="canMoveVideos"
-            :playlist-items-length="shownPlaylistItems.length"
-            :can-remove-from-playlist="true"
-            :dragged-video="draggedVideo"
-            :is-video-dragging="isVideoDragging"
-            :video-dragging-possible="videoDraggingPossible"
-            @drag-video="setDraggedVideo"
-            @drag-video-end="onDragVideoEnd"
-            @move-dragged-video="moveDraggedVideoTemporarilyThrottled"
-            @move-video-up="moveVideoUp"
-            @move-video-down="moveVideoDown"
-            @move-video-to-the-top="moveVideoToTheTop"
-            @move-video-to-the-bottom="moveVideoToTheBottom"
-            @remove-from-playlist="removeVideoFromPlaylist"
-          />
-          <TransitionGroup
-            v-else
-            name="playlistItem"
-            tag="span"
-            class="playlistItems"
+          <p class="alertLabel">
+            {{ t("Playlist.Unavailable videos are hidden") }}
+          </p>
+          <button
+            class="alertButton"
+            :aria-label="t('Close')"
+            :title="t('Close')"
+            @click="handleCloseAlert"
           >
-            <FtListVideoNumbered
-              v-for="(item, index) in visiblePlaylistItems"
-              :key="`${item.videoId}-${item.playlistItemId || index}`"
-              class="playlistItem"
-              :data="item"
+            <FontAwesomeIcon
+              :icon="['fas', 'times']"
+            />
+          </button>
+        </FtFlexBox>
+        <template
+          v-if="shownPlaylistItems.length > 0"
+        >
+          <FtSelect
+            v-if="isUserPlaylistRequested && shownPlaylistItems.length > 1"
+            class="sortSelect"
+            :value="sortOrder"
+            :select-names="sortBySelectNames"
+            :select-values="SORT_BY_SELECT_VALUES"
+            :placeholder="t('Global.Sort By')"
+            :icon="sortOrderIcon"
+            @change="updateUserPlaylistSortOrder"
+          />
+          <AutoScrollWrapper
+            v-if="visiblePlaylistItems.length > 0"
+            :hot-zone-enabled="isSortOrderCustom && isVideoDragging"
+          >
+            <FtElementList
+              v-if="listType === 'grid'"
+              :data="visiblePlaylistItems"
+              display="grid"
               :playlist-id="playlistId"
               :playlist-type="infoSource"
-              :playlist-index="playlistInVideoSearchMode ? shownPlaylistItems.findIndex(i => i === item) : index"
-              :playlist-item-id="item.playlistItemId"
-              appearance="result"
+              :show-video-with-last-viewed-playlist="true"
+              :use-channels-hidden-preference="false"
+              :use-hide-upcoming-premieres-preference="false"
+              :hide-forbidden-titles="false"
               :always-show-add-to-playlist-button="true"
               :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
-              :can-move-video-up="index > 0 && canMoveVideos"
-              :can-move-video-down="index < shownPlaylistItems.length - 1 && canMoveVideos"
+              :can-move-video-up="canMoveVideos"
+              :can-move-video-down="canMoveVideos"
+              :playlist-items-length="shownPlaylistItems.length"
               :can-remove-from-playlist="true"
-              :video-index="playlistInVideoSearchMode ? shownPlaylistItems.findIndex(i => i === item) : index"
-              :initial-visible-state="index < 10"
               :dragged-video="draggedVideo"
-              :is-sort-order-custom="isSortOrderCustom"
               :is-video-dragging="isVideoDragging"
+              :video-dragging-possible="videoDraggingPossible"
               @drag-video="setDraggedVideo"
               @drag-video-end="onDragVideoEnd"
               @move-dragged-video="moveDraggedVideoTemporarilyThrottled"
@@ -153,43 +119,79 @@
               @move-video-to-the-bottom="moveVideoToTheBottom"
               @remove-from-playlist="removeVideoFromPlaylist"
             />
-          </TransitionGroup>
-          <FtAutoLoadNextPageWrapper
-            v-if="moreVideoDataAvailable && !isLoadingMore"
-            @load-next-page="getNextPage"
-          >
-            <FtFlexBox>
-              <FtButton
-                :label="t('Subscriptions.Load More Videos')"
-                background-color="var(--primary-color)"
-                text-color="var(--text-with-main-color)"
-                @click="getNextPage"
+            <TransitionGroup
+              v-else
+              name="playlistItem"
+              tag="span"
+              class="playlistItems"
+            >
+              <FtListVideoNumbered
+                v-for="(item, index) in visiblePlaylistItems"
+                :key="`${item.videoId}-${item.playlistItemId || index}`"
+                class="playlistItem"
+                :data="item"
+                :playlist-id="playlistId"
+                :playlist-type="infoSource"
+                :playlist-index="playlistInVideoSearchMode ? shownPlaylistItems.findIndex(i => i === item) : index"
+                :playlist-item-id="item.playlistItemId"
+                appearance="result"
+                :always-show-add-to-playlist-button="true"
+                :quick-bookmark-button-enabled="quickBookmarkButtonEnabled"
+                :can-move-video-up="index > 0 && canMoveVideos"
+                :can-move-video-down="index < shownPlaylistItems.length - 1 && canMoveVideos"
+                :can-remove-from-playlist="true"
+                :video-index="playlistInVideoSearchMode ? shownPlaylistItems.findIndex(i => i === item) : index"
+                :initial-visible-state="index < 10"
+                :dragged-video="draggedVideo"
+                :is-sort-order-custom="isSortOrderCustom"
+                :is-video-dragging="isVideoDragging"
+                @drag-video="setDraggedVideo"
+                @drag-video-end="onDragVideoEnd"
+                @move-dragged-video="moveDraggedVideoTemporarilyThrottled"
+                @move-video-up="moveVideoUp"
+                @move-video-down="moveVideoDown"
+                @move-video-to-the-top="moveVideoToTheTop"
+                @move-video-to-the-bottom="moveVideoToTheBottom"
+                @remove-from-playlist="removeVideoFromPlaylist"
               />
-            </FtFlexBox>
-          </FtAutoLoadNextPageWrapper>
-          <div
-            v-if="isLoadingMore"
-            class="loadNextPageWrapper"
+            </TransitionGroup>
+            <FtAutoLoadNextPageWrapper
+              v-if="moreVideoDataAvailable && !isLoadingMore"
+              @load-next-page="getNextPage"
+            >
+              <FtFlexBox>
+                <FtButton
+                  :label="t('Subscriptions.Load More Videos')"
+                  background-color="var(--primary-color)"
+                  text-color="var(--text-with-main-color)"
+                  @click="getNextPage"
+                />
+              </FtFlexBox>
+            </FtAutoLoadNextPageWrapper>
+            <div
+              v-if="isLoadingMore"
+              class="loadNextPageWrapper"
+            >
+              <FtLoader />
+            </div>
+          </AutoScrollWrapper>
+          <FtFlexBox
+            v-else
           >
-            <FtLoader />
-          </div>
-        </AutoScrollWrapper>
+            <p class="message">
+              {{ t("User Playlists['Empty Search Message']") }}
+            </p>
+          </FtFlexBox>
+        </template>
         <FtFlexBox
           v-else
         >
           <p class="message">
-            {{ t("User Playlists['Empty Search Message']") }}
+            {{ t("User Playlists['This playlist currently has no videos.']") }}
           </p>
         </FtFlexBox>
-      </template>
-      <FtFlexBox
-        v-else
-      >
-        <p class="message">
-          {{ t("User Playlists['This playlist currently has no videos.']") }}
-        </p>
-      </FtFlexBox>
-    </FtCard>
+      </FtCard>
+    </template>
   </div>
 </template>
 

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -34,17 +34,16 @@
           />
         </div>
         <div
+          v-if="fullData.length > 1"
           class="optionsRow"
         >
           <FtToggleSwitch
-            v-if="fullData.length > 1"
             :label="$t('User Playlists.Playlists with Matching Videos')"
             :compact="true"
             :default-value="doSearchPlaylistsWithMatchingVideos"
             @change="doSearchPlaylistsWithMatchingVideos = !doSearchPlaylistsWithMatchingVideos"
           />
           <FtSelect
-            v-if="fullData.length > 1"
             class="sortSelect"
             :value="sortBy"
             :select-names="sortByNames"


### PR DESCRIPTION
## Pull Request Type

- [x] Performance improvement

## Description

_I recommend turning on Hide Whitespace while reviewing this pull request, as various code blocks have different indentation._

This pull request implements some neglible performance improvements in the form of some v-if, v-else and v-else-if optimisations. Vue always uses tenaries for v-if, so if we have two consecutive v-ifs with inverted conditions, that means we'll get two tenaries that are both `condition ? component : ""`, whereas replacing it with a v-if reduces that to a single tenary without the empty string resulting in less branching. Am I expecting noticable performance improvements, no, but historically my rule has been that every little helps (appart from ones where I have managed to locate a major improvement). Faster doesn't hurt as long as it doesn't break anything.

## Testing

Test that the modified components still work e.g. visiting different types of post,s visiting the history and playlist pages, etc.

## Desktop

- **OS:** Wiondows
- **OS Version:** 11