### PR TITLE
Add support for shows tab on channels

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -656,6 +656,7 @@ function handleDragStart(event) {
           case 'releases':
           case 'podcasts':
           case 'courses':
+          case 'shows':
           case 'playlists':
           case 'about':
             transformedURL.pathname += `/${pathParts[2]}`

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -189,6 +189,22 @@
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
+            v-if="visibleTabs.includes('shows')"
+            id="showsTab"
+            class="tab"
+            role="tab"
+            :aria-selected="currentTab === 'shows'"
+            aria-controls="showsPanel"
+            :tabindex="currentTab === 'shows' ? 0 : -1"
+            :class="{ selectedTab: currentTab === 'shows' }"
+            @click="changeTab('shows')"
+            @keydown.left.right="focusTab('shows', $event)"
+            @keydown.enter.space.prevent="changeTab('shows')"
+          >
+            {{ $t("Channel.Shows.Shows") }}
+          </div>
+          <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+          <div
             v-if="visibleTabs.includes('playlists')"
             id="playlistsTab"
             class="tab"

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -200,6 +200,12 @@
           :default-value="hideChannelPodcasts"
           @change="updateHideChannelPodcasts"
         />
+        <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Hide Channel Shows')"
+          :compact="true"
+          :default-value="hideChannelShows"
+          @change="updateHideChannelShows"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -225,12 +231,6 @@
           :compact="true"
           :default-value="hideChannelCourses"
           @change="updateHideChannelCourses"
-        />
-        <FtToggleSwitch
-          :label="t('Settings.Distraction Free Settings.Hide Channel Shows')"
-          :compact="true"
-          :default-value="hideChannelShows"
-          @change="updateHideChannelShows"
         />
       </div>
     </div>

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -226,6 +226,12 @@
           :default-value="hideChannelCourses"
           @change="updateHideChannelCourses"
         />
+        <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Hide Channel Shows')"
+          :compact="true"
+          :default-value="hideChannelShows"
+          @change="updateHideChannelShows"
+        />
       </div>
     </div>
     <h4
@@ -550,6 +556,16 @@ const hideChannelCourses = computed(() => store.getters.getHideChannelCourses)
  */
 function updateHideChannelCourses(value) {
   store.dispatch('updateHideChannelCourses', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideChannelShows = computed(() => store.getters.getHideChannelShows)
+
+/**
+ * @param {boolean} value
+ */
+function updateHideChannelShows(value) {
+  store.dispatch('updateHideChannelShows', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -123,7 +123,7 @@ export async function invidiousGetChannelId(url) {
  *  description: string,
  *  descriptionHtml: string,
  *  allowedRegions: string[],
- *  tabs: ('home' | 'videos' | 'shorts' | 'live' | 'podcasts' | 'releases' | 'courses' | 'playlists' | 'community')[],
+ *  tabs: ('home' | 'videos' | 'shorts' | 'live' | 'podcasts' | 'releases' | 'courses' | 'shows' | 'playlists' | 'community')[],
  *  latestVideos: InvidiousVideoType[],
  *  relatedChannels: InvidiousChannelObject[]
  * }>}
@@ -253,6 +253,15 @@ export async function getInvidiousChannelPodcasts(channelId, continuation) {
 export async function getInvidiousChannelCourses(channelId, continuation) {
   /** @type {{continuation: string?, playlists: InvidiousPlaylistObject[]}} */
   return await getInvidiousChannelTab('courses', channelId, continuation)
+}
+
+/**
+ * @param {string} channelId
+ * @param {string | undefined | null} continuation
+ */
+export async function getInvidiousChannelShows(channelId, continuation) {
+  /** @type {{continuation: string?, playlists: InvidiousPlaylistObject[]}} */
+  return await getInvidiousChannelTab('shows', channelId, continuation)
 }
 
 /**

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1389,6 +1389,23 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
       channelId: gridPlaylist.author?.id,
       videoCount: extractNumberFromString(gridPlaylist.video_count.text)
     }
+  } else if (playlist.type === 'GridShow') {
+    /** @type {import('youtubei.js').YTNodes.GridShow} */
+    const gridPlaylist = playlist
+
+    /** @type {import('youtubei.js').YTNodes.BrowseEndpoint} */
+    const browseEndpoint = gridPlaylist.endpoint.command
+
+    return {
+      type: 'playlist',
+      dataSource: 'local',
+      title: gridPlaylist.title.text,
+      thumbnail: gridPlaylist.thumbnail_renderer.thumbnail.at(0).url,
+      playlistId: browseEndpoint.buildRequest().browseId.substring(2),
+      channelName: gridPlaylist.author?.name,
+      channelId: gridPlaylist.author?.id,
+      videoCount: extractNumberFromString(gridPlaylist.thumbnail_overlays?.at(0).text.runs?.at(0)?.text)
+    }
   } else {
     let internalChannelName
     let internalChannelId = null

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -197,6 +197,7 @@ const state = {
   hideChannelReleases: false,
   hideChannelPodcasts: false,
   hideChannelCourses: false,
+  hideChannelShows: false,
   hideChannelShorts: false,
   hideChannelSubscriptions: false,
   hideCommentLikes: false,

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -373,7 +373,7 @@ const actions = {
     let urlType = 'unknown'
 
     const channelPattern =
-      /^\/(?:(?:channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(?<tab>join|featured|videos|shorts|live|streams|podcasts|releases|courses|playlists|about|community|channels))?\/?$/
+      /^\/(?:(?:channel|user|c)\/)?(?<channelId>[^/]+)(?:\/(?<tab>join|featured|videos|shorts|live|streams|podcasts|releases|courses|shows|playlists|about|community|channels))?\/?$/
 
     const hashtagPattern = /^\/hashtag\/(?<tag>[^#&/?]+)$/
 
@@ -524,6 +524,9 @@ const actions = {
             break
           case 'courses':
             subPath = 'courses'
+            break
+          case 'shows':
+            subPath = 'shows'
             break
           case 'releases':
             subPath = 'releases'

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -192,6 +192,21 @@
           </p>
         </FtFlexBox>
         <FtElementList
+          v-if="!hideChannelShows && currentTab === 'shows'"
+          id="showsPanel"
+          :data="latestShows"
+          :use-channels-hidden-preference="false"
+          role="tabpanel"
+          aria-labelledby="showsTab"
+        />
+        <FtFlexBox
+          v-if="!hideChannelShows && currentTab === 'shows' && latestShows.length === 0"
+        >
+          <p class="message">
+            {{ $t("Channel.Shows.This channel does not currently have any shows") }}
+          </p>
+        </FtFlexBox>
+        <FtElementList
           v-if="!hideChannelPlaylists && currentTab === 'playlists'"
           id="playlistPanel"
           :data="latestPlaylists"
@@ -304,6 +319,7 @@ import {
   getInvidiousChannelPodcasts,
   getInvidiousChannelReleases,
   getInvidiousChannelCourses,
+  getInvidiousChannelShows,
   getInvidiousChannelShorts,
   getInvidiousChannelVideos,
   invidiousGetChannelId,
@@ -405,6 +421,7 @@ const SUPPORTED_CHANNEL_TABS = [
   'releases',
   'podcasts',
   'courses',
+  'shows',
   'playlists',
   'community',
   'about'
@@ -417,6 +434,7 @@ const channelTabs = shallowRef([
   'releases',
   'podcasts',
   'courses',
+  'shows',
   'playlists',
   'community',
   'about'
@@ -470,6 +488,9 @@ const hideChannelReleases = computed(() => store.getters.getHideChannelReleases)
 const hideChannelCourses = computed(() => store.getters.getHideChannelCourses)
 
 /** @type {import('vue').ComputedRef<boolean>} */
+const hideChannelShows = computed(() => store.getters.getHideChannelShows)
+
+/** @type {import('vue').ComputedRef<boolean>} */
 const hideChannelPlaylists = computed(() => store.getters.getHideChannelPlaylists)
 
 /** @type {import('vue').ComputedRef<boolean>} */
@@ -512,6 +533,10 @@ const tabInfoValues = computed(() => {
 
   if (hideChannelCourses.value) {
     removeFromArrayIfExists(values, 'courses')
+  }
+
+  if (hideChannelShows.value) {
+    removeFromArrayIfExists(values, 'shows')
   }
 
   return values
@@ -814,6 +839,11 @@ async function getChannelLocal() {
       getChannelReleasesLocal()
     }
 
+    if (!hideChannelCourses.value && channelInstance.has_shows) {
+      tabs.push('shows')
+      getChannelShowsLocal()
+    }
+
     if (!hideChannelCourses.value && channelInstance.has_courses) {
       tabs.push('courses')
       getChannelCoursesLocal()
@@ -1028,6 +1058,10 @@ async function getChannelInfoInvidious() {
 
     if (!hideChannelCourses.value && response.tabs.includes('courses')) {
       channelInvidiousCourses()
+    }
+
+    if (!hideChannelShows.value && response.tabs.includes('shows')) {
+      channelInvidiousShows()
     }
 
     if (!hideChannelPlaylists.value && response.tabs.includes('playlists')) {
@@ -1944,6 +1978,101 @@ async function channelInvidiousCoursesMore() {
   }
 }
 
+const latestShows = shallowRef([])
+const showsContinuationData = shallowRef(null)
+
+async function getChannelShowsLocal() {
+  isElementListLoading.value = true
+  const expectedId = id.value
+
+  try {
+    await ensureChannelInstance()
+
+    const showsTab = await channelInstance.getShows()
+
+    if (expectedId !== id.value) {
+      return
+    }
+
+    latestShows.value = showsTab.playlists.map(playlist => parseLocalListPlaylist(playlist, id.value, channelName.value))
+    showsContinuationData.value = showsTab.has_continuation ? showsTab : null
+    isElementListLoading.value = false
+  } catch (err) {
+    console.error(err)
+
+    const errorMessage = t('Local API Error (Click to copy)')
+    showToast(`${errorMessage}: ${err}`, 10000, () => {
+      copyToClipboard(err)
+    })
+
+    if (backendPreference.value === 'local' && backendFallback.value) {
+      showToast(t('Falling back to Invidious API'))
+      channelInvidiousShows()
+    } else {
+      isLoading.value = false
+    }
+  }
+}
+
+async function getChannelShowsLocalMore() {
+  try {
+    /**
+     * @type {import('youtubei.js').YT.ChannelListContinuation}
+     */
+    const continuation = await showsContinuationData.value.getContinuation()
+
+    const parsedShows = continuation.playlists.map(playlist => parseLocalListPlaylist(playlist, id.value, channelName.value))
+    latestShows.value = latestShows.value.concat(parsedShows)
+    showsContinuationData.value = continuation.has_continuation ? continuation : null
+  } catch (err) {
+    console.error(err)
+    const errorMessage = t('Local API Error (Click to copy)')
+    showToast(`${errorMessage}: ${err}`, 10000, () => {
+      copyToClipboard(err)
+    })
+  }
+}
+
+async function channelInvidiousShows() {
+  isElementListLoading.value = true
+
+  try {
+    const response = await getInvidiousChannelShows(id.value)
+    showsContinuationData.value = response.continuation || null
+    latestShows.value = response.playlists
+    isElementListLoading.value = false
+  } catch (err) {
+    console.error(err)
+
+    const errorMessage = t('Invidious API Error (Click to copy)')
+    showToast(`${errorMessage}: ${err}`, 10000, () => {
+      copyToClipboard(err)
+    })
+
+    if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
+      showToast(t('Falling back to Local API'))
+      getChannelShowsLocal()
+    } else {
+      isLoading.value = false
+    }
+  }
+}
+
+async function channelInvidiousShowsMore() {
+  try {
+    const response = await getInvidiousChannelShows(id.value, showsContinuationData.value)
+    showsContinuationData.value = response.continuation || null
+    latestShows.value = latestShows.value.concat(response.playlists)
+    isElementListLoading.value = false
+  } catch (err) {
+    console.error(err)
+    const errorMessage = t('Invidious API Error (Click to copy)')
+    showToast(`${errorMessage}: ${err}`, 10000, () => {
+      copyToClipboard(err)
+    })
+  }
+}
+
 const latestCommunityPosts = shallowRef([])
 const communityContinuationData = shallowRef(null)
 
@@ -2239,6 +2368,8 @@ const showFetchMoreButton = computed(() => {
       return !isNullOrEmpty(podcastContinuationData.value)
     case 'courses':
       return !isNullOrEmpty(coursesContinuationData.value)
+    case 'shows':
+      return !isNullOrEmpty(showsContinuationData.value)
     case 'playlists':
       return !isNullOrEmpty(playlistContinuationData.value)
     case 'community':
@@ -2296,6 +2427,13 @@ async function handleFetchMore() {
         await getChannelCoursesLocalMore()
       } else {
         await channelInvidiousCoursesMore()
+      }
+      break
+    case 'shows':
+      if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
+        await getChannelShowsLocalMore()
+      } else {
+        await channelInvidiousShowsMore()
       }
       break
     case 'playlists':

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -834,6 +834,9 @@ Channel:
   Courses:
     Courses: Courses
     This channel does not currently have any courses: This channel does not currently have any courses
+  Shows:
+    Shows: Shows
+    This channel does not currently have any shows: This channel does not currently have any shows
   About:
     About: About
     Channel Description: Channel Description

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -588,6 +588,7 @@ Settings:
     Hide Channel Podcasts: Hide Channel "Podcasts" Tab
     Hide Channel Releases: Hide Channel "Releases" Tab
     Hide Channel Courses: Hide Channel "Courses" Tab
+    Hide Channel Shows: Hide Channel "Shows" Tab
     Hide Videos, Playlists and Channels Containing Text: Hide Videos, Playlists and Channels Containing Text
     Hide Videos, Playlists and Channels Containing Text Placeholder: Word, Word Fragment, or Phrase
     Hide Subscriptions Videos: Hide Subscriptions Videos


### PR DESCRIPTION
## Pull Request Type
- [x] Feature Implementation

## Related issue
closes #9764
https://github.com/iv-org/invidious/pull/6033
https://github.com/LuanRT/YouTube.js/pull/1260

## Description
This PR adds support for the `Shows` tab on channels 

## Screenshots 
<img width="1095" height="1031" alt="image" src="https://github.com/user-attachments/assets/b82e749c-4f5d-4ecb-9088-943b80678017" />

<img width="1074" height="977" alt="image" src="https://github.com/user-attachments/assets/e7cba0f0-161a-46dc-accd-af1340f8d955" />

<img width="855" height="267" alt="image" src="https://github.com/user-attachments/assets/863b6972-bffa-49a6-86b5-b6478d26e7f7" />

## Testing
With Local API (requires changes from: https://github.com/LuanRT/YouTube.js/pull/1260 ) and with Invidious API (requires changes from: https://github.com/iv-org/invidious/pull/6033 )
- Go to Linus Tech Tips channel ( https://www.youtube.com/channel/UCXuqSBlHAE6Xw-yeJA0Tunw )
- Go to `Shows` tab
- Click on a show

Other test:
- Go to Settings > Distraction Free Settings > Channel
- Enable `Hide Channel "Shows" Tab`
- Go to Linus Tech Tips channel and don't see `Shows` tab

## Desktop
- **OS:** Fedora Linux 
- **OS Version:**
- **FreeTube version:** latest nightly