### PR TITLE
Add handling for  `/show/` urls

### DIFF
--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -331,6 +331,7 @@ async function handleActionIconChange() {
     switch (result.urlType) {
       case 'video':
       case 'playlist':
+      case 'show':
       case 'search':
       case 'channel':
       case 'hashtag':

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -378,9 +378,11 @@ const actions = {
     const hashtagPattern = /^\/hashtag\/(?<tag>[^#&/?]+)$/
 
     const postPattern = /^\/post\/(?<postId>.+)/
+    const showPattern = /^\/show\/(?<showId>.+)/
     const feedPattern = /^\/feed\/(?<type>trending|subscriptions|history|playlists|you|library)/
     const typePatterns = new Map([
       ['playlist', /^(\/playlist\/?|\/embed(\/?videoseries)?)$/],
+      ['show', showPattern],
       ['search', /^\/results|search\/?$/],
       ['hashtag', hashtagPattern],
       ['post', postPattern],
@@ -414,6 +416,15 @@ const actions = {
           urlType: 'playlist',
           playlistId,
           query
+        }
+      }
+
+      case 'show': {
+        const match = url.pathname.match(showPattern)
+        const playlistId = match.groups.showId.substring(2)
+        return {
+          urlType: 'playlist',
+          playlistId
         }
       }
 


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
Related to: #9764 

## Description
This PR adds support for handling youtube show urls by parsing it as a playlist

## Screenshots
<img width="1050" height="618" alt="image" src="https://github.com/user-attachments/assets/db7c0334-c892-466e-bf9f-eacdcad0bd6d" />

## Testing
Enter `https://www.youtube.com/show/VLPL8mG-RkN2uTxSji4CqbV35lGf-w45S5Vr?sbp=QAE%253D` in the search bar and navigate to the page


## Desktop
<!-- Please complete the following information-->
- **OS:** Fedora Linux
- **OS Version:** 44
- **FreeTube version:** v0.25.3 Beta (latest nightly)